### PR TITLE
Fixed device filter display white block when node name is too long

### DIFF
--- a/lib/page/devices/views/devices_filter_widget.dart
+++ b/lib/page/devices/views/devices_filter_widget.dart
@@ -184,10 +184,10 @@ class _FilteredChipsWidgetState<T>
           runSpacing: 8,
           children: [
             ...widget.dataList.map((e) => FilterChip(
-                  label: AppText.bodySmall(widget.chipName(e)),
-                  // shape: const RoundedRectangleBorder(
-                  //     borderRadius: BorderRadius.all(Radius.circular(40))),
-                  // showCheckmark: false,
+                  label: AppText.bodySmall(
+                    widget.chipName(e),
+                    overflow: TextOverflow.ellipsis,
+                  ),
                   onSelected: widget.onSelected != null
                       ? (value) {
                           widget.onSelected?.call(e, value);

--- a/test/common/test_responsive_widget.dart
+++ b/test/common/test_responsive_widget.dart
@@ -96,6 +96,7 @@ void testLocalizations(
       .where((element) => envScreens.toSet().contains(element))
       .toList();
   final isScreenIncluded = supportedDevices.isNotEmpty;
+  print('XXXXX: supportedDevice - ${supportedDevices.length}, skip:${(skip ?? false) || !isScreenIncluded}');
   final set = supportedLocales
       .map((locale) => supportedDevices.map((device) =>
           LocalizedScreen.fromScreenSize(locale: locale, screen: device)))
@@ -116,7 +117,7 @@ void testLocalizations(
       await expectLater(actualFinder, matchesGoldenFile('goldens/$name.png'));
     },
     onCompleted: onCompleted,
-    variants: variants,
+    variants: !isScreenIncluded ? null : variants,
     skip: (skip ?? false) || !isScreenIncluded,
     timeout: timeout,
     semanticsEnabled: semanticsEnabled,


### PR DESCRIPTION
- Fixed device filter display white block when node name is too long
- Fixed unexcepted error when given a specific device size but the test case not supported