### PR TITLE
NOW-450: [Incredible Wifi] Add device then disable WIFI MAC Filteringstill can click Save button; NOW-453: DMZ: If the end IP of the source IP address is equal to the start IP, the setting cannot be saved; NOW-454: Port range forwarding/Port range triggering: If the port/protocol of the rule does not overlap with other rules, the error message should disappear; NOW-455: [Enhancement] Too small QRCode can be hide.; NOW-457: Update MLO warning description

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -770,7 +770,7 @@
   "refresh": "Refresh",
   "wifiListSaveModalTitle": "You're updating WiFi settings",
   "wifiListSaveModalDesc": "Changing Wi-Fi settings will disconnect all devices, including this one, from the router. Simply reconnect the devices using the new wireless settings shown below. You may want to write them down before continuing.",
-  "mloWarning": "Multi-Link Operation (MLO) requires all bands to have the same settings. MLO will not work correctly if you continue.",
+  "mloWarning": "Multi-Link Operation (MLO) requires Networks name to be identical across all bands. MLO will not work correctly in case they are different. For MLO to function, the network security mode must be set to WPA2/WPA3 Mixed Mode or higher. These changes can be made under the \"Incredible WiFi\" page.",
   "doYouWantToContinue": "Do you want to Continue?",
   "advancedMLOWarning": "Your bands do not share the same settings which will prevent MLO from working. Go to the Wireless tab and change the SSID and passwords to be the same.",
   "administrationAllowLocalManagementWirelessly": "Allow local management wirelessly",

--- a/lib/page/advanced_settings/apps_and_gaming/ports/views/port_range_forwarding_list_view.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/ports/views/port_range_forwarding_list_view.dart
@@ -343,7 +343,7 @@ class _PortRangeForwardingContentViewState
           1 => notifier.isPortRangeValid(
                   int.tryParse(internalPortTextController.text) ?? 0,
                   int.tryParse(externalPortTextController.text) ?? 0)
