### PR TITLE
NOW-553: WiFi channel didn't change once DFS settings is enabled in WiFi advanced settings

### DIFF
--- a/lib/page/wifi_settings/views/wifi_advanced_settings_view.dart
+++ b/lib/page/wifi_settings/views/wifi_advanced_settings_view.dart
@@ -83,7 +83,11 @@ class _WifiAdvancedSettingsViewState
   Future save() {
     return doSomethingWithSpinner(
       context,
-      ref.read(wifiAdvancedProvider.notifier).save().then(
+      ref.read(wifiAdvancedProvider.notifier).save().then((state) async{
+        // Fetch wifi list to update the wifi list state
+        await ref.read(wifiListProvider.notifier).fetch(true);
+        return state;
+      }).then(
         (state) {
           success(state);
         },


### PR DESCRIPTION

- Fetch wifi settings after save wifi advanced settings