### PR TITLE
[NOW-436]

### DIFF
--- a/lib/core/jnap/providers/device_manager_state.dart
+++ b/lib/core/jnap/providers/device_manager_state.dart
@@ -173,7 +173,14 @@ class DeviceManagerState extends Equatable {
 
   // Calculated properties
   List<LinksysDevice> get nodeDevices {
-    return deviceList.where((device) => device.nodeType != null).toList();
+    return deviceList
+        .where(
+          // Note: NodeType is null but isAuthority is true in factory settings
+          // To avoid errors caused by empty node device list while entering
+          // the dashboard on an unconfigured router, isAuthority is also checked
+          (device) => device.nodeType != null || device.isAuthority == true,
+        )
+        .toList();
   }
 
   List<LinksysDevice> get externalDevices {


### PR DESCRIPTION
NodeType will be NULL but isAuthority will be True in factory settings. To avoid errors caused by empty node devices while entering the dashboard on an unconfigured router, add a check for isAuthority.

Deliberately changing passwords by executing specific JNAP API is not a normal use case. This is unlikely to happen to ordinary users.