### PR TITLE
NOW-632: CLONE - instant-device: client's Manufacturer, Device and IPv6 Address info is empty.

### DIFF
--- a/lib/page/instant_device/providers/device_list_provider.dart
+++ b/lib/page/instant_device/providers/device_list_provider.dart
@@ -69,7 +69,7 @@ class DeviceListNotifier extends Notifier<DeviceListState> {
     ipv6Address = isOnline ? (device.connections.first.ipv6Address ?? '') : '';
     macAddress = device.getMacAddress();
     manufacturer = device.manufacturer ?? '';
-    model = device.modelNumber ?? '';
+    model = device.modelNumber ?? device.model.deviceType;
     operatingSystem = device.operatingSystem ?? '';
     band = ref.read(deviceManagerProvider.notifier).getBandConnectedBy(device);
     signalStrength = device.signalDecibels;


### PR DESCRIPTION

- Add fallback to retrieve model.deviceType if modelNumber is empty