### PR TITLE
[NOW-628] improved WiFi password validation, addressing the special handling for PSK

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -886,6 +886,7 @@
   "wifiName": "اسم WiFi",
   "wifiPassword": "كلمة مرور WiFi",
   "wifiPasswordLimit": "8 - 64 حرفًا",
+  "wifiPasswordRuleHex": "مفتاح PSK سداسي عشري مطلوب (0-9، A-F، a-f)",
   "wifiSSIDLengthLimit": "يجب أن يكون أقل من 32 حرفًا",
   "wifiShareQRScan": "قم بمسح رمز الاستجابة السريعة للانضمام إلى هذه الشبكة",
   "wildcard": "حرف بدل",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -885,6 +885,7 @@
   "wifiName": "WiFi navn",
   "wifiPassword": "WiFi adgangskode",
   "wifiPasswordLimit": "8 - 64 tegn",
+  "wifiPasswordRuleHex": "Hexadecimal PSK påkrævet (0-9, A-F, a-f)",
   "wifiSSIDLengthLimit": "Skal indeholde mindre end 32 tegn",
   "wifiShareQRScan": "Scan QR-koden for at deltage i dette netværk",
   "wildcard": "Jokertegn",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -885,6 +885,7 @@
   "wifiName": "WLAN-Name",
   "wifiPassword": "WLAN-Passwort",
   "wifiPasswordLimit": "8 - 64 Zeichen",
+  "wifiPasswordRuleHex": "Hexadezimaler PSK erforderlich (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Muss weniger als 32 Zeichen enthalten",
   "wifiShareQRScan": "Scannen Sie den QR-Code, um diesem Netzwerk beizutreten",
   "wildcard": "Platzhalter",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -838,6 +838,7 @@
   "wifiName": "Όνομα WiFi",
   "wifiPassword": "Κωδικός πρόσβασης WiFi",
   "wifiPasswordLimit": "8 - 64 χαρακτήρες",
+  "wifiPasswordRuleHex": "Απαιτείται δεκαεξαδικό PSK (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Πρέπει να είναι λιγότερο από 32 χαρακτήρες",
   "wifiShareQRScan": "Σαρώστε τον κωδικό QR για να συνδεθείτε σε αυτό το δίκτυο",
   "wildcard": "Χαρακτήρας μπαλαντέρ",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1009,6 +1009,7 @@
   "wifiName": "WiFi name",
   "wifiPassword": "WiFi password",
   "wifiPasswordLimit": "8 - 64 characters",
+  "wifiPasswordRuleHex": "Hexadecimal PSK required (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Must less than 32 character",
   "wifiShareQRScan": "Scan the QR code to join this network",
   "wildcard": "Wildcard",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -885,6 +885,7 @@
   "wifiName": "Nombre de WiFi",
   "wifiPassword": "Contraseña de WiFi",
   "wifiPasswordLimit": "8 - 64 caracteres",
+  "wifiPasswordRuleHex": "Se requiere PSK hexadecimal (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Debe tener menos de 32 caracteres",
   "wifiShareQRScan": "Escanee el código QR para unirse a esta red",
   "wildcard": "Comodín",

--- a/lib/l10n/app_es_ar.arb
+++ b/lib/l10n/app_es_ar.arb
@@ -885,6 +885,7 @@
   "wifiName": "Nombre de WiFi",
   "wifiPassword": "Contraseña de WiFi",
   "wifiPasswordLimit": "8 - 64 caracteres",
+  "wifiPasswordRuleHex": "Se requiere PSK hexadecimal (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Debe tener menos de 32 caracteres",
   "wifiShareQRScan": "Escanee el código QR para unirse a esta red",
   "wildcard": "Comodín",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -838,6 +838,7 @@
   "wifiName": "WiFi-verkon nimi",
   "wifiPassword": "WiFi-salasana",
   "wifiPasswordLimit": "8–64 merkkiä",
+  "wifiPasswordRuleHex": "Heksadesimaalinen PSK vaaditaan (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Enintään 32 merkkiä",
   "wifiShareQRScan": "Skannaa QR-koodi liittyäksesi tähän verkkoon",
   "wildcard": "Yleismerkki",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -885,6 +885,7 @@
   "wifiName": "Nom WiFi",
   "wifiPassword": "Mot de passe WiFi",
   "wifiPasswordLimit": "8 à 64 caractères",
+  "wifiPasswordRuleHex": "PSK hexadécimal requis (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Doit être inférieur à 32 caractères",
   "wifiShareQRScan": "Scanner le code QR pour rejoindre ce réseau",
   "wildcard": "Caractère générique ",

--- a/lib/l10n/app_fr_ca.arb
+++ b/lib/l10n/app_fr_ca.arb
@@ -885,6 +885,7 @@
   "wifiName": "Nom du réseau sans-fil",
   "wifiPassword": "Mot de passe du réseau sans-fil",
   "wifiPasswordLimit": "8 à 64 caractères",
