### PR TITLE
[NOW-149] Add wired and wireless pairing from topology view

### DIFF
--- a/lib/core/jnap/actions/better_action.dart
+++ b/lib/core/jnap/actions/better_action.dart
@@ -652,6 +652,10 @@ void initBetterActions() {
       _JNAPActionValue.getBluetoothAutoOnboardingStatus.value;
   _betterActionMap[JNAPAction.startBlueboothAutoOnboarding] =
       _JNAPActionValue.startBluetoothAutoOnboarding.value;
+  _betterActionMap[JNAPAction.setWiredAutoOnboardingSettings] =
+      _JNAPActionValue.setWiredAutoOnboardingSettings.value;
+  _betterActionMap[JNAPAction.getWiredAutoOnboardingSettings] =
+      _JNAPActionValue.getWiredAutoOnboardingSettings.value;
   _betterActionMap[JNAPAction.getVLANTaggingSettings] =
       _JNAPActionValue.getVLANTaggingSettings.value;
   _betterActionMap[JNAPAction.setVLANTaggingSettings] =

--- a/lib/core/jnap/actions/better_action.dart
+++ b/lib/core/jnap/actions/better_action.dart
@@ -602,6 +602,10 @@ void initBetterActions() {
       _JNAPActionValue.verifyRouterResetCode.value;
   _betterActionMap[JNAPAction.getVersionInfo] =
       _JNAPActionValue.getVersionInfo.value;
+  _betterActionMap[JNAPAction.getSmartConnectPin] =
+      _JNAPActionValue.getSmartConnectPin.value;
+  _betterActionMap[JNAPAction.getSmartConnectStatus] =
+      _JNAPActionValue.getSmartConnectStatus.value;
   _betterActionMap[JNAPAction.getDeviceMode] =
       _JNAPActionValue.getDeviceMode.value;
   _betterActionMap[JNAPAction.getSupportedDeviceMode] =

--- a/lib/core/jnap/actions/jnap_action.dart
+++ b/lib/core/jnap/actions/jnap_action.dart
@@ -9,6 +9,8 @@ enum JNAPAction {
   getBluetoothAutoOnboardingStatus,
   getBluetoothAutoOnboardingSettings,
   setBluetoothAutoOnboardingSettings,
+  setWiredAutoOnboardingSettings,
+  getWiredAutoOnboardingSettings,
   // bluetooth
   btGetScanUnconfiguredResult,
   btRequestScanUnconfigured,

--- a/lib/core/jnap/actions/jnap_action.dart
+++ b/lib/core/jnap/actions/jnap_action.dart
@@ -177,6 +177,9 @@ enum JNAPAction {
   startBlinkNodeLed,
   stopBlinkNodeLed,
   setUserAcknowledgedAutoConfiguration,
+  // SmartConnect
+  getSmartConnectPin,
+  getSmartConnectStatus,
   // smartMode
   getDeviceMode,
   getSupportedDeviceMode,

--- a/lib/core/jnap/actions/jnap_action_value.dart
+++ b/lib/core/jnap/actions/jnap_action_value.dart
@@ -354,6 +354,8 @@ enum _JNAPActionValue {
   startBluetoothAutoOnboarding2(
       value:
           'http://linksys.com/jnap/nodes/autoonboarding/StartBluetoothAutoOnboarding2'),
+  setWiredAutoOnboardingSettings(value: 'http://linksys.com/jnap/nodes/autoonboarding/SetWiredAutoOnboardingSettings'),
+  getWiredAutoOnboardingSettings(value: 'http://linksys.com/jnap/nodes/autoonboarding/GetWiredAutoOnboardingSettings'),
   btGetScanUnconfiguredResult2(
       value:
           'http://linksys.com/jnap/nodes/bluetooth/BTGetScanUnconfiguredResult2'),

--- a/lib/core/jnap/actions/jnap_action_value.dart
+++ b/lib/core/jnap/actions/jnap_action_value.dart
@@ -287,6 +287,9 @@ enum _JNAPActionValue {
   verifyRouterResetCode(
       value: 'http://linksys.com/jnap/nodes/setup/VerifyRouterResetCode'),
   getVersionInfo(value: 'http://linksys.com/jnap/nodes/setup/GetVersionInfo'),
+    // SmartConnect
+  getSmartConnectPin(value: 'http://linksys.com/jnap/nodes/smartconnect/GetSmartConnectPIN'),
+  getSmartConnectStatus(value: 'http://linksys.com/jnap/nodes/smartconnect/GetSmartConnectStatus'),
   getDeviceMode(value: 'http://linksys.com/jnap/nodes/smartmode/GetDeviceMode'),
   getSupportedDeviceModes(
       value: 'http://linksys.com/jnap/nodes/smartmode/GetSupportedDeviceModes'),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1019,5 +1019,10 @@
   "addWiredDevicesDesc1": "Start with the new device turned off",
   "addWiredDevicesDesc2": "Connect an Ethernet cable to one of the LAN ports on your existing device.",
   "addWiredDevicesDesc3": "Connect the other end of the cable to the WAN port of the new device you're adding.",
-  "addWiredDevicesDesc4": "Then, power on the new device."
+  "addWiredDevicesDesc4": "Then, power on the new device.",
+  "pairWiredNode": "Pair wired node",
+  "pairWirelessNode": "Pair wireless node",
+  "pairWiredNodeDone": "Pairing wired node. Click 'Done pairing' to finish.",
+  "donePairing": "Done pairing",
+  "refreshing": "Refreshing"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1015,7 +1015,7 @@
   "wins": "WINS",
   "wired": "Wired",
   "wireless": "Wireless",
-  "addWiredDevices": "Add wried devices",
+  "addWiredDevices": "Add wired devices",
   "addWiredDevicesDesc1": "Start with the new device turned off",
   "addWiredDevicesDesc2": "Connect an Ethernet cable to one of the LAN ports on your existing device.",
   "addWiredDevicesDesc3": "Connect the other end of the cable to the WAN port of the new device you're adding.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1014,5 +1014,10 @@
   "wildcard": "Wildcard",
   "wins": "WINS",
   "wired": "Wired",
-  "wireless": "Wireless"
+  "wireless": "Wireless",
+  "addWiredDevices": "Add wried devices",
+  "addWiredDevicesDesc1": "Start with the new device turned off",
+  "addWiredDevicesDesc2": "Connect an Ethernet cable to one of the LAN ports on your existing device.",
+  "addWiredDevicesDesc3": "Connect the other end of the cable to the WAN port of the new device you're adding.",
+  "addWiredDevicesDesc4": "Then, power on the new device."
 }

--- a/lib/page/components/customs/stateful_popup_menu_item.dart
+++ b/lib/page/components/customs/stateful_popup_menu_item.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+class StatefulPopupMenuItem<T> extends PopupMenuEntry<T> {
+  const StatefulPopupMenuItem({
+    Key? key,
+    this.enabled = true,
+    this.height = kMinInteractiveDimension,
+    required this.child,
+    this.onTap,
+    this.padding,
+    this.expandChild = false,
+  }) : super(key: key);
+
+  /// Whether the user can interact with this item.
+  final bool enabled;
+
+  /// The height of the menu item.
+  ///
+  /// Defaults to [kMinInteractiveDimension] pixels.
+  @override
+  final double height;
+
+  final VoidCallback? onTap;
+  final EdgeInsets? padding;
+  final bool expandChild;
+
+  /// The widget below this widget in the tree.
+  final Widget child;
+
+  @override
+  State<StatefulPopupMenuItem<T>> createState() =>
+      _StatefulPopupMenuItemState<T>();
+
+  @override
+  bool represents(T? value) =>
+      false; // Crucial: Doesn't represent a value, so it won't trigger onSelected
+}
+
+class _StatefulPopupMenuItemState<T> extends State<StatefulPopupMenuItem<T>> {
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+
+    final EdgeInsetsGeometry padding = widget.padding ??
+        (theme.useMaterial3
+            ? const EdgeInsets.symmetric(horizontal: 12.0)
+            : const EdgeInsets.symmetric(horizontal: 16.0));
+
+    final Widget itemContent = widget.expandChild
+        ? widget.child
+        : Align(
+            alignment: AlignmentDirectional.centerStart, child: widget.child);
+
+    // This is the core layout that mimics PopupMenuItem.
+    Widget item = ConstrainedBox(
+      constraints: BoxConstraints(minHeight: widget.height),
+      child: Padding(
+        key: const Key('menu item padding'),
+        padding: padding,
+        child: itemContent,
+      ),
+    );
+
+    // If disabled, return the item without the InkWell.
+    if (!widget.enabled) {
+      return item;
+    }
+
+    // Wrap in an InkWell to get the ripple effect without closing the menu.
+    return InkWell(
+      onTap: widget.onTap,
+      canRequestFocus: false, // Prevents the item from being focused.
+      child: item,
+    );
+  }
+}

--- a/lib/page/components/shortcuts/dialogs.dart
+++ b/lib/page/components/shortcuts/dialogs.dart
@@ -50,6 +50,7 @@ Future<T?> showAppSpinnerDialog<T>(
   double? width,
   List<String> messages = const [],
   Duration? period,
+  List<Widget>? actions = const [],
 }) {
   return showDialog<T?>(
     context: context,
@@ -72,14 +73,16 @@ Future<T?> showAppSpinnerDialog<T>(
                         child: AppText.titleLarge(title))
                     : null,
                 content: SizedBox(
-                    width: width ?? kDefaultDialogWidth,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        loadingWidget ?? const AppSpinner(),
-                        if (snapshot.hasData) AppText.labelLarge(snapshot.data!)
-                      ],
-                    )),
+                  width: width ?? kDefaultDialogWidth,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      loadingWidget ?? const AppSpinner(),
+                      if (snapshot.hasData) AppText.labelLarge(snapshot.data!)
+                    ],
+                  ),
+                ),
+                actions: actions,
               );
             });
       });

