### PR TITLE
[NOW-525][NOW-522]

### DIFF
--- a/lib/page/advanced_settings/advanced_settings_view.dart
+++ b/lib/page/advanced_settings/advanced_settings_view.dart
@@ -30,9 +30,7 @@ class _AdvancedSettingsViewState extends ConsumerState<AdvancedSettingsView> {
 
   @override
   Widget build(BuildContext context) {
-    if (advancedSettings.isEmpty) {
-      advancedSettings = _initAdvancedSettingsItems();
-    }
+    advancedSettings = _initAdvancedSettingsItems();
     return StyledAppPageView(
       title: loc(context).advancedSettings,
       child: ResponsiveLayout(


### PR DESCRIPTION
1. Added error handler for WiFi toggles on the grid of the dashboard to prevent infinite spinner issues
2. Remove the empty condition check in every build() of the advanced setting view to prevent the issue where languages cannot be switched


https://github.com/user-attachments/assets/d25f6b2c-3d58-4e41-b33f-3d010a1c59c6

