### PR TITLE
[NOW-544]: Remove time estimation on FW update page. Use infinite linear progress bar instead.

### DIFF
--- a/lib/page/advanced_settings/internet_settings/providers/internet_settings_provider.dart
+++ b/lib/page/advanced_settings/internet_settings/providers/internet_settings_provider.dart
@@ -244,7 +244,7 @@ class InternetSettingsNotifier extends Notifier<InternetSettingsState> {
       final originalWanType =
           WanType.resolve(originalState?.ipv4Setting.ipv4ConnectionType ?? '');
       final redirectionMap = originalWanType == WanType.bridge
-          ? {'hostName': 'myrouter', 'domain': 'info'}
+          ? {'hostName': 'www.myrouter', 'domain': 'info'}
           : _getRedirectionMap(results);
       _handleWebRedirection(redirectionMap);
     }).catchError(
@@ -257,7 +257,7 @@ class InternetSettingsNotifier extends Notifier<InternetSettingsState> {
           final originalWanType = WanType.resolve(
               originalState?.ipv4Setting.ipv4ConnectionType ?? '');
           final redirectionMap = originalWanType == WanType.bridge
-              ? {'hostName': 'myrouter', 'domain': 'info'}
+              ? {'hostName': 'www.myrouter', 'domain': 'info'}
               : _getRedirectionMap(result.data);
           _handleWebRedirection(redirectionMap);
         } else {

--- a/lib/page/instant_admin/views/manual_firmware_update_view.dart
+++ b/lib/page/instant_admin/views/manual_firmware_update_view.dart
@@ -172,25 +172,9 @@ class _ManualFirmwareUpdateViewState
                   child: Column(
                     children: [
                       LinearProgressIndicator(
-                          value: double.tryParse(status.value) ?? 0,
                           backgroundColor: Theme.of(context)
                               .colorSchemeExt
                               .surfaceContainerHighest),
-                      AppGap.small2(),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          AppText.bodyMedium(
-                              loc(context).manualFirmwareEstimatedTime),
-                          AppText.bodyMedium(DateFormatUtils.formatDuration(
-                              Duration(
-                                  seconds: (60 *
-                                          (1 -
-                                              (double.tryParse(status.value) ??
-                                                  1)))
-                                      .round()))),
-                        ],
-                      ),
                     ],
                   ),
                 ),


### PR DESCRIPTION
Remove time estimation on FW update page. Use infinite linear progress bar instead.