### PR TITLE
[NOW-610] [PPPoE - Error Handling] When entering an invalid value into the PPPoE settings, the expected error handling does not appear.

### DIFF
--- a/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
+++ b/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
@@ -115,12 +115,17 @@ class _PnpIspSaveSettingsViewState
     }).onError((error, stackTrace) {
       logger.e(
           '[PnP]: Troubleshooter - Failed to save the new settings - $error');
-      
+
       if (error is JNAPSideEffectError) {
-        // Handle side effect error
-        showRouterNotFoundAlert(context, ref, onComplete: () async {
-          context.goNamed(RouteNamed.pnp);
-        });
+        final lastHandledResult = error.lastHandledResult;
+        if (lastHandledResult != null && lastHandledResult is JNAPSuccess) {
+          context.pop(_getErrorMessage(wanType));
+        } else {
+          // Handle side effect error
+          showRouterNotFoundAlert(context, ref, onComplete: () async {
+            context.goNamed(RouteNamed.pnp);
+          });
+        }
       } else if (error is JNAPError) {
         // Saving new settings failed
         context.pop(


### PR DESCRIPTION
This branch refactors the side effect provider to be able to catch the latest JNAP result. When saving ISP settings failed, instead of showing a generic error message, it now shows a more specific error message to indicate what went wrong.