### PR TITLE
Minor issues fixing 1.1.3

### DIFF
--- a/lib/constants/error_code.dart
+++ b/lib/constants/error_code.dart
@@ -34,7 +34,7 @@ const errorInvalidInput = "_ErrorInvalidInput";
 const errorInvalidServer = "ErrorInvalidServer";
 const errorInvalidDestinationIpAddress = "ErrorInvalidDestinationIPAddress";
 const errorMissingDestination = "ErrorMissingDestination";
-
+const errorRuleOverlap = "ErrorRulesOverlap";
 
 // JNAP retry list
 const errorJNAPRetryList = [errorUnexpected];

--- a/lib/core/jnap/models/ddns_settings_model.dart
+++ b/lib/core/jnap/models/ddns_settings_model.dart
@@ -7,7 +7,6 @@ import 'dyn_dns_settings.dart';
 import 'no_ip_settings.dart';
 import 'tzo_settings.dart';
 
-
 class DDNSSettings extends Equatable {
   final String ddnsProvider;
   final DynDNSSettings? dynDNSSettings;
@@ -39,7 +38,7 @@ class DDNSSettings extends Equatable {
       'ddnsProvider': ddnsProvider,
       'dynDNSSettings': dynDNSSettings?.toMap(),
       'tzoSettings': tzoSettings?.toMap(),
-      'noIPSettings': noIPSettings?.toMap(),
+      'noipSettings': noIPSettings?.toMap(),
     };
   }
 
@@ -53,8 +52,8 @@ class DDNSSettings extends Equatable {
       tzoSettings: map['tzoSettings'] != null
           ? TZOSettings.fromMap(map['tzoSettings'] as Map<String, dynamic>)
           : null,
-      noIPSettings: map['noIPSettings'] != null
-          ? NoIPSettings.fromMap(map['noIPSettings'] as Map<String, dynamic>)
+      noIPSettings: map['noipSettings'] != null
+          ? NoIPSettings.fromMap(map['noipSettings'] as Map<String, dynamic>)
           : null,
     );
   }

--- a/lib/core/jnap/providers/dashboard_manager_provider.dart
+++ b/lib/core/jnap/providers/dashboard_manager_provider.dart
@@ -139,6 +139,7 @@ class DashboardManagerNotifier extends Notifier<DashboardManagerState> {
     final result = await routerRepository.send(
       JNAPAction.getDeviceInfo,
       fetchRemote: true,
+      retries: 0,
     );
     nodeDeviceInfo = NodeDeviceInfo.fromJson(result.output);
     final prefs = await SharedPreferences.getInstance();

--- a/lib/core/jnap/providers/polling_provider.dart
+++ b/lib/core/jnap/providers/polling_provider.dart
@@ -7,7 +7,6 @@ import 'package:privacy_gui/core/jnap/actions/better_action.dart';
 import 'package:privacy_gui/core/jnap/actions/jnap_service_supported.dart';
 import 'package:privacy_gui/core/jnap/actions/jnap_transaction.dart';
 import 'package:privacy_gui/core/jnap/providers/node_light_settings_provider.dart';
-import 'package:privacy_gui/core/jnap/providers/wan_external_provider.dart';
 import 'package:privacy_gui/core/jnap/result/jnap_result.dart';
 import 'package:privacy_gui/core/jnap/router_repository.dart';
 import 'package:privacy_gui/core/utils/bench_mark.dart';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1047,5 +1047,9 @@
   "doYouWantToSaveTheLocalNetworkSettings": "Do you want to save the Local Network Settings?",
   "allDayOff": "All day off",
   "nightModeTime": "8PM - 8AM",
-  "invalidCharacters": "Invalid characters"
+  "invalidCharacters": "Invalid characters",
+  "mloCapableModalDesc1": "Multi-Link Operation (MLO) allows devices to use multiple bands and frequency channels simultaneously.",
+  "mloCapableModalDesc2": "This increases speed, reduces latency, and makes for a more reliable connection.",
+  "connectedWithMLO": "Connected with MLO",
+  "mloCapable": "MLO capable"
 }

--- a/lib/page/advanced_settings/administration/views/administration_settings_view.dart
+++ b/lib/page/advanced_settings/administration/views/administration_settings_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/advanced_settings/_advanced_settings.dart';
 import 'package:privacy_gui/page/components/shortcuts/dialogs.dart';
