### PR TITLE
[NOW-629]: Advanced Routing - Static routing can be set but has no function

### DIFF
--- a/lib/core/utils/nodes.dart
+++ b/lib/core/utils/nodes.dart
@@ -336,6 +336,7 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'SPNM60',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
+    'isHidingRipRouting': true,
     'pattern': '^spnm60',
   },
   {
@@ -344,6 +345,7 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'SPNM61',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
+    'isHidingRipRouting': true,
     'pattern': '^spnm61',
   },
   {
@@ -352,6 +354,7 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'SPNM62',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
+    'isHidingRipRouting': true,
     'pattern': '^spnm62',
   },
   {
@@ -360,6 +363,7 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'M60',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
+    'isHidingRipRouting': true,
     'pattern': '^m60',
   },
   {
@@ -368,6 +372,7 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'M61',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
+    'isHidingRipRouting': true,
     'pattern': '^m61',
   },
   {
@@ -376,6 +381,7 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'M62',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
+    'isHidingRipRouting': true,
     'pattern': '^m62',
   },
   {
@@ -506,4 +512,14 @@ bool isHorizontalPorts({
         modelNumber: modelNumber,
         hardwareVersion: hardwareVersion,
         paramName: 'isHorizontalPorts') ??
+    false;
+
+bool isHidingRipRouting({
+  required String modelNumber,
+  required String hardwareVersion,
+}) =>
+    doVelopModelTests(
+        modelNumber: modelNumber,
+        hardwareVersion: hardwareVersion,
+        paramName: 'isHidingRipRouting') ??
     false;

--- a/lib/page/advanced_settings/advanced_settings_view.dart
+++ b/lib/page/advanced_settings/advanced_settings_view.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/core/jnap/providers/dashboard_manager_provider.dart';
 import 'package:privacy_gui/core/utils/extension.dart';
+import 'package:privacy_gui/core/utils/nodes.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/components/styled/styled_page_view.dart';
 import 'package:privacy_gui/page/dashboard/_dashboard.dart';
@@ -85,11 +87,12 @@ class _AdvancedSettingsViewState extends ConsumerState<AdvancedSettingsView> {
           title: loc(context).localNetwork,
           onTap: () => context.goNamed(RouteNamed.settingsLocalNetwork),
           disabledOnBridge: true),
-      AppSectionItemData(
-        title: loc(context).advancedRouting,
-        onTap: () => context.goNamed(RouteNamed.settingsStaticRouting),
-        disabledOnBridge: true,
-      ),
+      if (!_isHidingRipRouting)
+        AppSectionItemData(
+          title: loc(context).advancedRouting,
+          onTap: () => context.goNamed(RouteNamed.settingsStaticRouting),
+          disabledOnBridge: true,
+        ),
       AppSectionItemData(
         title: loc(context).administration,
         onTap: () => context.goNamed(RouteNamed.settingsAdministration),
@@ -124,5 +127,12 @@ class _AdvancedSettingsViewState extends ConsumerState<AdvancedSettingsView> {
         onTap: disabled ? null : item.onTap,
       ),
     );
+  }
+
+  bool get _isHidingRipRouting {
+    final deviceInfo = ref.read(dashboardManagerProvider).deviceInfo;
+    return isHidingRipRouting(
+        modelNumber: deviceInfo?.modelNumber ?? '',
+        hardwareVersion: deviceInfo?.hardwareVersion ?? '1');
   }
 }


### PR DESCRIPTION
This change hides the RIP routing settings for specific Velop models.

- Added isHidingRipRouting property to the node configuration for several Velop models in lib/core/utils/nodes.dart.
- Introduced a new utility function, isHidingRipRouting, to determine whether to hide the routing feature based on the devices model and hardware version.
- Updated lib/page/advanced_settings/advanced_settings_view.dart to conditionally display the Advanced Routing section based on the output of the isHidingRipRouting function.