### PR TITLE
NOW-435: Add Pinnacle device to the linksysNow code base

### DIFF
--- a/lib/core/utils/icon_rules.dart
+++ b/lib/core/utils/icon_rules.dart
@@ -169,6 +169,36 @@ const List<Map<String, dynamic>> iconRules = [
     'iconClass': 'routerMbe7100',
   },
   {
+    'description': 'Linksys SPNM61 (SPNM61/Pinnacle 2.1)',
+    'test': {
+      'model': {
+        'manufacturer': 'Linksys',
+        'modelNumber': '^spnm61',
+      },
+    },
+    'iconClass': 'routerSpnm61',
+  },
+  {
+    'description': 'Linksys SPNM62 (SPNM62/Pinnacle 2.2)',
+    'test': {
+      'model': {
+        'manufacturer': 'Linksys',
+        'modelNumber': '^spnm62',
+      },
+    },
+    'iconClass': 'routerSpnm62',
+  },
+  {
+    'description': 'Linksys SPNM60 (SPNM60/Pinnacle 2.0)',
+    'test': {
+      'model': {
+        'manufacturer': 'Linksys',
+        'modelNumber': '^spnm60',
+      },
+    },
+    'iconClass': 'routerSpnm60',
+  },
+  {
     'description': 'Linksys Router (modelNumber passthrough)',
     'test': {
       'model': {
@@ -683,10 +713,13 @@ String _iconMapping(String iconClass, {String? fallback}) {
       return 'routerLn11';
     case 'routerLn12':
     case 'routerLn16':
+    case 'routerSpnm60':
+    case 'routerSpnm61':
+    case 'routerSpnm62':
       return 'routerLn12';
     default:
       // do router check
-      return fallback ?? 'routerLn11';
+      return fallback ?? 'routerLn12';
   }
 }
 

--- a/lib/core/utils/nodes.dart
+++ b/lib/core/utils/nodes.dart
@@ -104,6 +104,30 @@
 
             EA9350v3        Official Model Number
 
+        Oak Node (Cognitive Mesh) -
+
+            MBE7000          Official Model Number (currently not used)
+            MBE7000 Series   Model Number to show for all SKU Variants (when modelNumber starts with 'MBE70')
+
+        Oak SP1  (Cognitive Mesh) -
+
+            MBE7100          Official Model Number (currently not used)
+            MBE7100 Series   Model Number to show for all SKU Variants (when modelNumber starts with 'MBE71')
+
+        Elm (Cognitive Mesh) -
+
+            LN11             Official Model Number (currently not used)
+            LN11 Series      Model Number to show for all SKU Variants (when modelNumber starts with 'LN11')
+
+        Cherry (Cognitive Mesh) -
+
+            LN12             Official Model Number (currently not used)
+            LN12 Series      Model Number to show for all SKU Variants (when modelNumber starts with 'LN12')
+
+        Pinnacle -
+
+            SPNM60
+
     */
 import 'package:collection/collection.dart';
 import 'package:privacy_gui/core/cache/linksys_cache_manager.dart';
@@ -307,6 +331,30 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'pattern': 'ln16',
   },
   {
+    'model': 'SPNM60',
+    'baseModel': 'SPNM60',
+    'seriesModel': 'SPNM60',
+    'isMeshRouter': false,
+    'isCognitiveMesh': true,
+    'pattern': '^spnm60',
+  },
+  {
+    'model': 'SPNM61',
+    'baseModel': 'SPNM61',
+    'seriesModel': 'SPNM61',
+    'isMeshRouter': false,
+    'isCognitiveMesh': true,
+    'pattern': '^spnm61',
+  },
+  {
+    'model': 'SPNM62',
+    'baseModel': 'SPNM62',
+    'seriesModel': 'SPNM62',
+    'isMeshRouter': false,
+    'isCognitiveMesh': true,
+    'pattern': '^spnm62',
+  },
+  {
     'model': 'EA9350',
     'hardwareVersions': ['3'],
     'baseModel': 'EA9350',
@@ -324,38 +372,6 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'baseModel': 'MR8300',
     'isMeshRouter': true,
     'pattern': '^mr'
-  }
-];
-
-// array describing the Children that are compatible with a given Parent Cognitive Mesh Node
-const List<Map<String, dynamic>> _cognitiveMeshCompatibilityMap = [
-  {
-    'parentModel': 'MX6200',
-    'compatibleChildren': [
-      {'model': 'MX6200'},
-      {'model': 'MBE7000'}
-    ]
-  },
-  {
-    'parentModel': 'MBE7000',
-    'compatibleChildren': [
-      {'model': 'MBE7000'},
-      {'model': 'MX6200'}
-    ]
-  },
-  {
-    'parentModel': 'LN11',
-    'compatibleChildren': [
-      {'model': 'LN11'},
-      {'model': 'LN12'}
-    ]
-  },
-  {
-    'parentModel': 'LN12',
-    'compatibleChildren': [
-      {'model': 'LN12'},
-      {'model': 'LN11'}
-    ]
   }
 ];
 

