### PR TITLE
[Now-111] Reset password: Password tips collapse once leave password column.

### DIFF
--- a/lib/page/login/views/local_reset_router_password_view.dart
+++ b/lib/page/login/views/local_reset_router_password_view.dart
@@ -74,7 +74,7 @@ class _LocalResetRouterPasswordViewState
                   const AppGap.large3(),
                   AppPasswordField(
                     border: const OutlineInputBorder(),
-                    withValidator: state.hasEdited,
+                    withValidator: true,
                     validations: [
                       Validation(
                           description: loc(context).routerPasswordRuleTenChars,


### PR DESCRIPTION
[Solution]
Always display the tips on the reset password page