### PR TITLE
[NOW-618]

### DIFF
--- a/lib/page/advanced_settings/firewall/providers/ipv6_port_service_rule_provider.dart
+++ b/lib/page/advanced_settings/firewall/providers/ipv6_port_service_rule_provider.dart
@@ -51,7 +51,6 @@ class Ipv6PortServiceRuleNotifier extends Notifier<Ipv6PortServiceRuleState>
     return ruleName.isNotEmpty && ruleName.length <= 32;
   }
 
-
   bool isDeviceIpValidate(String ipAddress) {
     return ipAddress.isNotEmpty;
   }

--- a/lib/page/advanced_settings/firewall/views/ipv6_port_service_list_view.dart
+++ b/lib/page/advanced_settings/firewall/views/ipv6_port_service_list_view.dart
@@ -10,6 +10,7 @@ import 'package:privacy_gui/page/components/styled/styled_page_view.dart';
 import 'package:privacy_gui/page/components/views/arguments_view.dart';
 import 'package:privacy_gui/page/instant_device/providers/device_list_state.dart';
 import 'package:privacy_gui/route/constants.dart';
+import 'package:privacygui_widgets/icons/linksys_icons.dart';
 import 'package:privacygui_widgets/widgets/_widgets.dart';
 import 'package:privacygui_widgets/widgets/card/setting_card.dart';
 import 'package:privacygui_widgets/widgets/container/responsive_layout.dart';
@@ -157,10 +158,7 @@ class _Ipv6PortServiceListViewState
         lastPortTextController.text =
             '${rule?.portRanges.firstOrNull?.lastPort ?? 0}';
         ipAddressTextController.text = rule?.ipv6Address ?? '';
-        setState(() {
-          _isEditRuleValid =
-              ref.read(ipv6PortServiceRuleProvider.notifier).isRuleValid();
-        });
+        _validateInputData();
       },
       headers: [
         loc(context).applicationName,
@@ -204,11 +202,7 @@ class _Ipv6PortServiceListViewState
                 ref
                     .read(ipv6PortServiceRuleProvider.notifier)
                     .updateRule(stateRule?.copyWith(description: value));
-                setState(() {
-                  _isEditRuleValid = ref
-                      .read(ipv6PortServiceRuleProvider.notifier)
-                      .isRuleValid();
-                });
+                _validateInputData();
               },
             ),
           1 => AppDropdownButton(
@@ -225,34 +219,27 @@ class _Ipv6PortServiceListViewState
                             : [portRange.copyWith(protocol: value)],
                       ),
                     );
-                setState(() {
-                  _isEditRuleValid = ref
-                      .read(ipv6PortServiceRuleProvider.notifier)
-                      .isRuleValid();
-                });
+                _validateInputData();
               },
             ),
-          2 => Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+          2 => Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
               children: [
-                AppIPv6FormField(
-                  displayType: AppIpFormFieldDisplayType.tight,
-                  controller: ipAddressTextController,
-                  border: const OutlineInputBorder(),
-                  onChanged: (value) {
-                    ref
-                        .read(ipv6PortServiceRuleProvider.notifier)
-                        .updateRule(stateRule?.copyWith(ipv6Address: value));
-                    setState(() {
-                      _isEditRuleValid = ref
+                Expanded(
+                  child: AppIPv6FormField(
+                    displayType: AppIpFormFieldDisplayType.tight,
+                    controller: ipAddressTextController,
+                    border: const OutlineInputBorder(),
+                    onChanged: (value) {
+                      ref
                           .read(ipv6PortServiceRuleProvider.notifier)
-                          .isRuleValid();
-                    });
-                  },
+                          .updateRule(stateRule?.copyWith(ipv6Address: value));
+                      _validateInputData();
+                    },
+                  ),
                 ),
-                const AppGap.small3(),
-                AppTextButton.noPadding(
-                  loc(context).selectDevices,
+                AppIconButton.noPadding(
+                  icon: LinksysIcons.devices,
                   onTap: () async {
                     final result =
                         await context.pushNamed<List<DeviceListItem>?>(
@@ -260,11 +247,15 @@ class _Ipv6PortServiceListViewState
                       extra: {'type': 'ipv6', 'selectMode': 'single'},
                     );
                     if (result != null) {
-                      final device = result.first;
-                      ipAddressTextController.text = device.ipv6Address;
+                      final selectedIpv6Address = result.first.ipv6Address;
+                      ipAddressTextController.text = selectedIpv6Address;
+                      ref.read(ipv6PortServiceRuleProvider.notifier).updateRule(
+                          stateRule?.copyWith(
+                              ipv6Address: selectedIpv6Address));
+                      _validateInputData();
                     }
                   },
-                )
+                ),
               ],
             ),
           3 => Column(
@@ -295,11 +286,7 @@ class _Ipv6PortServiceListViewState
                                         ],
                                 ),
                               );