--- a/lib/page/wifi_settings/views/mac_filtering_view.dart
+++ b/lib/page/wifi_settings/views/mac_filtering_view.dart
@@ -112,7 +112,8 @@ class _MacFilteringViewState extends ConsumerState<MacFilteringView>
                     children: [
                       _enableTile(state),
                       const AppGap.small2(),
-                      _infoCard(deviceList.length),
+                      _infoCard(
+                          state.mode == MacFilterMode.deny, deviceList.length),
                     ],
                   ),
                 ),
@@ -137,7 +138,7 @@ class _MacFilteringViewState extends ConsumerState<MacFilteringView>
           ],
           _enableTile(state),
           const AppGap.small2(),
-          _infoCard(deviceList.length),
+          _infoCard(state.mode == MacFilterMode.deny, deviceList.length),
           const AppGap.large2(),
         ],
       ),
@@ -155,15 +156,20 @@ class _MacFilteringViewState extends ConsumerState<MacFilteringView>
     );
   }
 
-  Widget _infoCard(int length) {
-    return AppInfoCard(
-      padding: const EdgeInsets.all(Spacing.medium),
-      onTap: () {
-        context.pushNamed(RouteNamed.macFilteringInput);
-      },
-      title: loc(context).nDevices(length).capitalizeWords(),
-      description: loc(context).denyAccessDesc,
-      trailing: Icon(LinksysIcons.chevronRight),
+  Widget _infoCard(bool enabled, int length) {
+    return Opacity(
+      opacity: enabled ? 1 : .5,
+      child: AppInfoCard(
+        padding: const EdgeInsets.all(Spacing.medium),
+      onTap: enabled
+            ? () {
+                context.pushNamed(RouteNamed.macFilteringInput);
+              }
+            : null,
+        title: loc(context).nDevices(length).capitalizeWords(),
+        description: loc(context).denyAccessDesc,
+        trailing: Icon(LinksysIcons.chevronRight),
+      ),
     );
   }
 

--- a/test/core/utils/icon_rules_test.dart
+++ b/test/core/utils/icon_rules_test.dart
@@ -46,6 +46,29 @@ void main() {
       final result = iconTest(jsonDecode(deviceJson));
       expect(result, 'routerLn11');
     });
+
+    test('test iconTest - Pinnacle 2.0', () {
+      const deviceJson = '''
+    {"model": {"deviceType": "Infrastructure", "manufacturer": "Linksys", "modelNumber": "SPNM60", "hardwareVersion": "1"}}
+    ''';
+      final result = iconTest(jsonDecode(deviceJson));
+      expect(result, 'routerLn12');
+    });
+    test('test iconTest - Pinnacle 2.1', () {
+      const deviceJson = '''
+    {"model": {"deviceType": "Infrastructure", "manufacturer": "Linksys", "modelNumber": "SPNM61", "hardwareVersion": "1"}}
+    ''';
+      final result = iconTest(jsonDecode(deviceJson));
+      expect(result, 'routerLn12');
+    });
+    test('test iconTest - Pinnacle 2.2', () {
+      const deviceJson = '''
+    {"model": {"deviceType": "Infrastructure", "manufacturer": "Linksys", "modelNumber": "SPNM62", "hardwareVersion": "1"}}
+    ''';
+      final result = iconTest(jsonDecode(deviceJson));
+      expect(result, 'routerLn12');
+    });
+
     test('test iconTest - iPhone', () {
       const device = {
         "model": {
@@ -97,7 +120,7 @@ void main() {
   group('test testRouterIcon series', () {
     test('test routerIconTest - Unknown model number', () {
       final result = routerIconTestByModel(modelNumber: 'MR9500');
-      expect(result, 'routerLn11');
+      expect(result, 'routerLn12');
     });
     test('test routerIconTest - MR9600', () {
       final result = routerIconTestByModel(modelNumber: 'MR9600');

--- a/test/core/utils/nodes_test.dart
+++ b/test/core/utils/nodes_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/core/utils/nodes.dart';
+
+void main() {
+  group('Node Model Tests', () {
+    test('WHW03B (Velop - Black)', () {
+      expect(isNodeModel(modelNumber: 'WHW03B', hardwareVersion: '1'), true);
+    });
+
+    test('WHW03 (Velop)', () {
+      expect(isNodeModel(modelNumber: 'WHW03', hardwareVersion: '1'), true);
+      expect(isNodeModel(modelNumber: 'ND0001', hardwareVersion: '1'), true);
+      expect(isNodeModel(modelNumber: 'NODES', hardwareVersion: '1'), true);
+      expect(isNodeModel(modelNumber: 'WHW0301', hardwareVersion: '1'), true);
+      expect(isNodeModel(modelNumber: 'A03', hardwareVersion: '1'), true);
+    });
+
+    test('WHW01P (Velop Plugin)', () {
+      expect(isNodeModel(modelNumber: 'WHW01P', hardwareVersion: '1'), true);
+    });
+
+    test('WHW01B (Velop Jr - Black)', () {
+      expect(isNodeModel(modelNumber: 'WHW01B', hardwareVersion: '1'), true);
+      expect(isNodeModel(modelNumber: 'VLP01B', hardwareVersion: '1'), true);
+    });
+
+    test('WHW01 (Velop Jr)', () {
+      expect(isNodeModel(modelNumber: 'WHW01', hardwareVersion: '1'), true);
+      expect(isNodeModel(modelNumber: 'VLP01', hardwareVersion: '1'), true);
+      expect(isNodeModel(modelNumber: 'A01', hardwareVersion: '1'), true);
+    });
+
+    test('MX5300 (Bronx)', () {
+      expect(isNodeModel(modelNumber: 'MX5300', hardwareVersion: '1'), true);
+      expect(isNodeModel(modelNumber: 'MX5400', hardwareVersion: '1'), true);
+    });
+
+    test('MX6200 (Maple)', () {
+      expect(isNodeModel(modelNumber: 'MX6200', hardwareVersion: '1'), true);
+      expect(isNodeModel(modelNumber: 'MX6201', hardwareVersion: '1'),
+          true); // Example variant
+    });
+
+    test('MBE7000 (Oak)', () {
+      expect(isNodeModel(modelNumber: 'MBE7000', hardwareVersion: '1'), true);
+      expect(isNodeModel(modelNumber: 'MBE7001', hardwareVersion: '1'),
+          true); // Example variant
+    });
+
+    test('MBE7100 (Oak SP1)', () {
+      expect(isNodeModel(modelNumber: 'MBE7100', hardwareVersion: '1'), true);
+      expect(isNodeModel(modelNumber: 'MBE7101', hardwareVersion: '1'),
+          true); // Example variant
+    });
+
+    test('LN11 (Elm)', () {
+      expect(isNodeModel(modelNumber: 'LN11', hardwareVersion: '1'), true);
+    });
+
+    test('LN12 (Cherry)', () {
+      expect(isNodeModel(modelNumber: 'LN12', hardwareVersion: '1'), true);
+    });
+
+    test('SPNM60 (Pinnacle 2.0)', () {
+      expect(isNodeModel(modelNumber: 'SPNM60', hardwareVersion: '1'), true);
+    });
+    test('SPNM61 (Pinnacle 2.1)', () {
+      expect(isNodeModel(modelNumber: 'SPNM61', hardwareVersion: '1'), true);
+    });
+    test('SPNM62 (Pinnacle 2.2)', () {
+      expect(isNodeModel(modelNumber: 'SPNM62', hardwareVersion: '1'), true);
+    });
+    test('Random Model (Should be false)', () {
+      expect(isNodeModel(modelNumber: 'XYZ123', hardwareVersion: '1'), false);
+    });
+
+    test('MR9600 (Bobcat)', () {
+      expect(isNodeModel(modelNumber: 'MR9600', hardwareVersion: '1'), true);
+    });
+  });
+
+  group("treatAsMode Tests", () {
+    test("Verify WHW03B returns WHW03B", () {
+      String? result =
+          treatAsModes(modelNumber: "WHW03B", hardwareVersion: "1");
+      expect(result, "WHW03B");
+    });
+    test("Verify WHW03B with hardwareVersion 2 returns WHW03B", () {
+      String? result =
+          treatAsModes(modelNumber: "WHW03B", hardwareVersion: "2");
+      expect(result, 'WHW03B');
+    });
+
+    test("Verify EA9350 returns EA9350 with hardwareVersion 1 returns null",
+        () {
+      String? result =
+          treatAsModes(modelNumber: "EA9350", hardwareVersion: "1");
+      expect(result, null);
+    });
+
+    test("Verify EA9350 returns EA9350 with hardwareVersion 1 returns EA9350",
+        () {
+      String? result =
+          treatAsModes(modelNumber: "EA9350", hardwareVersion: "3");
+      expect(result, 'EA9350');
+    });
+  });
+}


### PR DESCRIPTION
 - Add Pinnacle 2.0/2.1/2.2 model
 - Add support Pinnacle icon
 - Add test cases for icon rules and nodes
 - Fixed minor UI issue on MAC filtering