### PR TITLE
NOW-509: display CPU/Memory up 2 decimal spaces (ie. 12.34%)

### DIFF
--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -133,8 +133,6 @@ ${_getWebLogByTag(tag: routeLogTag)}
 ${keys.map((e) => '[$e]\n${_getWebLogByTag(tag: e)}').join('\n\n')}
 ============================== State Management ==============================
 ${_stateLogCache.entries.map((e) => '[${e.key}]\n${e.value}').join('\n\n')}
-=============================== Linksys Manager ================================
-${await _getLinksysCacheData()}\n
 ================================== Full Logs ===================================
 ${_getWebLogByTag()}\n
 ''';

--- a/lib/page/instant_verify/views/instant_verify_view.dart
+++ b/lib/page/instant_verify/views/instant_verify_view.dart
@@ -303,7 +303,7 @@ class _InstantVerifyViewState extends ConsumerState<InstantVerifyView> {
                   children: [
                     AppText.bodySmall(loc(context).cpuUtilization),
                     AppText.labelMedium(
-                        '${(double.tryParse(cpuLoad.padLeft(2, '0')) ?? 0) * 100}%'),
+                        '${((double.tryParse(cpuLoad.padLeft(2, '0')) ?? 0) * 100).toStringAsFixed(2)}%'),
                   ],
                 ),
               ),
@@ -314,7 +314,7 @@ class _InstantVerifyViewState extends ConsumerState<InstantVerifyView> {
                   children: [
                     AppText.bodySmall(loc(context).memoryUtilization),
                     AppText.labelMedium(
-                        '${(double.tryParse(memoryLoad.padRight(2, '0')) ?? 0) * 100}%'),
+                        '${((double.tryParse(memoryLoad.padRight(2, '0')) ?? 0) * 100).toStringAsFixed(2)}%'),
                   ],
                 ),
               ),
@@ -816,10 +816,10 @@ class _InstantVerifyViewState extends ConsumerState<InstantVerifyView> {
           '${loc(context).firmwareVersion}: ${master.unit.firmwareVersion ?? '--'}'),
       if (cpuLoad != null)
         pw.Text(
-            'CPU Utilization: ${(double.tryParse(cpuLoad.padLeft(2, '0')) ?? 0) * 100}%'),
+            'CPU Utilization: ${((double.tryParse(cpuLoad.padLeft(2, '0')) ?? 0) * 100).toStringAsFixed(2)}%'),
       if (memoryLoad != null)
         pw.Text(
-            'Memory Utilization: ${(double.tryParse(memoryLoad.padLeft(2, '0')) ?? 0) * 100}%'),
+            'Memory Utilization: ${((double.tryParse(memoryLoad.padLeft(2, '0')) ?? 0) * 100).toStringAsFixed(2)}%'),
       pw.Divider(height: Spacing.medium),
       //
       pw.Text(loc(context).connectivity),


### PR DESCRIPTION
- Add toStringAsFixed(2) to fixed 2 decimal spaces
- Remove cache log when export logs