### PR TITLE
NOW-298: Instant-Privacy: Child node MAC addresses should not be listed in the devices list when this feature is enabled

### DIFF
--- a/lib/page/instant_privacy/providers/instant_privacy_device_list_provider.dart
+++ b/lib/page/instant_privacy/providers/instant_privacy_device_list_provider.dart
@@ -21,6 +21,7 @@ final instantPrivacyDeviceListProvider = Provider((ref) {
               DeviceListItem(macAddress: e))
           .where((device) =>
               !macFilteringState.bssids.contains(device.macAddress) &&
+              deviceList.any((e) => e.macAddress == device.macAddress) &&
               !nodeList.any((e) => e.getMacAddress() == device.macAddress))
           .toList()
       : deviceList


### PR DESCRIPTION

- Hide MACs which can not be found on devices