### PR TITLE
Fixed NOW-147

### DIFF
--- a/lib/page/nodes/views/node_detail_view.dart
+++ b/lib/page/nodes/views/node_detail_view.dart
@@ -395,7 +395,7 @@ class _NodeDetailViewState extends ConsumerState<NodeDetailView> {
 
     bool isCognitive = isCognitiveMeshRouter(
         modelNumber: state.modelNumber, hardwareVersion: state.hardwareVersion);
-    if (!isSupportNodeLight && !isCognitive) {
+    if (!isSupportNodeLight || !isCognitive) {
       return const Center();
     }
     return _nodeDetailBackgroundCard(


### PR DESCRIPTION
- NOW-147: [Instant-Topology] "Blink Device Light" should be hidden when the node doesn't support the function.