### PR TITLE
Fixing manual fw update

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -120,28 +120,28 @@ class _LinksysAppState extends ConsumerState<LinksysApp>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     logger.i('didChangeAppLifecycleState: ${state.name}');
-    if (state == AppLifecycleState.resumed) {
-      ref
-          .read(connectivityProvider.notifier)
-          .forceUpdate()
-          .then((_) => SharedPreferences.getInstance())
-          .then((prefs) {
-        final currentSN = prefs.getString(pCurrentSN);
-        if (currentSN != null &&
-            ref.read(dashboardManagerProvider).deviceInfo?.serialNumber !=
-                currentSN) {
-          // TODO
-          // if (mounted) {
-          //   showRouterNotFoundAlert(context, ref);
-          // }
-        } else if (ref.read(authProvider).value?.loginType != LoginType.none &&
-            currentSN?.isNotEmpty == true) {
-          ref.read(pollingProvider.notifier).startPolling();
-        }
-      });
-    } else if (state == AppLifecycleState.paused) {
-      ref.read(pollingProvider.notifier).stopPolling();
-    }
+    // if (state == AppLifecycleState.resumed) {
+    //   ref
+    //       .read(connectivityProvider.notifier)
+    //       .forceUpdate()
+    //       .then((_) => SharedPreferences.getInstance())
+    //       .then((prefs) {
+    //     final currentSN = prefs.getString(pCurrentSN);
+    //     if (currentSN != null &&
+    //         ref.read(dashboardManagerProvider).deviceInfo?.serialNumber !=
+    //             currentSN) {
+    //       // TODO
+    //       // if (mounted) {
+    //       //   showRouterNotFoundAlert(context, ref);
+    //       // }
+    //     } else if (ref.read(authProvider).value?.loginType != LoginType.none &&
+    //         currentSN?.isNotEmpty == true) {
+    //       ref.read(pollingProvider.notifier).startPolling();
+    //     }
+    //   });
+    // } else if (state == AppLifecycleState.paused) {
+    //   ref.read(pollingProvider.notifier).stopPolling();
+    // }
   }
 
   _initAuth() {

--- a/lib/constants/build_config.dart
+++ b/lib/constants/build_config.dart
@@ -66,24 +66,20 @@ CloudEnvironment cloudEnvTarget = CloudEnvironment.values
 Map<String, dynamic> get cloudEnvironmentConfig =>
     kCloudEnvironmentMap[cloudEnvTarget];
 
-Future<String> getVersion({bool full = false}) async {
-  final version =
+Future<String> getVersion() async {
+  final version = await getBuildNumber() ;
+  return version ??
       await PackageInfo.fromPlatform().then((value) => value.version);
-  if (!full) {
-    return version;
-  }
-  final build = await getBuildNumber().then((value) => '.$value');
-  return '$version$build';
 }
 
-Future<int> getBuildNumber() async {
-  int buildNumber = 0;
+Future<String?> getBuildNumber() async {
+  String? buildNumber;
   final json = await rootBundle
       .loadString('assets/resources/versions.json')
       .then((value) => jsonDecode(value))
       .onError((error, stackTrace) => null);
   if (json != null) {
-    buildNumber = json['build_number'] as int? ?? 0;
+    buildNumber = json['version'] as String?;
   }
   return buildNumber;
 }

--- a/lib/core/jnap/providers/firmware_update_provider.dart
+++ b/lib/core/jnap/providers/firmware_update_provider.dart
@@ -318,13 +318,13 @@ class FirmwareUpdateNotifier extends Notifier<FirmwareUpdateState> {
       }
       logger.e('[FIRMWARE]: Manual firmware update: Error: $error');
       throw ManualFirmwareUpdateException('UnknownError');
-    }).whenComplete(() {
-      ref.read(pollingProvider.notifier).startPolling();
     });
   }
 
   Future waitForRouterBackOnline() {
-    return ref.read(sideEffectProvider.notifier).manualDeviceRestart();
+    return ref.read(sideEffectProvider.notifier).manualDeviceRestart().whenComplete(() {
+      ref.read(pollingProvider.notifier).startPolling();
+    });
   }
 }
 