@@ -27,8 +28,8 @@ class _AdministrationSettingsViewState
   @override
   void initState() {
     super.initState();
-    doSomethingWithSpinner(
-            context, ref.read(administrationSettingsProvider.notifier).fetch())
+    doSomethingWithSpinner(context,
+            ref.read(administrationSettingsProvider.notifier).fetch(true))
         .then((value) {
       _preservedState = value;
     });

--- a/lib/page/advanced_settings/advanced_settings_view.dart
+++ b/lib/page/advanced_settings/advanced_settings_view.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/core/utils/extension.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/components/styled/styled_page_view.dart';
+import 'package:privacy_gui/page/dashboard/_dashboard.dart';
+import 'package:privacy_gui/page/dashboard/providers/dashboard_home_provider.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacygui_widgets/icons/linksys_icons.dart';
 import 'package:privacygui_widgets/widgets/_widgets.dart';
@@ -20,8 +22,7 @@ class AdvancedSettingsView extends ConsumerStatefulWidget {
       _AdvancedSettingsViewState();
 }
 
-class _AdvancedSettingsViewState
-    extends ConsumerState<AdvancedSettingsView> {
+class _AdvancedSettingsViewState extends ConsumerState<AdvancedSettingsView> {
   List<AppSectionItemData> advancedSettings = [];
   @override
   void initState() {
@@ -65,6 +66,7 @@ class _AdvancedSettingsViewState
   }
 
   List<AppSectionItemData> _initAdvancedSettingsItems() {
+    final isBridge = ref.watch(dashboardHomeProvider).isBridgeMode;
     return [
       AppSectionItemData(
         title: loc(context).internetSettings.capitalizeWords(),
@@ -74,7 +76,7 @@ class _AdvancedSettingsViewState
       AppSectionItemData(
         title: loc(context).localNetwork,
         // iconData: getCharactersIcons(context).nodesDefault,
-        onTap: () => context.goNamed(RouteNamed.settingsLocalNetwork),
+        onTap: isBridge ? null: () => context.goNamed(RouteNamed.settingsLocalNetwork),
       ),
       AppSectionItemData(
         title: loc(context).advancedRouting,
@@ -99,7 +101,7 @@ class _AdvancedSettingsViewState
       AppSectionItemData(
         title: loc(context).appsGaming,
         // iconData: getCharactersIcons(context).nodesDefault,
-        onTap: () => context.goNamed(RouteNamed.settingsAppsGaming),
+        onTap: isBridge ? null : () => context.goNamed(RouteNamed.settingsAppsGaming),
       ),
     ];
   }

--- a/lib/page/advanced_settings/apps_and_gaming/ddns/providers/ddns_provider.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/ddns/providers/ddns_provider.dart
@@ -68,7 +68,7 @@ class DDNSNotifier extends Notifier<DDNSState> {
           ddnsStatusData != null ? ddnsStatusData.output['status'] : null;
 
       state = state.copyWith(
-        supportedProvider: ['disabled', ...ddnsSupportedProviders],
+        supportedProvider: [noDNSProviderName, ...ddnsSupportedProviders],
         status: ddnsStatus,
         provider: DDNSProvider.reslove(ddnsSettings),
         ipAddress: wanStatus?.wanConnection?.ipAddress,

--- a/lib/page/advanced_settings/apps_and_gaming/ddns/views/ddns_settings_view.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/ddns/views/ddns_settings_view.dart
@@ -41,49 +41,49 @@ class _DDNSSettingsViewState extends ConsumerState<DDNSSettingsView> {
   void initState() {
     super.initState();
 
-    doSomethingWithSpinner(
-            context, ref.read(ddnsProvider.notifier).fetch(false))
-        .then((state) {
-      setState(() {
-        _preserveState = state;
-        ref.read(appsAndGamingProvider.notifier).setChanged(false);
-      });
-    });
+    // doSomethingWithSpinner(
+    //         context, ref.read(ddnsProvider.notifier).fetch(false))
+    //     .then((state) {
+    //   setState(() {
+    //     _preserveState = state;
+    //     // ref.read(appsAndGamingProvider.notifier).setChanged(false);
+    //   });
+    // });
   }
 
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(ddnsProvider);
-    ref.listen(ddnsProvider, (previous, next) {
-      ref
-          .read(appsAndGamingProvider.notifier)
-          .setChanged(next != _preserveState);
-    });
+    // ref.listen(ddnsProvider, (previous, next) {
+    //   ref
+    //       .read(appsAndGamingProvider.notifier)
+    //       .setChanged(next != _preserveState);
+    // });
     return StyledAppPageView(
       useMainPadding: false,
       appBarStyle: AppBarStyle.none,
       padding: EdgeInsets.zero,
       scrollable: true,
       title: loc(context).ddns,
-      bottomBar: PageBottomBar(
-        isPositiveEnabled: _preserveState != state,
-        negitiveLable: loc(context).delete,
-        onPositiveTap: () {
-          doSomethingWithSpinner(
-            context,
-            ref.read(ddnsProvider.notifier).save(),
-          ).then(
-            (state) {
-              setState(() {
-                _preserveState = state;
-              });
-              showSuccessSnackBar(context, loc(context).saved);
-            },
-          ).onError((error, stackTrace) {
-            showFailedSnackBar(context, loc(context).failedExclamation);
-          });
-        },
-      ),
+      // bottomBar: PageBottomBar(
+      //   isPositiveEnabled: _preserveState != state,
+      //   negitiveLable: loc(context).delete,
+      //   onPositiveTap: () {
+      //     doSomethingWithSpinner(
+      //       context,
+      //       ref.read(ddnsProvider.notifier).save(),
+      //     ).then(
+      //       (state) {
+      //         setState(() {
+      //           _preserveState = state;
+      //         });
+      //         showSuccessSnackBar(context, loc(context).saved);
+      //       },
+      //     ).onError((error, stackTrace) {
+      //       showFailedSnackBar(context, loc(context).failedExclamation);
+      //     });
+      //   },
+      // ),
       child: AppBasicLayout(
         content: ResponsiveLayout(
           desktop: Row(
@@ -132,6 +132,8 @@ class _DDNSSettingsViewState extends ConsumerState<DDNSSettingsView> {
                   return 'No-IP.com';
                 } else if (item == tzoDNSProviderName) {
                   return 'tzo.com';
+                } else if (item == noDNSProviderName) {
+                  return loc(context).disabled;
                 } else {
                   return item;
                 }

--- a/lib/page/advanced_settings/apps_and_gaming/ports/providers/port_range_forwarding_list_provider.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/ports/providers/port_range_forwarding_list_provider.dart
@@ -52,14 +52,12 @@ class PortRangeForwardingListNotifier
   Future<PortRangeForwardingListState> save() async {
     final rules = List<PortRangeForwardingRule>.from(state.rules);
     final repo = ref.read(routerRepositoryProvider);
-    await repo
-        .send(
-          JNAPAction.setPortRangeForwardingRules,
-          data: {'rules': rules.map((e) => e.toMap()).toList()},
-          auth: true,
-        )
-        .then((value) => true)
-        .onError((error, stackTrace) => false);
+    await repo.send(
+      JNAPAction.setPortRangeForwardingRules,
+      data: {'rules': rules.map((e) => e.toMap()).toList()},
+      auth: true,
+    );
+  
     await fetch(true);
     return state;
   }

--- a/lib/page/advanced_settings/apps_and_gaming/ports/providers/port_range_forwarding_rule_provider.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/ports/providers/port_range_forwarding_rule_provider.dart
@@ -62,16 +62,19 @@ class PortRangeForwardingRuleNotifier
     return singlePortsState.any((rule) =>
             rule.externalPort > firstPort &&
             rule.externalPort < lastPort &&
-            (protocol == rule.protocol || protocol == 'Both')) ||
-        state.rules
-            .whereIndexed((index, rule) => index != state.editIndex)
-            .any((rule) =>
+            (protocol == rule.protocol ||
+                protocol == 'Both' ||
+                rule.protocol == 'Both')) ||
+        state.rules.whereIndexed((index, rule) => index != state.editIndex).any(
+            (rule) =>
                 doesRangeOverlap(
                   rule.firstExternalPort,
                   rule.lastExternalPort,
                   firstPort,
                   lastPort,
                 ) &&
-                (protocol == rule.protocol || protocol == 'Both'));
+                (protocol == rule.protocol ||
+                    protocol == 'Both' ||
+                    rule.protocol == 'Both'));
   }
 }

--- a/lib/page/advanced_settings/apps_and_gaming/ports/providers/port_range_triggering_list_provider.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/ports/providers/port_range_triggering_list_provider.dart
@@ -42,14 +42,11 @@ class PortRangeTriggeringListNotifier
   Future<PortRangeTriggeringListState> save() async {
     final rules = List<PortRangeTriggeringRule>.from(state.rules);
     final repo = ref.read(routerRepositoryProvider);
-    await repo
-        .send(
-          JNAPAction.setPortRangeTriggeringRules,
-          data: {'rules': rules.map((e) => e.toMap()).toList()},
-          auth: true,
-        )
-        .then((value) => true)
-        .onError((error, stackTrace) => false);
+    await repo.send(
+      JNAPAction.setPortRangeTriggeringRules,
+      data: {'rules': rules.map((e) => e.toMap()).toList()},
+      auth: true,
+    );
     await fetch(true);
     return state;
   }

--- a/lib/page/advanced_settings/apps_and_gaming/ports/providers/single_port_forwarding_list_provider.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/ports/providers/single_port_forwarding_list_provider.dart
@@ -41,7 +41,12 @@ class SinglePortForwardingListNotifier
       final int maxRules = value.output['maxRules'] ?? 50;
       final int maxDesc = value.output['maxDescriptionLength'] ?? 32;
       state = state.copyWith(
-          rules: rules, maxRules: maxRules, maxDescriptionLength: maxDesc, routerIp: ipAddress, subnetMask: subnetMask,);
+        rules: rules,
+        maxRules: maxRules,
+        maxDescriptionLength: maxDesc,
+        routerIp: ipAddress,
+        subnetMask: subnetMask,
+      );
     }).onError(
       (error, stackTrace) {
         return null;
@@ -53,14 +58,11 @@ class SinglePortForwardingListNotifier
   Future<SinglePortForwardingListState> save() async {
     final rules = List<SinglePortForwardingRule>.from(state.rules);
     final repo = ref.read(routerRepositoryProvider);
-    await repo
-        .send(
-          JNAPAction.setSinglePortForwardingRules,
-          data: {'rules': rules.map((e) => e.toMap()).toList()},
-          auth: true,
-        )
-        .then((value) => true)
-        .onError((error, stackTrace) => false);
+    await repo.send(
+      JNAPAction.setSinglePortForwardingRules,
+      data: {'rules': rules.map((e) => e.toMap()).toList()},
+      auth: true,
+    );
     await fetch(true);
     return state;
   }

--- a/lib/page/advanced_settings/apps_and_gaming/ports/providers/single_port_forwarding_rule_provider.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/ports/providers/single_port_forwarding_rule_provider.dart
@@ -51,10 +51,18 @@ class SinglePortForwardingRuleNotifier
   }
 
   bool isPortConflict(int externalPort, String protocol) {
-    return state.rules
-        .whereIndexed((index, rule) => index != state.editIndex)
-        .any((rule) =>
-            rule.externalPort == externalPort &&
-            (protocol == rule.protocol || protocol == 'Both'));
+    final portRangeState = ref.read(portRangeForwardingListProvider).rules;
+    return portRangeState.any((rule) =>
+            externalPort > rule.firstExternalPort &&
+            externalPort < rule.lastExternalPort &&
+            (protocol == rule.protocol ||
+                protocol == 'Both' ||
+                rule.protocol == 'Both')) ||
+        state.rules.whereIndexed((index, rule) => index != state.editIndex).any(
+            (rule) =>
+                rule.externalPort == externalPort &&
+                (protocol == rule.protocol ||
+                    protocol == 'Both' ||
+                    rule.protocol == 'Both'));
   }
 }

--- a/lib/page/advanced_settings/apps_and_gaming/ports/views/port_range_forwarding_list_view.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/ports/views/port_range_forwarding_list_view.dart
@@ -57,15 +57,15 @@ class _PortRangeForwardingContentViewState
   @override
   void initState() {
     _notifier = ref.read(portRangeForwardingListProvider.notifier);
-    doSomethingWithSpinner(
-      context,
-      _notifier.fetch(),
-    ).then((state) {
-      setState(() {
-        preservedState = state;
-      });
-      ref.read(appsAndGamingProvider.notifier).setChanged(false);
-    });
+    // doSomethingWithSpinner(
+    //   context,
+    //   _notifier.fetch(),
+    // ).then((state) {
+    //   setState(() {
+    //     preservedState = state;
+    //   });
+    //   // ref.read(appsAndGamingProvider.notifier).setChanged(false);
+    // });
 
     super.initState();
   }
@@ -80,27 +80,27 @@ class _PortRangeForwardingContentViewState
     final state = ref.watch(portRangeForwardingListProvider);
     final submaskToken = state.subnetMask.split('.');
     final prefixIP = state.routerIp;
-    ref.listen(portRangeForwardingListProvider, (previous, next) {
-      ref
-          .read(appsAndGamingProvider.notifier)
-          .setChanged(next != preservedState);
-    });
+    // ref.listen(portRangeForwardingListProvider, (previous, next) {
+    //   ref
+    //       .read(appsAndGamingProvider.notifier)
+    //       .setChanged(next != preservedState);
+    // });
     return StyledAppPageView(
       scrollable: true,
       useMainPadding: false,
       appBarStyle: AppBarStyle.none,
       padding: EdgeInsets.zero,
       title: loc(context).portRangeForwarding,
-      bottomBar: PageBottomBar(
-          isPositiveEnabled: state != preservedState,
-          onPositiveTap: () {
-            doSomethingWithSpinner(context, _notifier.save()).then((state) {
-              setState(() {
-                preservedState = state;
-              });
-              ref.read(appsAndGamingProvider.notifier).setChanged(false);
-            });
-          }),
+      // bottomBar: PageBottomBar(
+      //     isPositiveEnabled: state != preservedState,
+      //     onPositiveTap: () {
+      //       doSomethingWithSpinner(context, _notifier.save()).then((state) {
+      //         setState(() {
+      //           preservedState = state;
+      //         });
+      //         // ref.read(appsAndGamingProvider.notifier).setChanged(false);
+      //       });
+      //     }),
       child: AppBasicLayout(
         content: Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/page/advanced_settings/apps_and_gaming/ports/views/port_range_triggering_list_view.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/ports/views/port_range_triggering_list_view.dart
@@ -58,15 +58,15 @@ class _PortRangeTriggeringContentViewState
   void initState() {
     super.initState();
     _notifier = ref.read(portRangeTriggeringListProvider.notifier);
-    doSomethingWithSpinner(
-      context,
-      _notifier.fetch(),
-    ).then((state) {
-      setState(() {
-        preservedState = state;
-      });
-      ref.read(appsAndGamingProvider.notifier).setChanged(false);
-    });
+    // doSomethingWithSpinner(
+    //   context,
+    //   _notifier.fetch(),
+    // ).then((state) {
+    //   setState(() {
+    //     preservedState = state;
+    //   });
+    //   // ref.read(appsAndGamingProvider.notifier).setChanged(false);
+    // });
   }
 
   @override
@@ -82,27 +82,27 @@ class _PortRangeTriggeringContentViewState
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(portRangeTriggeringListProvider);
-    ref.listen(portRangeTriggeringListProvider, (previous, next) {
-      ref
-          .read(appsAndGamingProvider.notifier)
-          .setChanged(next != preservedState);
-    });
+    // ref.listen(portRangeTriggeringListProvider, (previous, next) {
+    //   ref
+    //       .read(appsAndGamingProvider.notifier)
+    //       .setChanged(next != preservedState);
+    // });
     return StyledAppPageView(
       scrollable: true,
       useMainPadding: false,
       appBarStyle: AppBarStyle.none,
       padding: EdgeInsets.zero,
       title: loc(context).portRangeTriggering,
-      bottomBar: PageBottomBar(
-          isPositiveEnabled: state != preservedState,
-          onPositiveTap: () {
-            doSomethingWithSpinner(context, _notifier.save()).then((state) {
-              setState(() {
-                preservedState = state;
-              });
-            });
-            ref.read(appsAndGamingProvider.notifier).setChanged(false);
-          }),
+      // bottomBar: PageBottomBar(
+      //     isPositiveEnabled: state != preservedState,
+      //     onPositiveTap: () {
+      //       doSomethingWithSpinner(context, _notifier.save()).then((state) {
+      //         setState(() {
+      //           preservedState = state;
+      //         });
+      //       });
+      //       // ref.read(appsAndGamingProvider.notifier).setChanged(false);
+      //     }),
       child: AppBasicLayout(
         content: Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/page/advanced_settings/apps_and_gaming/ports/views/single_port_forwarding_list_view.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/ports/views/single_port_forwarding_list_view.dart
@@ -59,15 +59,15 @@ class _SinglePortForwardingContentViewState
   void initState() {
     _notifier = ref.read(singlePortForwardingListProvider.notifier);
 
-    doSomethingWithSpinner(
-      context,
-      _notifier.fetch(),
-    ).then((state) {
-      setState(() {
-        preservedState = state;
-      });
-      ref.read(appsAndGamingProvider.notifier).setChanged(false);
-    });
+    // doSomethingWithSpinner(
+    //   context,
+    //   _notifier.fetch(),
+    // ).then((state) {
+    //   setState(() {
+    //     preservedState = state;
+    //   });
+    //   // ref.read(appsAndGamingProvider.notifier).setChanged(false);
+    // });
 
     super.initState();
   }
@@ -86,27 +86,27 @@ class _SinglePortForwardingContentViewState
     final state = ref.watch(singlePortForwardingListProvider);
     final submaskToken = state.subnetMask.split('.');
     final prefixIP = state.routerIp;
-    ref.listen(singlePortForwardingListProvider, (previous, next) {
-      ref
-          .read(appsAndGamingProvider.notifier)
-          .setChanged(next != preservedState);
-    });
+    // ref.listen(singlePortForwardingListProvider, (previous, next) {
+    //   ref
+    //       .read(appsAndGamingProvider.notifier)
+    //       .setChanged(next != preservedState);
+    // });
     return StyledAppPageView(
       title: loc(context).singlePortForwarding,
       scrollable: true,
       useMainPadding: false,
       appBarStyle: AppBarStyle.none,
       padding: EdgeInsets.zero,
-      bottomBar: PageBottomBar(
-          isPositiveEnabled: state != preservedState,
-          onPositiveTap: () {
-            doSomethingWithSpinner(context, _notifier.save()).then((state) {
-              setState(() {
-                preservedState = state;
-              });
-              ref.read(appsAndGamingProvider.notifier).setChanged(false);
-            });
-          }),
+      // bottomBar: PageBottomBar(
+      //     isPositiveEnabled: state != preservedState,
+      //     onPositiveTap: () {
+      //       doSomethingWithSpinner(context, _notifier.save()).then((state) {
+      //         setState(() {
+      //           preservedState = state;
+      //         });
+      //         // ref.read(appsAndGamingProvider.notifier).setChanged(false);
+      //       });
+      //     }),
       child: AppBasicLayout(
         content: Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/page/advanced_settings/apps_and_gaming/providers/apps_and_gaming_provider.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/providers/apps_and_gaming_provider.dart
@@ -10,17 +10,52 @@ final appsAndGamingProvider =
 class AppsAndGamingViewNotifier extends Notifier<AppsAndGamingViewState> {
   @override
   AppsAndGamingViewState build() {
-    return AppsAndGamingViewState(isCurrentViewStateChanged: false);
+    return AppsAndGamingViewState();
   }
 
-  Future fetch([bool force = false]) async {
-    await ref.read(ddnsProvider.notifier).fetch(force);
-    await ref.read(singlePortForwardingListProvider.notifier).fetch(force);
-    await ref.read(portRangeForwardingListProvider.notifier).fetch(force);
-    await ref.read(portRangeTriggeringListProvider.notifier).fetch(force);
+  Future<AppsAndGamingViewState> fetch([bool force = false]) async {
+    final pDDNSState = await ref.read(ddnsProvider.notifier).fetch(force);
+    final pSinglePortState =
+        await ref.read(singlePortForwardingListProvider.notifier).fetch(force);
+    final pPortRangeForwardingState =
+        await ref.read(portRangeForwardingListProvider.notifier).fetch(force);
+    final pPortRangeTriggeringState =
+        await ref.read(portRangeTriggeringListProvider.notifier).fetch(force);
+    state = state.copyWith(
+      preserveDDNSState: () => pDDNSState,
+      preserveSinglePortForwardingListState: () => pSinglePortState,
+      preservePortRangeForwardingListState: () => pPortRangeForwardingState,
+      preservePortRangeTriggeringListState: () => pPortRangeTriggeringState,
+    );
+    return state;
   }
 
-  void setChanged(bool value) {
-    state = state.copyWith(isCurrentViewStateChanged: value);
+  Future<AppsAndGamingViewState> save() async {
+    if (ref.read(ddnsProvider) != state.preserveDDNSState) {
+      await ref.read(ddnsProvider.notifier).save();
+    }
+    if (ref.read(singlePortForwardingListProvider) !=
+        state.preserveSinglePortForwardingListState) {
+      await ref.read(singlePortForwardingListProvider.notifier).save();
+    }
+    if (ref.read(portRangeForwardingListProvider) !=
+        state.preservePortRangeForwardingListState) {
+      await ref.read(portRangeForwardingListProvider.notifier).save();
+    }
+    if (ref.read(portRangeTriggeringListProvider) !=
+        state.preservePortRangeTriggeringListState) {
+      await ref.read(portRangeTriggeringListProvider.notifier).save();
+    }
+    return fetch(true);
+  }
+
+  bool isChanged() {
+    return ref.read(ddnsProvider) != state.preserveDDNSState ||
+        ref.read(singlePortForwardingListProvider) !=
+            state.preserveSinglePortForwardingListState ||
+        ref.read(portRangeForwardingListProvider) !=
+            state.preservePortRangeForwardingListState ||
+        ref.read(portRangeTriggeringListProvider) !=
+            state.preservePortRangeTriggeringListState;
   }
 }

--- a/lib/page/advanced_settings/apps_and_gaming/providers/apps_and_gaming_state.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/providers/apps_and_gaming_state.dart
@@ -1,40 +1,102 @@
 import 'dart:convert';
 
 import 'package:equatable/equatable.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:privacy_gui/page/advanced_settings/_advanced_settings.dart';
+import 'package:privacy_gui/page/advanced_settings/apps_and_gaming/ddns/providers/ddns_state.dart';
 
 class AppsAndGamingViewState extends Equatable {
-  final bool isCurrentViewStateChanged;
+  final DDNSState? preserveDDNSState;
+  final SinglePortForwardingListState? preserveSinglePortForwardingListState;
+  final PortRangeForwardingListState? preservePortRangeForwardingListState;
+  final PortRangeTriggeringListState? preservePortRangeTriggeringListState;
+
   const AppsAndGamingViewState({
-    required this.isCurrentViewStateChanged,
+    this.preserveDDNSState,
+    this.preserveSinglePortForwardingListState,
+    this.preservePortRangeForwardingListState,
+    this.preservePortRangeTriggeringListState,
   });
 
   AppsAndGamingViewState copyWith({
-    bool? isCurrentViewStateChanged,
+    ValueGetter<DDNSState?>? preserveDDNSState,
+    ValueGetter<SinglePortForwardingListState?>?
+        preserveSinglePortForwardingListState,
+    ValueGetter<PortRangeForwardingListState?>?
+        preservePortRangeForwardingListState,
+    ValueGetter<PortRangeTriggeringListState?>?
+        preservePortRangeTriggeringListState,
   }) {
     return AppsAndGamingViewState(
-      isCurrentViewStateChanged: isCurrentViewStateChanged ?? this.isCurrentViewStateChanged,
+      preserveDDNSState: preserveDDNSState != null
+          ? preserveDDNSState()
+          : this.preserveDDNSState,
+      preserveSinglePortForwardingListState:
+          preserveSinglePortForwardingListState != null
+              ? preserveSinglePortForwardingListState()
+              : this.preserveSinglePortForwardingListState,
+      preservePortRangeForwardingListState:
+          preservePortRangeForwardingListState != null
+              ? preservePortRangeForwardingListState()
+              : this.preservePortRangeForwardingListState,
+      preservePortRangeTriggeringListState:
+          preservePortRangeTriggeringListState != null
+              ? preservePortRangeTriggeringListState()
+              : this.preservePortRangeTriggeringListState,
     );
   }
 
   Map<String, dynamic> toMap() {
     return {
-      'isCurrentViewStateChanged': isCurrentViewStateChanged,
+      'preserveDDNSState': preserveDDNSState?.toMap(),
+      'preserveSinglePortForwardingListState':
+          preserveSinglePortForwardingListState?.toMap(),
+      'preservePortRangeForwardingListState':
+          preservePortRangeForwardingListState?.toMap(),
+      'preservePortRangeTriggeringListState':
+          preservePortRangeTriggeringListState?.toMap(),
     };
   }
 
   factory AppsAndGamingViewState.fromMap(Map<String, dynamic> map) {
     return AppsAndGamingViewState(
-      isCurrentViewStateChanged: map['isCurrentViewStateChanged'] ?? false,
+      preserveDDNSState: map['preserveDDNSState'] != null
+          ? DDNSState.fromMap(map['preserveDDNSState'])
+          : null,
+      preserveSinglePortForwardingListState:
+          map['preserveSinglePortForwardingListState'] != null
+              ? SinglePortForwardingListState.fromMap(
+                  map['preserveSinglePortForwardingListState'])
+              : null,
+      preservePortRangeForwardingListState:
+          map['preservePortRangeForwardingListState'] != null
+              ? PortRangeForwardingListState.fromMap(
+                  map['preservePortRangeForwardingListState'])
+              : null,
+      preservePortRangeTriggeringListState:
+          map['preservePortRangeTriggeringListState'] != null
+              ? PortRangeTriggeringListState.fromMap(
+                  map['preservePortRangeTriggeringListState'])
+              : null,
     );
   }
 
   String toJson() => json.encode(toMap());
 
-  factory AppsAndGamingViewState.fromJson(String source) => AppsAndGamingViewState.fromMap(json.decode(source));
+  factory AppsAndGamingViewState.fromJson(String source) =>
+      AppsAndGamingViewState.fromMap(json.decode(source));
 
   @override
-  String toString() => 'AppsAndGamingState(isCurrentViewStateChanged: $isCurrentViewStateChanged)';
+  String toString() {
+    return 'AppsAndGamingViewState(preserveDDNSState: $preserveDDNSState, preserveSinglePortForwardingListState: $preserveSinglePortForwardingListState, preservePortRangeForwardingListState: $preservePortRangeForwardingListState, preservePortRangeTriggeringListState: $preservePortRangeTriggeringListState)';
+  }
 
   @override
-  List<Object> get props => [isCurrentViewStateChanged];
+  List<Object?> get props => [
+        preserveDDNSState,
+        preserveSinglePortForwardingListState,
+        preservePortRangeForwardingListState,
+        preservePortRangeTriggeringListState
+      ];
 }

--- a/lib/page/advanced_settings/apps_and_gaming/views/apps_and_gaming_view.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/views/apps_and_gaming_view.dart
@@ -4,7 +4,10 @@ import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/advanced_settings/_advanced_settings.dart';
 import 'package:privacy_gui/page/advanced_settings/apps_and_gaming/providers/apps_and_gaming_provider.dart';
+import 'package:privacy_gui/page/components/mixin/page_snackbar_mixin.dart';
 import 'package:privacy_gui/page/components/shortcuts/dialogs.dart';
+import 'package:privacy_gui/page/components/styled/consts.dart';
+import 'package:privacy_gui/page/components/styled/styled_page_view.dart';
 import 'package:privacy_gui/page/components/styled/styled_tab_page_view.dart';
 import 'package:privacy_gui/page/components/views/arguments_view.dart';
 import 'package:privacy_gui/page/advanced_settings/apps_and_gaming/ddns/_ddns.dart';
@@ -17,8 +20,8 @@ class AppsGamingSettingsView extends ArgumentsConsumerStatefulView {
       _AppsGamingSettingsViewState();
 }
 
-class _AppsGamingSettingsViewState
-    extends ConsumerState<AppsGamingSettingsView> {
+class _AppsGamingSettingsViewState extends ConsumerState<AppsGamingSettingsView>
+    with PageSnackbarMixin {
   @override
   void initState() {
     super.initState();
@@ -34,6 +37,11 @@ class _AppsGamingSettingsViewState
 
   @override
   Widget build(BuildContext context) {
+    ref.watch(appsAndGamingProvider);
+    ref.watch(singlePortForwardingListProvider);
+    ref.watch(portRangeForwardingListProvider);
+    ref.watch(portRangeTriggeringListProvider);
+    ref.watch(ddnsProvider);
     final tabs = [
       Tab(
         text: loc(context).ddns,
@@ -54,22 +62,39 @@ class _AppsGamingSettingsViewState
       PortRangeForwardingListView(),
       PortRangeTriggeringListView(),
     ];
-    return StyledAppTabPageView(
-      title: loc(context).appsGaming,
-      tabs: tabs,
-      tabContentViews: tabContents,
-      expandedHeight: 120,
-      onBackTap: () async {
-        final isCurrentChanged =
-            ref.read(appsAndGamingProvider).isCurrentViewStateChanged;
-        if (isCurrentChanged && (await showUnsavedAlert(context) != true)) {
-          return;
-        }
-        context.pop();
-      },
-      onTap: (index) {
-        ref.read(appsAndGamingProvider.notifier).setChanged(false);
-      },
+    return StyledAppPageView(
+      appBarStyle: AppBarStyle.none,
+      bottomBar: PageBottomBar(
+        isPositiveEnabled: ref.read(appsAndGamingProvider.notifier).isChanged(),
+        onPositiveTap: () {
+          doSomethingWithSpinner(
+                  context, ref.read(appsAndGamingProvider.notifier).save())
+              .then((_) {
+            showChangesSavedSnackBar();
+          }).onError(
+            (error, stackTrace) {
+              showErrorMessageSnackBar(error);
+            },
+          );
+        },
+      ),
+      child: StyledAppTabPageView(
+        title: loc(context).appsGaming,
+        padding: EdgeInsets.zero,
+        useMainPadding: false,
+        onBackTap: () async {
+          final isCurrentChanged =
+              ref.read(appsAndGamingProvider.notifier).isChanged();
+          if (isCurrentChanged && (await showUnsavedAlert(context) != true)) {
+            return;
+          }
+          context.pop();
+        },
+        tabs: tabs,
+        tabContentViews: tabContents,
+        expandedHeight: 120,
+        onTap: (index) {},
+      ),
     );
   }
 }

--- a/lib/page/advanced_settings/static_routing/static_routing_view.dart
+++ b/lib/page/advanced_settings/static_routing/static_routing_view.dart
@@ -6,6 +6,7 @@ import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/advanced_settings/static_routing/providers/static_routing_provider.dart';
 import 'package:privacy_gui/page/advanced_settings/static_routing/providers/static_routing_rule_provider.dart';
 import 'package:privacy_gui/page/advanced_settings/static_routing/providers/static_routing_state.dart';
+import 'package:privacy_gui/page/components/mixin/page_snackbar_mixin.dart';
 import 'package:privacy_gui/page/components/settings_view/editable_card_list_settings_view.dart';
 import 'package:privacy_gui/page/components/settings_view/editable_table_settings_view.dart';
 import 'package:privacy_gui/page/components/shortcuts/dialogs.dart';
@@ -32,7 +33,8 @@ class StaticRoutingView extends ArgumentsConsumerStatefulView {
   ConsumerState<StaticRoutingView> createState() => _StaticRoutingViewState();
 }
 
-class _StaticRoutingViewState extends ConsumerState<StaticRoutingView> {
+class _StaticRoutingViewState extends ConsumerState<StaticRoutingView>
+    with PageSnackbarMixin {
   late final StaticRoutingNotifier _notifier;
   StaticRoutingState? preservedState;
 
@@ -86,6 +88,9 @@ class _StaticRoutingViewState extends ConsumerState<StaticRoutingView> {
               setState(() {
                 preservedState = state;
               });
+              showChangesSavedSnackBar();
+            }).onError((error, stackTrace) {
+              showErrorMessageSnackBar(error);
             });
           }),
       onBackTap: state != preservedState
@@ -101,7 +106,7 @@ class _StaticRoutingViewState extends ConsumerState<StaticRoutingView> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           AppRadioList(
-            initial: state.setting.isNATEnabled
+            selected: state.setting.isNATEnabled
                 ? RoutingSettingNetwork.nat
                 : RoutingSettingNetwork.dynamicRouting,
             itemHeight: 56,

--- a/lib/page/dashboard/providers/dashboard_home_provider.dart
+++ b/lib/page/dashboard/providers/dashboard_home_provider.dart
@@ -68,6 +68,10 @@ class DashboardHomeNotifier extends Notifier<DashboardHomeState> {
     // Get WAN connection status
     final isWanConnected =
         deviceManagerState.wanStatus?.wanStatus == 'Connected';
+
+    // Get WAN type
+    final wanType = deviceManagerState.wanStatus?.wanConnection?.wanType;
+
     // If is first polling
     final isFirstPolling = deviceManagerState.lastUpdateTime == 0;
     // Get master node icon
@@ -110,6 +114,7 @@ class DashboardHomeNotifier extends Notifier<DashboardHomeState> {
       speedCheckTimestamp: speedTestTimeStamp,
       isHorizontalLayout: horizontalPortLayout,
       isHealthCheckSupported: isSpeedCheckSupported,
+      wanType: wanType,
     );
 
     logger.d('[State]:[dashboardHome]: ${newState.toJson()}');

--- a/lib/page/dashboard/providers/dashboard_home_state.dart
+++ b/lib/page/dashboard/providers/dashboard_home_state.dart
@@ -124,6 +124,7 @@ class DashboardHomeState extends Equatable {
   final String? wanPortConnection;
   final List<String> lanPortConnections;
   final List<DashboardWiFiItem> wifis;
+  final String? wanType;
 
   const DashboardHomeState({
     this.isWanConnected = false,
@@ -139,6 +140,7 @@ class DashboardHomeState extends Equatable {
     this.wanPortConnection,
     this.lanPortConnections = const [],
     this.wifis = const [],
+    this.wanType,
   });
 
   DashboardHomeState copyWith({
@@ -155,6 +157,7 @@ class DashboardHomeState extends Equatable {
     String? wanPortConnection,
     List<String>? lanPortConnections,
     List<DashboardWiFiItem>? wifis,
+    String? wanType,
   }) {
     return DashboardHomeState(
       isWanConnected: isWanConnected ?? this.isWanConnected,
@@ -171,6 +174,7 @@ class DashboardHomeState extends Equatable {
       wanPortConnection: wanPortConnection ?? this.wanPortConnection,
       lanPortConnections: lanPortConnections ?? this.lanPortConnections,
       wifis: wifis ?? this.wifis,
+      wanType: wanType ?? this.wanType,
     );
   }
 
@@ -186,7 +190,8 @@ class DashboardHomeState extends Equatable {
       'wanPortConnection': wanPortConnection,
       'lanPortConnections': lanPortConnections,
       'wifis': wifis.map((x) => x.toMap()).toList(),
-    };
+      'wanType': wanType,
+    }..removeWhere((key, value) => value == null);
   }
 
   factory DashboardHomeState.fromMap(Map<String, dynamic> map) {
@@ -207,6 +212,7 @@ class DashboardHomeState extends Equatable {
           (x) => DashboardWiFiItem.fromMap(x as Map<String, dynamic>),
         ),
       ),
+      wanType: map['wanType'],
     );
   }
 
@@ -231,10 +237,13 @@ class DashboardHomeState extends Equatable {
       wanPortConnection,
       lanPortConnections,
       wifis,
+      wanType,
     ];
   }
 }
 
 extension DashboardHomeStateExt on DashboardHomeState {
   String get mainSSID => wifis.firstOrNull?.ssid ?? '';
+
+  bool get isBridgeMode => wanType == 'Bridge';
 }

--- a/lib/page/dashboard/views/components/networks.dart
+++ b/lib/page/dashboard/views/components/networks.dart
@@ -6,6 +6,7 @@ import 'package:privacy_gui/core/jnap/providers/device_manager_provider.dart';
 import 'package:privacy_gui/core/jnap/providers/firmware_update_provider.dart';
 import 'package:privacy_gui/core/jnap/providers/node_wan_status_provider.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
+import 'package:privacy_gui/page/dashboard/_dashboard.dart';
 import 'package:privacy_gui/page/dashboard/providers/dashboard_home_provider.dart';
 import 'package:privacy_gui/page/dashboard/views/components/shimmer.dart';
 import 'package:privacy_gui/page/nodes/providers/node_detail_id_provider.dart';
@@ -67,6 +68,7 @@ class _DashboardNetworksState extends ConsumerState<DashboardNetworks> {
             116.0;
     final hasLanPort =
         ref.read(dashboardHomeProvider).lanPortConnections.isNotEmpty;
+    final isBridge = ref.watch(dashboardHomeProvider).isBridgeMode;
     return Container(
       constraints: BoxConstraints(minHeight: 200 + nodeTopologyHeight),
       child: ShimmerContainer(
@@ -106,7 +108,7 @@ class _DashboardNetworksState extends ConsumerState<DashboardNetworks> {
                             extra: entry.node.data.isMaster
                                 ? '${loc(context).uptime}: $uptime'
                                 : null,
-                            onTap: entry.node.data.isOnline
+                            onTap: entry.node.data.isOnline && !isBridge
                                 ? () {
                                     ref
                                         .read(nodeDetailIdProvider.notifier)
@@ -294,6 +296,7 @@ class _DashboardNetworksState extends ConsumerState<DashboardNetworks> {
   Widget _nodesInfoTile(
       BuildContext context, WidgetRef ref, InstantTopologyState state) {
     final nodes = state.root.children.firstOrNull?.toFlatList() ?? [];
+    final isBridge = ref.watch(dashboardHomeProvider).isBridgeMode;
     return _infoTile(
       iconData: LinksysIcons.networkNode,
       text: nodes.length == 1 ? loc(context).node : loc(context).nodes,
@@ -306,17 +309,19 @@ class _DashboardNetworksState extends ConsumerState<DashboardNetworks> {
               color: Theme.of(context).colorScheme.error,
             )
           : null,
-      onTap: () {
-        ref.read(topologySelectedIdProvider.notifier).state = '';
-        context.pushNamed(RouteNamed.menuInstantTopology);
-      },
+      onTap: isBridge
+          ? null
+          : () {
+              ref.read(topologySelectedIdProvider.notifier).state = '';
+              context.pushNamed(RouteNamed.menuInstantTopology);
+            },
     );
   }
 
   Widget _devicesInfoTile(
       BuildContext context, WidgetRef ref, InstantTopologyState state) {
     final nodes = state.root.children.firstOrNull?.toFlatList() ?? [];
-
+    final isBridge = ref.watch(dashboardHomeProvider).isBridgeMode;
     final count = nodes.fold(
         0,
         (previousValue, element) =>
@@ -325,9 +330,11 @@ class _DashboardNetworksState extends ConsumerState<DashboardNetworks> {
       text: count == 1 ? loc(context).device : loc(context).devices,
       count: count,
       iconData: LinksysIcons.devices,
-      onTap: () {
-        context.pushNamed(RouteNamed.menuInstantDevices);
-      },
+      onTap: isBridge
+          ? null
+          : () {
+              context.pushNamed(RouteNamed.menuInstantDevices);
+            },
     );
   }
 

--- a/lib/page/dashboard/views/dashboard_menu_view.dart
+++ b/lib/page/dashboard/views/dashboard_menu_view.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/constants/build_config.dart';
-import 'package:privacy_gui/core/jnap/providers/dashboard_manager_provider.dart';
 import 'package:privacy_gui/core/jnap/providers/polling_provider.dart';
 import 'package:privacy_gui/core/jnap/providers/side_effect_provider.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
@@ -11,6 +10,7 @@ import 'package:privacy_gui/page/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/page/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/page/components/styled/consts.dart';
 import 'package:privacy_gui/page/components/styled/styled_page_view.dart';
+import 'package:privacy_gui/page/dashboard/_dashboard.dart';
 import 'package:privacy_gui/page/instant_privacy/providers/instant_privacy_provider.dart';
 import 'package:privacy_gui/page/instant_privacy/providers/instant_privacy_state.dart';
 import 'package:privacy_gui/page/instant_safety/providers/_providers.dart';
@@ -96,13 +96,21 @@ class _DashboardMenuViewState extends ConsumerState<DashboardMenuView> {
   }
 
   Widget _buildDeviceGridCell(AppSectionItemData item) {
-    return AppMenuCard(
-      iconData: item.iconData,
-      title: item.title,
-      description: item.description,
-      status: item.status,
-      isBeta: item.isBeta,
-      onTap: item.onTap,
+    final isBridge =
+        ref.watch(dashboardHomeProvider).isBridgeMode && item.disabledOnBridge;
+    return Opacity(
+      opacity: isBridge ? .3 : 1,
+      child: AbsorbPointer(
+        absorbing: isBridge,
+        child: AppMenuCard(
+          iconData: item.iconData,
+          title: item.title,
+          description: item.description,
+          status: item.status,
+          isBeta: item.isBeta,
+          onTap: item.onTap,
+        ),
+      ),
     );
   }
 
@@ -135,6 +143,7 @@ class _DashboardMenuViewState extends ConsumerState<DashboardMenuView> {
           title: loc(context).instantTopology,
           description: loc(context).instantTopologyDesc,
           iconData: LinksysIcons.router,
+          disabledOnBridge: true,
           onTap: () {
             _navigateTo(RouteNamed.menuInstantTopology);
           }),
@@ -142,6 +151,7 @@ class _DashboardMenuViewState extends ConsumerState<DashboardMenuView> {
           title: loc(context).instantSafety,
           description: loc(context).instantSafetyDesc,
           iconData: LinksysIcons.encrypted,
+          disabledOnBridge: true,
           status: safetyState.safeBrowsingType == InstantSafetyType.off,
           onTap: () {
             _navigateTo(RouteNamed.menuInstantSafety);
@@ -152,6 +162,7 @@ class _DashboardMenuViewState extends ConsumerState<DashboardMenuView> {
           iconData: LinksysIcons.smartLock,
           status: privacyState.mode != MacFilterMode.allow,
           isBeta: true,
+          disabledOnBridge: true,
           onTap: () {
             _navigateTo(RouteNamed.menuInstantPrivacy);
           }),
@@ -159,6 +170,7 @@ class _DashboardMenuViewState extends ConsumerState<DashboardMenuView> {
           title: loc(context).instantDevices,
           description: loc(context).instantDevicesDesc,
           iconData: LinksysIcons.devices,
+          disabledOnBridge: true,
           onTap: () {
             _navigateTo(RouteNamed.menuInstantDevices);
           }),

--- a/lib/page/instant_device/providers/device_list_provider.dart
+++ b/lib/page/instant_device/providers/device_list_provider.dart
@@ -6,7 +6,6 @@ import 'package:privacy_gui/core/utils/devices.dart';
 import 'package:privacy_gui/core/utils/icon_rules.dart';
 import 'package:privacy_gui/page/instant_device/_instant_device.dart';
 import 'package:privacy_gui/page/instant_device/extensions/icon_device_category_ext.dart';
-import 'package:privacygui_widgets/icons/linksys_icons.dart';
 
 final offlineDeviceListProvider = Provider((ref) {
   final deviceListState = ref.watch(deviceListProvider);

--- a/lib/page/instant_device/providers/device_list_state.dart
+++ b/lib/page/instant_device/providers/device_list_state.dart
@@ -68,6 +68,7 @@ class DeviceListItem extends Equatable {
   final bool isWired;
   final WifiConnectionType type;
   final String ssid;
+  final bool isMLO;
 
   const DeviceListItem({
     this.deviceId = '',
@@ -88,6 +89,7 @@ class DeviceListItem extends Equatable {
     this.isWired = false,
     this.type = WifiConnectionType.main,
     this.ssid = '',
+    this.isMLO = false,
   });
 
   DeviceListItem copyWith({
@@ -109,6 +111,7 @@ class DeviceListItem extends Equatable {
     bool? isWired,
     WifiConnectionType? type,
     String? ssid,
+    bool? isMLO,
   }) {
     return DeviceListItem(
       deviceId: deviceId ?? this.deviceId,
@@ -129,6 +132,7 @@ class DeviceListItem extends Equatable {
       isWired: isWired ?? this.isWired,
       type: type ?? this.type,
       ssid: ssid ?? this.ssid,
+      isMLO: isMLO ?? this.isMLO,
     );
   }
 
@@ -153,6 +157,7 @@ class DeviceListItem extends Equatable {
       isWired,
       type,
       ssid,
+      isMLO,
     ];
   }
 
@@ -176,6 +181,7 @@ class DeviceListItem extends Equatable {
       'isWired': isWired,
       'type': type.value,
       'ssid': ssid,
+      'isMLO': isMLO,
     };
   }
 
@@ -201,6 +207,7 @@ class DeviceListItem extends Equatable {
           WifiConnectionType.values.firstWhereOrNull((e) => e == map['type']) ??
               WifiConnectionType.main,
       ssid: map['ssid'] as String,
+      isMLO: map['isMLO'],
     );
   }
 

--- a/lib/page/instant_device/views/device_detail_view.dart
+++ b/lib/page/instant_device/views/device_detail_view.dart
@@ -181,14 +181,29 @@ class _DeviceDetailViewState extends ConsumerState<DeviceDetailView> {
         ),
         if (state.item.isOnline && !state.item.isWired) ...[
           const AppGap.small2(),
-          AppSettingCard(
+          AppListCard(
             padding: const EdgeInsets.symmetric(
               horizontal: Spacing.large2,
               vertical: Spacing.medium,
             ),
-            title: loc(context).ssid,
-            description:
-                _formatEmptyValue('${state.item.ssid} • ${state.item.band}'),
+            title: AppText.bodyMedium(loc(context).ssid),
+            description: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                AppText.labelLarge(_formatEmptyValue(
+                    '${state.item.ssid} • ${state.item.isMLO ? '6GHz, 5GHz' : state.item.band}')),
+                if (state.item.isMLO) ...[
+                  const AppGap.small2(),
+                  AppTextButton.noPadding(
+                    loc(context).mloCapable,
+                    onTap: () {
+                      showMLOCapableModal(context);
+                    },
+                  ),
+                ],
+              ],
+            ),
           ),
           const AppGap.small2(),
           AppListCard(

--- a/lib/page/instant_privacy/providers/instant_privacy_device_list_provider.dart
+++ b/lib/page/instant_privacy/providers/instant_privacy_device_list_provider.dart
@@ -1,18 +1,27 @@
+import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:privacy_gui/page/instant_device/providers/device_list_provider.dart';
+import 'package:privacy_gui/core/jnap/providers/device_manager_provider.dart';
+import 'package:privacy_gui/core/utils/devices.dart';
+import 'package:privacy_gui/page/instant_device/_instant_device.dart';
 import 'package:privacy_gui/page/instant_privacy/providers/instant_privacy_provider.dart';
 import 'package:privacy_gui/page/instant_privacy/providers/instant_privacy_state.dart';
 
 final instantPrivacyDeviceListProvider = Provider((ref) {
   final deviceListState = ref.watch(deviceListProvider);
   final macFilteringState = ref.watch(instantPrivacyProvider);
+  final nodeList =
+      ref.watch(deviceManagerProvider.select((state) => state.nodeDevices));
   final deviceList = deviceListState.devices;
   final macAddresses = macFilteringState.macAddresses;
   final isEnable = macFilteringState.mode == MacFilterMode.allow;
   return isEnable
-      ? deviceList
+      ? macAddresses
+          .map((e) =>
+              deviceList.firstWhereOrNull((device) => device.macAddress == e) ??
+              DeviceListItem(macAddress: e))
           .where((device) =>
-              macAddresses.contains(device.macAddress.toUpperCase()))
+              !macFilteringState.bssids.contains(device.macAddress) &&
+              !nodeList.any((e) => e.getMacAddress() == device.macAddress))
           .toList()
       : deviceList
           .where((device) => !device.isWired && device.isOnline)

--- a/lib/page/instant_privacy/providers/instant_privacy_provider.dart
+++ b/lib/page/instant_privacy/providers/instant_privacy_provider.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/jnap/actions/better_action.dart';
+import 'package:privacy_gui/core/jnap/actions/jnap_service_supported.dart';
 import 'package:privacy_gui/core/jnap/command/base_command.dart';
 import 'package:privacy_gui/core/jnap/models/mac_filter_settings.dart';
 import 'package:privacy_gui/core/jnap/providers/device_manager_provider.dart';
@@ -32,10 +33,24 @@ class InstantPrivacyNotifier extends Notifier<InstantPrivacyState> {
           auth: true,
         )
         .then((result) => MACFilterSettings.fromMap(result.output));
+    final List<String> staBSSIDS = ServiceHelper().isSupportGetSTABSSID() ? await ref
+        .read(routerRepositoryProvider)
+        .send(
+          JNAPAction.getSTABSSIDs,
+          fetchRemote: true,
+          auth: true,
+        )
+        .then((result) {
+      return List<String>.from(result.output['staBSSIDS']);
+    }).onError((error, _) {
+      logger.d('Not able to get STA BSSIDs');
+      return [];
+    }) : [];
     state = state.copyWith(
       mode: MacFilterMode.reslove(settings.macFilterMode),
       macAddresses: settings.macAddresses.map((e) => e.toUpperCase()).toList(),
       maxMacAddresses: settings.maxMACAddresses,
+      bssids: staBSSIDS,
     );
     return state;
   }
@@ -47,19 +62,6 @@ class InstantPrivacyNotifier extends Notifier<InstantPrivacyState> {
   Future save() async {
     var macAddresses = [];
     if (state.mode == MacFilterMode.allow) {
-      final List<String> staBSSIDS = await ref
-          .read(routerRepositoryProvider)
-          .send(
-            JNAPAction.getSTABSSIDs,
-            fetchRemote: true,
-            auth: true,
-          )
-          .then((result) {
-        return List<String>.from(result.output['staBSSIDS']);
-      }).onError((error, _) {
-        logger.d('Not able to get STA BSSIDs');
-        return [];
-      });
       final nodesMacAddresses = ref
           .read(deviceManagerProvider)
           .nodeDevices
@@ -68,7 +70,7 @@ class InstantPrivacyNotifier extends Notifier<InstantPrivacyState> {
       macAddresses = [
         ...state.macAddresses,
         ...nodesMacAddresses,
-        ...staBSSIDS,
+        ...state.bssids,
       ].unique();
     }
     await ref.read(routerRepositoryProvider).send(

--- a/lib/page/instant_privacy/providers/instant_privacy_state.dart
+++ b/lib/page/instant_privacy/providers/instant_privacy_state.dart
@@ -22,6 +22,7 @@ class InstantPrivacyState extends Equatable {
   final MacFilterMode mode;
   final List<String> macAddresses;
   final int maxMacAddresses;
+  final List<String> bssids;
 
   @override
   List<Object> get props => [mode, macAddresses, maxMacAddresses];
@@ -30,6 +31,7 @@ class InstantPrivacyState extends Equatable {
     required this.mode,
     required this.macAddresses,
     required this.maxMacAddresses,
+    this.bssids = const [],
   });
 
   factory InstantPrivacyState.init() {
@@ -44,11 +46,13 @@ class InstantPrivacyState extends Equatable {
     MacFilterMode? mode,
     List<String>? macAddresses,
     int? maxMacAddresses,
+    List<String>? bssids,
   }) {
     return InstantPrivacyState(
       mode: mode ?? this.mode,
       macAddresses: macAddresses ?? this.macAddresses,
       maxMacAddresses: maxMacAddresses ?? this.maxMacAddresses,
+      bssids: bssids ?? this.bssids,
     );
   }
 
@@ -57,6 +61,7 @@ class InstantPrivacyState extends Equatable {
       'status': mode.name,
       'macAddresses': macAddresses,
       'maxMacAddresses': maxMacAddresses,
+      'bssids': bssids,
     };
   }
 
@@ -65,6 +70,7 @@ class InstantPrivacyState extends Equatable {
       mode: MacFilterMode.reslove(map['status']),
       macAddresses: List.from(map['macAddresses']),
       maxMacAddresses: map['maxMacAddresses'] as int,
+      bssids: List.from(map['bssids']),
     );
   }
 

--- a/lib/page/instant_privacy/views/instant_privacy_view.dart
+++ b/lib/page/instant_privacy/views/instant_privacy_view.dart
@@ -34,6 +34,8 @@ class InstantPrivacyView extends ArgumentsConsumerStatefulView {
 
 class _InstantPrivacyViewState extends ConsumerState<InstantPrivacyView> {
   late final InstantPrivacyNotifier _notifier;
+  bool _isRefreshing = false;
+
   @override
   void initState() {
     _notifier = ref.read(instantPrivacyProvider.notifier);
@@ -165,12 +167,18 @@ class _InstantPrivacyViewState extends ConsumerState<InstantPrivacyView> {
                 icon: LinksysIcons.refresh,
                 color: Theme.of(context).colorScheme.primary,
                 onTap: () {
+                  setState(() {
+                    _isRefreshing = true;
+                  });
                   controller.repeat();
                   ref
                       .read(pollingProvider.notifier)
                       .forcePolling()
                       .then((value) {
                     controller.stop();
+                    setState(() {
+                      _isRefreshing = false;
+                    });
                   });
                 },
               );
@@ -275,9 +283,11 @@ class _InstantPrivacyViewState extends ConsumerState<InstantPrivacyView> {
         AppSwitch(
           semanticLabel: 'instant privacy',
           value: state.mode != MacFilterMode.disabled,
-          onChanged: (value) {
-            _showEnableDialog(value);
-          },
+          onChanged: _isRefreshing
+              ? null
+              : (value) {
+                  _showEnableDialog(value);
+                },
         )
       ],
     ));

--- a/lib/page/nodes/providers/node_detail_provider.dart
+++ b/lib/page/nodes/providers/node_detail_provider.dart
@@ -58,6 +58,7 @@ class NodeDetailNotifier extends Notifier<NodeDetailState> {
     var lanIpAddress = '';
     var wanIpAddress = '';
     var hardwareVersion = '';
+    var isMLO = false;
 
     RawDevice? master = deviceManagerState.deviceList
         .firstWhereOrNull((element) => element.isAuthority);
@@ -85,6 +86,7 @@ class NodeDetailNotifier extends Notifier<NodeDetailState> {
         connectedDevices = device.connectedDevices
             .map((e) => ref.read(deviceListProvider.notifier).createItem(e))
             .toList();
+        isMLO = device.wirelessConnectionInfo?.isMultiLinkOperation ?? false;
       }
     }
 
@@ -103,6 +105,7 @@ class NodeDetailNotifier extends Notifier<NodeDetailState> {
       hardwareVersion: hardwareVersion,
       lanIpAddress: lanIpAddress,
       wanIpAddress: wanIpAddress,
+      isMLO: isMLO,
     );
 
     return state;

--- a/lib/page/nodes/providers/node_detail_state.dart
+++ b/lib/page/nodes/providers/node_detail_state.dart
@@ -69,6 +69,7 @@ class NodeDetailState extends Equatable {
   final String lanIpAddress;
   final String wanIpAddress;
   final BlinkingStatus blinkingStatus;
+  final bool isMLO;
 
   const NodeDetailState({
     this.deviceId = '',
@@ -86,6 +87,7 @@ class NodeDetailState extends Equatable {
     this.lanIpAddress = '',
     this.wanIpAddress = '',
     this.blinkingStatus = BlinkingStatus.blinkNode,
+    this.isMLO = false,
   });
 
   NodeDetailState copyWith({
@@ -105,6 +107,7 @@ class NodeDetailState extends Equatable {
     String? wanIpAddress,
     NodeLightSettings? nodeLightSettings,
     BlinkingStatus? blinkingStatus,
+    bool? isMLO,
   }) {
     return NodeDetailState(
       deviceId: deviceId ?? this.deviceId,
@@ -122,6 +125,7 @@ class NodeDetailState extends Equatable {
       lanIpAddress: lanIpAddress ?? this.lanIpAddress,
       wanIpAddress: wanIpAddress ?? this.wanIpAddress,
       blinkingStatus: blinkingStatus ?? this.blinkingStatus,
+      isMLO: isMLO ?? this.isMLO,
     );
   }
 
@@ -142,6 +146,7 @@ class NodeDetailState extends Equatable {
       'lanIpAddress': lanIpAddress,
       'wanIpAddress': wanIpAddress,
       'blinkingStatus': blinkingStatus.value,
+      'isMLO': isMLO,
     };
   }
 
@@ -166,6 +171,7 @@ class NodeDetailState extends Equatable {
       lanIpAddress: map['lanIpAddress'] as String,
       wanIpAddress: map['wanIpAddress'] as String,
       blinkingStatus: BlinkingStatus.resolve(map['blinkingStatus'] as String),
+      isMLO: map['isMLO'],
     );
   }
 
@@ -195,6 +201,7 @@ class NodeDetailState extends Equatable {
       lanIpAddress,
       wanIpAddress,
       blinkingStatus,
+      isMLO,
     ];
   }
 }

--- a/lib/page/nodes/views/node_detail_view.dart
+++ b/lib/page/nodes/views/node_detail_view.dart
@@ -382,6 +382,17 @@ class _NodeDetailViewState extends ConsumerState<NodeDetailView>
               title: loc(context).connectTo,
               description: _checkEmptyValue(state.upstreamDevice),
             ),
+            if (state.isMLO)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: Spacing.medium),
+              child: AppTextButton.noPadding(
+                loc(context).connectedWithMLO,
+                onTap: () {
+                  showMLOCapableModal(context);
+                },
+              ),
+            ),
+            const AppGap.medium(),
           ],
         ),
       ),

--- a/lib/page/wifi_settings/views/wifi_list_view.dart
+++ b/lib/page/wifi_settings/views/wifi_list_view.dart
@@ -902,8 +902,8 @@ class _WiFiListViewState extends ConsumerState<WiFiListView>
         showChangesSavedSnackBar();
       }).catchError((error, stackTrace) {
         showRouterNotFoundAlert(context, ref,
-                onComplete: () => ref.read(wifiListProvider.notifier).fetch())
-            .then((state) {
+            onComplete: () =>
+                ref.read(wifiListProvider.notifier).fetch(true)).then((state) {
           ref.read(wifiViewProvider.notifier).setChanged(false);
           update(state);
           showChangesSavedSnackBar();

--- a/lib/util/error_code_helper.dart
+++ b/lib/util/error_code_helper.dart
@@ -38,6 +38,7 @@ String? errorCodeHelper(BuildContext context, String? code) {
     errorInvalidInput => loc(context).invalidInput,
     errorInvalidServer => loc(context).errorInvalidServer,
     errorMissingDestination => loc(context).invalidDestinationIpAddress,
+    errorRuleOverlap => loc(context).rulesOverlapError,
     _ => unknownHandle(code),
   };
 }


### PR DESCRIPTION
- [NOW-259] Oak_DYN.com_keep getting "Failed" error message
- [NOW-295] Administration: Exiting the page without making changes should not prompt the user for unsaved changes
- [NOW-297] Advanced Routing: Routing mode is displayed incorrectly
- [NOW-298] Instant-Privacy: Child node MAC addresses should not be listed in the devices list when this feature is enabled
- [NOW-299] Apps & Gaming: It should prompt the user when a rule overlaps with other rules