### PR TITLE
NOW-389: Instant-Admin: Cannot change time zone to a time zone that does not support daylight saving time

### DIFF
--- a/lib/page/instant_admin/providers/timezone_provider.dart
+++ b/lib/page/instant_admin/providers/timezone_provider.dart
@@ -44,18 +44,18 @@ class TimezoneNotifier extends Notifier<TimezoneState> {
       JNAPAction.setTimeSettings,
       data: {
         'timeZoneID': state.timezoneId,
-        'autoAdjustForDST': state.isDaylightSaving,
+        'autoAdjustForDST': (state.supportedTimezones
+                    .firstWhereOrNull((e) => e.timeZoneID == state.timezoneId)
+                    ?.observesDST) ??
+                false
+            ? state.isDaylightSaving
+            : false,
       },
       auth: true,
     )
         .then<void>((value) async {
       await fetch(fetchRemote: true);
       await ref.read(pollingProvider.notifier).forcePolling();
-    }).onError((error, stackTrace) {
-      if (error is JNAPError) {
-        // handle error
-        state = state.copyWith(error: error.error);
-      }
     });
   }
 

--- a/lib/page/instant_admin/views/timezone_view.dart
+++ b/lib/page/instant_admin/views/timezone_view.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/core/jnap/models/timezone.dart';
 import 'package:privacy_gui/core/jnap/result/jnap_result.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
+import 'package:privacy_gui/page/components/mixin/page_snackbar_mixin.dart';
 import 'package:privacy_gui/page/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/page/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/page/instant_admin/providers/timezone_provider.dart';
@@ -27,7 +28,8 @@ class TimezoneView extends ArgumentsConsumerStatefulView {
   ConsumerState<TimezoneView> createState() => _TimezoneContentViewState();
 }
 
-class _TimezoneContentViewState extends ConsumerState<TimezoneView> {
+class _TimezoneContentViewState extends ConsumerState<TimezoneView>
+    with PageSnackbarMixin {
   late final TimezoneNotifier _notifier;
   late final String previousTimezoneId;
 
@@ -60,14 +62,9 @@ class _TimezoneContentViewState extends ConsumerState<TimezoneView> {
               context,
               _notifier.save().then((value) {
                 context.pop(true);
-              }).catchError(
-                (error, stackTrace) {
-                  showFailedSnackBar(
-                      context, loc(context).unknownErrorCode(error ?? ''));
-                },
-                test: (error) => error is JNAPError,
-              ).onError((error, stackTrace) {
-                showFailedSnackBar(context, loc(context).generalError);
+                showChangesSavedSnackBar();
+              }).onError((error, stackTrace) {
+                showErrorMessageSnackBar(error);
               }),
               title: loc(context).savingChanges,
             );


### PR DESCRIPTION
- Set autoAdjustForDST as false if selected timeZone doesn't support it.
- Show snackbar for set timezone operation