### PR TITLE
[NOW-562] Show a confirmation dialog when toggling the Wi-Fi switches on the dashboard

### DIFF
--- a/lib/page/wifi_settings/views/wifi_list_view.dart
+++ b/lib/page/wifi_settings/views/wifi_list_view.dart
@@ -1022,8 +1022,7 @@ class _WiFiListViewState extends ConsumerState<WiFiListView>
             AppGap.small2(),
             ...disabledWiFiBands
                 .map((e) => AppText.labelMedium(
-                      loc(context).disableBandWarning(
-                          getWifiRadioBandTitle(context, e.radioID)),
+                      loc(context).disableBandWarning(e.radioID.bandName),
                       color: Theme.of(context).colorScheme.error,
                     ))
                 .toList()


### PR DESCRIPTION
1. Show confirm dialog when toggling the Wi-Fi items on the dashboard home
2. Fix the incorrect layout of incredible Wi-Fi view