### PR TITLE
NOW-507: Region string [United States] replace to wrong [Australia / New Zealand]

### DIFF
--- a/lib/page/instant_admin/providers/power_table_provider.dart
+++ b/lib/page/instant_admin/providers/power_table_provider.dart
@@ -62,8 +62,8 @@ enum PowerTableCountries {
         PowerTableCountries.tur => loc(context).middleEastTurkey,
         PowerTableCountries.are => loc(context).middleEastUnitedArabEmirates,
         PowerTableCountries.xme => loc(context).middleEast,
-        PowerTableCountries.nzl => loc(context).newZealand,
-        PowerTableCountries.usa => '${loc(context).australia}/${loc(context).newZealand}',
+        PowerTableCountries.nzl => '${loc(context).australia}/${loc(context).newZealand}',
+        PowerTableCountries.usa => loc(context).unitedState,
       };
 
   int compareTo(PowerTableCountries other) => index - other.index;


### PR DESCRIPTION

- Correct right strings