--- a/lib/page/instant_topology/views/instant_topology_view.dart
+++ b/lib/page/instant_topology/views/instant_topology_view.dart
@@ -368,11 +368,16 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
   }
 
   _doInstantPair() {
-    context.pushNamed(RouteNamed.addNodes).then((result) {
+    context.pushNamed(RouteNamed.addWiredNodes).then((result) {
       if (result is bool && result) {
         _showMoveChildNodesModal();
       }
     });
+    // context.pushNamed(RouteNamed.addNodes).then((result) {
+    //   if (result is bool && result) {
+    //     _showMoveChildNodesModal();
+    //   }
+    // });
   }
 
   Widget _buildHeader(

--- a/lib/page/instant_topology/views/instant_topology_view.dart
+++ b/lib/page/instant_topology/views/instant_topology_view.dart
@@ -228,7 +228,7 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
               onNodeTap(context, ref, node);
             },
             onActionTap: (action) {
-              _handleNodeAction(action, node, supportChildReboot);
+              _handleSelectedNodeAction(action, node, supportChildReboot);
             },
           )
         : TopologyNodeItem(
@@ -257,12 +257,12 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
               onNodeTap(context, ref, node);
             },
             onActionTap: (action) {
-              _handleNodeAction(action, node, supportChildReboot);
+              _handleSelectedNodeAction(action, node, supportChildReboot);
             },
           );
   }
 
-  _handleNodeAction(
+  _handleSelectedNodeAction(
     NodeInstantActions action,
     RouterTreeNode node,
     bool supportChildReboot,

--- a/lib/page/instant_topology/views/widgets/tree_node_item.dart
+++ b/lib/page/instant_topology/views/widgets/tree_node_item.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/page/components/customs/stateful_popup_menu_item.dart';
 import 'package:privacygui_widgets/theme/_theme.dart';
 import 'package:privacygui_widgets/widgets/_widgets.dart';
 import 'package:privacygui_widgets/widgets/card/card.dart';
@@ -673,81 +674,6 @@ class _SelectToCopyWidgetState extends State<SelectToCopyWidget> {
         },
         child: widget.child,
       ),
-    );
-  }
-}
-
-class StatefulPopupMenuItem<T> extends PopupMenuEntry<T> {
-  const StatefulPopupMenuItem({
-    Key? key,
-    this.enabled = true,
-    this.height = kMinInteractiveDimension,
-    required this.child,
-    this.onTap,
-    this.padding,
-    this.expandChild = false,
-  }) : super(key: key);
-
-  /// Whether the user can interact with this item.
-  final bool enabled;
-
-  /// The height of the menu item.
-  ///
-  /// Defaults to [kMinInteractiveDimension] pixels.
-  @override
-  final double height;
-
-  final VoidCallback? onTap;
-  final EdgeInsets? padding;
-  final bool expandChild;
-
-  /// The widget below this widget in the tree.
-  final Widget child;
-
-  @override
-  State<StatefulPopupMenuItem<T>> createState() =>
-      _StatefulPopupMenuItemState<T>();
-
-  @override
-  bool represents(T? value) =>
-      false; // Crucial: Doesn't represent a value, so it won't trigger onSelected
-}
-
-class _StatefulPopupMenuItemState<T> extends State<StatefulPopupMenuItem<T>> {
-  @override
-  Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-
-    final EdgeInsetsGeometry padding = widget.padding ??
-        (theme.useMaterial3
-            ? const EdgeInsets.symmetric(horizontal: 12.0)
-            : const EdgeInsets.symmetric(horizontal: 16.0));
-
-    final Widget itemContent = widget.expandChild
-        ? widget.child
-        : Align(
-            alignment: AlignmentDirectional.centerStart, child: widget.child);
-
-    // This is the core layout that mimics PopupMenuItem.
-    Widget item = ConstrainedBox(
-      constraints: BoxConstraints(minHeight: widget.height),
-      child: Padding(
-        key: const Key('menu item padding'),
-        padding: padding,
-        child: itemContent,
-      ),
-    );
-
-    // If disabled, return the item without the InkWell.
-    if (!widget.enabled) {
-      return item;
-    }
-
-    // Wrap in an InkWell to get the ripple effect without closing the menu.
-    return InkWell(
-      onTap: widget.onTap,
-      canRequestFocus: false, // Prevents the item from being focused.
-      child: item,
     );
   }
 }

