### PR TITLE
[NOW-568]: Dashboard: The speed test section does not update the last result after performing a speed test

### DIFF
--- a/lib/page/health_check/providers/health_check_provider.dart
+++ b/lib/page/health_check/providers/health_check_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/jnap/command/base_command.dart';
+import 'package:privacy_gui/core/jnap/providers/polling_provider.dart';
 import 'package:privacy_gui/core/jnap/result/jnap_result.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/page/health_check/providers/health_check_state.dart';
@@ -69,6 +70,7 @@ class HealthCheckProvider extends Notifier<HealthCheckState> {
                 // Set state
                 if (result is JNAPSuccess) {
                   state = state.copyWith(step: 'success');
+                  ref.read(pollingProvider.notifier).forcePolling();
                 } else if (result is JNAPError) {
                   state = state.copyWith(step: 'error');
                 }

--- a/lib/page/health_check/views/speed_test_view.dart
+++ b/lib/page/health_check/views/speed_test_view.dart
@@ -68,7 +68,7 @@ class _SpeedTestViewState extends ConsumerState<SpeedTestView> {
                       ?.speedTestResult
                       ?.downloadBandwidth ??
                   0) /
-              1000.0);
+              1024.0);
           _meterValue = downloadBandwidth;
           _randomValue = 0;
         });
@@ -554,14 +554,14 @@ class _SpeedTestViewState extends ConsumerState<SpeedTestView> {
   (String, String, String) _getDataText(SpeedTestResult? result) {
     var latency = result?.latency?.toStringAsFixed(0) ?? '—';
     var downloadBandWidth =
-        ((result?.downloadBandwidth ?? 0) / 1000.0).toStringAsFixed(1);
+        ((result?.downloadBandwidth ?? 0) / 1024.0).toStringAsFixed(1);
     var uploadBandWidth =
-        ((result?.uploadBandwidth ?? 0) / 1000.0).toStringAsFixed(1);
+        ((result?.uploadBandwidth ?? 0) / 1024.0).toStringAsFixed(1);
     return (latency, downloadBandWidth, uploadBandWidth);
   }
 
   (String, String) _getTestResultDesc(SpeedTestResult? result) {
-    var downloadBandWidth = (result?.downloadBandwidth ?? 0) / 1000.0;
+    var downloadBandWidth = (result?.downloadBandwidth ?? 0) / 1024.0;
     var resultTitle = switch (downloadBandWidth) {
       < 50 => loc(context).speedOkay,
       < 100 => loc(context).speedGood,


### PR DESCRIPTION
[Root cause]
1. The logic of transforming speed test result is wrong
2. Did not update dashboard infomation after the speed check finish

[Solution]
1. Adjust bandwidth calculations in speed test view to use correct conversion factor
2. Call polling to update dashboard after the speed check finish