### PR TITLE
NOW-585: Internet Settings: Unknown error displayed when changing the Internet connection type to bridge mode

### DIFF
--- a/lib/page/advanced_settings/internet_settings/providers/internet_settings_provider.dart
+++ b/lib/page/advanced_settings/internet_settings/providers/internet_settings_provider.dart
@@ -480,7 +480,9 @@ class InternetSettingsNotifier extends Notifier<InternetSettingsState> {
           wanType: wanType.type,
           ipv6AutomaticSettings: IPv6AutomaticSettings(
             isIPv6AutomaticEnabled: ipv6Setting.isIPv6AutomaticEnabled,
-            ipv6rdTunnelMode: ipv6Setting.ipv6rdTunnelMode?.value,
+            ipv6rdTunnelMode: ipv6Setting.isIPv6AutomaticEnabled
+                ? null
+                : ipv6Setting.ipv6rdTunnelMode?.value,
             ipv6rdTunnelSettings: hasIPv6rdTunnelSettings
                 ? IPv6rdTunnelSettings(
                     prefix: ipv6Setting.ipv6Prefix ?? '',


### PR DESCRIPTION

- Fixs merge error which didn't update the latest changes