--- a/lib/page/nodes/providers/add_wired_nodes_provider.dart
+++ b/lib/page/nodes/providers/add_wired_nodes_provider.dart
@@ -1,0 +1,147 @@
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:privacy_gui/core/jnap/actions/better_action.dart';
+import 'package:privacy_gui/core/jnap/models/back_haul_info.dart';
+import 'package:privacy_gui/core/jnap/providers/device_manager_provider.dart';
+import 'package:privacy_gui/core/jnap/providers/polling_provider.dart';
+import 'package:privacy_gui/core/jnap/result/jnap_result.dart';
+import 'package:privacy_gui/core/jnap/router_repository.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/page/nodes/providers/add_wired_nodes_state.dart';
+
+final addWiredNodesProvider =
+    NotifierProvider.autoDispose<AddWiredNodesNotifier, AddWiredNodesState>(
+        () => AddWiredNodesNotifier());
+
+class AddWiredNodesNotifier extends AutoDisposeNotifier<AddWiredNodesState> {
+  StreamSubscription? _streamSubscription;
+
+  @override
+  AddWiredNodesState build() => const AddWiredNodesState(isLoading: false);
+
+  Future<void> setAutoOnboardingSettings(bool enabled) {
+    return ref
+        .read(routerRepositoryProvider)
+        .send(JNAPAction.setWiredAutoOnboardingSettings,
+            data: {
+              'isAutoOnboardingEnabled': true,
+            },
+            auth: true);
+  }
+
+  Future<bool> getAutoOnboardingSettings() {
+    return ref
+        .read(routerRepositoryProvider)
+        .send(JNAPAction.getWiredAutoOnboardingSettings, auth: true)
+        .then(
+            (response) => response.output['isAutoOnboardingEnabled'] ?? false);
+  }
+
+  Future startAutoOnboarding() async {
+    ref.read(pollingProvider.notifier).stopPolling();
+    await setAutoOnboardingSettings(true);
+    final backhaulList = ref.read(deviceManagerProvider).backhaulInfoData;
+    state = state.copyWith(
+      isLoading: true,
+      nodesSnapshot: backhaulList,
+    );
+    _checkBackhaulChanges();
+  }
+
+  void _checkBackhaulChanges() {
+    _streamSubscription?.cancel();
+    _streamSubscription = pollBackhaulInfo().listen((result) {
+      if (result is! JNAPSuccess) {
+        return;
+      }
+      state = state.copyWith(onboardingProceed: true);
+      final backhaulInfoList = List.from(
+        result.output['backhaulDevices'] ?? [],
+      ).map((e) => BackHaulInfoData.fromMap(e)).toList();
+      final foundCounting = backhaulInfoList.fold<int>(0, (value, infoData) {
+        final dateFormat = DateFormat("yyyy-MM-ddThh:mm:ssZ");
+        return (state.backhaulSnapshot?.any((e) =>
+                    e.deviceUUID == infoData.deviceUUID &&
+                    (dateFormat.tryParse(e.timestamp)?.millisecondsSinceEpoch ??
+                            0) <
+                        (dateFormat
+                                .tryParse(infoData.timestamp)
+                                ?.millisecondsSinceEpoch ??
+                            0)) ==
+                true)
+            ? value
+            : value + 1;
+      });
+      logger.i('[AddWiredNodes]: Found $foundCounting new nodes');
+    }, onDone: () {
+      stopCheckingBackhaul();
+    });
+
+    // await for (final result in pollBackhaulInfo()) {
+    //   if (result is! JNAPSuccess) {
+    //     return;
+    //   }
+    //   state = state.copyWith(onboardingProceed: true);
+    //   final backhaulInfoList = List.from(
+    //     result.output['backhaulDevices'] ?? [],
+    //   ).map((e) => BackHaulInfoData.fromMap(e)).toList();
+    //   final foundCounting = backhaulInfoList.fold<int>(0, (value, infoData) {
+    //     final dateFormat = DateFormat("yyyy-MM-ddThh:mm:ssZ");
+    //     return (state.backhaulSnapshot?.any((e) =>
+    //                 e.deviceUUID == infoData.deviceUUID &&
+    //                 (dateFormat.tryParse(e.timestamp)?.millisecondsSinceEpoch ??
+    //                         0) <
+    //                     (dateFormat
+    //                             .tryParse(infoData.timestamp)
+    //                             ?.millisecondsSinceEpoch ??
+    //                         0)) ==
+    //             true)
+    //         ? value
+    //         : value + 1;
+    //   });
+    //   logger.i('[AddWiredNodes]: Found $foundCounting new nodes');
+    // }
+  }
+
+  Stream pollBackhaulInfo() {
+    final repo = ref.read(routerRepositoryProvider);
+
+    return repo.scheduledCommand(
+      action: JNAPAction.getBackhaulInfo,
+      auth: true,
+      firstDelayInMilliSec: 1 * 1000,
+      retryDelayInMilliSec: 10 * 1000,
+      maxRetry: 30,
+      // condition: (result) {
+      //   if (result is! JNAPSuccess) {
+      //     return false;
+      //   }
+      //   state = state.copyWith(onboardingProceed: true);
+      //   final backhaulInfoList = List.from(
+      //     result.output['backhaulDevices'] ?? [],
+      //   ).map((e) => BackHaulInfoData.fromMap(e)).toList();
+      //   final foundCounting = backhaulInfoList.fold<int>(0, (value, infoData) {
+      //     return (state.nodesSnapshot
+      //                 ?.any((e) => e.deviceUUID == infoData.deviceUUID) ==
+      //             true)
+      //         ? value
+      //         : value + 1;
+      //   });
+      //   logger.i('[AddWiredNodes]: Found $foundCounting new nodes');
+      //   return false;
+      // },
+    );
+  }
+
+  void stopCheckingBackhaul() {
+    _streamSubscription?.cancel();
+    state = state.copyWith(
+      isLoading: false,
+    );
+  }
+
+  Future stopAutoOnboarding() async {
+    await setAutoOnboardingSettings(false);
+  }
+}

--- a/lib/page/nodes/providers/add_wired_nodes_provider.dart
+++ b/lib/page/nodes/providers/add_wired_nodes_provider.dart
@@ -2,11 +2,14 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:privacy_gui/core/jnap/actions/better_action.dart';
+import 'package:privacy_gui/core/jnap/command/base_command.dart';
 import 'package:privacy_gui/core/jnap/models/back_haul_info.dart';
 import 'package:privacy_gui/core/jnap/providers/device_manager_provider.dart';
+import 'package:privacy_gui/core/jnap/providers/device_manager_state.dart';
 import 'package:privacy_gui/core/jnap/providers/polling_provider.dart';
 import 'package:privacy_gui/core/jnap/result/jnap_result.dart';
 import 'package:privacy_gui/core/jnap/router_repository.dart';
+import 'package:privacy_gui/core/utils/bench_mark.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/page/nodes/providers/add_wired_nodes_state.dart';
 
@@ -15,8 +18,6 @@ final addWiredNodesProvider =
         () => AddWiredNodesNotifier());
 
 class AddWiredNodesNotifier extends AutoDisposeNotifier<AddWiredNodesState> {
-  StreamSubscription? _streamSubscription;
-
   @override
   AddWiredNodesState build() => const AddWiredNodesState(isLoading: false);
 
@@ -25,7 +26,7 @@ class AddWiredNodesNotifier extends AutoDisposeNotifier<AddWiredNodesState> {
         .read(routerRepositoryProvider)
         .send(JNAPAction.setWiredAutoOnboardingSettings,
             data: {
-              'isAutoOnboardingEnabled': true,
+              'isAutoOnboardingEnabled': enabled,
             },
             auth: true);
   }
@@ -39,105 +40,189 @@ class AddWiredNodesNotifier extends AutoDisposeNotifier<AddWiredNodesState> {
   }
 
   Future startAutoOnboarding() async {
+    logger.d('[AddWiredNode]: start auto onboarding');
+    final log = BenchMarkLogger(name: 'Add Wired Node Process')..start();
     ref.read(pollingProvider.notifier).stopPolling();
     await setAutoOnboardingSettings(true);
     final backhaulList = ref.read(deviceManagerProvider).backhaulInfoData;
     state = state.copyWith(
-      isLoading: true,
-      nodesSnapshot: backhaulList,
-    );
-    _checkBackhaulChanges();
+        isLoading: true,
+        backhaulSnapshot: backhaulList,
+        loadingMessage: 'searching');
+
+    logger.d('[AddWiredNode]: polling connect status');
+    await _startPollingConnectStatus();
+
+    state = state.copyWith(loadingMessage: 'onboarding');
+    logger.d('[AddWiredNode]: check backhaul changes');
+    await _checkBackhaulChanges();
+    await stopAutoOnboarding();
+    logger.d('[AddWiredNode]: fetch nodes');
+    final nodes = await _fetchNodes();
+    state = state.copyWith(nodes: nodes);
+    stopCheckingBackhaul();
+    await ref.read(pollingProvider.notifier).forcePolling();
+
+    ref.read(pollingProvider.notifier).startPolling();
+    final delta = log.end();
+    logger.d('[AddWiredNode]: start auto onboarding, cost time: ${delta}ms');
   }
 
