### PR TITLE
[NOW-623]: Improve wired pairing UX

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1024,5 +1024,7 @@
   "pairWirelessNode": "Pair wireless node",
   "pairWiredNodeDone": "Pairing wired node. Click 'Done pairing' to finish.",
   "donePairing": "Done pairing",
-  "refreshing": "Refreshing"
+  "refreshing": "Refreshing",
+  "foundNNodesOnline": "{count, plural, other{{count} child nodes have just come online.} one{1 child node has just come online.}}",
+  "pairingWiredChildNodeDesc": "To complete the pairing, make sure your child node is connected to the master via a wired connection."
 }

--- a/lib/page/components/layouts/root_container.dart
+++ b/lib/page/components/layouts/root_container.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/page/components/layouts/idle_checker.dart';
 import 'package:privacy_gui/providers/auth/_auth.dart';
+import 'package:privacy_gui/providers/idle_checker_pause_provider.dart';
 import 'package:privacy_gui/providers/root/root_config.dart';
 import 'package:privacy_gui/providers/root/root_provider.dart';
 
@@ -62,6 +63,10 @@ class _AppRootContainerState extends ConsumerState<AppRootContainer> {
           // white list
           final routeName = widget.route?.name;
           if (routeName != null && idleCheckWhiteList.contains(routeName)) {
+            return;
+          }
+          // pause?
+          if (ref.read(idleCheckerPauseProvider) == true) {
             return;
           }
           logger.d('Idled!');

--- a/lib/page/instant_topology/views/instant_topology_view.dart
+++ b/lib/page/instant_topology/views/instant_topology_view.dart
@@ -378,6 +378,7 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
     final addWiredNodesNotifier = ref.read(addWiredNodesProvider.notifier);
     addWiredNodesNotifier.startAutoOnboarding(context);
     final addWiredNodesState = ref.watch(addWiredNodesProvider);
+
     showAppSpinnerDialog(
       context,
       title: loc(context).instantPair,
@@ -394,6 +395,28 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
         )
       ],
     );