+  "wifiPasswordRuleHex": "PSK hexadécimal requis (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Doit être inférieur à 32 caractères",
   "wifiShareQRScan": "Scanner le code QR pour rejoindre ce réseau",
   "wildcard": "Caractère générique ",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -838,6 +838,7 @@
   "wifiName": "Nama WiFi",
   "wifiPassword": "Kata Sandi WiFi",
   "wifiPasswordLimit": "8 - 64 karakter",
+  "wifiPasswordRuleHex": "PSK heksadesimal diperlukan (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Harus kurang dari 32 karakter",
   "wifiShareQRScan": "Pindai kode QR untuk bergabung dengan jaringan ini",
   "wildcard": "Wildcard",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -885,6 +885,7 @@
   "wifiName": "Nome WiFi",
   "wifiPassword": "Password WiFi",
   "wifiPasswordLimit": "8 - 64 caratteri",
+  "wifiPasswordRuleHex": "PSK esadecimale richiesto (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Deve essere inferiore a 32 caratteri",
   "wifiShareQRScan": "Scansionare il codice QR per unirsi alla rete",
   "wildcard": "Wildcard",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -886,6 +886,7 @@
   "wifiName": "WiFi の名前",
   "wifiPassword": "WiFi のパスワード",
   "wifiPasswordLimit": "8 - 64文字",
+  "wifiPasswordRuleHex": "16進数PSKが必要です (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "32文字未満でなければなりません。",
   "wifiShareQRScan": "このネットワークに参加するにはQRコードをスキャンしてください。",
   "wildcard": "ワイルドカード",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -838,6 +838,7 @@
   "wifiName": "WiFi 이름",
   "wifiPassword": "WiFi 암호",
   "wifiPasswordLimit": "8 - 64자",
+  "wifiPasswordRuleHex": "16진수 PSK 필요 (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "32자 미만이어야 함",
   "wifiShareQRScan": "QR 코드를 스캔하여 이 네트워크에 참여",
   "wildcard": "와일드카드",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -885,6 +885,7 @@
   "wifiName": "WiFi-navn",
   "wifiPassword": "WiFi-passord",
   "wifiPasswordLimit": "8 - 64 tegn",
+  "wifiPasswordRuleHex": "Hexadesimal PSK påkrevd (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Må inneholde mindre enn 32 tegn",
   "wifiShareQRScan": "Skann QR-koden for å bli med i dette nettverket",
   "wildcard": "Jokertegn",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -885,6 +885,7 @@
   "wifiName": "WiFi-naam",
   "wifiPassword": "WiFi-wachtwoord",
   "wifiPasswordLimit": "8 - 64 tekens",
+  "wifiPasswordRuleHex": "Hexadecimale PSK vereist (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Moet minder dan 32 tekens lang zijn",
   "wifiShareQRScan": "Scan de QR-code om lid te worden van dit netwerk",
   "wildcard": "Joker",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -838,6 +838,7 @@
   "wifiName": "Nazwa sieci WiFi",
   "wifiPassword": "Hasło sieci WiFi",
   "wifiPasswordLimit": "8-64 znaki",
+  "wifiPasswordRuleHex": "Wymagany szesnastkowy klucz PSK (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Musi mieć mniej niż 32 znaki",
   "wifiShareQRScan": "Zeskanuj kod QR, aby dołączyć do tej sieci",
   "wildcard": "Wyrażenie wieloznaczne",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -885,6 +885,7 @@
   "wifiName": "Nome do WiFi",
   "wifiPassword": "Senha do WiFi",
   "wifiPasswordLimit": "8 - 64 caracteres",
+  "wifiPasswordRuleHex": "PSK hexadecimal necessário (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Deve ter menos de 32 caracteres",
   "wifiShareQRScan": "Leia o código QR para entrar nesta rede",
   "wildcard": "Caractere curinga",

--- a/lib/l10n/app_pt_pt.arb
+++ b/lib/l10n/app_pt_pt.arb
@@ -885,6 +885,7 @@
   "wifiName": "Nome WiFi",
   "wifiPassword": "Palavra-passe do WiFi",
   "wifiPasswordLimit": "8 - 64 caracteres",
+  "wifiPasswordRuleHex": "PSK hexadecimal necessário (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Deve ter menos de 32 caracteres",
   "wifiShareQRScan": "Leia o código QR para entrar nesta rede",
   "wildcard": "Carácter universal",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -838,6 +838,7 @@
   "wifiName": "Имя сети WiFi",
   "wifiPassword": "Пароль WiFi",
   "wifiPasswordLimit": "8 - 64 символа",
