### PR TITLE
[NOW-159]: Local Network: Clearing DNS server settings should not prompt the user for unsaved changes

### DIFF
--- a/lib/page/advanced_settings/local_network_settings/providers/local_network_settings_provider.dart
+++ b/lib/page/advanced_settings/local_network_settings/providers/local_network_settings_provider.dart
@@ -80,7 +80,7 @@ class LocalNetworkSettingsNotifier extends Notifier<LocalNetworkSettingsState> {
   }
 
   Future<void> saveSettings(LocalNetworkSettingsState settings) {
-    final currentIPAddress = state.ipAddress;
+    final previousIPAddress = state.ipAddress;
     final newSettings = SetRouterLANSettings(
       ipAddress: settings.ipAddress,
       networkPrefixLength:
@@ -111,7 +111,7 @@ class LocalNetworkSettingsNotifier extends Notifier<LocalNetworkSettingsState> {
       await fetch(fetchRemote: true);
     }).catchError(
       (error) {
-        if (kIsWeb) {
+        if (kIsWeb && previousIPAddress != newSettings.ipAddress) {
           ref.read(redirectionProvider.notifier).state =
               'https://${newSettings.ipAddress}';
         }

--- a/lib/page/advanced_settings/local_network_settings/views/local_network_settings_view.dart
+++ b/lib/page/advanced_settings/local_network_settings/views/local_network_settings_view.dart
@@ -346,7 +346,9 @@ class _LocalNetworkSettingsViewState
       context,
       ref.read(localNetworkSettingProvider.notifier).saveSettings(state).then(
         (value) {
-          originalSettings = state;
+          setState(() {
+            originalSettings = state;
+          });
           showSuccessSnackBar(context, loc(context).changesSaved);
         },
       ).catchError(


### PR DESCRIPTION
[Root cause]
Did not call the setState funciton when update the latest state.
    
[Solution]
Update the state in the setState function.