### PR TITLE
[NOW-611] Fixed the issue where the error message is not shown for overly long WiFi SSIDs

### DIFF
--- a/lib/page/instant_setup/widgets/wifi_ssid_widget.dart
+++ b/lib/page/instant_setup/widgets/wifi_ssid_widget.dart
@@ -47,12 +47,11 @@ class _WiFiSSIDFieldState extends ConsumerState<WiFiSSIDField> {
             .validateDetail(widget.controller?.text ?? '', onlyFailed: true);
         if (errorKeys.isEmpty) {
           return null;
-        } else if (errorKeys.keys.first ==
-            (NoSurroundWhitespaceRule).toString()) {
+        } else if (errorKeys.keys.first == NoSurroundWhitespaceRule().name) {
           return loc(context).routerPasswordRuleStartEndWithSpace;
-        } else if (errorKeys.keys.first == (LengthRule).toString()) {
+        } else if (errorKeys.keys.first == LengthRule().name) {
           return loc(context).wifiSSIDLengthLimit;
-        } else if (errorKeys.keys.first == (WiFiSsidRule).toString()) {
+        } else if (errorKeys.keys.first == WiFiSsidRule().name) {
           return loc(context).theNameMustNotBeEmpty;
         } else {
           return null;

--- a/lib/page/wifi_settings/views/wifi_list_view.dart
+++ b/lib/page/wifi_settings/views/wifi_list_view.dart
@@ -626,12 +626,12 @@ class _WiFiListViewState extends ConsumerState<WiFiListView>
               if (errorKeys.isEmpty) {
                 return null;
               } else if (errorKeys.keys.first ==
-                  (NoSurroundWhitespaceRule).toString()) {
+                  NoSurroundWhitespaceRule().name) {
                 return loc(context).routerPasswordRuleStartEndWithSpace;
-              } else if (errorKeys.keys.first == (WiFiSsidRule).toString() ||
-                  errorKeys.keys.first == (RequiredRule).toString()) {
+              } else if (errorKeys.keys.first == WiFiSsidRule().name ||
+                  errorKeys.keys.first == RequiredRule().name) {
                 return loc(context).theNameMustNotBeEmpty;
-              } else if (errorKeys.keys.first == (LengthRule).toString()) {
+              } else if (errorKeys.keys.first == LengthRule().name) {
                 return loc(context).wifiSSIDLengthLimit;
               } else {
                 return null;


### PR DESCRIPTION
Fixed the issue where the error message is not shown for overly long WiFi SSIDs assigned in
(1) input boxes of several bands on the Incredible WiFi 
(2) input box in the Instant Setup flow