### PR TITLE
NOW-512: Add supports MTU validation check

### DIFF
--- a/lib/page/advanced_settings/internet_settings/providers/internet_settings_provider.dart
+++ b/lib/page/advanced_settings/internet_settings/providers/internet_settings_provider.dart
@@ -22,6 +22,7 @@ import 'package:privacy_gui/core/utils/devices.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/page/advanced_settings/internet_settings/providers/internet_settings_state.dart';
 import 'package:privacy_gui/providers/redirection/redirection_provider.dart';
+import 'package:privacy_gui/utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 final internetSettingsProvider =
@@ -341,7 +342,7 @@ class InternetSettingsNotifier extends Notifier<InternetSettingsState> {
 
   RouterWANSettings _createIpv4WanSettings(
       Ipv4Setting ipv4Setting, WanType wanType) {
-    final mtu = ipv4Setting.mtu;
+    final mtu = NetworkUtils.isMtuValid(wanType.type, ipv4Setting.mtu) ? ipv4Setting.mtu : 0;
     final behavior = ipv4Setting.behavior ?? PPPConnectionBehavior.keepAlive;
     final vlanId = ipv4Setting.vlanId;
     bool wanTaggingSettingsEnabled = false;

--- a/lib/page/advanced_settings/internet_settings/views/internet_settings_view.dart
+++ b/lib/page/advanced_settings/internet_settings/views/internet_settings_view.dart
@@ -1653,14 +1653,7 @@ class _InternetSettingsViewState extends ConsumerState<InternetSettingsView> {
   }
 
   int _getMaxMtu(String wanType) {
-    return switch (WanType.resolve(wanType)) {
-      WanType.dhcp => 1500,
-      WanType.pppoe => 1492,
-      WanType.static => 1500,
-      WanType.pptp => 1460,
-      WanType.l2tp => 1460,
-      _ => 0,
-    };
+    return NetworkUtils.getMaxMtu(wanType);
   }
 
   String _getWanConnectedTypeText(String type) {

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -7,13 +7,11 @@ import 'package:collection/collection.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 import 'package:privacy_gui/core/utils/wifi.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/util/uuid.dart';
-import 'package:privacygui_widgets/hook/icon_hooks.dart';
 import 'package:privacygui_widgets/icons/linksys_icons.dart';
 import 'package:privacygui_widgets/theme/_theme.dart';
 import 'package:share_plus/share_plus.dart';
@@ -543,6 +541,32 @@ extension NetworkUtils on Utils {
     }
 
     return maxUserLimit - startingIPAddress - 1;
+  }
+
+  static bool isMtuValid(String wanType, int mtu) {
+    return mtu == 0 || (getMinMtu(wanType) <= mtu && mtu <= getMaxMtu(wanType));
+  }
+
+  static int getMinMtu(String wanType) {
+    return switch (wanType.toLowerCase()) {
+      'dhcp' => 576,
+      'pppoe' => 576,
+      'static' => 576,
+      'pptp' => 576,
+      'l2tp' => 576,
+      _ => 0,
+    };
+  }
+
+  static int getMaxMtu(String wanType) {
+    return switch (wanType.toLowerCase()) {
+      'dhcp' => 1500,
+      'pppoe' => 1492,
+      'static' => 1500,
+      'pptp' => 1460,
+      'l2tp' => 1460,
+      _ => 0,
+    };
   }
 }
 

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -863,5 +863,106 @@ void main() {
 
     //   expect(() => NetworkUtils.getIpPrefix(ipAddress, subnetMask), throwsArgumentError);
     // });
+
+    // Tests for getMinMtu
+    test('getMinMtu: returns correct minimum MTU for known WAN types', () {
+      expect(NetworkUtils.getMinMtu('dhcp'), 576);
+      expect(NetworkUtils.getMinMtu('DHCP'), 576); // Test case-insensitivity
+      expect(NetworkUtils.getMinMtu('pppoe'), 576);
+      expect(NetworkUtils.getMinMtu('static'), 576);
+      expect(NetworkUtils.getMinMtu('pptp'), 576);
+      expect(NetworkUtils.getMinMtu('l2tp'), 576);
+    });
+
+    test('getMinMtu: returns 0 for unknown WAN type', () {
+      expect(NetworkUtils.getMinMtu('unknown'), 0);
+      expect(NetworkUtils.getMinMtu(''), 0);
+    });
+
+    // Tests for getMaxMtu
+    test('getMaxMtu: returns correct maximum MTU for known WAN types', () {
+      expect(NetworkUtils.getMaxMtu('dhcp'), 1500);
+      expect(NetworkUtils.getMaxMtu('DHCP'), 1500); // Test case-insensitivity
+      expect(NetworkUtils.getMaxMtu('pppoe'), 1492);
+      expect(NetworkUtils.getMaxMtu('static'), 1500);
+      expect(NetworkUtils.getMaxMtu('pptp'), 1460);
+      expect(NetworkUtils.getMaxMtu('l2tp'), 1460);
+    });
+
+    test('getMaxMtu: returns 0 for unknown WAN type', () {
+      expect(NetworkUtils.getMaxMtu('unknown'), 0);
+      expect(NetworkUtils.getMaxMtu(''), 0);
+    });
+
+    // Tests for isMtuValid
+    test('isMtuValid: returns true for MTU 0 regardless of WAN type', () {
+      expect(NetworkUtils.isMtuValid('dhcp', 0), true);
+      expect(NetworkUtils.isMtuValid('pppoe', 0), true);
+      expect(NetworkUtils.isMtuValid('static', 0), true);
+      expect(NetworkUtils.isMtuValid('pptp', 0), true);
+      expect(NetworkUtils.isMtuValid('l2tp', 0), true);
+      expect(NetworkUtils.isMtuValid('unknown', 0), true); // Also true for unknown
+    });
+
+    test('isMtuValid: returns true for valid MTU within range for DHCP', () {
+      expect(NetworkUtils.isMtuValid('dhcp', 576), true); // Min
+      expect(NetworkUtils.isMtuValid('dhcp', 1000), true); // Mid
+      expect(NetworkUtils.isMtuValid('dhcp', 1500), true); // Max
+    });
+
+    test('isMtuValid: returns false for invalid MTU outside range for DHCP', () {
+      expect(NetworkUtils.isMtuValid('dhcp', 575), false); // Below min
+      expect(NetworkUtils.isMtuValid('dhcp', 1501), false); // Above max
+    });
+
+    test('isMtuValid: returns true for valid MTU within range for PPPoE', () {
+      expect(NetworkUtils.isMtuValid('pppoe', 576), true); // Min
+      expect(NetworkUtils.isMtuValid('pppoe', 1000), true); // Mid
+      expect(NetworkUtils.isMtuValid('pppoe', 1492), true); // Max
+    });
+
+    test('isMtuValid: returns false for invalid MTU outside range for PPPoE', () {
+      expect(NetworkUtils.isMtuValid('pppoe', 575), false); // Below min
+      expect(NetworkUtils.isMtuValid('pppoe', 1500), false); // Above max
+    });
+
+    test('isMtuValid: returns true for valid MTU within range for Static', () {
+      expect(NetworkUtils.isMtuValid('static', 576), true); // Min
+      expect(NetworkUtils.isMtuValid('static', 1000), true); // Mid
+      expect(NetworkUtils.isMtuValid('static', 1500), true); // Max
+    });
+
+    test('isMtuValid: returns false for invalid MTU outside range for Static', () {
+      expect(NetworkUtils.isMtuValid('static', 575), false); // Below min
+      expect(NetworkUtils.isMtuValid('static', 1501), false); // Above max
+    });
+
+     test('isMtuValid: returns true for valid MTU within range for PPTP', () {
+      expect(NetworkUtils.isMtuValid('pptp', 576), true); // Min
+      expect(NetworkUtils.isMtuValid('pptp', 1000), true); // Mid
+      expect(NetworkUtils.isMtuValid('pptp', 1460), true); // Max
+    });
+
+    test('isMtuValid: returns false for invalid MTU outside range for PPTP', () {
+      expect(NetworkUtils.isMtuValid('pptp', 575), false); // Below min
+      expect(NetworkUtils.isMtuValid('pptp', 1461), false); // Above max
+    });
+
+     test('isMtuValid: returns true for valid MTU within range for L2TP', () {
+      expect(NetworkUtils.isMtuValid('l2tp', 576), true); // Min
+      expect(NetworkUtils.isMtuValid('l2tp', 1000), true); // Mid
+      expect(NetworkUtils.isMtuValid('l2tp', 1460), true); // Max
+    });
+
+    test('isMtuValid: returns false for invalid MTU outside range for L2TP', () {
+      expect(NetworkUtils.isMtuValid('l2tp', 575), false); // Below min
+      expect(NetworkUtils.isMtuValid('l2tp', 1461), false); // Above max
+    });
+
+    test('isMtuValid: returns false for any non-zero MTU for unknown WAN type', () {
+      expect(NetworkUtils.isMtuValid('unknown', 1), false);
+      expect(NetworkUtils.isMtuValid('unknown', 1000), false);
+      expect(NetworkUtils.isMtuValid('', 576), false); // Empty string as unknown
+    });
   });
 }


### PR DESCRIPTION
- Add getMinMtu, getMaxMtu and isMtuValid functions on NetworkUtils
- Add test cases for testing  getMinMtu, getMaxMtu and isMtuValid functions
- Check mtu validation on _createIpv4WanSettings function