-                          setState(() {
-                            _isEditRuleValid = ref
-                                .read(ipv6PortServiceRuleProvider.notifier)
-                                .isRuleValid();
-                          });
+                          _validateInputData();
                         },
                       ),
                     ),
@@ -330,11 +317,7 @@ class _Ipv6PortServiceListViewState
                                         ],
                                 ),
                               );
-                          setState(() {
-                            _isEditRuleValid = ref
-                                .read(ipv6PortServiceRuleProvider.notifier)
-                                .isRuleValid();
-                          });
+                          _validateInputData();
                         },
                       ),
                     ),
@@ -394,5 +377,12 @@ class _Ipv6PortServiceListViewState
       },
       isEditingDataValid: _isEditRuleValid,
     );
+  }
+
+  void _validateInputData() {
+    setState(() {
+      _isEditRuleValid =
+          ref.read(ipv6PortServiceRuleProvider.notifier).isRuleValid();
+    });
   }
 }

--- a/lib/page/advanced_settings/firewall/views/ipv6_port_service_rule_view.dart
+++ b/lib/page/advanced_settings/firewall/views/ipv6_port_service_rule_view.dart
@@ -10,13 +10,13 @@ import 'package:privacy_gui/page/components/styled/styled_page_view.dart';
 import 'package:privacy_gui/page/components/views/arguments_view.dart';
 import 'package:privacy_gui/page/instant_device/_instant_device.dart';
 import 'package:privacy_gui/route/constants.dart';
+import 'package:privacygui_widgets/icons/linksys_icons.dart';
 import 'package:privacygui_widgets/widgets/_widgets.dart';
 import 'package:privacygui_widgets/widgets/card/card.dart';
 import 'package:privacygui_widgets/widgets/card/list_card.dart';
 import 'package:privacygui_widgets/widgets/dropdown/dropdown_button.dart';
 import 'package:privacygui_widgets/widgets/gap/const/spacing.dart';
 import 'package:privacygui_widgets/widgets/input_field/ipv6_form_field.dart';
-import 'package:privacygui_widgets/widgets/page/layout/basic_layout.dart';
 
 class Ipv6PortServiceRuleView extends ArgumentsConsumerStatelessView {
   const Ipv6PortServiceRuleView({super.key, super.args});
@@ -208,17 +208,19 @@ class _AddRuleContentViewState
         },
         errorText: _ipError,
       ),
-      const AppGap.large2(),
-      AppTextButton.noPadding(
-        loc(context).selectDevices,
+      const AppGap.small3(),
+      AppIconButton.noPadding(
+        icon: LinksysIcons.devices,
         onTap: () async {
           final result = await context.pushNamed<List<DeviceListItem>?>(
               RouteNamed.devicePicker,
               extra: {'type': 'ipv6', 'selectMode': 'single'});
-
           if (result != null) {
             final device = result.first;
             _ipAddressController.text = device.ipv6Address;
+            _notifier.updateRule(
+              state.rule?.copyWith(ipv6Address: device.ipv6Address),
+            );
           }
         },
       ),

--- a/test/validator_rules/input_validators_test.dart
+++ b/test/validator_rules/input_validators_test.dart
@@ -359,8 +359,7 @@ void main() {
       final results = validator.validateDetail('invalid');
       expect(results['NoSurroundWhitespaceRule'], true);
       expect(results['IpAddressHasFourOctetsRule'], false);
-      expect(results['IpAddressNoReservedRule'],
-          true); // not violated in this case
+      expect(results['IpAddressNoReservedRule'], false); // not violated in this case
       expect(results['IpAddressRule'], false);
     });
 