-  void _checkBackhaulChanges() {
-    _streamSubscription?.cancel();
-    _streamSubscription = pollBackhaulInfo().listen((result) {
+  Future startRefresh() async {
+    state = state.copyWith(
+      isLoading: true,
+      loadingMessage: 'refreshing',
+    );
+    await _checkBackhaulChanges(true);
+    final nodes = await _fetchNodes();
+    state = state.copyWith(
+      isLoading: false,
+      loadingMessage: '',
+      nodes: nodes,
+    );
+  }
+
+  _startPollingConnectStatus() async {
+    final repo = ref.read(routerRepositoryProvider);
+    final pin = await repo
+        .send(JNAPAction.getSmartConnectPin,
+            fetchRemote: true, cacheLevel: CacheLevel.noCache, auth: true)
+        .then((result) => result.output['pin'])
+        .onError((error, stackTrace) {
+      logger.d('[AddWiredNode]: get pin error');
+    });
+    String getStatus(JNAPSuccess result) {
+      final status = result.output['status'] ?? '';
+      return status;
+    }
+
+    final pollStatusStream = repo.scheduledCommand(
+        action: JNAPAction.getSmartConnectStatus,
+        data: {'pin': pin},
+        auth: true,
+        maxRetry: 30,
+        retryDelayInMilliSec: 3000,
+        condition: (result) {
+          if (result is! JNAPSuccess) {
+            return false;
+          }
+          final status = getStatus(result);
+          if (status == 'Connecting') {
+            state = state.copyWith(onboardingProceed: true);
+          }
+          return status == 'Success' && state.onboardingProceed == true;
+        });
+
+    await for (final result in pollStatusStream) {
+      if (result is JNAPSuccess) {
+        final status = getStatus(result);
+        logger.d('[AddWiredNode]: polling smart connect status: $status');
+      }
+    }
+  }
+
+  Future _checkBackhaulChanges([bool refreshing = false]) async {
+    final pollBackhaul = pollBackhaulInfo(refreshing);
+
+    await for (final result in pollBackhaul) {
       if (result is! JNAPSuccess) {
         return;
       }
       state = state.copyWith(onboardingProceed: true);
-      final backhaulInfoList = List.from(
-        result.output['backhaulDevices'] ?? [],
-      ).map((e) => BackHaulInfoData.fromMap(e)).toList();
-      final foundCounting = backhaulInfoList.fold<int>(0, (value, infoData) {
-        final dateFormat = DateFormat("yyyy-MM-ddThh:mm:ssZ");
-        return (state.backhaulSnapshot?.any((e) =>
-                    e.deviceUUID == infoData.deviceUUID &&
-                    (dateFormat.tryParse(e.timestamp)?.millisecondsSinceEpoch ??
-                            0) <
-                        (dateFormat
-                                .tryParse(infoData.timestamp)
-                                ?.millisecondsSinceEpoch ??
-                            0)) ==
-                true)
-            ? value
-            : value + 1;
-      });
-      logger.i('[AddWiredNodes]: Found $foundCounting new nodes');
-    }, onDone: () {
-      stopCheckingBackhaul();
-    });
-
-    // await for (final result in pollBackhaulInfo()) {
-    //   if (result is! JNAPSuccess) {
-    //     return;
-    //   }
-    //   state = state.copyWith(onboardingProceed: true);
-    //   final backhaulInfoList = List.from(
-    //     result.output['backhaulDevices'] ?? [],
-    //   ).map((e) => BackHaulInfoData.fromMap(e)).toList();
-    //   final foundCounting = backhaulInfoList.fold<int>(0, (value, infoData) {
-    //     final dateFormat = DateFormat("yyyy-MM-ddThh:mm:ssZ");
-    //     return (state.backhaulSnapshot?.any((e) =>
-    //                 e.deviceUUID == infoData.deviceUUID &&
-    //                 (dateFormat.tryParse(e.timestamp)?.millisecondsSinceEpoch ??
-    //                         0) <
-    //                     (dateFormat
-    //                             .tryParse(infoData.timestamp)
-    //                             ?.millisecondsSinceEpoch ??
-    //                         0)) ==
-    //             true)
-    //         ? value
-    //         : value + 1;
-    //   });
-    //   logger.i('[AddWiredNodes]: Found $foundCounting new nodes');
-    // }
+    }
   }
 
-  Stream pollBackhaulInfo() {
+  Stream pollBackhaulInfo([bool refreshing = false]) {
     final repo = ref.read(routerRepositoryProvider);
-
+    int nodeCounting = 0;
+    int noChangesCounting = 0;
+    final noChangesThrethold = refreshing ? 6 : 12;
+    final now = DateTime.now();
     return repo.scheduledCommand(
       action: JNAPAction.getBackhaulInfo,
       auth: true,
       firstDelayInMilliSec: 1 * 1000,
       retryDelayInMilliSec: 10 * 1000,
-      maxRetry: 30,
-      // condition: (result) {
-      //   if (result is! JNAPSuccess) {
-      //     return false;
-      //   }
-      //   state = state.copyWith(onboardingProceed: true);
-      //   final backhaulInfoList = List.from(
-      //     result.output['backhaulDevices'] ?? [],
-      //   ).map((e) => BackHaulInfoData.fromMap(e)).toList();
-      //   final foundCounting = backhaulInfoList.fold<int>(0, (value, infoData) {
-      //     return (state.nodesSnapshot
-      //                 ?.any((e) => e.deviceUUID == infoData.deviceUUID) ==
-      //             true)
-      //         ? value
-      //         : value + 1;
-      //   });
-      //   logger.i('[AddWiredNodes]: Found $foundCounting new nodes');
-      //   return false;
-      // },
+      maxRetry: refreshing ? 6 : 30,
+      condition: (result) {
+        if (result is! JNAPSuccess) {
+          return false;
+        }
+        final backhaulInfoList = List.from(
+          result.output['backhaulDevices'] ?? [],
+        ).map((e) => BackHaulInfoData.fromMap(e)).toList();
+        final foundCounting = backhaulInfoList.fold<int>(0, (value, infoData) {
+          final dateFormat = DateFormat("yyyy-MM-ddThh:mm:ssZ");
+          // find the node which uuid is already exist on backhaul snapshot,
+          // and the connection type is "Wired"
+          // and the timestamp is less than current time
+          // and if the uuid is exist the timestamp is less than snapshot one
+          // if satisfy the above condition, then this is not the new added one.
+          return (state.backhaulSnapshot?.any((e) =>
+                      e.deviceUUID == infoData.deviceUUID &&
+                      infoData.connectionType == 'Wired' &&
+                      now.millisecondsSinceEpoch >
+                          (dateFormat
+                                  .tryParse(infoData.timestamp)
+                                  ?.millisecondsSinceEpoch ??
+                              0) &&
+                      (dateFormat
+                                  .tryParse(e.timestamp)
+                                  ?.millisecondsSinceEpoch ??
+                              0) <
+                          (dateFormat
+                                  .tryParse(infoData.timestamp)
+                                  ?.millisecondsSinceEpoch ??
+                              0)) ==
+                  true)
+              ? value
+              : value + 1;
+        });
+        // if found counting is changed then record the counting
+        // if not changed, increase no changes counting
+        // if no changes counting exceed to 12 (no changes within 2 minutes) and has found changes
+        // then end this check process
+        if (foundCounting != nodeCounting) {
+          nodeCounting = foundCounting;
+        } else {
+          noChangesCounting++;
+          logger.i(
+            '[AddWiredNode]: There has no changes on the backhaul. found counting=$foundCounting, check times=$noChangesCounting',
+          );
+          return noChangesCounting > noChangesThrethold && nodeCounting > 0;
+        }
+        logger.i('[AddWiredNode]: Found $foundCounting new nodes');
+        return false;
+      },
+      onCompleted: () {
+        logger.i('[AddWiredNode]: poll backhaul info is completed');
+      },
     );
   }
 
+  Future _fetchNodes() async {
+    final repo = ref.read(routerRepositoryProvider);
+    return repo
+        .send(JNAPAction.getDevices, fetchRemote: true, auth: true)
+        .then((result) {
+      // nodes
+      final nodeList = List.from(
+        result.output['devices'],
+      )
+          .map((e) => LinksysDevice.fromMap(e))
+          .where((device) => device.nodeType != null)
+          .toList();
+      return nodeList;
+    }).onError((error, stackTrace) {
+      logger.i('[AddWiredNode]: fetch node failed! $error');
+      return [];
+    });
+  }
+
   void stopCheckingBackhaul() {
-    _streamSubscription?.cancel();
     state = state.copyWith(
       isLoading: false,
+      loadingMessage: '',
     );
   }
 

--- a/lib/page/nodes/providers/add_wired_nodes_state.dart
+++ b/lib/page/nodes/providers/add_wired_nodes_state.dart
@@ -11,6 +11,7 @@ class AddWiredNodesState extends Equatable {
   final bool? anyOnboarded;
   final List<BackHaulInfoData>? backhaulSnapshot;
   final bool isLoading;
+  final bool forceStop;
   final String? loadingMessage;
   final int onboardingTime;
   final List<LinksysDevice>? nodes;
@@ -20,6 +21,7 @@ class AddWiredNodesState extends Equatable {
     this.anyOnboarded,
     this.backhaulSnapshot,
     required this.isLoading,
+    this.forceStop = false,
     this.loadingMessage,
     this.onboardingTime = 0,
     this.nodes,
@@ -30,6 +32,7 @@ class AddWiredNodesState extends Equatable {
     bool? anyOnboarded,
     List<BackHaulInfoData>? backhaulSnapshot,
     bool? isLoading,
+    bool? forceStop,
     String? loadingMessage,
     int? onboardingTime,
     List<LinksysDevice>? nodes,
@@ -39,6 +42,7 @@ class AddWiredNodesState extends Equatable {
       anyOnboarded: anyOnboarded ?? this.anyOnboarded,
       backhaulSnapshot: backhaulSnapshot ?? this.backhaulSnapshot,
       isLoading: isLoading ?? this.isLoading,
+      forceStop: forceStop ?? this.forceStop,
       loadingMessage: loadingMessage ?? this.loadingMessage,
       onboardingTime: onboardingTime ?? this.onboardingTime,
       nodes: nodes ?? this.nodes,
@@ -51,6 +55,7 @@ class AddWiredNodesState extends Equatable {
       'anyOnboarded': anyOnboarded,
       'backhaulSnapshot': backhaulSnapshot?.map((x) => x.toMap()).toList(),
       'isLoading': isLoading,
+      'forceStop': forceStop,
       'loadingMessage': loadingMessage,
       'onboardingTime': onboardingTime,
       'nodes': nodes,
@@ -66,6 +71,7 @@ class AddWiredNodesState extends Equatable {
               map['backhaulSnapshot']?.map((x) => BackHaulInfoData.fromMap(x)))
           : null,
       isLoading: map['isLoading'] ?? false,
+      forceStop: map['forceStop'] ?? false,
       loadingMessage: map['loadingMessage'],
       onboardingTime: map['onboardingTime'],
       nodes: map['nodes'] != null
@@ -92,6 +98,7 @@ class AddWiredNodesState extends Equatable {
       anyOnboarded,
       backhaulSnapshot,
       isLoading,
+      forceStop,
       loadingMessage,
       onboardingTime,
       nodes,

--- a/lib/page/nodes/providers/add_wired_nodes_state.dart
+++ b/lib/page/nodes/providers/add_wired_nodes_state.dart
@@ -1,0 +1,89 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
+import 'dart:convert';
+
+import 'package:equatable/equatable.dart';
+
+import 'package:privacy_gui/core/jnap/models/back_haul_info.dart';
+
+class AddWiredNodesState extends Equatable {
+  final bool? onboardingProceed;
+  final bool? anyOnboarded;
+  final List<BackHaulInfoData>? backhaulSnapshot;
+  final bool isLoading;
+  final String? loadingMessage;
+  final int onboardingTime;
+
+  const AddWiredNodesState({
+    this.onboardingProceed,
+    this.anyOnboarded,
+    this.backhaulSnapshot,
+    required this.isLoading,
+    this.loadingMessage,
+    this.onboardingTime = 0,
+  });
+
+  AddWiredNodesState copyWith({
+    bool? onboardingProceed,
+    bool? anyOnboarded,
+    List<BackHaulInfoData>? nodesSnapshot,
+    bool? isLoading,
+    String? loadingMessage,
+    int? onboardingTime,
+  }) {
+    return AddWiredNodesState(
+      onboardingProceed: onboardingProceed ?? this.onboardingProceed,
+      anyOnboarded: anyOnboarded ?? this.anyOnboarded,
+      backhaulSnapshot: nodesSnapshot ?? this.backhaulSnapshot,
+      isLoading: isLoading ?? this.isLoading,
+      loadingMessage: loadingMessage ?? this.loadingMessage,
+      onboardingTime: onboardingTime ?? this.onboardingTime,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'onboardingProceed': onboardingProceed,
+      'anyOnboarded': anyOnboarded,
+      'nodesSnapshot': backhaulSnapshot?.map((x) => x.toMap()).toList(),
+      'isLoading': isLoading,
+      'loadingMessage': loadingMessage,
+      'onboardingTime': onboardingTime,
+    };
+  }
+
+  factory AddWiredNodesState.fromMap(Map<String, dynamic> map) {
+    return AddWiredNodesState(
+      onboardingProceed: map['onboardingProceed'],
+      anyOnboarded: map['anyOnboarded'],
+      backhaulSnapshot: map['nodesSnapshot'] != null
+          ? List<BackHaulInfoData>.from(
+              map['nodesSnapshot']?.map((x) => BackHaulInfoData.fromMap(x)))
+          : null,
+      isLoading: map['isLoading'] ?? false,
+      loadingMessage: map['loadingMessage'],
+      onboardingTime: map['onboardingTime'],
+    );
+  }
+
+  String toJson() => json.encode(toMap());
+
+  factory AddWiredNodesState.fromJson(String source) =>
+      AddWiredNodesState.fromMap(json.decode(source));
+
+  @override
+  String toString() {
+    return 'AddWiredNodesState(onboardingProceed: $onboardingProceed, anyOnboarded: $anyOnboarded, nodesSnapshot: $backhaulSnapshot, isLoading: $isLoading, loadingMessage: $loadingMessage, onboardingTime: $onboardingTime)';
+  }
+
+  @override
+  List<Object?> get props {
+    return [
+      onboardingProceed,
+      anyOnboarded,
+      backhaulSnapshot,
+      isLoading,
+      loadingMessage,
+      onboardingTime,
+    ];
+  }
+}

--- a/lib/page/nodes/providers/add_wired_nodes_state.dart
+++ b/lib/page/nodes/providers/add_wired_nodes_state.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:equatable/equatable.dart';
 
 import 'package:privacy_gui/core/jnap/models/back_haul_info.dart';
+import 'package:privacy_gui/core/jnap/providers/device_manager_state.dart';
 
 class AddWiredNodesState extends Equatable {
   final bool? onboardingProceed;
@@ -12,6 +13,7 @@ class AddWiredNodesState extends Equatable {
   final bool isLoading;
   final String? loadingMessage;
   final int onboardingTime;
+  final List<LinksysDevice>? nodes;
 
   const AddWiredNodesState({
     this.onboardingProceed,
@@ -20,23 +22,26 @@ class AddWiredNodesState extends Equatable {
     required this.isLoading,
     this.loadingMessage,
     this.onboardingTime = 0,
+    this.nodes,
   });
 
   AddWiredNodesState copyWith({
     bool? onboardingProceed,
     bool? anyOnboarded,
-    List<BackHaulInfoData>? nodesSnapshot,
+    List<BackHaulInfoData>? backhaulSnapshot,
     bool? isLoading,
     String? loadingMessage,
     int? onboardingTime,
+    List<LinksysDevice>? nodes,
   }) {
     return AddWiredNodesState(
       onboardingProceed: onboardingProceed ?? this.onboardingProceed,
       anyOnboarded: anyOnboarded ?? this.anyOnboarded,
-      backhaulSnapshot: nodesSnapshot ?? this.backhaulSnapshot,
+      backhaulSnapshot: backhaulSnapshot ?? this.backhaulSnapshot,
       isLoading: isLoading ?? this.isLoading,
       loadingMessage: loadingMessage ?? this.loadingMessage,
       onboardingTime: onboardingTime ?? this.onboardingTime,
+      nodes: nodes ?? this.nodes,
     );
   }
 
@@ -44,10 +49,11 @@ class AddWiredNodesState extends Equatable {
     return {
       'onboardingProceed': onboardingProceed,
       'anyOnboarded': anyOnboarded,
-      'nodesSnapshot': backhaulSnapshot?.map((x) => x.toMap()).toList(),
+      'backhaulSnapshot': backhaulSnapshot?.map((x) => x.toMap()).toList(),
       'isLoading': isLoading,
       'loadingMessage': loadingMessage,
       'onboardingTime': onboardingTime,
+      'nodes': nodes,
     };
   }
 
@@ -55,13 +61,17 @@ class AddWiredNodesState extends Equatable {
     return AddWiredNodesState(
       onboardingProceed: map['onboardingProceed'],
       anyOnboarded: map['anyOnboarded'],
-      backhaulSnapshot: map['nodesSnapshot'] != null
+      backhaulSnapshot: map['backhaulSnapshot'] != null
           ? List<BackHaulInfoData>.from(
-              map['nodesSnapshot']?.map((x) => BackHaulInfoData.fromMap(x)))
+              map['backhaulSnapshot']?.map((x) => BackHaulInfoData.fromMap(x)))
           : null,
       isLoading: map['isLoading'] ?? false,
       loadingMessage: map['loadingMessage'],
       onboardingTime: map['onboardingTime'],
+      nodes: map['nodes'] != null
+          ? List<LinksysDevice>.from(
+              map['nodes']?.map((x) => LinksysDevice.fromMap(x)))
+          : null,
     );
   }
 
@@ -72,7 +82,7 @@ class AddWiredNodesState extends Equatable {
 
   @override
   String toString() {
-    return 'AddWiredNodesState(onboardingProceed: $onboardingProceed, anyOnboarded: $anyOnboarded, nodesSnapshot: $backhaulSnapshot, isLoading: $isLoading, loadingMessage: $loadingMessage, onboardingTime: $onboardingTime)';
+    return 'AddWiredNodesState(onboardingProceed: $onboardingProceed, anyOnboarded: $anyOnboarded, nodesSnapshot: $backhaulSnapshot, isLoading: $isLoading, loadingMessage: $loadingMessage, onboardingTime: $onboardingTime), nodes: $nodes';
   }
 
   @override
@@ -84,6 +94,7 @@ class AddWiredNodesState extends Equatable {
       isLoading,
       loadingMessage,
       onboardingTime,
+      nodes,
     ];
   }
 }

--- a/lib/page/nodes/views/add_wired_nodes_view.dart
+++ b/lib/page/nodes/views/add_wired_nodes_view.dart
@@ -9,10 +9,8 @@ import 'package:privacy_gui/core/utils/devices.dart';
 import 'package:privacy_gui/core/utils/icon_rules.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/page/components/shared_widgets.dart';
-import 'package:privacy_gui/page/nodes/providers/add_nodes_state.dart';
 import 'package:privacy_gui/page/nodes/providers/add_wired_nodes_provider.dart';
 import 'package:privacy_gui/page/nodes/providers/add_wired_nodes_state.dart';
-import 'package:privacy_gui/utils.dart';
 import 'package:privacygui_widgets/hook/icon_hooks.dart';
 import 'package:privacygui_widgets/theme/_theme.dart';
 import 'package:privacygui_widgets/widgets/_widgets.dart';
@@ -23,7 +21,6 @@ import 'package:privacygui_widgets/widgets/dialogs/multiple_page_alert_dialog.da
 import 'package:privacygui_widgets/widgets/page/layout/basic_layout.dart';
 import 'package:privacygui_widgets/widgets/progress_bar/full_screen_spinner.dart';
 
-import 'package:privacy_gui/constants/_constants.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/components/styled/styled_page_view.dart';
 import 'package:privacy_gui/page/components/views/arguments_view.dart';
@@ -46,7 +43,6 @@ class _AddWiredNodesViewState extends ConsumerState<AddWiredNodesView> {
   @override
   void initState() {
     super.initState();
-    ref.read(addNodesProvider.notifier).getAutoOnboardingSettings();
   }
 
   @override
@@ -94,81 +90,75 @@ class _AddWiredNodesViewState extends ConsumerState<AddWiredNodesView> {
           content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Row(
-          //   children: [
-          //     AppText.bodyMedium(loc(context).pnpYourNetworkDesc),
-          //     const AppGap.small1(),
-          //     AppTextButton.noPadding(
-          //       loc(context).refresh,
-          //       onTap: () {
-          //         logger.d('[AddNodes]: Start to refresh the children list');
-          //         ref.read(addNodesProvider.notifier).startRefresh();
-          //       },
-          //     ),
-          //   ],
-          // ),
-          // const AppGap.medium(),
-          // if (state?.addedNodes?.isEmpty == true)
-          //   AppStyledText.link(
-          //     loc(context).addNodesNoNodesFound,
-          //     key: const ValueKey('troubleshoot'),
-          //     defaultTextStyle: Theme.of(context)
-          //         .textTheme
-          //         .bodyMedium!
-          //         .copyWith(color: Theme.of(context).colorScheme.error),
-          //     color: Theme.of(context).colorScheme.primary,
-          //     tags: const ['l'],
-          //     callbackTags: {
-          //       'l': (String? text, Map<String?, String?> attrs) {
-          //         _showTroubleshootNoNodesFoundModal();
-          //       }
-          //     },
-          //   ),
-          // const AppGap.medium(),
-          // Column(
-          //   children: [
-          //     ...state?.childNodes?.map((e) {
-          //           final node = LinksysDevice.fromMap(e.toMap());
-          //           return AppNodeListCard(
-          //               leading: CustomTheme.of(context)
-          //                   .images
-          //                   .devices
-          //                   .getByName(routerIconTest(e.toMap())),
-          //               title: e.getDeviceLocation(),
-          //               trailing: SharedWidgets.resolveSignalStrengthIcon(
-          //                 context,
-          //                 node.signalDecibels ?? 0,
-          //                 isOnline: node.isOnline(),
-          //                 isWired: node.getConnectionType() == DeviceConnectionType.wired,
-          //               ));
-          //         }).expandIndexed((index, element) sync* {
-          //           yield element;
-          //           yield const AppGap.medium();
-          //         }).toList() ??
-          //         []
-          //   ],
-          // ),
-          // const AppGap.medium(),
-          // AppTextButton.noPadding(
-          //   loc(context).tryAgain,
-          //   onTap: () {
-          //     logger.d('[AddNodes]: Retry to search for more nodes');
-          //     ref.read(addNodesProvider.notifier).startAutoOnboarding();
-          //   },
-          // ),
-          // const AppGap.large3(),
-          // AppFilledButton(
-          //   loc(context).next,
-          //   onTap: () {
-          //     final callback = widget.args['callback'] as VoidCallback?;
-          //     if (callback != null) {
-          //       callback.call();
-          //       context.pop(state?.addedNodes?.isNotEmpty ?? false);
-          //     } else {
-          //       context.pop(state?.addedNodes?.isNotEmpty ?? false);
-          //     }
-          //   },
-          // )
+          Row(
+            children: [
+              AppText.bodyMedium(loc(context).pnpYourNetworkDesc),
+              const AppGap.small1(),
+              AppTextButton.noPadding(
+                loc(context).refresh,
+                onTap: () {
+                  logger
+                      .d('[AddWiredNode]: Start to refresh the children list');
+                  ref.read(addWiredNodesProvider.notifier).startRefresh();
+                },
+              ),
+            ],
+          ),
+          const AppGap.medium(),
+          if (state?.nodes?.isEmpty == true)
+            AppStyledText.link(
+              loc(context).addNodesNoNodesFound,
+              key: const ValueKey('troubleshoot'),
+              defaultTextStyle: Theme.of(context)
+                  .textTheme
+                  .bodyMedium!
+                  .copyWith(color: Theme.of(context).colorScheme.error),
+              color: Theme.of(context).colorScheme.primary,
+              tags: const ['l'],
+              callbackTags: {
+                'l': (String? text, Map<String?, String?> attrs) {
+                  _showTroubleshootNoNodesFoundModal();
+                }
+              },
+            ),
+          const AppGap.medium(),
+          Column(
+            children: [
+              ...state?.nodes?.map((e) {
+                    final node = LinksysDevice.fromMap(e.toMap());
+                    return AppNodeListCard(
+                        leading: CustomTheme.of(context)
+                            .images
+                            .devices
+                            .getByName(routerIconTest(e.toMap())),
+                        title: e.getDeviceLocation(),
+                        trailing: SharedWidgets.resolveSignalStrengthIcon(
+                          context,
+                          node.signalDecibels ?? 0,
+                          isOnline: node.isOnline(),
+                          isWired: node.getConnectionType() ==
+                              DeviceConnectionType.wired,
+                        ));
+                  }).expandIndexed((index, element) sync* {
+                    yield element;
+                    yield const AppGap.medium();
+                  }).toList() ??
+                  []
+            ],
+          ),
+          const AppGap.large3(),
+          AppFilledButton(
+            loc(context).next,
+            onTap: () {
+              final callback = widget.args['callback'] as VoidCallback?;
+              if (callback != null) {
+                callback.call();
+                context.pop(state?.nodes?.isNotEmpty ?? false);
+              } else {
+                context.pop(state?.nodes?.isNotEmpty ?? false);
+              }
+            },
+          )
         ],
       )),
     );

--- a/lib/page/nodes/views/add_wired_nodes_view.dart
+++ b/lib/page/nodes/views/add_wired_nodes_view.dart
@@ -1,0 +1,276 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/core/jnap/providers/device_manager_state.dart';
+import 'package:privacy_gui/core/utils/devices.dart';
+import 'package:privacy_gui/core/utils/icon_rules.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/page/components/shared_widgets.dart';
+import 'package:privacy_gui/page/nodes/providers/add_nodes_state.dart';
+import 'package:privacy_gui/page/nodes/providers/add_wired_nodes_provider.dart';
+import 'package:privacy_gui/page/nodes/providers/add_wired_nodes_state.dart';
+import 'package:privacy_gui/utils.dart';
+import 'package:privacygui_widgets/hook/icon_hooks.dart';
+import 'package:privacygui_widgets/theme/_theme.dart';
+import 'package:privacygui_widgets/widgets/_widgets.dart';
+import 'package:privacygui_widgets/widgets/bullet_list/bullet_list.dart';
+import 'package:privacygui_widgets/widgets/bullet_list/bullet_style.dart';
+import 'package:privacygui_widgets/widgets/card/node_list_card.dart';
+import 'package:privacygui_widgets/widgets/dialogs/multiple_page_alert_dialog.dart';
+import 'package:privacygui_widgets/widgets/page/layout/basic_layout.dart';
+import 'package:privacygui_widgets/widgets/progress_bar/full_screen_spinner.dart';
+
+import 'package:privacy_gui/constants/_constants.dart';
+import 'package:privacy_gui/localization/localization_hook.dart';
+import 'package:privacy_gui/page/components/styled/styled_page_view.dart';
+import 'package:privacy_gui/page/components/views/arguments_view.dart';
+import 'package:privacy_gui/page/nodes/providers/add_nodes_provider.dart';
+import 'package:privacy_gui/page/nodes/views/light_different_color_modal.dart';
+
+class AddWiredNodesView extends ArgumentsConsumerStatefulView {
+  const AddWiredNodesView({
+    Key? key,
+    super.args,
+  }) : super(key: key);
+
+  @override
+  ConsumerState<AddWiredNodesView> createState() => _AddWiredNodesViewState();
+}
+
+class _AddWiredNodesViewState extends ConsumerState<AddWiredNodesView> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    ref.read(addNodesProvider.notifier).getAutoOnboardingSettings();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _controller.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(addWiredNodesProvider);
+    if (state.isLoading) {
+      final message = _getLoadingMessages(state.loadingMessage ?? '');
+      return Stack(
+        children: [
+          AppFullScreenSpinner(
+            title: message.$1,
+            text: message.$2,
+          ),
+          Align(
+            alignment: Alignment.bottomRight,
+            child: AppFilledButton(
+              loc(context).ok,
+              onTap: () {
+                ref.read(addWiredNodesProvider.notifier).stopCheckingBackhaul();
+              },
+            ),
+          )
+        ],
+      );
+    } else {
+      if (state.onboardingProceed != null) {
+        return _resultView(state);
+      } else {
+        return _contentView();
+      }
+    }
+  }
+
+  Widget _resultView(AddWiredNodesState? state) {
+    return StyledAppPageView(
+      scrollable: true,
+      title: loc(context).addNodes,
+      child: AppBasicLayout(
+          content: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Row(
+          //   children: [
+          //     AppText.bodyMedium(loc(context).pnpYourNetworkDesc),
+          //     const AppGap.small1(),
+          //     AppTextButton.noPadding(
+          //       loc(context).refresh,
+          //       onTap: () {
+          //         logger.d('[AddNodes]: Start to refresh the children list');
+          //         ref.read(addNodesProvider.notifier).startRefresh();
+          //       },
+          //     ),
+          //   ],
+          // ),
+          // const AppGap.medium(),
+          // if (state?.addedNodes?.isEmpty == true)
+          //   AppStyledText.link(
+          //     loc(context).addNodesNoNodesFound,
+          //     key: const ValueKey('troubleshoot'),
+          //     defaultTextStyle: Theme.of(context)
+          //         .textTheme
+          //         .bodyMedium!
+          //         .copyWith(color: Theme.of(context).colorScheme.error),
+          //     color: Theme.of(context).colorScheme.primary,
+          //     tags: const ['l'],
+          //     callbackTags: {
+          //       'l': (String? text, Map<String?, String?> attrs) {
+          //         _showTroubleshootNoNodesFoundModal();
+          //       }
+          //     },
+          //   ),
+          // const AppGap.medium(),
+          // Column(
+          //   children: [
+          //     ...state?.childNodes?.map((e) {
+          //           final node = LinksysDevice.fromMap(e.toMap());
+          //           return AppNodeListCard(
+          //               leading: CustomTheme.of(context)
+          //                   .images
+          //                   .devices
+          //                   .getByName(routerIconTest(e.toMap())),
+          //               title: e.getDeviceLocation(),
+          //               trailing: SharedWidgets.resolveSignalStrengthIcon(
+          //                 context,
+          //                 node.signalDecibels ?? 0,
+          //                 isOnline: node.isOnline(),
+          //                 isWired: node.getConnectionType() == DeviceConnectionType.wired,
+          //               ));
+          //         }).expandIndexed((index, element) sync* {
+          //           yield element;
+          //           yield const AppGap.medium();
+          //         }).toList() ??
+          //         []
+          //   ],
+          // ),
+          // const AppGap.medium(),
+          // AppTextButton.noPadding(
+          //   loc(context).tryAgain,
+          //   onTap: () {
+          //     logger.d('[AddNodes]: Retry to search for more nodes');
+          //     ref.read(addNodesProvider.notifier).startAutoOnboarding();
+          //   },
+          // ),
+          // const AppGap.large3(),
+          // AppFilledButton(
+          //   loc(context).next,
+          //   onTap: () {
+          //     final callback = widget.args['callback'] as VoidCallback?;
+          //     if (callback != null) {
+          //       callback.call();
+          //       context.pop(state?.addedNodes?.isNotEmpty ?? false);
+          //     } else {
+          //       context.pop(state?.addedNodes?.isNotEmpty ?? false);
+          //     }
+          //   },
+          // )
+        ],
+      )),
+    );
+  }
+
+  Widget _contentView() {
+    return StyledAppPageView(
+      scrollable: true,
+      title: loc(context).addNodes,
+      child: AppBasicLayout(
+          content: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          AppBulletList(
+            style: AppBulletStyle.number,
+            children: [
+              AppText.bodyLarge(loc(context).addWiredDevicesDesc1),
+              AppText.bodyLarge(loc(context).addWiredDevicesDesc2),
+              AppText.bodyLarge(loc(context).addWiredDevicesDesc3),
+              AppText.bodyLarge(loc(context).addWiredDevicesDesc4),
+            ],
+          ),
+          const AppGap.large2(),
+          SvgPicture(
+            CustomTheme.of(context).images.imgPlaceWiredNodes,
+            semanticsLabel: 'add nodes image',
+          ),
+          const AppGap.large3(),
+          AppFilledButton(
+            loc(context).next,
+            onTap: () {
+              logger.d('[AddNodes]: Start to search for more nodes');
+              ref.read(addWiredNodesProvider.notifier).startAutoOnboarding();
+            },
+          )
+        ],
+      )),
+    );
+  }
+
+  _showTroubleshootNoNodesFoundModal() {
+    showDialog(
+        context: context,
+        builder: (context) {
+          return MultiplePagesAlertDialog(
+            onClose: () {
+              context.pop();
+            },
+            pages: [
+              MultipleAlertDialogPage(
+                  title: loc(context).modalTroubleshootNoNodesFound,
+                  buttonText: loc(context).close,
+                  contentBuilder: (context, controller, index) {
+                    return Container(
+                      constraints: const BoxConstraints(maxWidth: 312),
+                      child: AppBulletList(
+                          style: AppBulletStyle.number,
+                          itemSpacing: 24,
+                          children: [
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                AppText.bodyMedium(loc(context)
+                                    .modalTroubleshootNoNodesFoundDesc1),
+                                const AppGap.medium(),
+                                AppTextButton.noPadding(
+                                  loc(context).addNodesLightDifferentColor,
+                                  onTap: () {
+                                    controller.goTo(index + 1);
+                                  },
+                                )
+                              ],
+                            ),
+                            AppText.bodyMedium(loc(context)
+                                .modalTroubleshootNoNodesFoundDesc2),
+                          ]),
+                    );
+                  }),
+              MultipleAlertDialogPage(
+                  title: loc(context).addNodesLightDifferentColor,
+                  buttonText: loc(context).back,
+                  contentBuilder: (BuildContext context,
+                          MultiplePagesAlertDialogController controller,
+                          int current) =>
+                      const LightDifferentColorModal()),
+            ],
+          );
+        });
+  }
+
+  (String, String) _getLoadingMessages(String key) {
+    return switch (key) {
+      'searching' => (
+          loc(context).addNodesSearchingNodes,
+          loc(context).addNodesSearchingNodesDesc
+        ),
+      'onboarding' => ('Onboarding nodes', 'Bringing your nodes online'),
+      _ => (
+          loc(context).addNodesSearchingNodes,
+          loc(context).addNodesSearchingNodesDesc
+        )
+    };
+  }
+}

--- a/lib/page/nodes/views/add_wired_nodes_view.dart
+++ b/lib/page/nodes/views/add_wired_nodes_view.dart
@@ -67,7 +67,7 @@ class _AddWiredNodesViewState extends ConsumerState<AddWiredNodesView> {
             child: AppFilledButton(
               loc(context).ok,
               onTap: () {
-                ref.read(addWiredNodesProvider.notifier).stopCheckingBackhaul();
+                ref.read(addWiredNodesProvider.notifier).stopCheckingBackhaul(context);
               },
             ),
           )
@@ -86,7 +86,7 @@ class _AddWiredNodesViewState extends ConsumerState<AddWiredNodesView> {
     return StyledAppPageView(
       scrollable: true,
       title: loc(context).addNodes,
-      child: AppBasicLayout(
+      child: (context, constraints) => AppBasicLayout(
           content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -99,7 +99,7 @@ class _AddWiredNodesViewState extends ConsumerState<AddWiredNodesView> {
                 onTap: () {
                   logger
                       .d('[AddWiredNode]: Start to refresh the children list');
-                  ref.read(addWiredNodesProvider.notifier).startRefresh();
+                  ref.read(addWiredNodesProvider.notifier).startRefresh(context);
                 },
               ),
             ],
@@ -168,7 +168,7 @@ class _AddWiredNodesViewState extends ConsumerState<AddWiredNodesView> {
     return StyledAppPageView(
       scrollable: true,
       title: loc(context).addNodes,
-      child: AppBasicLayout(
+      child: (context, constraints) => AppBasicLayout(
           content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -191,7 +191,7 @@ class _AddWiredNodesViewState extends ConsumerState<AddWiredNodesView> {
             loc(context).next,
             onTap: () {
               logger.d('[AddNodes]: Start to search for more nodes');
-              ref.read(addWiredNodesProvider.notifier).startAutoOnboarding();
+              ref.read(addWiredNodesProvider.notifier).startAutoOnboarding(context);
             },
           )
         ],

--- a/lib/route/constants.dart
+++ b/lib/route/constants.dart
@@ -65,6 +65,7 @@ class RoutePath {
   static const changeNodeName = 'changeNodeName';
   static const nodeLightSettings = 'nodeLightSettings';
   static const addNodes = '/addNodes';
+  static const addWiredNodes = '/addWiredNodes';
   static const firmwareUpdateDetail = 'firmwareUpdateDetail';
   static const manualFirmwareUpdate = 'manualFirmwareUpdate';
 
@@ -206,6 +207,7 @@ class RouteNamed {
   static const changeNodeName = 'changeNodeName';
   static const nodeLightSettings = 'nodeLightSettings';
   static const addNodes = 'addNodes';
+  static const addWiredNodes = 'addWiredNodes';
   static const firmwareUpdateDetail = 'firmwareUpdateDetail';
   static const manualFirmwareUpdate = 'manualFirmwareUpdate';
 

--- a/lib/route/route_add_nodes.dart
+++ b/lib/route/route_add_nodes.dart
@@ -10,3 +10,14 @@ final addNodesRoute = LinksysRoute(
   ),
   routes: [],
 );
+
+final addWiredNodesRoute = LinksysRoute(
+  name: RouteNamed.addWiredNodes,
+  path: RoutePath.addWiredNodes,
+  config: LinksysRouteConfig(
+      noNaviRail: true, column: ColumnGrid(column: 6, centered: true)),
+  builder: (context, state) => AddWiredNodesView(
+    args: state.extra as Map<String, dynamic>? ?? {},
+  ),
+  routes: [],
+);

--- a/lib/route/router_provider.dart
+++ b/lib/route/router_provider.dart
@@ -35,6 +35,7 @@ import 'package:privacy_gui/page/login/views/local_reset_router_password_view.da
 import 'package:privacy_gui/page/instant_admin/_instant_admin.dart';
 import 'package:privacy_gui/page/nodes/_nodes.dart';
 import 'package:privacy_gui/page/nodes/views/add_nodes_view.dart';
+import 'package:privacy_gui/page/nodes/views/add_wired_nodes_view.dart';
 import 'package:privacy_gui/page/otp_flow/providers/_providers.dart';
 import 'package:privacy_gui/page/otp_flow/views/_views.dart';
 import 'package:privacy_gui/page/instant_setup/troubleshooter/views/call_support/call_support_main_region_view.dart';
@@ -121,6 +122,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       pnpRoute,
       pnpTroubleshootingRoute,
       addNodesRoute,
+      addWiredNodesRoute,
     ],
     redirect: (context, state) {
       if (state.matchedLocation == '/') {


### PR DESCRIPTION
This pull request introduces the ability to initiate both wired and wireless node pairing directly from the topology view.

- The "Instant Pair" action in the node's context menu has been replaced with a submenu containing "Pair wired node" and "Pair wireless node".
- Selecting "Pair wired node" now triggers the auto-onboarding process for wired nodes and displays a progress dialog. The user can cancel this process.
- Selecting "Pair wireless node" navigates to the existing wireless node adding flow.
- Added new translations for the pairing actions and dialogs.
- Introduced a `StatefulPopupMenuItem` to support complex widgets within popup menus.
- Refactored the `add_wired_nodes_provider` to allow for better control and cancellation of the pairing process.