### PR TITLE
Handle no parent but online devices

### DIFF
--- a/lib/core/jnap/providers/device_manager_provider.dart
+++ b/lib/core/jnap/providers/device_manager_provider.dart
@@ -161,8 +161,11 @@ class DeviceManagerNotifier extends Notifier<DeviceManagerState> {
           final parentDeviceId = device.connections.firstOrNull?.parentDeviceID;
           // Count it if this item's parentId is the target node,
           // or if its parentId is null and the target node is master
-          return ((parentDeviceId == node.deviceID) ||
-              (parentDeviceId == null && node.deviceID == masterId));
+          // return ((parentDeviceId == node.deviceID) ||
+          //     (parentDeviceId == null && node.deviceID == masterId));
+
+          // For orphan nodes, don't caculate into any nodes
+          return parentDeviceId == node.deviceID;
         }
         return false;
       }).toList();
@@ -326,12 +329,14 @@ class DeviceManagerNotifier extends Notifier<DeviceManagerState> {
     final device = currentState.deviceList
         .firstWhereOrNull((element) => element.deviceID == deviceID);
     if (device == null) {
-      return master;
+      return null;
     }
     if (!device.isOnline()) {
-      return master;
+      return null;
     }
     String? parentIpAddr;
+
+    // Check connections from backhaul info data.
     for (var element in device.connections) {
       for (var backhaul in currentState.backhaulInfoData) {
         if (backhaul.ipAddress == element.ipAddress) {
@@ -355,7 +360,7 @@ class DeviceManagerNotifier extends Notifier<DeviceManagerState> {
     // or if its parentId is null and the target node is master
     return currentState.deviceList.firstWhereOrNull(
             (element) => parentDeviceId == element.deviceID) ??
-        master;
+        (device.nodeType != null ? master : null);
   }
 
   // Update the name(location) of nodes and external devices

--- a/lib/core/jnap/providers/device_manager_state.dart
+++ b/lib/core/jnap/providers/device_manager_state.dart
@@ -146,7 +146,7 @@ class LinksysDevice extends RawDevice {
       upstream: map['upstream'] != null
           ? LinksysDevice.fromMap(map['upstream'])
           : null,
-      connectionType: map['connectionType'] ?? 'wireless',
+      connectionType: map['connectionType'] ?? 'wired',
       wirelessConnectionInfo: map['wirelessConnectionInfo'] != null
           ? WirelessConnectionInfo.fromMap(map['wirelessConnectionInfo'])
           : null,

--- a/lib/core/utils/devices.dart
+++ b/lib/core/utils/devices.dart
@@ -109,13 +109,14 @@ extension LinksysDeviceExt on LinksysDevice {
   }
 
   bool isOnline() {
-    return nodeType == 'Master'
-        ? connections.isNotEmpty
-        : connections.isNotEmpty &&
-            knownInterfaces?.any((element) =>
-                    element.interfaceType == 'Wired' ||
-                    element.interfaceType == 'Wireless') ==
-                true;
+    // return nodeType == 'Master'
+    //     ? connections.isNotEmpty
+    //     : connections.isNotEmpty &&
+    //         knownInterfaces?.any((element) =>
+    //                 element.interfaceType == 'Wired' ||
+    //                 element.interfaceType == 'Wireless') ==
+    //             true;
+    return connections.isNotEmpty;
   }
 }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1061,5 +1061,6 @@
   "errorGuestSSIDConflict": "Guest network names must be different from your main network names. Please enter a different name.",
   "deviceNameAndIcon": "Device Name and Icon",
   "connectionStatus": "Connection Status",
-  "connectedVia": "Connected via"
+  "connectedVia": "Connected via",
+  "unknown": "Unknown"
 }

--- a/lib/page/dashboard/views/components/networks.dart
+++ b/lib/page/dashboard/views/components/networks.dart
@@ -7,7 +7,9 @@ import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/core/jnap/providers/device_manager_provider.dart';
 import 'package:privacy_gui/core/jnap/providers/firmware_update_provider.dart';
 import 'package:privacy_gui/core/jnap/providers/node_wan_status_provider.dart';
+import 'package:privacy_gui/core/utils/devices.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
+import 'package:privacy_gui/page/advanced_settings/internet_settings/providers/internet_settings_provider.dart';
 import 'package:privacy_gui/page/dashboard/_dashboard.dart';
 import 'package:privacy_gui/page/nodes/providers/node_detail_id_provider.dart';
 import 'package:privacy_gui/page/instant_topology/providers/_providers.dart';
@@ -318,15 +320,18 @@ class _DashboardNetworksState extends ConsumerState<DashboardNetworks> {
 
   Widget _devicesInfoTile(
       BuildContext context, WidgetRef ref, InstantTopologyState state) {
+    final externalDeviceCount = ref
+        .watch(deviceManagerProvider)
+        .externalDevices
+        .where((e) => e.isOnline())
+        .length;
     final nodes = state.root.children.firstOrNull?.toFlatList() ?? [];
     final isBridge = ref.watch(dashboardHomeProvider).isBridgeMode;
-    final count = nodes.fold(
-        0,
-        (previousValue, element) =>
-            previousValue += element.data.connectedDeviceCount);
+
     return _infoTile(
-      text: count == 1 ? loc(context).device : loc(context).devices,
-      count: count,
+      text:
+          externalDeviceCount == 1 ? loc(context).device : loc(context).devices,
+      count: externalDeviceCount,
       iconData: LinksysIcons.devices,
       onTap: isBridge
           ? null

--- a/lib/page/instant_device/providers/device_filtered_list_provider.dart
+++ b/lib/page/instant_device/providers/device_filtered_list_provider.dart
@@ -11,15 +11,23 @@ import 'package:privacy_gui/util/extensions.dart';
 final filteredDeviceListProvider = Provider((ref) {
   final config = ref.watch(deviceFilterConfigProvider);
   final deviceListState = ref.watch(deviceListProvider);
+  final allNodes = ref.watch(deviceManagerProvider).nodeDevices;
   final nodeId = config.nodeFilter;
   final wifiName = config.wifiFilter;
   final band = config.bandFilter;
   final connection = config.connectionFilter;
+  final showOrphan = config.showOrphanNodes;
   final filteredDevices = deviceListState.devices
-      .where((device) => wifiName.contains(device.ssid))
       .where((device) => connection == device.isOnline)
+      .where((device) => device.isOnline
+          ? device.isWired || wifiName.contains(device.ssid)
+          : true)
       .where((device) {
         if (!device.isOnline) {
+          return true;
+        }
+        // Show all, if no preselect router && all node ids are selected
+        if (showOrphan && nodeId.length == allNodes.length) {
           return true;
         }
         if (nodeId.contains(device.upstreamDeviceID)) {
@@ -54,6 +62,7 @@ class DeviceFilterConfigNotifier extends Notifier<DeviceFilterConfigState> {
       nodeFilter: nodes,
       wifiFilter: wifiNames,
       bandFilter: bands,
+      showOrphanNodes: preselectedNodeId == null,
     );
   }
 

--- a/lib/page/instant_device/providers/device_filtered_list_state.dart
+++ b/lib/page/instant_device/providers/device_filtered_list_state.dart
@@ -8,12 +8,14 @@ class DeviceFilterConfigState extends Equatable {
   final List<String> nodeFilter;
   final List<String> wifiFilter;
   final List<String> bandFilter;
+  final bool showOrphanNodes;
 
   const DeviceFilterConfigState({
     required this.connectionFilter,
     required this.nodeFilter,
     required this.wifiFilter,
     required this.bandFilter,
+     this.showOrphanNodes = false,
   });
 
   DeviceFilterConfigState copyWith({
@@ -21,47 +23,54 @@ class DeviceFilterConfigState extends Equatable {
     List<String>? nodeFilter,
     List<String>? wifiFilter,
     List<String>? bandFilter,
+    bool? showOrphanNodes,
   }) {
     return DeviceFilterConfigState(
       connectionFilter: connectionFilter ?? this.connectionFilter,
       nodeFilter: nodeFilter ?? this.nodeFilter,
       wifiFilter: wifiFilter ?? this.wifiFilter,
       bandFilter: bandFilter ?? this.bandFilter,
+      showOrphanNodes: showOrphanNodes ?? this.showOrphanNodes,
     );
   }
 
   @override
-  List<Object> get props => [
-        connectionFilter,
-        nodeFilter,
-        wifiFilter,
-        bandFilter,
-      ];
+  List<Object> get props {
+    return [
+      connectionFilter,
+      nodeFilter,
+      wifiFilter,
+      bandFilter,
+      showOrphanNodes,
+    ];
+  }
 
   Map<String, dynamic> toMap() {
-    return <String, dynamic>{
+    return {
       'connectionFilter': connectionFilter,
       'nodeFilter': nodeFilter,
       'wifiFilter': wifiFilter,
       'bandFilter': bandFilter,
+      'showOrphanNodes': showOrphanNodes,
     };
   }
 
   factory DeviceFilterConfigState.fromMap(Map<String, dynamic> map) {
     return DeviceFilterConfigState(
-      connectionFilter: map['connectionFilter'] as bool,
-      nodeFilter:
-          map['nodeFilter'] == null ? [] : List<String>.from(map['nodeFilter']),
-      wifiFilter:
-          map['wifiFilter'] == null ? [] : List<String>.from(map['wifiFilter']),
-      bandFilter:
-          map['bandFilter'] == null ? [] : List<String>.from(map['bandFilter']),
+      connectionFilter: map['connectionFilter'] ?? false,
+      nodeFilter: List<String>.from(map['nodeFilter']),
+      wifiFilter: List<String>.from(map['wifiFilter']),
+      bandFilter: List<String>.from(map['bandFilter']),
+      showOrphanNodes: map['showOrphanNodes'] ?? false,
     );
   }
 
   String toJson() => json.encode(toMap());
 
-  factory DeviceFilterConfigState.fromJson(String source) =>
-      DeviceFilterConfigState.fromMap(
-          json.decode(source) as Map<String, dynamic>);
+  factory DeviceFilterConfigState.fromJson(String source) => DeviceFilterConfigState.fromMap(json.decode(source));
+
+  @override
+  String toString() {
+    return 'DeviceFilterConfigState(connectionFilter: $connectionFilter, nodeFilter: $nodeFilter, wifiFilter: $wifiFilter, bandFilter: $bandFilter, showOrphanNodes: $showOrphanNodes)';
+  }
 }

--- a/lib/page/instant_device/views/device_detail_view.dart
+++ b/lib/page/instant_device/views/device_detail_view.dart
@@ -10,7 +10,6 @@ import 'package:privacy_gui/core/jnap/result/jnap_result.dart';
 import 'package:privacy_gui/core/utils/extension.dart';
 import 'package:privacy_gui/core/utils/icon_device_category.dart';
 import 'package:privacy_gui/core/utils/wifi.dart';
-import 'package:privacy_gui/page/advanced_settings/apps_and_gaming/ddns/views/dyn_ddns_form.dart';
 import 'package:privacy_gui/page/advanced_settings/local_network_settings/providers/local_network_settings_provider.dart';
 import 'package:privacy_gui/page/components/shared_widgets.dart';
 import 'package:privacy_gui/page/components/shortcuts/dialogs.dart';
@@ -179,7 +178,9 @@ class _DeviceDetailViewState extends ConsumerState<DeviceDetailView> {
             vertical: Spacing.medium,
           ),
           title: loc(context).connectTo,
-          description: state.item.upstreamDevice,
+          description: state.item.upstreamDevice.isEmpty
+              ? loc(context).unknown
+              : state.item.upstreamDevice,
         ),
         if (state.item.isOnline && !state.item.isWired) ...[
           const AppGap.small2(),

--- a/lib/page/instant_device/views/devices_filter_widget.dart
+++ b/lib/page/instant_device/views/devices_filter_widget.dart
@@ -138,19 +138,22 @@ class _DevicesFilterWidgetState extends ConsumerState<DevicesFilterWidget> {
                   title: loc(context).byWifi,
                   dataList: wifiNames,
                   chipName: (data) => data ?? '',
-                  checkIsSelected: (data) => selectedWifi.contains(data),
-                  onSelected: (data, value) {
-                    if (data == null) {
-                      return;
-                    }
-                    if (value) {
-                      notifier
-                          .updateWifiFilter(List.from(selectedWifi..add(data)));
-                    } else {
-                      notifier.updateWifiFilter(
-                          List.from(selectedWifi..remove(data)));
-                    }
-                  }),
+                  checkIsSelected: (data) =>
+                      selectConnection ? selectedWifi.contains(data) : false,
+                  onSelected: selectConnection
+                      ? (data, value) {
+                          if (data == null) {
+                            return;
+                          }
+                          if (value) {
+                            notifier.updateWifiFilter(
+                                List.from(selectedWifi..add(data)));
+                          } else {
+                            notifier.updateWifiFilter(
+                                List.from(selectedWifi..remove(data)));
+                          }
+                        }
+                      : null),
               FilteredChipsWidget<String>(
                   title: loc(context).byConnection.capitalizeWords(),
                   dataList: radios,


### PR DESCRIPTION
- devices tile on dashboard display all online devices count
- mini topology only display devices which connected the the router
- Instant-Device display all devices if "by nodes" are all checked.
- router detail display devices connected to this router.
- device detail display unknown if no parent