### PR TITLE
[NOW-531][Internet Settings] IPv6 set to passthrough, Release & Renew option should be disabled.

### DIFF
--- a/lib/page/advanced_settings/internet_settings/providers/internet_settings_provider.dart
+++ b/lib/page/advanced_settings/internet_settings/providers/internet_settings_provider.dart
@@ -628,7 +628,7 @@ class InternetSettingsNotifier extends Notifier<InternetSettingsState> {
     final wanIpv6Type = WanIPv6Type.resolve(ipv6Setting.ipv6ConnectionType);
     newIpv6Setting = switch (wanIpv6Type) {
       WanIPv6Type.automatic => newIpv6Setting.copyWith(
-          ipv6rdTunnelMode: () => ipv6Setting.ipv6rdTunnelMode,
+          ipv6rdTunnelMode: () => ipv6Setting.ipv6rdTunnelMode ?? IPv6rdTunnelMode.disabled,
           ipv6Prefix: () => ipv6Setting.ipv6Prefix,
           ipv6PrefixLength: () => ipv6Setting.ipv6PrefixLength,
           ipv6BorderRelay: () => ipv6Setting.ipv6BorderRelay,

--- a/lib/page/advanced_settings/internet_settings/views/internet_settings_view.dart
+++ b/lib/page/advanced_settings/internet_settings/views/internet_settings_view.dart
@@ -298,7 +298,7 @@ class _InternetSettingsViewState extends ConsumerState<InternetSettingsView> {
     final tabContents = [
       _connectionTypeView(InternetSettingsViewType.ipv4, state),
       _connectionTypeView(InternetSettingsViewType.ipv6, state),
-      _releaseAndRenewView(),
+      _releaseAndRenewView(state),
     ];
     return StyledAppPageView(
       appBarStyle: AppBarStyle.none,
@@ -366,9 +366,11 @@ class _InternetSettingsViewState extends ConsumerState<InternetSettingsView> {
     );
   }
 
-  Widget _releaseAndRenewView() {
+  Widget _releaseAndRenewView(InternetSettingsState state) {
     final wanStatus =
         ref.watch(deviceManagerProvider.select((state) => state.wanStatus));
+    final wanIpv6Type =
+        WanIPv6Type.resolve(state.ipv6Setting.ipv6ConnectionType);
     return SingleChildScrollView(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -401,7 +403,7 @@ class _InternetSettingsViewState extends ConsumerState<InternetSettingsView> {
                   wanStatus?.wanIPv6Connection?.networkInfo?.ipAddress ?? '-'),
               trailing: AppTextButton.noPadding(
                 loc(context).releaseAndRenew,
-                onTap: isBridgeMode
+                onTap: isBridgeMode || wanIpv6Type == WanIPv6Type.passThrough
                     ? null
                     : () {
                         _showRenewIPAlert(InternetSettingsViewType.ipv6);
@@ -1484,6 +1486,7 @@ class _InternetSettingsViewState extends ConsumerState<InternetSettingsView> {
                         duid: state.ipv6Setting.duid,
                         isIPv6AutomaticEnabled:
                             state.ipv6Setting.isIPv6AutomaticEnabled,
+                        ipv6rdTunnelMode: state.ipv6Setting.ipv6rdTunnelMode,
                       ));
             setState(() {
               initUI(ref.read(internetSettingsProvider));


### PR DESCRIPTION
Disable Release & Renew button when IPv6 set to passthrough. Fix a settings issue on setting ipv6 back to automatic.