### PR TITLE
NOW-440:Password didn't bring to PnP flow on Pre-paired scenario

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,8 +54,6 @@ void main() async {
 
   // GetIt
   dependencySetup();
-  // Path url strategy
-  config();
 
   runApp(app());
 }

--- a/lib/page/wifi_settings/views/mac_filtering_view.dart
+++ b/lib/page/wifi_settings/views/mac_filtering_view.dart
@@ -161,7 +161,7 @@ class _MacFilteringViewState extends ConsumerState<MacFilteringView>
       opacity: enabled ? 1 : .5,
       child: AppInfoCard(
         padding: const EdgeInsets.all(Spacing.medium),
-      onTap: enabled
+        onTap: enabled
             ? () {
                 context.pushNamed(RouteNamed.macFilteringInput);
               }
@@ -182,8 +182,9 @@ class _MacFilteringViewState extends ConsumerState<MacFilteringView>
           semanticLabel: 'wifi mac filtering',
           value: state.mode == MacFilterMode.deny,
           onChanged: (value) {
-            _notifier
-                .setAccess(value ? MacFilterMode.deny : MacFilterMode.disabled);
+            _notifier.setAccess(value
+                ? MacFilterMode.deny
+                : preservedState?.mode ?? MacFilterMode.disabled);
           },
         )
       ],

--- a/lib/page/wifi_settings/views/wifi_list_view.dart
+++ b/lib/page/wifi_settings/views/wifi_list_view.dart
@@ -259,7 +259,9 @@ class _WiFiListViewState extends ConsumerState<WiFiListView>
           value: state.isEnabled,
           onChanged: (value) {
             ref.read(wifiListProvider.notifier).setWiFiEnabled(value);
-            final preservedMainWiFiState = _preservedMainWiFiState;
+            final preservedMainWiFiState = _preservedMainWiFiState?.copyWith(
+                guestWiFi: _preservedMainWiFiState?.guestWiFi
+                    .copyWith(isEnabled: value));
             // if disabled, reset the guest ssid and password
             if (!value && preservedMainWiFiState != null) {
               final guestWifi = preservedMainWiFiState.guestWiFi;
@@ -267,7 +269,7 @@ class _WiFiListViewState extends ConsumerState<WiFiListView>
               ref
                   .read(wifiListProvider.notifier)
                   .setWiFiPassword(guestWifi.password);
-              update(preservedMainWiFiState);
+              updateController(preservedMainWiFiState);
             }
           },
         ),
@@ -970,14 +972,18 @@ class _WiFiListViewState extends ConsumerState<WiFiListView>
       ref
           .read(wifiViewProvider.notifier)
           .setWifiListViewStateChanged(state != _preservedMainWiFiState);
-      for (var wifi in state.mainWiFi) {
-        final controller = TextEditingController()..text = wifi.password;
-        _advancedPasswordController.putIfAbsent(
-            wifi.radioID.value, () => controller);
-      }
-      _advancedPasswordController.putIfAbsent('guest',
-          () => TextEditingController()..text = state.guestWiFi.password);
+      updateController(state);
     });
+  }
+
+  void updateController(WiFiState state) {
+    for (var wifi in state.mainWiFi) {
+      final controller = TextEditingController()..text = wifi.password;
+      _advancedPasswordController.putIfAbsent(
+          wifi.radioID.value, () => controller);
+    }
+    _advancedPasswordController.putIfAbsent('guest',
+        () => TextEditingController()..text = state.guestWiFi.password);
   }
 
   List<Widget> _disableBandWarning(WiFiState state) {


### PR DESCRIPTION
- Revert usePathStrategy
- Fixs GuestWiFi enable/disable didn't trigger discard warning.
- Fixs MacFiltering incorrect trigger discard warning when InstantPrivacy enabled