### PR TITLE
[NOW-104]: Instant-Admin: After changing, the time zone still displays the previous setting

### DIFF
--- a/lib/page/instant_admin/providers/timezone_provider.dart
+++ b/lib/page/instant_admin/providers/timezone_provider.dart
@@ -47,6 +47,7 @@ class TimezoneNotifier extends Notifier<TimezoneState> {
       auth: true,
     )
         .then<void>((value) async {
+      await fetch(fetchRemote: true);
       await ref.read(pollingProvider.notifier).forcePolling();
     }).onError((error, stackTrace) {
       if (error is JNAPError) {

--- a/lib/page/instant_admin/views/instant_admin_view.dart
+++ b/lib/page/instant_admin/views/instant_admin_view.dart
@@ -130,7 +130,6 @@ class _RouterPasswordContentViewState extends ConsumerState<NetworkAdminView> {
             ),
           ),
           const AppGap.small2(),
-
           AppListCard(
             title: AppText.bodyLarge(loc(context).timezone),
             description: AppText.labelLarge(_getTimezone(timezoneState)),


### PR DESCRIPTION
[Root cause]
Fetch cache data not the latest.

[Soluiton]
Fetch the latest data after save changes.