### PR TITLE
Minor UI fixes

### DIFF
--- a/lib/page/components/styled/styled_tab_page_view.dart
+++ b/lib/page/components/styled/styled_tab_page_view.dart
@@ -148,15 +148,21 @@ class StyledAppTabPageView extends ConsumerWidget {
                       mainAxisSize: MainAxisSize.min,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        AppText.titleLarge(
-                          title,
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
+                        Expanded(
+                          child: Wrap(
+                            children: [
+                              AppText.titleLarge(
+                                title,
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                              if (markLabel != null) ...[
+                                const AppGap.small2(),
+                                StatusLabel(label: markLabel!),
+                              ],
+                            ],
+                          ),
                         ),
-                        if (markLabel != null) ...[
-                          const AppGap.small2(),
-                          StatusLabel(label: markLabel!),
-                        ],
                       ],
                     ),
                   ),

--- a/lib/page/dashboard/views/components/networks.dart
+++ b/lib/page/dashboard/views/components/networks.dart
@@ -260,8 +260,9 @@ class _DashboardNetworksState extends ConsumerState<DashboardNetworks> {
       onTap: newFirmware
           ? () => context.pushNamed(RouteNamed.firmwareUpdateDetail)
           : null,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      child: Wrap(
+        alignment: WrapAlignment.spaceBetween,
+        crossAxisAlignment: WrapCrossAlignment.center,
         children: [
           newFirmware
               ? AppText.labelMedium(
@@ -345,25 +346,25 @@ class _DashboardNetworksState extends ConsumerState<DashboardNetworks> {
       constraints: const BoxConstraints(minWidth: 112),
       child: AppCard(
         onTap: onTap,
-        child: Wrap(
-          alignment: WrapAlignment.spaceBetween,
-          crossAxisAlignment: WrapCrossAlignment.start,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Column(
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 AppText.titleSmall('$count'),
-                const AppGap.medium(),
-                AppText.titleSmall(text),
+                Icon(
+                  iconData,
+                  semanticLabel: 'info icon',
+                  size: 20,
+                  color: iconColor,
+                ),
+                if (sub != null) sub,
               ],
             ),
-            Icon(
-              iconData,
-              semanticLabel: 'info icon',
-              size: 20,
-              color: iconColor,
-            ),
-            if (sub != null) sub,
+            const AppGap.medium(),
+            AppText.titleSmall(text),
           ],
         ),
       ),

--- a/lib/page/dashboard/views/components/port_and_speed.dart
+++ b/lib/page/dashboard/views/components/port_and_speed.dart
@@ -218,7 +218,7 @@ class DashboardHomePortAndSpeed extends ConsumerWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               SizedBox(
-                height: 124,
+                height: 120,
                 child: Padding(
                   padding: const EdgeInsets.symmetric(
                     horizontal: Spacing.small2,
@@ -253,7 +253,7 @@ class DashboardHomePortAndSpeed extends ConsumerWidget {
                 ),
               ),
               SizedBox(
-                  height: 132,
+                  height: 136,
                   child: _createSpeedTestTile(context, ref, state)),
             ],
           )),
@@ -293,7 +293,7 @@ class DashboardHomePortAndSpeed extends ConsumerWidget {
             desktop: !hasLanPort
                 ? Padding(
                     padding:
-                        const EdgeInsets.symmetric(vertical: Spacing.large1),
+                        const EdgeInsets.symmetric(vertical: Spacing.small3),
                     child: Column(
                       children: [
                         if (dateTimeStr.isNotEmpty) ...[
@@ -396,7 +396,7 @@ class DashboardHomePortAndSpeed extends ConsumerWidget {
                                   state.uploadResult?.value ?? '--',
                                   state.uploadResult?.unit,
                                   isLegacy),
-                              const AppGap.large2(),
+                              const AppGap.medium(),
                               _speedTestButton(context, state),
                             ]),
                       ),
@@ -463,7 +463,7 @@ class DashboardHomePortAndSpeed extends ConsumerWidget {
                 ),
       ),
       padding: const EdgeInsets.symmetric(
-          horizontal: Spacing.large1, vertical: Spacing.medium),
+          horizontal: Spacing.large1, vertical: Spacing.small2),
       child: Column(
         children: [
           Row(
@@ -536,13 +536,16 @@ class DashboardHomePortAndSpeed extends ConsumerWidget {
   }
 
   Widget _speedTestButton(BuildContext context, DashboardHomeState state) {
-    return AppFilledButton(
-      fitText: true,
-      loc(context).speedTextTileStart,
-      radius: BorderRadius.circular(40),
-      onTap: () {
-        context.pushNamed(RouteNamed.dashboardSpeedTest);
-      },
+    return SizedBox(
+      height: 40,
+      child: AppFilledButton(
+        fitText: true,
+        loc(context).speedTextTileStart,
+        radius: BorderRadius.circular(40),
+        onTap: () {
+          context.pushNamed(RouteNamed.dashboardSpeedTest);
+        },
+      ),
     );
   }
 

--- a/lib/page/dashboard/views/components/wifi_grid.dart
+++ b/lib/page/dashboard/views/components/wifi_grid.dart
@@ -200,28 +200,38 @@ class _WiFiCardState extends ConsumerState<WiFiCard> {
               ],
             ),
             const AppGap.small2(),
-            AppText.titleMedium(
-              widget.item.ssid,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
+            FittedBox(
+              child: AppText.titleMedium(
+                widget.item.ssid,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
             const AppGap.small2(),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            Stack(
+              alignment: Alignment.center,
+              // mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Row(
-                  children: [
-                    const Icon(
-                      LinksysIcons.devices,
-                      semanticLabel: 'devices',
-                    ),
-                    const AppGap.medium(),
-                    AppText.labelLarge(
-                      loc(context).nDevices(widget.item.numOfConnectedDevices),
-                    ),
-                  ],
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Row(
+                    children: [
+                      const Icon(
+                        LinksysIcons.devices,
+                        semanticLabel: 'devices',
+                      ),
+                      const AppGap.small2(),
+                      AppText.labelLarge(
+                        loc(context)
+                            .nDevices(widget.item.numOfConnectedDevices),
+                        maxLines: 2,
+                      ),
+                    ],
+                  ),
                 ),
-                _buildTooltip(context),
+                Align(
+                    alignment: Alignment.centerRight,
+                    child: _buildTooltip(context)),
               ],
             )
           ],

--- a/lib/page/instant_device/views/device_detail_view.dart
+++ b/lib/page/instant_device/views/device_detail_view.dart
@@ -348,64 +348,67 @@ class _DeviceDetailViewState extends ConsumerState<DeviceDetailView> {
     void Function(void Function()) setState,
     void Function() onSubmit,
   ) {
-    return SizedBox(
-      width: 400,
-      child: Semantics(
-        explicitChildNodes: true,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const AppGap.large2(),
-            AppTextField.outline(
-              controller: _deviceNameController,
-              headerText: loc(context).deviceName,
-              errorText: _errorMessage,
-              onChanged: (text) {
-                setState(() {
-                  final overMaxSize = utf8.encoder.convert(text).length >= 256;
-                  _errorMessage = text.isEmpty
-                      ? loc(context).theNameMustNotBeEmpty
-                      : overMaxSize
-                          ? loc(context).deviceNameExceedMaxSize
-                          : null;
-                });
-              },
-              onSubmitted: (_) {
-                if (_errorMessage != null) {
-                  onSubmit();
-                }
-              },
-            ),
-            const AppGap.large3(),
-            AppText.labelLarge(loc(context).selectIcon.capitalizeWords()),
-            const AppGap.large3(),
-            GridView.builder(
-              shrinkWrap: true,
-              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 6,
+    return SingleChildScrollView(
+      child: SizedBox(
+        width: 400,
+        child: Semantics(
+          explicitChildNodes: true,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const AppGap.large2(),
+              AppTextField.outline(
+                controller: _deviceNameController,
+                headerText: loc(context).deviceName,
+                errorText: _errorMessage,
+                onChanged: (text) {
+                  setState(() {
+                    final overMaxSize =
+                        utf8.encoder.convert(text).length >= 256;
+                    _errorMessage = text.isEmpty
+                        ? loc(context).theNameMustNotBeEmpty
+                        : overMaxSize
+                            ? loc(context).deviceNameExceedMaxSize
+                            : null;
+                  });
+                },
+                onSubmitted: (_) {
+                  if (_errorMessage != null) {
+                    onSubmit();
+                  }
+                },
               ),
-              itemCount: IconDeviceCategory.values.length,
-              itemBuilder: ((context, index) {
-                return InkWell(
-                  onTap: () {
-                    setState(() {
-                      _iconIndex = index;
-                    });
-                  },
-                  child: Icon(
-                    IconDeviceCategoryExt.resolveByName(
-                      IconDeviceCategory.values[index].name,
+              const AppGap.large3(),
+              AppText.labelLarge(loc(context).selectIcon.capitalizeWords()),
+              const AppGap.large3(),
+              GridView.builder(
+                shrinkWrap: true,
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 6,
+                ),
+                itemCount: IconDeviceCategory.values.length,
+                itemBuilder: ((context, index) {
+                  return InkWell(
+                    onTap: () {
+                      setState(() {
+                        _iconIndex = index;
+                      });
+                    },
+                    child: Icon(
+                      IconDeviceCategoryExt.resolveByName(
+                        IconDeviceCategory.values[index].name,
+                      ),
+                      semanticLabel: IconDeviceCategory.values[index].name,
+                      color: index == _iconIndex
+                          ? Theme.of(context).colorScheme.primary
+                          : null,
                     ),
-                    semanticLabel: IconDeviceCategory.values[index].name,
-                    color: index == _iconIndex
-                        ? Theme.of(context).colorScheme.primary
-                        : null,
-                  ),
-                );
-              }),
-            ),
-          ],
+                  );
+                }),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/page/instant_setup/troubleshooter/views/pnp_unplug_modem_view.dart
+++ b/lib/page/instant_setup/troubleshooter/views/pnp_unplug_modem_view.dart
@@ -64,6 +64,7 @@ class _PnpUnplugModemViewState extends ConsumerState<PnpUnplugModemView> {
                 onTap: () {
                   showSimpleAppOkDialog(
                     context,
+                    scrollable: true,
                     content: _bottomSheetContent(),
                   );
                 },

--- a/run_generate_loc_snapshots.sh
+++ b/run_generate_loc_snapshots.sh
@@ -1,4 +1,4 @@
-while getopts l:s:f:c:o: flag
+while getopts l:s:f:c:v: flag
 do
     case "${flag}" in
         l) locales=${OPTARG};;

--- a/test/page/dashboard/localizations/dashboard_home_view_test.dart
+++ b/test/page/dashboard/localizations/dashboard_home_view_test.dart
@@ -160,6 +160,42 @@ void main() async {
       ...responsiveDesktopScreens.map((e) => e.copyWith(height: 1280)).toList()
     ]);
 
+    testLocalizations('Dashboard Home View - no LAN ports - child node offline',
+        (tester, locale) async {
+      when(mockInstantTopologyNotifier.build())
+          .thenReturn(topologyTestData.testTopology3OfflineState);
+      await tester.pumpWidget(
+        testableRouteShellWidget(
+          child: const DashboardHomeView(),
+          locale: locale,
+          overrides: [
+            dashboardHomeProvider.overrideWith(() => mockDashboardHomeNotifier),
+            dashboardManagerProvider
+                .overrideWith(() => mockDashboardManagerNotifier),
+            firmwareUpdateProvider
+                .overrideWith(() => mockFirmwareUpdateNotifier),
+            deviceManagerProvider.overrideWith(() => mockDeviceManagerNotifier),
+            internetStatusProvider.overrideWith((ref) => InternetStatus.online),
+            instantPrivacyProvider
+                .overrideWith(() => mockInstantPrivacyNotifier),
+            instantTopologyProvider
+                .overrideWith(() => mockInstantTopologyNotifier),
+            geolocationProvider.overrideWith(() => mockGeolocationNotifer),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.runAsync(() async {
+        final context = tester.element(find.byType(DashboardHomeView));
+        await precacheImage(
+            CustomTheme.of(context).images.devices.routerLn12, context);
+        await tester.pumpAndSettle();
+      });
+    }, screens: [
+      ...responsiveMobileScreens.map((e) => e.copyWith(height: 2480)).toList(),
+      ...responsiveDesktopScreens.map((e) => e.copyWith(height: 1280)).toList()
+    ]);
+
     testLocalizations('Dashboard Home View - no LAN ports with speed check',
         (tester, locale) async {
       when(mockDashboardHomeNotifier.build()).thenReturn(


### PR DESCRIPTION
- Adjust info tile on the dashboard network card
- Adjust wifi card on the dashboard
- Adjust speed test tile on the dashboard
- Adjust title layout on styled tab page
- Add offline node in node info tile screenshot test case
- Fixes overflowed on pnp unplug modem dialog
- Fixes overflowed on edit device name dialog
- Fixes version didn't pass into screenshot testing properly.