### PR TITLE
[NOW-477] Fixed the crashed screen on PNP setup pages

### DIFF
--- a/lib/validator_rules/rules.dart
+++ b/lib/validator_rules/rules.dart
@@ -69,7 +69,7 @@ class WiFiSsidRule extends RegExValidationRule {
   String get name => 'WiFiSsidRule';
 
   @override
-  RegExp get _rule => RegExp(r"^(?! ).{1,32}(?<! )$");
+  RegExp get _rule => RegExp(r"^(?!\s).{1,31}\S$");
 }
 
 class IpAddressRule extends RegExValidationRule {


### PR DESCRIPTION
Root cause: The Lookbehind assertion in JS RegExp is not supported by Safari, below the iOS version 16.4
https://caniuse.com/js-regexp-lookbehind

As a result, the RegExp used for the SSID check is revised.
