### PR TITLE
[NOW-77]: Log in: Unknown error displayed when logging in with wrong password and then refreshing the page and logging in with correct password

### DIFF
--- a/lib/constants/error_code.dart
+++ b/lib/constants/error_code.dart
@@ -21,6 +21,7 @@ const errorInvalidResetCode = 'ErrorInvalidResetCode';
 const errorConsecutiveInvalidResetCodeEntered =
     'ErrorConsecutiveInvalidResetCodeEntered';
 const errorInvalidAdminPassword = 'ErrorInvalidAdminPassword';
+const errorPasswordCheckDelayed = 'ErrorPasswordCheckDelayed';
 const errorInvalidGateway = 'ErrorInvalidGateway';
 const errorUnexpected = '_ErrorUnexpected';
 

--- a/lib/core/jnap/actions/jnap_service_supported.dart
+++ b/lib/core/jnap/actions/jnap_service_supported.dart
@@ -43,8 +43,13 @@ class ServiceHelper {
 
   bool isSupportChildReboot([List<String>? services]) =>
       isServiceSupport(JNAPService.core8, services);
+
   bool isSupportChildFactoryReset([List<String>? services]) =>
       isServiceSupport(JNAPService.core9, services);
+      
   bool isSupportWANExternal([List<String>? services]) =>
       isServiceSupport(JNAPService.router13);
+
+  bool isSupportAdminPasswordAuthStatus([List<String>? services]) =>
+      isServiceSupport(JNAPService.core7, services);
 }

--- a/lib/page/login/views/login_local_view.dart
+++ b/lib/page/login/views/login_local_view.dart
@@ -50,11 +50,14 @@ class _LoginViewState extends ConsumerState<LoginLocalView> {
     //Use this to prevent errors from modifying the state during the init stage
     Future.doWhile(() => !mounted).then((value) {
       _getAdminPasswordHint();
+      ref
+          .read(dashboardManagerProvider.notifier)
+          .checkDeviceInfo(null)
+          .then((value) {
+        buildBetterActions(value.services);
+        _getAdminPasswordAuthStatus(value.services);
+      });
     });
-    ref
-        .read(dashboardManagerProvider.notifier)
-        .checkDeviceInfo(null)
-        .then((value) => buildBetterActions(value.services));
   }
 
   @override
@@ -88,7 +91,8 @@ class _LoginViewState extends ConsumerState<LoginLocalView> {
   void setErrorMessage(JNAPError? error) {
     if (error != null) {
       // Check if it's the invalid admin password error from CheckAdminPassword3
-      if (error.result == errorInvalidAdminPassword || error.result == errorPasswordCheckDelayed) {
+      if (error.result == errorInvalidAdminPassword ||
+          error.result == errorPasswordCheckDelayed) {
         // Do not re-assign the error data while the timer is still running
         if (!_isTimerRunning()) {
           final errorContent =
@@ -99,19 +103,25 @@ class _LoginViewState extends ConsumerState<LoginLocalView> {
             // Trigger the timer as long as there is delay time
             _errorMessage = getCountdownPrompt(errorResult: error.result);
             _startTimer(errorResult: error.result);
-          } else {
+          } else if (_remainingAttempts == 0) {
             // delay time will be absent if remaining attempts reach to 0
             // No need to count down
-            _errorMessage = loc(context).localLoginTooManyAttemptsTitle;
+            setState(() {
+              _errorMessage = loc(context).localLoginTooManyAttemptsTitle;
+            });
           }
         }
       } else {
         // Older check admin password jnaps or other error types
-        _errorMessage = generalErrorCodeHandler(context, error.result);
+        setState(() {
+          _errorMessage = generalErrorCodeHandler(context, error.result);
+        });
       }
     } else {
       // Should not be here
-      _errorMessage = generalErrorCodeHandler(context, '');
+      setState(() {
+        _errorMessage = generalErrorCodeHandler(context, '');
+      });
     }
   }
 
@@ -240,6 +250,19 @@ class _LoginViewState extends ConsumerState<LoginLocalView> {
 
   void _getAdminPasswordHint() {
     auth.getPasswordHint();
+  }
+
+  void _getAdminPasswordAuthStatus(List<String> services) {
+    auth.getAdminPasswordAuthStatus(services).then((result) {
+      if (result != null && !isCountdownJustFinished) {
+        // Create the error and the countdown has yet to be triggered
+        final JNAPError jnapError = JNAPError(
+          result: errorPasswordCheckDelayed,
+          error: jsonEncode(result),
+        );
+        setErrorMessage(jnapError);
+      }
+    });
   }
 
   _doLogin() {

--- a/lib/providers/auth/auth_provider.dart
+++ b/lib/providers/auth/auth_provider.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:privacy_gui/core/jnap/actions/jnap_service_supported.dart';
 import 'package:privacy_gui/providers/auth/ra_session_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -327,6 +328,24 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         );
       });
     }
+  }
+
+  Future<Map<String, dynamic>?> getAdminPasswordAuthStatus(List<String> services) async {
+    if (serviceHelper.isSupportAdminPasswordAuthStatus(services) != true) {
+      return null;
+    }
+    final routerRepository = ref.read(routerRepositoryProvider);
+    final result = await routerRepository.send(
+      JNAPAction.getAdminPasswordAuthStatus,
+    );
+    return result.output;
+  }
+
+  Future<void> getDeviceInfo() async {
+    final routerRepository = ref.read(routerRepositoryProvider);
+    await routerRepository.send(
+      JNAPAction.getDeviceInfo,
+    );
   }
 
   Future logout() async {


### PR DESCRIPTION
[Root cause]
Did not handle the error response: errorPasswordCheckDelayed
    
[Solution]
Handle the error errorPasswordCheckDelayed, so that will not show unknown error to user.
Add getAdminPasswordAuthStatus to check the auth status