### PR TITLE
[NOW-133] MAC Address Clone: Unknown error when saving invalid MAC address

### DIFF
--- a/lib/page/advanced_settings/internet_settings/providers/internet_settings_provider.dart
+++ b/lib/page/advanced_settings/internet_settings/providers/internet_settings_provider.dart
@@ -215,7 +215,6 @@ class InternetSettingsNotifier extends Notifier<InternetSettingsState> {
           .doTransaction(transactions, fetchRemote: true)
           .then((results) async {
         _handleWebRedirection(results);
-        
       }).catchError(
         (error) {
           final sideEffectError = error as JNAPSideEffectError;
@@ -405,8 +404,8 @@ class InternetSettingsNotifier extends Notifier<InternetSettingsState> {
         macAddress: isMACAddressCloneEnabled ? macAddress : null,
       ).toMap(),
     )
-        .then((_) {
-      getMacAddressClone();
+        .then((_) async {
+      await getMacAddressClone();
     });
   }
 


### PR DESCRIPTION
[Soluiton]
Handle the error response 'ErrorInvalidMACAddress'. Fix the state error issue after saving.