### PR TITLE
Modifies logic of get master node and slave nodes

### DIFF
--- a/lib/core/jnap/providers/device_manager_state.dart
+++ b/lib/core/jnap/providers/device_manager_state.dart
@@ -200,11 +200,12 @@ class DeviceManagerState extends Equatable {
   }
 
   LinksysDevice get masterDevice {
-    return nodeDevices.firstWhere((device) => device.isAuthority == true);
+    return nodeDevices.firstWhere(
+        (device) => device.isAuthority == true || device.nodeType == 'Master');
   }
 
   List<LinksysDevice> get slaveDevices {
-    return nodeDevices.where((device) => device.isAuthority == false).toList();
+    return nodeDevices.where((device) => device.isAuthority == false && device.nodeType == 'Slave').toList();
   }
 
   const DeviceManagerState({


### PR DESCRIPTION
Modifies logic of get master node and slave nodes
Master node = device.isAuthority == true || device.nodeType == 'Master'
Slave nodes = device.isAuthority == false && device.nodeType == 'Slave'