### PR TITLE
NOW-618: Firewall: Unable to add IPv6 port service if selecting device from device list

### DIFF
--- a/lib/page/advanced_settings/firewall/providers/ipv6_port_service_rule_provider.dart
+++ b/lib/page/advanced_settings/firewall/providers/ipv6_port_service_rule_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/jnap/models/ipv6_firewall_rule.dart';
 import 'package:privacy_gui/page/advanced_settings/apps_and_gaming/ports/providers/port_util_mixin.dart';
 import 'package:privacy_gui/page/advanced_settings/firewall/providers/ipv6_port_service_rule_state.dart';
+import 'package:privacy_gui/validator_rules/rules.dart';
 
 final ipv6PortServiceRuleProvider =
     NotifierProvider<Ipv6PortServiceRuleNotifier, Ipv6PortServiceRuleState>(
@@ -52,7 +53,7 @@ class Ipv6PortServiceRuleNotifier extends Notifier<Ipv6PortServiceRuleState>
   }
 
   bool isDeviceIpValidate(String ipAddress) {
-    return ipAddress.isNotEmpty;
+    return IPv6Rule().validate(ipAddress);
   }
 
   bool isPortRangeValid(int firstPort, int lastPort) {

--- a/lib/page/advanced_settings/firewall/views/ipv6_port_service_list_view.dart
+++ b/lib/page/advanced_settings/firewall/views/ipv6_port_service_list_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/core/jnap/models/ipv6_firewall_rule.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/advanced_settings/_advanced_settings.dart';
 import 'package:privacy_gui/page/components/settings_view/editable_card_list_settings_view.dart';
@@ -41,6 +42,7 @@ class _Ipv6PortServiceListViewState
   final TextEditingController lastPortTextController = TextEditingController();
   final TextEditingController ipAddressTextController = TextEditingController();
   bool _isEditRuleValid = false;
+  bool _onSelectDevice = false;
 
   @override
   void initState() {
@@ -241,6 +243,7 @@ class _Ipv6PortServiceListViewState
                 AppIconButton.noPadding(
                   icon: LinksysIcons.devices,
                   onTap: () async {
+                    _onSelectDevice = true;
                     final result =
                         await context.pushNamed<List<DeviceListItem>?>(
                       RouteNamed.devicePicker,
@@ -254,6 +257,7 @@ class _Ipv6PortServiceListViewState
                               ipv6Address: selectedIpv6Address));
                       _validateInputData();
                     }
+                    _onSelectDevice = false;
                   },
                 ),
               ],
@@ -335,9 +339,11 @@ class _Ipv6PortServiceListViewState
           0 => notifier.isRuleNameValidate(applicationTextController.text)
               ? null
               : loc(context).notBeEmptyAndLessThanThirtyThree,
-          2 => notifier.isDeviceIpValidate(ipAddressTextController.text)
+          2 => _onSelectDevice
               ? null
-              : loc(context).invalidIpAddress,
+              : notifier.isDeviceIpValidate(ipAddressTextController.text)
+                  ? null
+                  : loc(context).invalidIpAddress,
           3 => notifier.isPortRangeValid(
                   int.tryParse(firstPortTextController.text) ?? 0,
                   int.tryParse(lastPortTextController.text) ?? 0)

--- a/lib/validator_rules/rules.dart
+++ b/lib/validator_rules/rules.dart
@@ -141,6 +141,29 @@ class MACAddressRule extends RegExValidationRule {
   RegExp get _rule => RegExp(r"^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$");
 }
 
+class IPv6Rule extends RegExValidationRule {
+  @override
+  String get name => 'IPv6Rule';
+
+  @override
+  RegExp get _rule => RegExp(
+      r'^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|' // 1:2:3:4:5:6:7:8
+      r'([0-9a-fA-F]{1,4}:){1,7}:|' // 1::, 1:2:3:4:5:6:7::
+      r'([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|' // 1::8, 1:2:3:4:5:6::8
+      r'([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|' // 1::7:8, 1:2:3:4:5::7:8, 1:2:3:4:5::8
+      r'([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|' // 1::6:7:8, 1:2:3:4::6:7:8, etc.
+      r'([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|'
+      r'([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|'
+      r'[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|' // 1::5:6:7:8:9:a:b, ::4:5:6:7:8:9:a:b, etc.
+      r':((:[0-9a-fA-F]{1,4}){1,7}|:)|' // ::2:3:4:5:6:7:8, ::
+      r'fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]+|' // link-local
+      r'::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}'
+      r'(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|' // IPv4-mapped IPv6 (::ffff:255.255.255.255)
+      r'([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}'
+      r'(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$' // IPv4-embedded IPv6 (2001:db8::192.168.0.1)
+      );
+}
+
 class IPv6WithReservedRule extends ValidationRule {
   @override
   String get name => 'IPv6WithReservedRule';
@@ -490,7 +513,8 @@ class IpAddressNoReservedRule extends ValidationRule {
 
       // 2. Check for 127.0.0.0/8 (Loopback)
       // This range includes any address where the first octet (byte) is 127.
-      if (rawAddress[0] == 0x7F) { // 0x7F is 127 in hexadecimal
+      if (rawAddress[0] == 0x7F) {
+        // 0x7F is 127 in hexadecimal
         // print('Reject: Loopback address (127.0.0.0/8).');
         return false;
       }

--- a/test/validator_rules/input_validators_test.dart
+++ b/test/validator_rules/input_validators_test.dart
@@ -159,6 +159,120 @@ void main() {
     });
   });
 
