### PR TITLE
NOW-443: MAC Filtering: Unable to disable MAC Filtering; NOW-444: Incredible-WiFi: WiFi password dialog displays repeated password requirements

### DIFF
--- a/lib/page/wifi_settings/views/mac_filtering_view.dart
+++ b/lib/page/wifi_settings/views/mac_filtering_view.dart
@@ -184,7 +184,9 @@ class _MacFilteringViewState extends ConsumerState<MacFilteringView>
           onChanged: (value) {
             _notifier.setAccess(value
                 ? MacFilterMode.deny
-                : preservedState?.mode ?? MacFilterMode.disabled);
+                : preservedState?.mode == MacFilterMode.deny
+                    ? MacFilterMode.disabled
+                    : preservedState?.mode ?? MacFilterMode.disabled);
           },
         )
       ],

--- a/lib/page/wifi_settings/views/wifi_list_view.dart
+++ b/lib/page/wifi_settings/views/wifi_list_view.dart
@@ -660,16 +660,6 @@ class _WiFiListViewState extends ConsumerState<WiFiListView>
                       wifiPasswordValidator.getRuleByIndex(2)?.validate(text) ??
                       false),
                 ),
-                Validation(
-                  description: loc(context).routerPasswordRuleStartEndWithSpace,
-                  validator: ((text) =>
-                      NoSurroundWhitespaceRule().validate(text)),
-                ),
-                Validation(
-                  description:
-                      loc(context).routerPasswordRuleUnsupportSpecialChar,
-                  validator: ((text) => AsciiRule().validate(text)),
-                ),
               ],
               onValidationChanged: (isValid) => setState(() {
                 isPasswordValid = isValid;


### PR DESCRIPTION
- Remove duplicate rules for WiFi password
- Fixes can not disable MAC filtering