### PR TITLE
NOW-432: Instant-Privacy: The Beta label is displayed in the wrong position

### DIFF
--- a/lib/page/components/styled/styled_page_view.dart
+++ b/lib/page/components/styled/styled_page_view.dart
@@ -274,7 +274,8 @@ class StyledAppPageView extends ConsumerWidget {
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Expanded(
+                      Flexible(
+                        fit: FlexFit.loose,
                         child: AppText.titleLarge(
                           title,
                           maxLines: 2,


### PR DESCRIPTION
- Adjust layout of title