+
+    // Consumer(
+    //   builder: (context, ref, child) {
+    //     final addWiredNodesState = ref.watch(addWiredNodesProvider);
+    //     showAppSpinnerDialog(
+    //       context,
+    //       title: loc(context).instantPair,
+    //       messages: [addWiredNodesState.loadingMessage ?? ''],
+    //       actions: [
+    //         AppTextButton(
+    //           loc(context).donePairing,
+    //           onTap: () {
+    //             if (!addWiredNodesState.isLoading) {
+    //               addWiredNodesNotifier.forceStopAutoOnboarding();
+    //             }
+    //             context.pop();
+    //           },
+    //         )
+    //       ],
+    //     );
+    //   },
+    // );
   }
 
   Widget _buildHeader(

--- a/lib/page/instant_topology/views/instant_topology_view.dart
+++ b/lib/page/instant_topology/views/instant_topology_view.dart
@@ -379,13 +379,15 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
     //   }
     // });
 
-    final addWiredNodesNotifier = ref.read(addWiredNodesProvider.notifier);
-    addWiredNodesNotifier.startAutoOnboarding(context);
-
     showDialog<void>(
       context: context,
       barrierDismissible: false,
       builder: (BuildContext dialogContext) {
+        final addWiredNodesNotifier = ref.read(addWiredNodesProvider.notifier);
+        Future.doWhile(() => !mounted).then((_) {
+          addWiredNodesNotifier.startAutoOnboarding(context);
+        });
+
         return AlertDialog(
           title: SizedBox(
             width: kDefaultDialogWidth,
@@ -399,11 +401,11 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
                 addWiredNodesState.isLoading
                     ? const AppSpinner()
                     : SizedBox(
-                        width: 60,
-                        height: 60,
-                        child: Icon(Icons.check_circle_outline, size: 60),
+                        width: 200,
+                        height: 200,
+                        child: Icon(Icons.check_circle_outline, size: 48),
                       ),
-                AppGap.small2(),
+                AppGap.medium(),
                 Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [

--- a/lib/page/instant_topology/views/instant_topology_view.dart
+++ b/lib/page/instant_topology/views/instant_topology_view.dart
@@ -30,6 +30,7 @@ import 'package:privacygui_widgets/widgets/bullet_list/bullet_list.dart';
 import 'package:privacygui_widgets/widgets/bullet_list/bullet_style.dart';
 import 'package:privacygui_widgets/widgets/container/responsive_layout.dart';
 import 'package:privacygui_widgets/widgets/progress_bar/full_screen_spinner.dart';
+import 'package:privacygui_widgets/widgets/progress_bar/spinner.dart';
 
 class InstantTopologyView extends ArgumentsConsumerStatefulView {
   const InstantTopologyView({super.key, super.args});
@@ -73,7 +74,6 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
   @override
   Widget build(BuildContext context) {
     final topologyState = ref.watch(instantTopologyProvider);
-
     treeController.roots = [topologyState.root];
     treeController.expandAll();
     return LayoutBuilder(builder: (context, constraint) {
@@ -370,53 +370,63 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
   }
 
   _doInstantPairWired(WidgetRef ref) {
+    ///
+    /// Original flow, go to addWiredNodes page
+    ///
     // context.pushNamed(RouteNamed.addWiredNodes).then((result) {
     //   if (result is bool && result) {
     //     _showMoveChildNodesModal();
     //   }
     // });
+
     final addWiredNodesNotifier = ref.read(addWiredNodesProvider.notifier);
     addWiredNodesNotifier.startAutoOnboarding(context);
-    final addWiredNodesState = ref.watch(addWiredNodesProvider);
 
-    showAppSpinnerDialog(
-      context,
-      title: loc(context).instantPair,
-      messages: [addWiredNodesState.loadingMessage ?? ''],
-      actions: [
-        AppTextButton(
-          loc(context).donePairing,
-          onTap: () {
-            if (!addWiredNodesState.isLoading) {
-              addWiredNodesNotifier.forceStopAutoOnboarding();
-            }
-            context.pop();
-          },
-        )
-      ],
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext dialogContext) {
+        return AlertDialog(
+          title: SizedBox(
+            width: kDefaultDialogWidth,
+            child: AppText.titleLarge(loc(context).instantPair),
+          ),
+          content: Consumer(builder: (context, ref, child) {
+            final addWiredNodesState = ref.watch(addWiredNodesProvider);
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                addWiredNodesState.isLoading
+                    ? const AppSpinner()
+                    : SizedBox(
+                        width: 60,
+                        height: 60,
+                        child: Icon(Icons.check_circle_outline, size: 60),
+                      ),
+                AppGap.small2(),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    AppText.bodyMedium(loc(context).pairingWiredChildNodeDesc),
+                    AppGap.small2(),
+                    AppText.bodyMedium(addWiredNodesState.loadingMessage ?? ''),
+                  ],
+                ),
+              ],
+            );
+          }),
+          actions: [
+            AppTextButton(
+              loc(context).donePairing,
+              onTap: () {
+                addWiredNodesNotifier.forceStopAutoOnboarding();
+                dialogContext.pop();
+              },
+            ),
+          ],
+        );
+      },
     );
-
-    // Consumer(
-    //   builder: (context, ref, child) {
-    //     final addWiredNodesState = ref.watch(addWiredNodesProvider);
-    //     showAppSpinnerDialog(
-    //       context,
-    //       title: loc(context).instantPair,
-    //       messages: [addWiredNodesState.loadingMessage ?? ''],
-    //       actions: [
-    //         AppTextButton(
-    //           loc(context).donePairing,
-    //           onTap: () {
-    //             if (!addWiredNodesState.isLoading) {
-    //               addWiredNodesNotifier.forceStopAutoOnboarding();
-    //             }
-    //             context.pop();
-    //           },
-    //         )
-    //       ],
-    //     );
-    //   },
-    // );
   }
 
   Widget _buildHeader(

--- a/lib/page/instant_topology/views/widgets/tree_node_item.dart
+++ b/lib/page/instant_topology/views/widgets/tree_node_item.dart
@@ -1,9 +1,7 @@
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
-import 'package:privacy_gui/page/components/customs/stateful_popup_menu_item.dart';
 import 'package:privacygui_widgets/theme/_theme.dart';
 import 'package:privacygui_widgets/widgets/_widgets.dart';
 import 'package:privacygui_widgets/widgets/card/card.dart';

--- a/lib/page/nodes/providers/add_wired_nodes_provider.dart
+++ b/lib/page/nodes/providers/add_wired_nodes_provider.dart
@@ -17,10 +17,10 @@ import 'package:privacy_gui/page/nodes/providers/add_wired_nodes_state.dart';
 import 'package:privacy_gui/providers/idle_checker_pause_provider.dart';
 
 final addWiredNodesProvider =
-    NotifierProvider<AddWiredNodesNotifier, AddWiredNodesState>(
+    NotifierProvider.autoDispose<AddWiredNodesNotifier, AddWiredNodesState>(
         () => AddWiredNodesNotifier());
 
-class AddWiredNodesNotifier extends Notifier<AddWiredNodesState> {
+class AddWiredNodesNotifier extends AutoDisposeNotifier<AddWiredNodesState> {
   @override
   AddWiredNodesState build() => const AddWiredNodesState(isLoading: false);
 
@@ -61,7 +61,7 @@ class AddWiredNodesNotifier extends Notifier<AddWiredNodesState> {
     // logger.d('[AddWiredNode]: polling connect status');
     // await _startPollingConnectStatus();
     // state = state.copyWith(loadingMessage: loc(context).addNodesOnboardingNodes);
-    
+
     logger.d('[AddWiredNode]: check backhaul changes');
     await _checkBackhaulChanges(context);
     // Set router auto onboarding to false

--- a/lib/providers/idle_checker_pause_provider.dart
+++ b/lib/providers/idle_checker_pause_provider.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final idleCheckerPauseProvider = StateProvider<bool>((ref) {
+  return false;
+});


### PR DESCRIPTION
This branch improves the wired pairing user experience by:
*   Removing the time period that disables wired onboarding.
*   Maintaining continuous polling to ensure the topology reflects the current status immediately.
*   Updating the UI to show when a wired child node is online.