### PR TITLE
NOW-612: Modify PnP flow to identify isAuthority=true as Master

### DIFF
--- a/lib/page/instant_setup/data/pnp_provider.dart
+++ b/lib/page/instant_setup/data/pnp_provider.dart
@@ -589,7 +589,7 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
         result.output['devices'],
       )
           .map((e) => LinksysDevice.fromMap(e))
-          .where((device) => device.nodeType != null)
+          .where((device) => device.nodeType != null || device.isAuthority)
           .toList();
       state = state.copyWith(childNodes: deviceList);
     });


### PR DESCRIPTION
## Description
Modify the logic in the PnP (Plug and Play) flow to identify devices with `isAuthority = true` as Master nodes.

## Changes
- Updated `PnpNotifier` to include devices where `isAuthority` is true in the node list, in addition to devices with a non-null `nodeType`.

## Testing
- [ ] Verified PnP flow correctly identifies Master nodes with isAuthority=true
- [ ] Tested in a multi-node setup to ensure proper Master/Slave identification

## Related JIRA
[NOW-612](https://jira.linksys.com/browse/NOW-612)