### PR TITLE
[NOW-617] CLONE - After enable mac filter child node mac will auto add into filtered devices

### DIFF
--- a/lib/page/instant_privacy/providers/instant_privacy_provider.dart
+++ b/lib/page/instant_privacy/providers/instant_privacy_provider.dart
@@ -68,7 +68,7 @@ class InstantPrivacyNotifier extends Notifier<InstantPrivacyState> {
       macAddresses: mode == MacFilterMode.allow ? macAddresses : [],
       denyMacAddresses: mode == MacFilterMode.deny ? macAddresses : [],
       maxMacAddresses: settings.maxMACAddresses,
-      bssids: staBSSIDS,
+      bssids: staBSSIDS.map((e) => e.toUpperCase()).toList(),
       myMac: myMac,
     );
     final InstantPrivacyStatus newStatus = InstantPrivacyStatus(

--- a/lib/page/wifi_settings/providers/displayed_mac_filtering_devices_provider.dart
+++ b/lib/page/wifi_settings/providers/displayed_mac_filtering_devices_provider.dart
@@ -8,7 +8,8 @@ final macFilteringDeviceListProvider = Provider((ref) {
   final macFilteringState = ref.watch(instantPrivacyProvider);
   final deviceList = deviceListState.devices.where((device) => !device.isWired);
   final macAddresses = macFilteringState.settings.denyMacAddresses;
-  return macAddresses
+  final bssidList = macFilteringState.settings.bssids;
+  return (macAddresses.toSet()).difference(bssidList.toSet()).toList()
       .map((e) =>
           deviceList.firstWhereOrNull((device) => device.macAddress == e) ??
           DeviceListItem(macAddress: e, name: '--'))

--- a/lib/page/wifi_settings/views/mac_filtered_devices_view.dart
+++ b/lib/page/wifi_settings/views/mac_filtered_devices_view.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/instant_privacy/providers/instant_privacy_provider.dart';
-import 'package:privacy_gui/page/instant_privacy/providers/instant_privacy_state.dart';
 import 'package:privacy_gui/page/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/page/components/styled/styled_page_view.dart';
 import 'package:privacy_gui/page/components/views/arguments_view.dart';


### PR DESCRIPTION
This branch addresses an issue where child node MAC addresses were being unintentionally added to the filtered devices list when MAC filtering was enabled.

Changes:
*   `bssids` from `InstantPrivacyState` are now converted to uppercase to ensure consistent MAC address comparison.
*   The `macAddresses` list in `displayed_mac_filtering_devices_provider.dart` is now filtered to exclude `bssids`.
*   The unused import of `instant_privacy_state.dart` has been removed from `mac_filtered_devices_view.dart`.