+  group('IPv6Rule', () {
+    late IPv6Rule rule;
+
+    setUp(() {
+      rule = IPv6Rule();
+    });
+
+    test('should have the correct name property', () {
+      expect(rule.name, 'IPv6Rule');
+    });
+
+    group('Valid IPv6 Addresses', () {
+      test('should return true for a standard full IPv6 address', () {
+        expect(
+            rule.validate('2001:0db8:85a3:0000:0000:8a2e:0370:7334'), isTrue);
+      });
+
+      test('should return true for an address with compressed zeros (::)', () {
+        expect(rule.validate('2001:0db8:85a3::8a2e:0370:7334'), isTrue);
+      });
+
+      test('should return true for an address starting with a double colon',
+          () {
+        expect(rule.validate('::1'), isTrue);
+      });
+
+      test('should return true for an address ending with a double colon', () {
+        expect(rule.validate('2001:db8:a0b:12f0::'), isTrue);
+      });
+
+      test('should return true for the unspecified address (::)', () {
+        expect(rule.validate('::'), isTrue);
+      });
+
+      test('should return true for an address with leading zeros in a group',
+          () {
+        expect(
+            rule.validate('2001:0db8:0000:0000:0000:0000:0000:0001'), isTrue);
+      });
+
+      test('should return true for an address with uppercase letters', () {
+        expect(rule.validate('2001:DB8:85A3::8A2E:370:7334'), isTrue);
+      });
+
+      test('should return true for a link-local address', () {
+        expect(rule.validate('fe80::1ff:fe23:4567:890a'), isTrue);
+      });
+
+      test('should return true for a link-local address with a zone index', () {
+        expect(rule.validate('fe80::1ff:fe23:4567:890a%eth0'), isTrue);
+      });
+
+      test('should return true for an IPv4-mapped IPv6 address', () {
+        expect(rule.validate('::ffff:192.0.2.128'), isTrue);
+      });
+
+      test('should return true for an IPv4-embedded IPv6 address', () {
+        expect(rule.validate('2001:db8::192.168.0.1'), isTrue);
+      });
+    });
+
+    group('Invalid IPv6 Addresses', () {
+      test('should return false for an address with more than 8 groups', () {
+        expect(rule.validate('2001:0db8:85a3:0000:0000:8a2e:0370:7334:1234'),
+            isFalse);
+      });
+
+      test('should return false for an address with invalid characters', () {
+        expect(
+            rule.validate('2001:0db8:85a3:000g:0000:8a2e:0370:7334'), isFalse);
+      });
+
+      test('should return false for a group with more than 4 hex digits', () {
+        expect(
+            rule.validate('2001:0db8:85a3:00000:0000:8a2e:0370:7334'), isFalse);
+      });
+
+      test('should return false for an address with more than one double colon',
+          () {
+        expect(rule.validate('2001::85a3::8a2e'), isFalse);
+      });
+
+      test('should return false for an incomplete address', () {
+        expect(rule.validate('2001:0db8:85a3:0000:0000:8a2e:0370'), isFalse);
+      });
+
+      test('should return false for an address with triple colons', () {
+        expect(rule.validate('2001:::8a2e'), isFalse);
+      });
+
+      test('should return false for an invalid IPv4 part in a mapped address',
+          () {
+        expect(rule.validate('::ffff:192.0.2.256'), isFalse);
+      });
+
+      test('should return false for an empty string', () {
+        expect(rule.validate(''), isFalse);
+      });
+
+      test('should return false for a random string', () {
+        expect(rule.validate('not an ip address'), isFalse);
+      });
+
+      test('should return false for an address ending with a colon', () {
+        expect(rule.validate('2001:db8:a0b:12f0:'), isFalse);
+      });
+
+      test(
+          'should return false for an address starting with a colon but not a double colon',
+          () {
+        expect(rule.validate(':2001:db8:a0b:12f0::'), isFalse);
+      });
+    });
+  });
   group('Test EmailValidator', () {
     test('validate method - valid email', () {
       final validator = EmailValidator();
@@ -359,7 +473,8 @@ void main() {
       final results = validator.validateDetail('invalid');
       expect(results['NoSurroundWhitespaceRule'], true);
       expect(results['IpAddressHasFourOctetsRule'], false);
-      expect(results['IpAddressNoReservedRule'], false); // not violated in this case
+      expect(results['IpAddressNoReservedRule'],
+          false); // not violated in this case
       expect(results['IpAddressRule'], false);
     });
 


### PR DESCRIPTION

- Add IPv6 rule
- A workaround to prevent invalid ip address is displayed when select device clicked