### PR TITLE
[NOW-318] Apps & Gaming: It should not prompt the user that the rule could not be created when the overlapping rule was removed

### DIFF
--- a/lib/page/advanced_settings/apps_and_gaming/providers/apps_and_gaming_provider.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/providers/apps_and_gaming_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/page/advanced_settings/apps_and_gaming/ddns/_ddns.dart';
 import 'package:privacy_gui/page/advanced_settings/apps_and_gaming/ports/_ports.dart';
 import 'package:privacy_gui/page/advanced_settings/apps_and_gaming/providers/apps_and_gaming_state.dart';
@@ -34,14 +35,36 @@ class AppsAndGamingViewNotifier extends Notifier<AppsAndGamingViewState> {
     if (ref.read(ddnsProvider) != state.preserveDDNSState) {
       await ref.read(ddnsProvider.notifier).save();
     }
-    if (ref.read(singlePortForwardingListProvider) !=
-        state.preserveSinglePortForwardingListState) {
-      await ref.read(singlePortForwardingListProvider.notifier).save();
+    bool saveForwardingSuccess = false;
+    /// Because UI can edit all rules at a same time
+    /// Here is an edge case - Port range deleted a exist rule and Single port add a rule which conflict with
+    /// the deleted rule. Then save will get overlap error becaule single port JNAP is called first, the Router
+    /// doesn't delete the deleted rule yet.
+    /// Workaround - if save failed, tried save vice verse.
+    try {
+      if (ref.read(singlePortForwardingListProvider) !=
+          state.preserveSinglePortForwardingListState) {
+        await ref.read(singlePortForwardingListProvider.notifier).save();
+      }
+      if (ref.read(portRangeForwardingListProvider) !=
+          state.preservePortRangeForwardingListState) {
+        await ref.read(portRangeForwardingListProvider.notifier).save();
+      }
+      saveForwardingSuccess = true;
+    } catch (e) {
+      logger.d('Save forwarding rules failed! try another combination');
     }
-    if (ref.read(portRangeForwardingListProvider) !=
-        state.preservePortRangeForwardingListState) {
-      await ref.read(portRangeForwardingListProvider.notifier).save();
+    if (!saveForwardingSuccess) {
+      if (ref.read(portRangeForwardingListProvider) !=
+          state.preservePortRangeForwardingListState) {
+        await ref.read(portRangeForwardingListProvider.notifier).save();
+      }
+      if (ref.read(singlePortForwardingListProvider) !=
+          state.preserveSinglePortForwardingListState) {
+        await ref.read(singlePortForwardingListProvider.notifier).save();
+      }
     }
+
     if (ref.read(portRangeTriggeringListProvider) !=
         state.preservePortRangeTriggeringListState) {
       await ref.read(portRangeTriggeringListProvider.notifier).save();


### PR DESCRIPTION
- Fixed as a workaround - try save using different order to saving port rules if failed.