### PR TITLE
[Wifi Setting] 1. Fix the duplicate mac address in mac filtering 2. Sync the guest wifi state to dashboard

### DIFF
--- a/lib/page/wifi_settings/providers/guest_wifi_provider.dart
+++ b/lib/page/wifi_settings/providers/guest_wifi_provider.dart
@@ -4,6 +4,7 @@ import 'package:privacy_gui/core/jnap/command/base_command.dart';
 import 'package:privacy_gui/core/jnap/models/guest_radio_settings.dart';
 import 'package:privacy_gui/core/jnap/providers/dashboard_manager_state.dart';
 import 'package:privacy_gui/core/jnap/providers/device_manager_state.dart';
+import 'package:privacy_gui/core/jnap/providers/polling_provider.dart';
 import 'package:privacy_gui/core/jnap/router_repository.dart';
 import 'package:privacy_gui/page/wifi_settings/providers/guest_wifi_state.dart';
 
@@ -48,13 +49,18 @@ class GuestWifiNotifier extends Notifier<GuestWiFiState> {
         .toList();
     final newSetGuestRadioSettings = setGuestRadioSettings.copyWith(
         isGuestNetworkEnabled: state.isEnabled, radios: newRadios);
-    await ref.read(routerRepositoryProvider).send(
+    await ref
+        .read(routerRepositoryProvider)
+        .send(
           JNAPAction.setGuestRadioSettings,
           data: newSetGuestRadioSettings.toMap(),
           fetchRemote: true,
           cacheLevel: CacheLevel.noCache,
           auth: true,
-        );
+        )
+        .then((_) {
+      ref.read(pollingProvider.notifier).forcePolling();
+    });
     return await fetch(true);
   }
 

--- a/lib/page/wifi_settings/views/guest_wifi_view.dart
+++ b/lib/page/wifi_settings/views/guest_wifi_view.dart
@@ -14,7 +14,6 @@ import 'package:privacygui_widgets/widgets/_widgets.dart';
 import 'package:privacygui_widgets/widgets/card/list_card.dart';
 import 'package:privacygui_widgets/widgets/card/setting_card.dart';
 import 'package:privacygui_widgets/widgets/page/layout/basic_layout.dart';
-import 'package:privacygui_widgets/widgets/progress_bar/full_screen_spinner.dart';
 
 class GuestWiFiSettingsView extends ArgumentsConsumerStatefulView {
   const GuestWiFiSettingsView({super.key});

--- a/lib/page/wifi_settings/views/mac_filtered_devices_view.dart
+++ b/lib/page/wifi_settings/views/mac_filtered_devices_view.dart
@@ -223,7 +223,7 @@ class _FilteredDevicesViewState extends ConsumerState<FilteredDevicesView> {
         ],
       ),
       event: () async {
-        return controller.text;
+        return controller.text.toUpperCase();
       },
       checkPositiveEnabled: () => isValid,
     );


### PR DESCRIPTION
1. Fix the duplicate mac address in mac filtering
2. Sync the guest wifi state to dashboard