### PR TITLE
[NOW-532]: CLONE - [GUI][UX][LAN] Since the maximum length of LAN Host Name is 15, suggest reminding user about this limitation, such as (1) add description/notification in GUI, (2) if len=16, disable the Save button in gray.

### DIFF
--- a/lib/page/advanced_settings/local_network_settings/providers/local_network_settings_provider.dart
+++ b/lib/page/advanced_settings/local_network_settings/providers/local_network_settings_provider.dart
@@ -10,6 +10,7 @@ import 'package:privacy_gui/page/advanced_settings/local_network_settings/provid
 import 'package:privacy_gui/page/instant_safety/providers/instant_safety_provider.dart';
 import 'package:privacy_gui/utils.dart';
 import 'package:privacy_gui/validator_rules/input_validators.dart';
+import 'package:privacy_gui/validator_rules/rules.dart';
 
 final localNetworkSettingProvider =
     NotifierProvider<LocalNetworkSettingsNotifier, LocalNetworkSettingsState>(
@@ -123,6 +124,18 @@ class LocalNetworkSettingsNotifier extends Notifier<LocalNetworkSettingsState> {
 
   void updateHostName(String hostName) {
     state = state.copyWith(hostName: hostName);
+    String? error;
+    if (hostName.isEmpty) {
+      error = LocalNetworkErrorPrompt.hostName.name;
+    } else if (!LengthRule(min:1, max: 15).validate(hostName)) {
+      error = LocalNetworkErrorPrompt.hostNameInvalid.name;
+    } else if (HostNameRule().validate(hostName)) {
+      error = LocalNetworkErrorPrompt.hostNameInvalid.name;
+    }
+    updateErrorPrompts(
+      LocalNetworkErrorPrompt.hostName.name,
+      error,
+    );
   }
 
   void updateErrorPrompts(String key, String? value) {
@@ -264,7 +277,9 @@ class LocalNetworkSettingsNotifier extends Notifier<LocalNetworkSettingsState> {
     );
     updateErrorPrompts(
       LocalNetworkErrorPrompt.maxUserAllowed.name,
-      maxUserAllowedResult.$1 ? null : LocalNetworkErrorPrompt.maxUserAllowed.name,
+      maxUserAllowedResult.$1
+          ? null
+          : LocalNetworkErrorPrompt.maxUserAllowed.name,
     );
   }
 
@@ -296,7 +311,9 @@ class LocalNetworkSettingsNotifier extends Notifier<LocalNetworkSettingsState> {
       );
       updateErrorPrompts(
         LocalNetworkErrorPrompt.maxUserAllowed.name,
-        maxUserAllowedResult.$1 ? null : LocalNetworkErrorPrompt.maxUserAllowed.name,
+        maxUserAllowedResult.$1
+            ? null
+            : LocalNetworkErrorPrompt.maxUserAllowed.name,
       );
     }
     // Update error
@@ -329,7 +346,9 @@ class LocalNetworkSettingsNotifier extends Notifier<LocalNetworkSettingsState> {
     );
     updateErrorPrompts(
       LocalNetworkErrorPrompt.maxUserAllowed.name,
-      maxUserAllowedResult.$1 ? null : LocalNetworkErrorPrompt.maxUserAllowed.name,
+      maxUserAllowedResult.$1
+          ? null
+          : LocalNetworkErrorPrompt.maxUserAllowed.name,
     );
   }
 
@@ -345,7 +364,9 @@ class LocalNetworkSettingsNotifier extends Notifier<LocalNetworkSettingsState> {
     // Update error
     updateErrorPrompts(
       LocalNetworkErrorPrompt.maxUserAllowed.name,
-      maxUserAllowedResult.$1 ? null : LocalNetworkErrorPrompt.maxUserAllowed.name,
+      maxUserAllowedResult.$1
+          ? null
+          : LocalNetworkErrorPrompt.maxUserAllowed.name,
     );
   }
 

--- a/lib/page/advanced_settings/local_network_settings/providers/local_network_settings_state.dart
+++ b/lib/page/advanced_settings/local_network_settings/providers/local_network_settings_state.dart
@@ -11,6 +11,7 @@ import 'package:privacy_gui/utils.dart';
 
 enum LocalNetworkErrorPrompt {
   hostName,
+  hostNameInvalid,
   startIpAddress,
   startIpAddressRange,
   ipAddress,
@@ -46,6 +47,7 @@ enum LocalNetworkErrorPrompt {
       LocalNetworkErrorPrompt.dns3 => loc(context).invalidIpAddress,
       LocalNetworkErrorPrompt.wins => loc(context).invalidIpAddress,
       LocalNetworkErrorPrompt.hostName => loc(context).hostNameCannotEmpty,
+      LocalNetworkErrorPrompt.hostNameInvalid => loc(context).invalidHostname,
       _ => null,
     };
   }

--- a/lib/page/advanced_settings/local_network_settings/views/local_network_settings_view.dart
+++ b/lib/page/advanced_settings/local_network_settings/views/local_network_settings_view.dart
@@ -169,10 +169,6 @@ class _LocalNetworkSettingsViewState
           focusNode: FocusNode()..requestFocus(),
           onChanged: (value) {
             _notifier.updateHostName(value);
-            _notifier.updateErrorPrompts(
-              LocalNetworkErrorPrompt.hostName.name,
-              value.isEmpty ? LocalNetworkErrorPrompt.hostName.name : null,
-            );
           },
         ),
       ),


### PR DESCRIPTION
Use host name rule to show the error prompt.