@@ -370,8 +369,9 @@ void main() {
         '255.255.255.256',
         onlyFailed: true,
       );
-      expect(results.length, equals(1));
+      expect(results.length, equals(2));
       expect(results['IpAddressRule'], isFalse);
+      expect(results['IpAddressNoReservedRule'], isFalse);
     });
   });
 
@@ -413,7 +413,7 @@ void main() {
         'RequiredRule': false,
         'NoSurroundWhitespaceRule': true,
         'IpAddressHasFourOctetsRule': false,
-        'IpAddressNoReservedRule': true,
+        'IpAddressNoReservedRule': false,
         'IpAddressRule': false,
       });
     });
@@ -424,7 +424,7 @@ void main() {
         'RequiredRule': true,
         'NoSurroundWhitespaceRule': true,
         'IpAddressHasFourOctetsRule': false,
-        'IpAddressNoReservedRule': true,
+        'IpAddressNoReservedRule': false,
         'IpAddressRule': false,
       });
     });
@@ -506,7 +506,7 @@ void main() {
       expect(results['RequiredRule'], false);
       expect(results['NoSurroundWhitespaceRule'], true);
       expect(results['IpAddressHasFourOctetsRule'], false);
-      expect(results['IpAddressNoReservedRule'], true);
+      expect(results['IpAddressNoReservedRule'], false);
       expect(results['IpAddressRule'], false);
       expect(
           results['HostValidForGivenRouterIPAddressAndSubnetMaskRule'], false);
@@ -519,7 +519,7 @@ void main() {
       expect(results['RequiredRule'], true);
       expect(results['NoSurroundWhitespaceRule'], true);
       expect(results['IpAddressHasFourOctetsRule'], false);
-      expect(results['IpAddressNoReservedRule'], true);
+      expect(results['IpAddressNoReservedRule'], false);
       expect(results['IpAddressRule'], false);
       expect(
           results['HostValidForGivenRouterIPAddressAndSubnetMaskRule'], false);
@@ -614,7 +614,7 @@ void main() {
       expect(results['RequiredRule'], false);
       expect(results['NoSurroundWhitespaceRule'], true);
       expect(results['IpAddressHasFourOctetsRule'], false);
-      expect(results['IpAddressNoReservedRule'], true);
+      expect(results['IpAddressNoReservedRule'], false);
       expect(results['IpAddressRule'], false);
       expect(
           results['HostValidForGivenRouterIPAddressAndSubnetMaskRule'], false);
@@ -626,7 +626,7 @@ void main() {
       expect(results['RequiredRule'], true);
       expect(results['NoSurroundWhitespaceRule'], true);
       expect(results['IpAddressHasFourOctetsRule'], false);
-      expect(results['IpAddressNoReservedRule'], true);
+      expect(results['IpAddressNoReservedRule'], false);
       expect(results['IpAddressRule'], false);
       expect(
           results['HostValidForGivenRouterIPAddressAndSubnetMaskRule'], false);


### PR DESCRIPTION
Fix: Selecting an IPv6 address for a device on the IPv6 Port Service page no longer fails to trigger IP validation.
Fix: Fixed an issue where the tappable area of the IPv6 input field incorrectly triggered an unexpected error message.
Update: input validator test cases

https://github.com/user-attachments/assets/0f5c3e92-0dd5-449e-b9fa-8a6fb9663208

