### PR TITLE
Fixed a part of advanced settings issues

### DIFF
--- a/lib/page/advanced_settings/dmz/providers/dmz_settings_provider.dart
+++ b/lib/page/advanced_settings/dmz/providers/dmz_settings_provider.dart
@@ -98,4 +98,12 @@ class DMZSettingNotifier extends Notifier<DMZSettingsState> {
   void setDestinationType(DMZDestinationType type) {
     state = state.copyWith(destinationType: type);
   }
+
+  void clearDestinations() {
+    state = state.copyWith(
+        settings: DMZSettings(
+      isDMZEnabled: state.settings.isDMZEnabled,
+      sourceRestriction: state.settings.sourceRestriction,
+    ));
+  }
 }

--- a/lib/page/advanced_settings/dmz/views/dmz_settings_view.dart
+++ b/lib/page/advanced_settings/dmz/views/dmz_settings_view.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/core/jnap/models/dmz_settings.dart';
-import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/advanced_settings/dmz/providers/dmz_settings_provider.dart';
 import 'package:privacy_gui/page/advanced_settings/dmz/providers/dmz_settings_state.dart';
@@ -239,6 +238,11 @@ class _DMZSettingsViewState extends ConsumerState<DMZSettingsView> {
                 _sourceLastIPController.text = '';
                 _sourceError = null;
               });
+              ref.read(dmzSettingsProvider.notifier).setSettings(DMZSettings(
+                    isDMZEnabled: state.settings.isDMZEnabled,
+                    destinationIPAddress: state.settings.destinationIPAddress,
+                    destinationMACAddress: state.settings.destinationMACAddress,
+                  ));
             } else {
               _sourceFirstIPController.text =
                   _preservedState?.settings.sourceRestriction?.firstIPAddress ??
@@ -246,6 +250,15 @@ class _DMZSettingsViewState extends ConsumerState<DMZSettingsView> {
               _sourceLastIPController.text =
                   _preservedState?.settings.sourceRestriction?.lastIPAddress ??
                       '';
+              ref.read(dmzSettingsProvider.notifier).setSettings(DMZSettings(
+                    isDMZEnabled: state.settings.isDMZEnabled,
+                    sourceRestriction: DMZSourceRestriction(
+                        firstIPAddress: _sourceFirstIPController.text,
+                        lastIPAddress: _sourceLastIPController.text),
+                    destinationIPAddress: state.settings.destinationIPAddress,
+                    destinationMACAddress: state.settings.destinationMACAddress,
+                  ));
+              _checkSourceIPRange();
             }
           },
         ));
@@ -339,11 +352,13 @@ class _DMZSettingsViewState extends ConsumerState<DMZSettingsView> {
                             .read(dmzSettingsProvider.notifier)
                             .ipAddress
                             .replaceAll('.0', '');
+                _checkDestinationIPAdress();
               } else {
                 _destinationError = null;
                 _destinationIPController.text = '';
                 _destinationMACController.text =
                     state.settings.destinationMACAddress ?? '';
+                _checkDestinationMACAddress();
               }
             },
           ),
@@ -361,8 +376,22 @@ class _DMZSettingsViewState extends ConsumerState<DMZSettingsView> {
               if (result != null) {
                 if (state.destinationType == DMZDestinationType.ip) {
                   _destinationIPController.text = result.first.ipv4Address;
+                  ref.read(dmzSettingsProvider.notifier).setSettings(
+                      DMZSettings(
+                          isDMZEnabled: state.settings.isDMZEnabled,
+                          sourceRestriction: state.settings.sourceRestriction,
+                          destinationIPAddress: result.first.ipv4Address));
+                  _checkDestinationIPAdress();
                 } else {
                   _destinationMACController.text = result.first.macAddress;
+                  ref
+                      .read(dmzSettingsProvider.notifier)
+                      .setSettings(DMZSettings(
+                        isDMZEnabled: state.settings.isDMZEnabled,
+                        sourceRestriction: state.settings.sourceRestriction,
+                        destinationMACAddress: result.first.macAddress,
+                      ));
+                  _checkDestinationMACAddress();
                 }
               }
             },

