### PR TITLE
Fix router password hint display incorrect after set a new router password

### DIFF
--- a/lib/core/jnap/extensions/batch_extension.dart
+++ b/lib/core/jnap/extensions/batch_extension.dart
@@ -24,6 +24,7 @@ extension BatchCommands on RouterRepository {
         const MapEntry(JNAPAction.isAdminPasswordSetByUser, {}),
         const MapEntry(JNAPAction.isAdminPasswordDefault, {}),
       ], auth: true),
+      fetchRemote: true,
     ).then((successWrap) => successWrap.data);
   }
 

--- a/lib/page/administration/network_admin/providers/router_password_provider.dart
+++ b/lib/page/administration/network_admin/providers/router_password_provider.dart
@@ -18,7 +18,7 @@ class RouterPasswordNotifier extends Notifier<RouterPasswordState> {
   @override
   RouterPasswordState build() => RouterPasswordState.init();
 
-  Future fetch() async {
+  Future fetch([bool force = false]) async {
     final repo = ref.read(routerRepositoryProvider);
     final results = await repo.fetchIsConfigured();
     final bool isAdminDefault = JNAPTransactionSuccessWrap.getResult(
@@ -32,7 +32,7 @@ class RouterPasswordNotifier extends Notifier<RouterPasswordState> {
     String passwordHint = '';
     if (isSetByUser) {
       passwordHint = await repo
-          .send(JNAPAction.getAdminPasswordHint)
+          .send(JNAPAction.getAdminPasswordHint, fetchRemote: force)
           .then((result) => result.output['passwordHint'] ?? '')
           .onError((error, stackTrace) => '');
     }
@@ -84,7 +84,7 @@ class RouterPasswordNotifier extends Notifier<RouterPasswordState> {
       await ref
           .read(authProvider.notifier)
           .localLogin(pwd ?? '', guardError: false);
-      await fetch();
+      await fetch(true);
     });
   }
 


### PR DESCRIPTION
Fix the router password hint display incorrect after set a new router password hint.
Force fetch password hint from the router
Tested with OAK on local build