+  "wifiPasswordRuleHex": "Требуется шестнадцатеричный PSK (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Должно быть меньше 32 символов",
   "wifiShareQRScan": "Отсканируйте QR-код, чтобы присоединиться к этой сети",
   "wildcard": "Подстановочный знак",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -885,6 +885,7 @@
   "wifiName": "WiFi-namn",
   "wifiPassword": "WiFi-lösenord",
   "wifiPasswordLimit": "8 - 64 tecken",
+  "wifiPasswordRuleHex": "Hexadecimal PSK krävs (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Måste innehålla mindre än 32 tecken",
   "wifiShareQRScan": "Skanna QR-koden för att ansluta till nätverket",
   "wildcard": "Jokertecken",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -838,6 +838,7 @@
   "wifiName": "ชื่อ WiFi",
   "wifiPassword": "รหัสผ่าน WiFi",
   "wifiPasswordLimit": "8 - 64 ตัวอักษร",
+  "wifiPasswordRuleHex": "ต้องระบุ PSK แบบเลขฐานสิบหก (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "ต้องน้อยกว่า 32 ตัวอักษร",
   "wifiShareQRScan": "สแกนรหัส QR เพื่อเข้าร่วมเครือข่ายนี้",
   "wildcard": "อักขระตัวแทน",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -838,6 +838,7 @@
   "wifiName": "WiFi Adı",
   "wifiPassword": "WiFi Şifresi",
   "wifiPasswordLimit": "8 - 64 karakter",
+  "wifiPasswordRuleHex": "Onaltılık PSK gerekli (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "32 karakterden az olmalı",
   "wifiShareQRScan": "Bu ağa katılmak için QR kodunu tarayın",
   "wildcard": "Joker karakter",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -838,6 +838,7 @@
   "wifiName": "Tên WiFi",
   "wifiPassword": "Mật khẩu WiFi",
   "wifiPasswordLimit": "Mật khẩu WiFi phải từ 8-63 ký tự",
+  "wifiPasswordRuleHex": "Yêu cầu PSK hệ thập lục phân (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "Tên WiFi phải từ 1-32 ký tự",
   "wifiShareQRScan": "Quét mã QR để chia sẻ WiFi",
   "wildcard": "Ký tự đại diện",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -893,6 +893,7 @@
   "wifiName": "WiFi名称",
   "wifiPassword": "WiFi密码",
   "wifiPasswordLimit": "8 - 64个字符",
+  "wifiPasswordRuleHex": "需要十六进制 PSK (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "必须少于32个字符",
   "wifiShareQRScan": "扫描此二维码可加入该网络",
   "wildcard": "通配符",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -893,6 +893,7 @@
   "wifiName": "WiFi 名稱",
   "wifiPassword": "WiFi 密碼",
   "wifiPasswordLimit": "8 - 64個字符",
+  "wifiPasswordRuleHex": "需要十六進位 PSK (0–9, A–F, a–f)",
   "wifiSSIDLengthLimit": "必須少於32個字符",
   "wifiShareQRScan": "掃描此二維碼即可加入該網絡",
   "wildcard": "萬用字元",

--- a/lib/page/instant_setup/widgets/wifi_password_widget.dart
+++ b/lib/page/instant_setup/widgets/wifi_password_widget.dart
@@ -31,7 +31,7 @@ class _WiFiPasswordFieldState extends ConsumerState<WiFiPasswordField> {
     RequiredRule(),
     NoSurroundWhitespaceRule(),
     WiFiPasswordRule(ignoreLength: true),
-    LengthRule(min: 8),
+    LengthRule(min: 8, max: 64),
   ]);
 
   @override
