### PR TITLE
[NOW-589] Fixed unexpected blank screen after updating FW versions

### DIFF
--- a/lib/page/firmware_update/views/firmware_update_detail_view.dart
+++ b/lib/page/firmware_update/views/firmware_update_detail_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/jnap/models/firmware_update_status.dart';
+import 'package:privacy_gui/core/jnap/providers/device_manager_provider.dart';
 import 'package:privacy_gui/core/jnap/providers/device_manager_state.dart';
 import 'package:privacy_gui/core/jnap/providers/firmware_update_provider.dart';
 import 'package:privacy_gui/core/utils/devices.dart';
@@ -36,13 +37,12 @@ class _FirmwareUpdateDetailViewState
     final statusRecords =
         ref.read(firmwareUpdateProvider.notifier).getIDStatusRecords();
     candicateIDs = statusRecords.where((record) {
-      return record.$2.availableUpdate != null;
+      // Before the update process, the node objects in record should not be null
+      return record.$2.availableUpdate != null && record.$1 != null;
     }).map((record) {
-      return record.$1.deviceID;
+      return record.$1!.deviceID;
     }).toList();
-    logger.i('[FIRMWARE]: Nodes and firmware maps: ${statusRecords.map((e) {
-      return (e.$1.friendlyName, e.$2);
-    })}');
+    logger.i('[FIRMWARE]: Nodes with available updates: $candicateIDs');
     super.initState();
   }
 
@@ -50,12 +50,32 @@ class _FirmwareUpdateDetailViewState
   Widget build(BuildContext context) {
     final state = ref.watch(firmwareUpdateProvider);
     // Build records for node deivces and their firmware status
-    final statusRecords =
+    var statusRecords =
         ref.read(firmwareUpdateProvider.notifier).getIDStatusRecords();
+    // If any node devices are null and cached candidates exists, use them
+    if (statusRecords.any((record) => record.$1 == null) &&
+        ref.read(firmwareUpdateCandidateProvider) != null) {
+      // Find any node device that is null and use the cached candidates to replace it
+      statusRecords = statusRecords.map((record) {
+        if (record.$1 == null) {
+          final cachedRecord = ref
+              .read(firmwareUpdateCandidateProvider)!
+              .firstWhere(
+                (candidate) => candidate.$1?.deviceID == record.$1?.deviceID,
+                orElse: () =>
+                    (ref.read(deviceManagerProvider).masterDevice, record.$2),
+              );
+          logger.d(
+              '[FIRMWARE]: Node device is null, use cached candidate: ${cachedRecord.$1?.deviceID}');
+          return (cachedRecord.$1, record.$2);
+        }
+        return record;
+      }).toList();
+    }
     // Find any ongoing updating operations for candicates
     final ongoingList = statusRecords.where((record) {
       return record.$2.pendingOperation != null &&
-          candicateIDs.contains(record.$1.deviceID);
+          candicateIDs.contains(record.$1?.deviceID);
     }).toList();
     final isUpdating = state.isUpdating;
     final isUpdateAvailable =
@@ -65,7 +85,7 @@ class _FirmwareUpdateDetailViewState
     logger.i(
         '[FIRMWARE]: Any update available: $isUpdateAvailable, isUpdating: $isUpdating');
     logger.i('[FIRMWARE]: Ongoing process: ${ongoingList.map((e) {
-      return (e.$1.friendlyName, e.$2);
+      return (e.$1?.friendlyName, e.$2);
     })}');
     // When the client fails to reconnect to the router after updating the firmware
     // the retry requests will reach the max limit and the alert will pop up
@@ -112,7 +132,7 @@ class _FirmwareUpdateDetailViewState
   }
 
   Widget _buildList(
-    List<(LinksysDevice, FirmwareUpdateStatus)> statusRecords,
+    List<(LinksysDevice?, FirmwareUpdateStatus)> statusRecords,
     bool isWaitingChildren,
   ) {
     return Expanded(
@@ -130,14 +150,14 @@ class _FirmwareUpdateDetailViewState
             // For updated nodes, we mock up the versions for a while to avoid a mismatch in displayed info,
             // For nodes without updates, remain the original versions
             currentVersion = updateStatus.availableUpdate?.firmwareVersion ??
-                (nodeDevice.unit.firmwareVersion ?? loc(context).unknown);
+                (nodeDevice?.unit.firmwareVersion ?? loc(context).unknown);
             newVersion = null;
           } else {
             currentVersion =
-                nodeDevice.unit.firmwareVersion ?? loc(context).unknown;
+                nodeDevice?.unit.firmwareVersion ?? loc(context).unknown;
             newVersion = updateStatus.availableUpdate?.firmwareVersion;
           }
-          final modelNumber = nodeDevice.modelNumber ?? '';
+          final modelNumber = nodeDevice?.modelNumber ?? '';
           final routerImage = Image(
             height: 40,
             image: CustomTheme.of(context).getRouterImage(
@@ -146,7 +166,7 @@ class _FirmwareUpdateDetailViewState
 
           return FirmwareUpdateNodeCard(
             image: routerImage,
-            title: nodeDevice.getDeviceName(),
+            title: nodeDevice?.getDeviceName() ?? loc(context).device,
             model: modelNumber,
             currentVersion: currentVersion,
             newVersion: newVersion,
@@ -159,7 +179,7 @@ class _FirmwareUpdateDetailViewState
   }
 
   Widget _updatingProgressView(
-      List<(LinksysDevice, FirmwareUpdateStatus)> list) {
+      List<(LinksysDevice?, FirmwareUpdateStatus)> list) {
     if (list.isEmpty) {
       // if updating is ture but there are not items in the ongoing list,
       // it is a temporary blank period before getting the operation data
@@ -189,9 +209,12 @@ class _FirmwareUpdateDetailViewState
     );
   }
 
-  Widget _buildProgressIndicator((LinksysDevice, FirmwareUpdateStatus) record) {
-    final name = record.$1.getDeviceName();
-    final operationType = _getOperationType(context, record.$2.pendingOperation?.operation);
+  Widget _buildProgressIndicator(
+      (LinksysDevice?, FirmwareUpdateStatus) record) {
+    // The device will not be null here because the master is at least fallback one
+    final name = record.$1?.getDeviceName() ?? loc(context).device;
+    final operationType =
+        _getOperationType(context, record.$2.pendingOperation?.operation);
     final progressPercent = record.$2.pendingOperation?.progressPercent ?? 0;
     return Stack(
       alignment: Alignment.center,
@@ -219,7 +242,7 @@ class _FirmwareUpdateDetailViewState
     );
   }
 
-    String _getOperationType(BuildContext context, String? operation) {
+  String _getOperationType(BuildContext context, String? operation) {
     final lowerOperation = operation?.toLowerCase() ?? '';
     return switch (lowerOperation) {
       'downloading' || 'checking' => loc(context).firmwareDownloadingTitle,


### PR DESCRIPTION
This is because some node objects that need to be updated are missing from the DeviceManager, and therefore the 'firstWhere' method will throw an error. (This may occur in the Pinnacle routers with CF production.)

Solution: Save the node objects and their corresponding status into memory as a cache, which can be used later if the node objects unexpectedly get lost during rebooting.