--- a/lib/page/components/customs/rotating_icon.dart
+++ b/lib/page/components/customs/rotating_icon.dart
@@ -4,12 +4,14 @@ class RotatingIcon extends StatefulWidget {
   final Duration? duration;
   final Icon icon;
   final bool animate;
+  final bool reverse;
 
   const RotatingIcon(
     this.icon, {
     Key? key,
     this.duration,
     this.animate = true,
+    this.reverse = false,
   }) : super(key: key);
 
   @override
@@ -19,7 +21,10 @@ class RotatingIcon extends StatefulWidget {
 class _RotatingIconState extends State<RotatingIcon>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
-
+  late final Animation<double> _animation = CurvedAnimation(
+    parent: _controller,
+    curve: Curves.easeInOut,
+  );
   @override
   void initState() {
     super.initState();
@@ -37,7 +42,7 @@ class _RotatingIconState extends State<RotatingIcon>
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: RotationTransition(
-        turns: _controller,
+        turns: widget.reverse ? ReverseAnimation(_animation) : _animation,
         child: widget.icon,
       ),
     );

--- a/lib/page/components/styled/general_settings_widget/general_settings_widget.dart
+++ b/lib/page/components/styled/general_settings_widget/general_settings_widget.dart
@@ -83,7 +83,7 @@ class _GeneralSettingsWidgetState extends ConsumerState<GeneralSettingsWidget> {
                 const AppGap.medium(),
                 ..._displayAdditional(loginType),
                 FutureBuilder(
-                    future: getVersion(full: false),
+                    future: getVersion(),
                     initialData: '-',
                     builder: (context, data) {
                       return Semantics(

--- a/lib/page/components/styled/styled_page_view.dart
+++ b/lib/page/components/styled/styled_page_view.dart
@@ -172,8 +172,9 @@ class StyledAppPageView extends ConsumerWidget {
             builder: (context, showColumnOverlay, _) {
               return Column(
                 children: [
-                  const PreferredSize(
-                      preferredSize: Size(0, 80), child: TopBar()),
+                  topbar ??
+                      const PreferredSize(
+                          preferredSize: Size(0, 80), child: TopBar()),
                   Expanded(
                     child: AppResponsiveColumnLayout(
                       column: config?.column?.column,

--- a/lib/page/instant_admin/views/manual_firmware_update_view.dart
+++ b/lib/page/instant_admin/views/manual_firmware_update_view.dart
@@ -122,6 +122,10 @@ class _ManualFirmwareUpdateViewState
                 });
                 _showSuccessSnackbar();
               }).catchError((error) {
+                setState(() {
+                  _status?.stop();
+                  _status = null;
+                });
                 showRouterNotFoundAlert(context, ref);
               }, test: (error) => error is JNAPSideEffectError);
             }, onError: (error, stackTrace) {

--- a/lib/page/instant_admin/views/manual_firmware_update_view.dart
+++ b/lib/page/instant_admin/views/manual_firmware_update_view.dart
@@ -199,6 +199,7 @@ class _ManualFirmwareUpdateViewState
                       Icon(_getProcessingIcon(),
                           size: 64,
                           color: Theme.of(context).colorScheme.primary),
+                          reverse: true,
                     )
                   : Icon(_getProcessingIcon(),
                       size: 64, color: Theme.of(context).colorScheme.primary),

--- a/lib/page/instant_admin/views/manual_firmware_update_view.dart
+++ b/lib/page/instant_admin/views/manual_firmware_update_view.dart
@@ -10,7 +10,6 @@ import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/components/customs/rotating_icon.dart';
 import 'package:privacy_gui/page/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/page/components/shortcuts/snack_bar.dart';
-import 'package:privacy_gui/page/components/styled/consts.dart';
 import 'package:privacy_gui/page/components/styled/styled_page_view.dart';
 import 'package:privacy_gui/page/components/views/arguments_view.dart';
 import 'package:privacy_gui/utils.dart';
@@ -51,7 +50,7 @@ class ManualUpdateInstalling implements ManualUpdateStatus<double> {
       ManualUpdateInstalling(progress ?? this.progress);
 
   @override
-  double get value => progress / 100.0;
+  double get value => (progress % 100) / 100.0;
 }
 
 class ManualUpdateRebooting implements ManualUpdateStatus<String> {
@@ -117,7 +116,7 @@ class _ManualFirmwareUpdateViewState
                   .read(firmwareUpdateProvider.notifier)
                   .waitForRouterBackOnline()
                   .then((_) {
-                setState(() {                                
+                setState(() {
                   _status?.stop();
                   _status = null;
                 });
@@ -125,7 +124,6 @@ class _ManualFirmwareUpdateViewState
               }).catchError((error) {
                 showRouterNotFoundAlert(context, ref);
               }, test: (error) => error is JNAPSideEffectError);
-              
             }, onError: (error, stackTrace) {
               setState(() {
                 _status?.stop();
@@ -185,10 +183,10 @@ class _ManualFirmwareUpdateViewState
   }
 
   Widget _processingView() {
-    return StyledAppPageView(
-      appBarStyle: AppBarStyle.none,
-      child: AppBasicLayout(
-        content: Center(
+    return AppBasicLayout(
+      content: Center(
+        child: SizedBox(
+          width: 6.col,
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -207,32 +205,37 @@ class _ManualFirmwareUpdateViewState
             ],
           ),
         ),
-        footer: _status is ManualUpdateInstalling
-            ? Column(
-                children: [
-                  LinearProgressIndicator(
-                      value: _status is ManualUpdateInstalling
-                          ? _status?.value ?? 0
-                          : 1.0,
-                      backgroundColor: Theme.of(context)
-                          .colorSchemeExt
-                          .surfaceContainerHighest),
-                  AppGap.small2(),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      AppText.bodyMedium(
-                          loc(context).manualFirmwareEstimatedTime),
-                      AppText.bodyMedium(DateFormatUtils.formatDuration(
-                          Duration(
-                              seconds:
-                                  (60 * (1 - (_status?.value ?? 1))).round()))),
-                    ],
-                  ),
-                ],
-              )
-            : Center(),
       ),
+      footer: _status is ManualUpdateInstalling
+          ? Center(
+              child: SizedBox(
+                width: 6.col,
+                child: Column(
+                  children: [
+                    LinearProgressIndicator(
+                        value: _status is ManualUpdateInstalling
+                            ? _status?.value ?? 0
+                            : 1.0,
+                        backgroundColor: Theme.of(context)
+                            .colorSchemeExt
+                            .surfaceContainerHighest),
+                    AppGap.small2(),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        AppText.bodyMedium(
+                            loc(context).manualFirmwareEstimatedTime),
+                        AppText.bodyMedium(DateFormatUtils.formatDuration(
+                            Duration(
+                                seconds: (60 * (1 - (_status?.value ?? 1)))
+                                    .round()))),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            )
+          : Center(),
     );
   }
 


### PR DESCRIPTION
- fixed restart poll data after router back
- UI update, to hide menu during updating and restarting
- Remove start/stop polling when tab lose focus
- Modify manual fw update flow
- refactor fetch ui version
- fixed manual fw update not align in middle and animations