@@ -40,22 +40,6 @@ class _WiFiPasswordFieldState extends ConsumerState<WiFiPasswordField> {
       border: const OutlineInputBorder(),
       headerText: widget.label,
       hintText: widget.hint,
-      // errorText: () {
-      //   if (widget.controller?.text.isEmpty == true) {
-      //     return null;
-      //   }
-      //   final errorKeys = wifiPasswordValidator
-      //       .validateDetail(widget.controller?.text ?? '', onlyFailed: true)
-      //     ..removeWhere((key, value) => key == (LengthRule).toString());
-      //   if (errorKeys.isEmpty) {
-      //     return null;
-      //   } else if (errorKeys.keys.first ==
-      //       (NoSurroundWhitespaceRule).toString()) {
-      //     return loc(context).routerPasswordRuleStartEndWithSpace;
-      //   } else if (errorKeys.keys.first == (WiFiPasswordRule).toString()) {
-      //     return loc(context).routerPasswordRuleUnsupportSpecialChar;
-      //   }
-      // }(),
       validations: [
         Validation(
             description: loc(context).wifiPasswordLimit,
@@ -65,8 +49,13 @@ class _WiFiPasswordFieldState extends ConsumerState<WiFiPasswordField> {
             validator: NoSurroundWhitespaceRule().validate),
         Validation(
           description: loc(context).routerPasswordRuleUnsupportSpecialChar,
-          validator: ((text) => AsciiRule().validate(text)),
+          validator: (AsciiRule().validate),
         ),
+        if (widget.controller?.text.length == 64)
+          Validation(
+            description: loc(context).wifiPasswordRuleHex,
+            validator: WiFiPSKRule().validate,
+          ),
       ],
       controller: widget.controller,
       onChanged: (value) {

--- a/lib/page/wifi_settings/views/wifi_list_view.dart
+++ b/lib/page/wifi_settings/views/wifi_list_view.dart
@@ -660,10 +660,12 @@ class _WiFiListViewState extends ConsumerState<WiFiListView>
     TextEditingController controller = TextEditingController()
       ..text = initValue;
     bool isPasswordValid = true;
+    bool isLength64 = initValue.length == 64;
     final InputValidator wifiPasswordValidator = InputValidator([
       LengthRule(min: 8, max: 64),
       NoSurroundWhitespaceRule(),
       AsciiRule(),
+      WiFiPSKRule(),
     ]);
     final result = await showSubmitAppDialog<String>(
       context,
@@ -697,9 +699,24 @@ class _WiFiListViewState extends ConsumerState<WiFiListView>
                       wifiPasswordValidator.getRuleByIndex(2)?.validate(text) ??
                       false),
                 ),
+                if (isLength64)
+                  Validation(
+                    description: loc(context).wifiPasswordRuleHex,
+                    validator: ((text) =>
+                        wifiPasswordValidator
+                            .getRuleByIndex(3)
+                            ?.validate(text) ??
+                        false),
+                  ),
               ],
+              onChanged: (value) {
+                setState(() {
+                  isLength64 = value.length == 64;
+                });
+              },
               onValidationChanged: (isValid) => setState(() {
-                isPasswordValid = isValid;
+                isPasswordValid =
+                    wifiPasswordValidator.validate(controller.text);
               }),
               onSubmitted: (_) {
                 if (wifiPasswordValidator.validate(controller.text)) {

--- a/lib/validator_rules/rules.dart
+++ b/lib/validator_rules/rules.dart
@@ -109,6 +109,23 @@ class AsciiRule extends RegExValidationRule {
   RegExp get _rule => RegExp(r'^[\x20-\x7E]+$');
 }
 
+class WiFiPSKRule extends RegExValidationRule {
+  @override
+  String get name => 'WiFiPSKRule';
+
+  @override
+  RegExp get _rule => RegExp(r'^[0-9a-fA-F]+$');
+
+  @override
+  bool validate(String input) {
+    // if length is 64, check if it is a valid hex
+    if (input.length >= 64) {
+      return _rule.hasMatch(input);
+    }
+    return true;
+  }
+}
+
 class WhiteSpaceRule extends RegExValidationRule {
   @override
   String get name => 'WhiteSpaceRule';

--- a/tools/update_translations.py
+++ b/tools/update_translations.py
@@ -4,134 +4,82 @@ import os
 # Translations for each language
 translations ={
   "ar": {
-    "factoryResetChildTitle": "إعادة ضبط العقدة وجميع العقد التابعة لها إلى إعدادات المصنع الافتراضية",
-    "menuRestartNetworkChildMessage": "إعادة تشغيل العقدة وجميع العقد الفرعية. ستؤدي إعادة تشغيل نظام شبكة الواي فاي المتداخلة إلى قطع الاتصال بالإنترنت مؤقتًا. إذا كان لديك عدة عقد، فستتم إعادة تشغيلها جميعًا. ستواجه الأجهزة المتصلة أيضًا انقطاعًا مؤقتًا ولكن ستتصل تلقائيًا بمجرد عودة النظام للاتصال.",
-    "rebootChildTitle": "إعادة تشغيل العقدة وجميع العقد التابعة لها"
+    "wifiPasswordRuleHex": "مفتاح PSK سداسي عشري مطلوب (0-9، A-F، a-f)"
   },
   "da": {
-    "factoryResetChildTitle": "Nulstil noden og alle dens underordnede til fabriksindstillinger",
-    "menuRestartNetworkChildMessage": "Genstart node og alle underordnede noder. Genstart af mesh Wi-Fi-systemet vil midlertidigt afbryde det fra internettet. Hvis du har flere noder, vil alle genstarte. Tilsluttede enheder vil også opleve en midlertidig afbrydelse, men vil automatisk genoprette forbindelse, når systemet er online igen.",
-    "rebootChildTitle": "Genstart noden og alle dens underordnede"
+    "wifiPasswordRuleHex": "Hexadecimal PSK påkrævet (0-9, A-F, a-f)"
   },
   "de": {
-    "factoryResetChildTitle": "Knoten und alle untergeordneten Knoten auf Werkseinstellungen zurücksetzen",
-    "menuRestartNetworkChildMessage": "Knoten und alle untergeordneten Knoten neu starten. Das Neustarten des Mesh-WLAN-Systems trennt es vorübergehend vom Internet. Wenn Sie mehrere Knoten haben, werden alle neu gestartet. Verbundene Geräte werden ebenfalls eine temporäre Trennung erfahren, verbinden sich jedoch automatisch wieder, sobald das System wieder online ist.",
-    "rebootChildTitle": "Knoten und alle untergeordneten Knoten neu starten"
+    "wifiPasswordRuleHex": "Hexadezimaler PSK erforderlich (0–9, A–F, a–f)"
   },
   "el": {
-    "factoryResetChildTitle": "Επαναφορά του κόμβου και όλων των θυγατρικών του στην εργοστασιακή προεπιλογή",
-    "menuRestartNetworkChildMessage": "Επανεκκίνηση κόμβου και όλων των θυγατρικών κόμβων. Η επανεκκίνηση του συστήματος mesh Wi-Fi θα το αποσυνδέσει προσωρινά από το Διαδίκτυο. Εάν έχετε πολλούς κόμβους, όλοι θα επανεκκινήσουν. Οι συνδεδεμένες συσκευές θα αντιμετωπίσουν επίσης μια προσωρινή αποσύνδεση, αλλά θα επανασυνδεθούν αυτόματα μόλις το σύστημα είναι ξανά συνδεδεμένο.",
-    "rebootChildTitle": "Επανεκκίνηση του κόμβου και όλων των θυγατρικών του"
+    "wifiPasswordRuleHex": "Απαιτείται δεκαεξαδικό PSK (0–9, A–F, a–f)"
   },
   "en": {
-    "factoryResetChildTitle": "Reset the node and all its child/s to Factory Default",
-    "menuRestartNetworkChildMessage": "Reboot Node and All Child Nodes Restarting the mesh WiFi system will temporarily disconnect it from the Internet. If you have multiple nodes, all will restart. Connected devices will also experience a temporary disconnection but will automatically reconnect once the system is back online.",
-    "rebootChildTitle": "Reboot the node and all its child/s"
+    "wifiPasswordRuleHex": "Hexadecimal PSK required (0–9, A–F, a–f)"
   },
   "es": {
-    "factoryResetChildTitle": "Restablecer el nodo y todos sus nodos secundarios a la configuración de fábrica",
-    "menuRestartNetworkChildMessage": "Reiniciar el nodo y todos los nodos secundarios. Reiniciar el sistema Wi-Fi en malla lo desconectará temporalmente de Internet. Si tiene varios nodos, todos se reiniciarán. Los dispositivos conectados también experimentarán una desconexión temporal, pero se volverán a conectar automáticamente una vez que el sistema esté en línea nuevamente.",
-    "rebootChildTitle": "Reiniciar el nodo y todos sus nodos secundarios"
+    "wifiPasswordRuleHex": "Se requiere PSK hexadecimal (0–9, A–F, a–f)"
   },
-  "es_AR": {
-    "factoryResetChildTitle": "Restablecer el nodo y todos sus nodos hijos a la configuración predeterminada de fábrica",
-    "menuRestartNetworkChildMessage": "Reiniciar el nodo y todos los nodos hijos. Reiniciar el sistema de Wi-Fi en malla lo desconectará temporalmente de Internet. Si tiene varios nodos, todos se reiniciarán. Los dispositivos conectados también experimentarán una desconexión temporal, pero se volverán a conectar automáticamente una vez que el sistema esté en línea nuevamente.",
-    "rebootChildTitle": "Reiniciar el nodo y todos sus nodos hijos"
+  "es-AR": {
+    "wifiPasswordRuleHex": "Se requiere PSK hexadecimal (0–9, A–F, a–f)"
   },
   "fi": {
-    "factoryResetChildTitle": "Nollaa solmu ja kaikki sen alisolmut tehdasasetuksiin",
-    "menuRestartNetworkChildMessage": "Käynnistä solmu ja kaikki alisolmut uudelleen. Mesh-Wi-Fi-järjestelmän uudelleenkäynnistys katkaisee sen väliaikaisesti Internet-yhteydestä. Jos sinulla on useita solmuja, kaikki käynnistyvät uudelleen. Liitetyt laitteet kokevat myös väliaikaisen yhteyden katkeamisen, mutta muodostavat automaattisesti yhteyden uudelleen, kun järjestelmä on taas online.",
-    "rebootChildTitle": "Käynnistä solmu ja kaikki sen alisolmut uudelleen"
+    "wifiPasswordRuleHex": "Heksadesimaalinen PSK vaaditaan (0–9, A–F, a–f)"
   },
   "fr": {
-    "factoryResetChildTitle": "Réinitialiser le nœud et tous ses nœuds enfants aux paramètres d'usine",
-    "menuRestartNetworkChildMessage": "Redémarrer le nœud et tous les nœuds enfants. Le redémarrage du système Wi-Fi maillé le déconnectera temporairement d'Internet. Si vous avez plusieurs nœuds, tous redémarreront. Les appareils connectés subiront également une déconnexion temporaire, mais se reconnecteront automatiquement une fois le système en ligne.",
-    "rebootChildTitle": "Redémarrer le nœud et tous ses nœuds enfants"
+    "wifiPasswordRuleHex": "PSK hexadécimal requis (0–9, A–F, a–f)"
   },
-  "fr_CA": {
-    "factoryResetChildTitle": "Réinitialiser le nœud et tous ses nœuds enfants aux paramètres d'usine par défaut",
-    "menuRestartNetworkChildMessage": "Redémarrer le nœud et tous les nœuds enfants. Le redémarrage du système Wi-Fi maillé le déconnectera temporairement d'Internet. Si vous avez plusieurs nœuds, tous redémarreront. Les appareils connectés subiront également une déconnexion temporaire, mais se reconnecteront automatiquement une fois le système en ligne.",
-    "rebootChildTitle": "Redémarrer le nœud et tous ses nœuds enfants"
+  "fr-CA": {
+    "wifiPasswordRuleHex": "PSK hexadécimal requis (0–9, A–F, a–f)"
   },
   "id": {
-    "factoryResetChildTitle": "Reset node dan semua child/nya ke Pengaturan Pabrik Default",
-    "menuRestartNetworkChildMessage": "Nyalakan Ulang Node dan Semua Node Child. Menyalakan ulang sistem WiFi mesh akan memutuskan koneksi internet sementara. Jika Anda memiliki beberapa node, semua akan menyala ulang. Perangkat yang terhubung juga akan mengalami pemutusan sementara tetapi akan secara otomatis terhubung kembali setelah sistem online kembali.",
-    "rebootChildTitle": "Nyalakan ulang node dan semua child/nya"
+    "wifiPasswordRuleHex": "PSK heksadesimal diperlukan (0–9, A–F, a–f)"
   },
   "it": {
-    "factoryResetChildTitle": "Ripristina il nodo e tutti i suoi nodi figli alle impostazioni predefinite di fabbrica",
-    "menuRestartNetworkChildMessage": "Riavvia il nodo e tutti i nodi figli. Il riavvio del sistema Wi-Fi mesh lo disconnetterà temporaneamente da Internet. Se hai più nodi, tutti si riavvieranno. Anche i dispositivi connessi subiranno una disconnessione temporanea ma si ricollegheranno automaticamente una volta che il sistema sarà di nuovo online.",
-    "rebootChildTitle": "Riavvia il nodo e tutti i suoi nodi figli"
+    "wifiPasswordRuleHex": "PSK esadecimale richiesto (0–9, A–F, a–f)"
   },
   "ja": {
-    "factoryResetChildTitle": "ノードとそのすべての子ノードを工場出荷時の設定にリセット",
-    "menuRestartNetworkChildMessage": "ノードとすべての子ノードを再起動します。メッシュWi-Fiシステムの再起動により、一時的にインターネットから切断されます。複数のノードがある場合、すべてが再起動します。接続されているデバイスも一時的に切断されますが、システムがオンラインに戻ると自動的に再接続されます。",
-    "rebootChildTitle": "ノードとそのすべての子ノードを再起動"
+    "wifiPasswordRuleHex": "16進数PSKが必要です (0–9, A–F, a–f)"
   },
   "ko": {
-    "factoryResetChildTitle": "노드 및 모든 하위 노드를 공장 기본값으로 재설정",
-    "menuRestartNetworkChildMessage": "노드 및 모든 하위 노드 재부팅. 메시 Wi-Fi 시스템을 다시 시작하면 일시적으로 인터넷 연결이 끊어집니다. 여러 개의 노드가 있는 경우 모두 다시 시작됩니다. 연결된 장치도 일시적으로 연결이 끊어지지만 시스템이 다시 온라인 상태가 되면 자동으로 다시 연결됩니다.",
-    "rebootChildTitle": "노드 및 모든 하위 노드 재부팅"
+    "wifiPasswordRuleHex": "16진수 PSK 필요 (0–9, A–F, a–f)"
   },
   "nb": {
-    "factoryResetChildTitle": "Tilbakestill noden og alle dens underordnede til fabrikkinnstillinger",
-    "menuRestartNetworkChildMessage": "Start node og alle underordnede noder på nytt. Omstart av mesh Wi-Fi-systemet vil midlertidig koble det fra Internett. Hvis du har flere noder, vil alle starte på nytt. Tilkoblede enheter vil også oppleve en midlertidig frakobling, men vil automatisk koble til igjen når systemet er tilbake på nett.",
-    "rebootChildTitle": "Start noden og alle dens underordnede på nytt"
+    "wifiPasswordRuleHex": "Hexadesimal PSK påkrevd (0–9, A–F, a–f)"
   },
   "nl": {
-    "factoryResetChildTitle": "Reset de node en al zijn kind-/kinderen naar fabrieksinstellingen",
-    "menuRestartNetworkChildMessage": "Herstart node en alle kindnodes. Het herstarten van het mesh Wi-Fi-systeem zal de internetverbinding tijdelijk verbreken. Als u meerdere nodes heeft, worden ze allemaal herstart. Verbonden apparaten zullen ook een tijdelijke onderbreking ervaren, maar zullen automatisch opnieuw verbinding maken zodra het systeem weer online is.",
-    "rebootChildTitle": "Herstart de node en al zijn kind-/kinderen"
+    "wifiPasswordRuleHex": "Hexadecimale PSK vereist (0–9, A–F, a–f)"
   },
   "pl": {
-    "factoryResetChildTitle": "Przywróć ustawienia fabryczne węzła i wszystkich jego węzłów podrzędnych",
-    "menuRestartNetworkChildMessage": "Uruchom ponownie węzeł i wszystkie węzły podrzędne. Ponowne uruchomienie systemu mesh WiFi tymczasowo rozłączy go z Internetem. Jeśli masz wiele węzłów, wszystkie zostaną ponownie uruchomione. Podłączone urządzenia również doświadczą tymczasowego rozłączenia, ale automatycznie ponownie połączą się, gdy system będzie ponownie online.",
-    "rebootChildTitle": "Uruchom ponownie węzeł i wszystkie jego węzły podrzędne"
+    "wifiPasswordRuleHex": "Wymagany szesnastkowy klucz PSK (0–9, A–F, a–f)"
   },
   "pt": {
-    "factoryResetChildTitle": "Redefinir o nó e todos os seus nós filhos para o padrão de fábrica",
-    "menuRestartNetworkChildMessage": "Reiniciar Nó e Todos os Nós Filhos. A reinicialização do sistema Wi-Fi em malha o desconectará temporariamente da Internet. Se você tiver vários nós, todos serão reiniciados. Os dispositivos conectados também experimentarão uma desconexão temporária, mas se reconectarão automaticamente assim que o sistema estiver online novamente.",
-    "rebootChildTitle": "Reiniciar o nó e todos os seus nós filhos"
+    "wifiPasswordRuleHex": "PSK hexadecimal necessário (0–9, A–F, a–f)"
   },
-  "pt_PT": {
-    "factoryResetChildTitle": "Repor o nó e todos os seus nós filhos para as predefinições de fábrica",
-    "menuRestartNetworkChildMessage": "Reiniciar o Nó e Todos os Nós Filhos. Reiniciar o sistema Wi-Fi em malha irá desconectá-lo temporariamente da Internet. Se tiver vários nós, todos irão reiniciar. Os dispositivos ligados também irão experimentar uma desconexão temporária, mas irão reconectar-se automaticamente assim que o sistema estiver online novamente.",
-    "rebootChildTitle": "Reiniciar o nó e todos os seus nós filhos"
+  "pt-PT": {
+    "wifiPasswordRuleHex": "PSK hexadecimal necessário (0–9, A–F, a–f)"
   },
   "ru": {
-    "factoryResetChildTitle": "Сбросить узел и все его дочерние узлы до заводских настроек",
-    "menuRestartNetworkChildMessage": "Перезагрузить узел и все дочерние узлы. Перезапуск mesh Wi-Fi системы временно отключит ее от Интернета. Если у вас несколько узлов, все они перезагрузятся. Подключенные устройства также испытают временное отключение, но автоматически переподключатся, как только система снова будет в сети.",
-    "rebootChildTitle": "Перезагрузить узел и все его дочерние узлы"
+    "wifiPasswordRuleHex": "Требуется шестнадцатеричный PSK (0–9, A–F, a–f)"
   },
   "sv": {
-    "factoryResetChildTitle": "Återställ noden och alla dess undernoder till fabriksinställningarna",
-    "menuRestartNetworkChildMessage": "Starta om noden och alla underordnade noder. Omstart av mesh Wi-Fi-systemet kommer tillfälligt att koppla bort det från Internet. Om du har flera noder kommer alla att starta om. Anslutna enheter kommer också att uppleva en tillfällig frånkoppling men kommer automatiskt att återansluta när systemet är online igen.",
-    "rebootChildTitle": "Starta om noden och alla dess undernoder"
+    "wifiPasswordRuleHex": "Hexadecimal PSK krävs (0–9, A–F, a–f)"
   },
   "th": {
-    "factoryResetChildTitle": "รีเซ็ตโหนดและโหนดลูกทั้งหมดเป็นค่าเริ่มต้นจากโรงงาน",
-    "menuRestartNetworkChildMessage": "รีบูตโหนดและโหนดลูกทั้งหมด การรีบูตระบบ Mesh WiFi จะตัดการเชื่อมต่อจากอินเทอร์เน็ตชั่วคราว หากคุณมีหลายโหนด ทุกโหนดจะรีบูต อุปกรณ์ที่เชื่อมต่อจะถูกตัดการเชื่อมต่อชั่วคราวด้วย แต่จะเชื่อมต่อใหม่โดยอัตโนมัติเมื่อระบบกลับมาออนไลน์",
-    "rebootChildTitle": "รีบูตโหนดและโหนดลูกทั้งหมด"
+    "wifiPasswordRuleHex": "ต้องระบุ PSK แบบเลขฐานสิบหก (0–9, A–F, a–f)"
   },
   "tr": {
-    "factoryResetChildTitle": "Düğümü ve tüm alt düğümlerini Fabrika Varsayılanlarına sıfırla",
-    "menuRestartNetworkChildMessage": "Düğümü ve Tüm Alt Düğümleri Yeniden Başlat. Mesh WiFi sistemini yeniden başlatmak, internet bağlantısını geçici olarak keser. Birden fazla düğümünüz varsa, hepsi yeniden başlar. Bağlı cihazlar da geçici bir bağlantı kesintisi yaşar ancak sistem tekrar çevrimiçi olduğunda otomatik olarak yeniden bağlanır.",
-    "rebootChildTitle": "Düğümü ve tüm alt düğümlerini yeniden başlat"
+    "wifiPasswordRuleHex": "Onaltılık PSK gerekli (0–9, A–F, a–f)"
   },
   "vi": {
-    "factoryResetChildTitle": "Đặt lại nút và tất cả các nút con về cài đặt gốc",
-    "menuRestartNetworkChildMessage": "Khởi động lại nút và tất cả các nút con. Khởi động lại hệ thống WiFi mesh sẽ tạm thời ngắt kết nối Internet. Nếu bạn có nhiều nút, tất cả sẽ khởi động lại. Các thiết bị đã kết nối cũng sẽ bị ngắt kết nối tạm thời nhưng sẽ tự động kết nối lại sau khi hệ thống hoạt động trở lại.",
-    "rebootChildTitle": "Khởi động lại nút và tất cả các nút con"
+    "wifiPasswordRuleHex": "Yêu cầu PSK hệ thập lục phân (0–9, A–F, a–f)"
   },
   "zh": {
-    "factoryResetChildTitle": "将节点及其所有子节点恢复出厂设置",
-    "menuRestartNetworkChildMessage": "重启节点和所有子节点。重启 Mesh WiFi 系统将暂时断开互联网连接。如果您有多个节点，所有节点都将重启。连接的设备也将暂时断开连接，但系统上线后会自动重新连接。",
-    "rebootChildTitle": "重启节点及其所有子节点"
+    "wifiPasswordRuleHex": "需要十六进制 PSK (0–9, A–F, a–f)"
   },
-  "zh_TW": {
-    "factoryResetChildTitle": "將節點及其所有子節點重設為原廠預設值",
-    "menuRestartNetworkChildMessage": "重新啟動節點和所有子節點。重新啟動網狀 Wi-Fi 系統將會暫時中斷網際網路連線。如果您有多個節點，所有節點都將重新啟動。已連線的裝置也將會暫時中斷連線，但系統重新上線後將會自動重新連線。",
-    "rebootChildTitle": "重新啟動節點及其所有子節點"
+  "zh_tw": {
+    "wifiPasswordRuleHex": "需要十六進位 PSK (0–9, A–F, a–f)"
   }
 }
 


### PR DESCRIPTION
Introduced improved WiFi password validation, specifically addressing the special handling required for 64-character Pre-Shared Keys (PSKs).

Traditionally, WiFi passwords range from 8 to 63 characters. However, a 64-character input is interpreted as a PSK, which requires a specific hexadecimal format. This update ensures proper validation and guidance for users entering such passwords

Key changes include:
1. Implemented a check to enforce 64-bit hexadecimal format when the password length is exactly 64 characters.
2. Added a new hint message to guide users on the acceptable password format.
3. Added a new string along with its translations for various locales to support the new hint.
4. Applied these changes to the Incredible WiFi and PnP Setup workflows to ensure consistent validation and user experience.


https://github.com/user-attachments/assets/c70b224c-7525-46f8-968b-e1392e408d67


https://github.com/user-attachments/assets/ef390d89-7542-4f8e-9aef-b9f024a19cc6