-              ? notifier.isPortConflict(
+              ? !notifier.isPortConflict(
                       int.tryParse(internalPortTextController.text) ?? 0,
                       int.tryParse(externalPortTextController.text) ?? 0,
                       ref

--- a/lib/page/advanced_settings/apps_and_gaming/ports/views/port_range_triggering_list_view.dart
+++ b/lib/page/advanced_settings/apps_and_gaming/ports/views/port_range_triggering_list_view.dart
@@ -369,7 +369,7 @@ class _PortRangeTriggeringContentViewState
           2 => notifier.isPortRangeValid(
                   int.tryParse(firstForwardedPortController.text) ?? 0,
                   int.tryParse(lastForwardedPortController.text) ?? 0)
-              ? notifier.isForwardedPortConflict(
+              ? !notifier.isForwardedPortConflict(
                       int.tryParse(firstForwardedPortController.text) ?? 0,
                       int.tryParse(lastForwardedPortController.text) ?? 0)
                   ? null

--- a/lib/page/advanced_settings/dmz/views/dmz_settings_view.dart
+++ b/lib/page/advanced_settings/dmz/views/dmz_settings_view.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/core/jnap/models/dmz_settings.dart';
 import 'package:privacy_gui/core/jnap/result/jnap_result.dart';
-import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/advanced_settings/dmz/providers/dmz_settings_provider.dart';
 import 'package:privacy_gui/page/advanced_settings/dmz/providers/dmz_settings_state.dart';
@@ -431,7 +430,7 @@ class _DMZSettingsViewState extends ConsumerState<DMZSettingsView> {
     final lastValue = NetworkUtils.ipToNum(_sourceLastIPController.text);
     setState(() {
       _sourceError =
-          lastValue - firstValue > 0 ? null : loc(context).dmzSourceRangeError;
+          lastValue - firstValue >= 0 ? null : loc(context).dmzSourceRangeError;
     });
   }
 

--- a/lib/page/dashboard/views/dashboard_menu_view.dart
+++ b/lib/page/dashboard/views/dashboard_menu_view.dart
@@ -147,7 +147,6 @@ class _DashboardMenuViewState extends ConsumerState<DashboardMenuView> {
           title: loc(context).instantTopology,
           description: loc(context).instantTopologyDesc,
           iconData: LinksysIcons.router,
-          disabledOnBridge: true,
           onTap: () {
             _navigateTo(RouteNamed.menuInstantTopology);
           }),

--- a/lib/page/wifi_settings/views/mac_filtering_view.dart
+++ b/lib/page/wifi_settings/views/mac_filtering_view.dart
@@ -79,7 +79,9 @@ class _MacFilteringViewState extends ConsumerState<MacFilteringView>
       appBarStyle: AppBarStyle.none,
       useMainPadding: false,
       bottomBar: PageBottomBar(
-          isPositiveEnabled: isStateChanged(state),
+          isPositiveEnabled: state.mode == MacFilterMode.deny
+              ? isStateChanged(state)
+              : state.mode != preservedState?.mode,
           onPositiveTap: () {
             _showEnableDialog(state.mode != MacFilterMode.disabled);
           }),

--- a/lib/page/wifi_settings/views/wifi_main_view.dart
+++ b/lib/page/wifi_settings/views/wifi_main_view.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -5,10 +6,14 @@ import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/page/components/styled/styled_tab_page_view.dart';
 import 'package:privacy_gui/page/components/views/arguments_view.dart';
+import 'package:privacy_gui/page/dashboard/_dashboard.dart';
+import 'package:privacy_gui/page/dashboard/providers/dashboard_home_provider.dart';
+import 'package:privacy_gui/page/instant_privacy/providers/instant_privacy_provider.dart';
 import 'package:privacy_gui/page/wifi_settings/_wifi_settings.dart';
 import 'package:privacy_gui/page/wifi_settings/providers/wifi_view_provider.dart';
 import 'package:privacy_gui/page/wifi_settings/views/mac_filtering_view.dart';
 import 'package:privacy_gui/page/wifi_settings/views/wifi_list_view.dart';
+import 'package:privacygui_widgets/widgets/text/app_text.dart';
 
 class WiFiMainView extends ArgumentsConsumerStatefulView {
   const WiFiMainView({Key? key, super.args}) : super(key: key);
@@ -25,23 +30,28 @@ class _WiFiMainViewState extends ConsumerState<WiFiMainView>
   @override
   void initState() {
     super.initState();
-
     _tabController = TabController(length: 3, vsync: this);
     _tabController.addListener(() async {
+      final isBridge = ref.read(dashboardHomeProvider).isBridgeMode;
       if (_tabController.indexIsChanging &&
           _tabController.previousIndex != _tabController.index &&
           _tabIsChanging == false) {
         final nextIndex = _tabController.index;
-        final isStateChange =
-            hasChangedWithTabIndex(_tabController.previousIndex);
-        if (isStateChange) {
-          _tabIsChanging = true;
+        if (isBridge && (nextIndex == _tabController.length - 1)) {
+          _tabIsChanging = false;
           _tabController.animateTo(_tabController.previousIndex);
-          if (await showUnsavedAlert(context) != true) {
-            _tabIsChanging = false;
-          } else {
-            _tabController.animateTo(nextIndex);
-            _tabIsChanging = false;
+        } else {
+          final isStateChange =
+              hasChangedWithTabIndex(_tabController.previousIndex);
+          if (isStateChange) {
+            _tabIsChanging = true;
+            _tabController.animateTo(_tabController.previousIndex);
+            if (await showUnsavedAlert(context) != true) {
+              _tabIsChanging = false;
+            } else {
+              _tabController.animateTo(nextIndex);
+              _tabIsChanging = false;
+            }
           }
         }
       }
@@ -57,6 +67,8 @@ class _WiFiMainViewState extends ConsumerState<WiFiMainView>
 
   @override
   Widget build(BuildContext context) {
+    final isBridge = ref.watch(dashboardHomeProvider).isBridgeMode;
+
     final tabs = [
       loc(context).wifi,
       loc(context).advanced,
@@ -73,6 +85,10 @@ class _WiFiMainViewState extends ConsumerState<WiFiMainView>
         final isCurrentChanged = hasChangedWithTabIndex(_tabController.index);
         if (isCurrentChanged && (await showUnsavedAlert(context) != true)) {
           return;
+        }
+        if (_tabController.index == 2) {
+          // Handle MAC filter, restore state if discard change
+          ref.read(instantPrivacyProvider.notifier).fetch();
         }
         context.pop();
       },
@@ -104,8 +120,13 @@ class _WiFiMainViewState extends ConsumerState<WiFiMainView>
       //     }),
       tabController: _tabController,
       tabs: tabs
-          .map((e) => Tab(
-                text: e,
+          .mapIndexed((index, e) => Tab(
+                child: AppText.titleSmall(
+                  e,
+                  color: index == _tabController.length - 1 && isBridge
+                      ? Theme.of(context).colorScheme.outline
+                      : null,
+                ),
               ))
           .toList(),
       tabContentViews: tabContents,


### PR DESCRIPTION

- Improve horver QR code btn behavior.
- Fixs wrong error message display on DMZ, Port settings.
- Fixs behavior on MAC Filtering.
- Update MLO warning on Advanced WiFi Settings page.
- Fixs Instant Topology cannot enter if in bridge mode.