--- a/lib/page/advanced_settings/port_forwarding/views/port_range_forwarding_rule_view.dart
+++ b/lib/page/advanced_settings/port_forwarding/views/port_range_forwarding_rule_view.dart
@@ -284,7 +284,7 @@ class _AddRuleContentViewState
       }
       final firstPort = int.tryParse(_firstExternalPortController.text) ?? 0;
       final lastPort = int.tryParse(_lastExternalPortController.text) ?? 0;
-      bool isValidPortRange = lastPort - firstPort > 0;
+      bool isValidPortRange = lastPort - firstPort >= 0;
       bool isRuleOverlap =
           _notifier.isPortConflict(firstPort, lastPort, _protocol);
       _portError = !isValidPortRange

--- a/lib/page/advanced_settings/port_forwarding/views/port_range_triggering_rule_view.dart
+++ b/lib/page/advanced_settings/port_forwarding/views/port_range_triggering_rule_view.dart
@@ -271,7 +271,7 @@ class _AddRuleContentViewState
       }
       final firstPort = int.tryParse(_firstForwardedPortController.text) ?? 0;
       final lastPort = int.tryParse(_lastForwardedPortController.text) ?? 0;
-      bool isValidPortRange = lastPort - firstPort > 0;
+      bool isValidPortRange = lastPort - firstPort >= 0;
       bool isRuleOverlap =
           _notifier.isForwardedPortConflict(firstPort, lastPort);
       _forwardedPortError = !isValidPortRange
@@ -291,7 +291,7 @@ class _AddRuleContentViewState
       }
       final firstPort = int.tryParse(_firstTriggerPortController.text) ?? 0;
       final lastPort = int.tryParse(_lastTriggerPortController.text) ?? 0;
-      bool isValidPortRange = lastPort - firstPort > 0;
+      bool isValidPortRange = lastPort - firstPort >= 0;
       bool isRuleOverlap =
           _notifier.isTriggeredPortConflict(firstPort, lastPort);
       _triggeredPortError = !isValidPortRange

--- a/lib/page/advanced_settings/static_routing/static_routing_detail_view.dart
+++ b/lib/page/advanced_settings/static_routing/static_routing_detail_view.dart
@@ -51,6 +51,9 @@ class _StaticRoutingDetailViewState
       _gatewayController.text = _currentSetting!.settings.gateway!;
       _destinationIpController.text = _currentSetting!.settings.destinationLAN;
     }
+    selectedInterface = RoutingSettingInterface.resolve(
+      _currentSetting?.settings.interface,
+    );
     super.initState();
   }
 
@@ -65,9 +68,6 @@ class _StaticRoutingDetailViewState
 
   @override
   Widget build(BuildContext context) {
-    selectedInterface = RoutingSettingInterface.resolve(
-      _currentSetting?.settings.interface,
-    );
     return StyledAppPageView(
       scrollable: true,
       title: _currentSetting == null
@@ -100,7 +100,9 @@ class _StaticRoutingDetailViewState
             initial: selectedInterface,
             label: (item) => getInterfaceTitle(item.value),
             onChanged: (value) {
-              selectedInterface = value;
+              setState(() {
+                selectedInterface = value;
+              });
             },
           ),
           const AppGap.large2(),
@@ -254,7 +256,7 @@ class _StaticRoutingDetailViewState
           .read(staticRoutingProvider.notifier)
           .saveRoutingSettingList(settingList)
           .then((value) {
-            // Succeeded, update the list to the state
+        // Succeeded, update the list to the state
         ref.read(staticRoutingProvider).setting.copyWith(entries: settingList);
         showSuccessSnackBar(context, loc(context).saved);
         context.pop();


### PR DESCRIPTION
- [NOW-178] DMZ: Error message displays when selecting destination target from DHCP client table then saving
- [NOW-179] DMZ: Unable to change Source IP Address setting
- [NOW-180] DMZ: Error message displays when changing destination IP address setting
- [NOW-181] Port Range Triggering: Should not display error message if the forwarded range's end port is equal to the start port
- [NOW-183] Port Range Forwarding/Port Range Triggering: Should not display error message when changing port setting