### PR TITLE
[NOW-449]: Local Network: After saving DHCP server changes and going to "DHCP Reservations", the user should no longer be prompted to save changes

### DIFF
--- a/lib/page/advanced_settings/local_network_settings/providers/local_network_settings_provider.dart
+++ b/lib/page/advanced_settings/local_network_settings/providers/local_network_settings_provider.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/jnap/actions/better_action.dart';
@@ -7,14 +6,10 @@ import 'package:privacy_gui/core/jnap/models/set_lan_settings.dart';
 import 'package:privacy_gui/core/jnap/providers/side_effect_provider.dart';
 import 'package:privacy_gui/core/jnap/router_repository.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
-import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/advanced_settings/local_network_settings/providers/local_network_settings_state.dart';
 import 'package:privacy_gui/page/instant_safety/providers/instant_safety_provider.dart';
 import 'package:privacy_gui/utils.dart';
 import 'package:privacy_gui/validator_rules/input_validators.dart';
-
-final localNetworkSettingNeedToSaveProvider =
-    StateProvider<bool>((ref) => false);
 
 final localNetworkSettingProvider =
     NotifierProvider<LocalNetworkSettingsNotifier, LocalNetworkSettingsState>(

--- a/lib/page/advanced_settings/local_network_settings/views/local_network_settings_view.dart
+++ b/lib/page/advanced_settings/local_network_settings/views/local_network_settings_view.dart
@@ -54,6 +54,7 @@ class _LocalNetworkSettingsViewState
   final ipAddressController = TextEditingController();
   final subnetMaskController = TextEditingController();
   int _selectedTabIndex = 0;
+  final _https = 'https://';
 
   @override
   void initState() {
@@ -90,21 +91,18 @@ class _LocalNetworkSettingsViewState
   @override
   Widget build(BuildContext context) {
     ref.listen(redirectionProvider, (previous, next) {
-      if (kIsWeb && next != null && originalSettings.ipAddress != next) {
+      if (kIsWeb &&
+          next != null &&
+          '$_https${originalSettings.ipAddress}' != next) {
         logger.d('Redirect to $next');
         assignWebLocation(next);
-      }
-    });
-    ref.listen(localNetworkSettingNeedToSaveProvider, (previous, next) {
-      if (previous == false && next == true) {
-        _saveSettings();
       }
     });
     final state = ref.watch(localNetworkSettingProvider);
     final tabContents = [
       _hostNameView(state),
       _ipAddressView(state),
-      _dhcpServerView(originalSettings),
+      _dhcpServerView(state),
     ];
     return StyledAppPageView(
       appBarStyle: AppBarStyle.none,
@@ -227,9 +225,14 @@ class _LocalNetworkSettingsViewState
     );
   }
 
-  Widget _dhcpServerView(LocalNetworkSettingsState? originalSettings) {
+  Widget _dhcpServerView(LocalNetworkSettingsState state) {
     return _viewLayout(
-      child: DHCPServerView(originalState: originalSettings),
+      child: DHCPServerView(
+        isEdited: () => _isEdited(state),
+        onSaveSettings: () async {
+          _saveSettings();
+        },
+      ),
     );
   }
 
@@ -329,7 +332,6 @@ class _LocalNetworkSettingsViewState
   }
 
   void _finishSaveSettings(LocalNetworkSettingsState state) {
-    ref.read(localNetworkSettingNeedToSaveProvider.notifier).state = false;
     setState(() {
       originalSettings = state;
     });
@@ -351,6 +353,6 @@ class _LocalNetworkSettingsViewState
   }
 
   void _doRedirect(String ip) {
-    ref.read(redirectionProvider.notifier).state = 'https://$ip';
+    ref.read(redirectionProvider.notifier).state = '$_https$ip';
   }
 }

--- a/lib/route/route_advanced_settings.dart
+++ b/lib/route/route_advanced_settings.dart
@@ -38,16 +38,6 @@ final advancedSettings = [
           args: state.extra as Map<String, dynamic>? ?? {},
         ),
       ),
-      LinksysRoute(
-        name: RouteNamed.dhcpServer,
-        path: RoutePath.dhcpServer,
-        config: LinksysRouteConfig(
-          column: ColumnGrid(column: 9),
-        ),
-        builder: (context, state) => DHCPServerView(
-          args: state.extra as Map<String, dynamic>? ?? {},
-        ),
-      ),
     ],
   ),
   LinksysRoute(


### PR DESCRIPTION
[Root cause]
The wrong logic causes the state not to update properly.

[Solution]
Remove the preserved state in dhcp server view. Use the function in local network settings view to make sure the logic is consistent.