### PR TITLE
[NOW-160]: Instant-Safety: The feature name should display "Instant-Safety" instead of "Safe Browsing"

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -83,7 +83,7 @@
   "provider": "Provider",
   "restart": "Restart",
   "restarting": "Restarting...",
-  "safeBrowsingDesc": "Protect your family and block pre-determined adult , illegal and malicious content with a single tap. Safe Browsing applies to all devices on your network.",
+  "safeBrowsingDesc": "Protect your family and block pre-determined adult , illegal and malicious content with a single tap. Instant-Safety applies to all devices on your network.",
   "save": "Save",
   "sms": "SMS",
   "successExclamation": "Success!",

--- a/lib/page/instant_safety/views/instant_safety_view.dart
+++ b/lib/page/instant_safety/views/instant_safety_view.dart
@@ -56,9 +56,9 @@ class _InstantSafetyViewState extends ConsumerState<InstantSafetyView> {
             AppText.bodyLarge(loc(context).safeBrowsingDesc),
             const AppGap.large3(),
             AppSettingCard(
-              title: loc(context).safeBrowsing,
+              title: loc(context).instantSafety,
               trailing: AppSwitch(
-                semanticLabel: 'safe browsing',
+                semanticLabel: 'instant safety',
                 value: enableSafeBrowsing,
                 onChanged: (enable) {
                   setState(() {


### PR DESCRIPTION
[Root cause]
Didn't update the string

[Solution]
Update the string.