### PR TITLE
fix(NOW-621): Add close button to filter page on mobile

### DIFF
--- a/lib/page/components/styled/styled_tab_page_view.dart
+++ b/lib/page/components/styled/styled_tab_page_view.dart
@@ -257,6 +257,7 @@ class StyledAppTabPageView extends ConsumerWidget {
           context: context,
           isScrollControlled: true,
           useRootNavigator: true,
+          showDragHandle: true,
           builder: (context) => Container(
               padding: const EdgeInsets.all(Spacing.large2),
               width: double.infinity,

--- a/lib/page/instant_device/views/instant_device_view.dart
+++ b/lib/page/instant_device/views/instant_device_view.dart
@@ -165,6 +165,7 @@ class _InstantDeviceViewState extends ConsumerState<InstantDeviceView> {
                         context: context,
                         isScrollControlled: true,
                         useRootNavigator: true,
+                        showDragHandle: true,
                         builder: (context) => Container(
                           padding: const EdgeInsets.all(Spacing.large2),
                           width: double.infinity,

--- a/lib/page/landing/views/home_view.dart
+++ b/lib/page/landing/views/home_view.dart
@@ -116,6 +116,7 @@ class _HomeViewState extends ConsumerState<HomeView> {
                   final _ = await showModalBottomSheet(
                       enableDrag: false,
                       context: context,
+                      showDragHandle: true,
                       builder: (context) => _createEnvPicker());
                   setState(() {});
                 })),

--- a/lib/page/nodes/views/node_detail_view.dart
+++ b/lib/page/nodes/views/node_detail_view.dart
@@ -255,6 +255,7 @@ class _NodeDetailViewState extends ConsumerState<NodeDetailView>
                     context: context,
                     isScrollControlled: true,
                     useRootNavigator: true,
+                    showDragHandle: true,
                     builder: (context) => Container(
                       padding: const EdgeInsets.all(Spacing.large2),
                       width: double.infinity,


### PR DESCRIPTION
fix(NOW-621): Add close button to filter page on mobile

**JIRA Ticket:** NOW-621

**Problem:**
On specific mobile devices, the filter page on the "Instant Device" screen opens in a full-screen modal without a visible close button, preventing users from dismissing it.

**Solution:**
This commit adds a drag handle to the top of the modal bottom sheet, providing a consistent and intuitive way for users to close it by dragging it down. This fix is applied to the following views to ensure a consistent user experience across the application:
- `StyledAppTabPageView`
- `InstantDeviceView`
- `HomeView`
- `NodeDetailView`

**Changes:**
- Set the `showDragHandle` property to `true` for `showModalBottomSheet` in the affected views.