### PR TITLE
NOW-634: Fix stuck on saving config page without WAN

### DIFF
--- a/lib/core/jnap/providers/firmware_update_provider.dart
+++ b/lib/core/jnap/providers/firmware_update_provider.dart
@@ -105,8 +105,8 @@ class FirmwareUpdateNotifier extends Notifier<FirmwareUpdateState> {
 
   Future fetchAvailableFirmwareUpdates() {
     logger.i('[FIRMWARE]: Examine if there are firmware updates available');
-    return fetchFirmwareUpdateStream(force: true, retry: 1)
-        .single
+    return fetchFirmwareUpdateStream(force: true, retry: 3)
+        .last
         .onError((error, stackTrace) => [])
         .then((resultList) {
       // In addition to the build function, state updates here should also be examined
@@ -264,6 +264,11 @@ class FirmwareUpdateNotifier extends Notifier<FirmwareUpdateState> {
     return (state.nodesStatus ?? [])
         .where((e) => e.availableUpdate != null)
         .length;
+  }
+
+  bool isFailedCheckFirmwareUpdate() {
+    return state.nodesStatus?.any((e) => e.lastOperationFailure != null) ??
+        false;
   }
 
   (List<FirmwareUpdateStatus>, bool) _examineStatusResult(

--- a/lib/page/login/auto_parent/providers/auto_parent_first_login_provider.dart
+++ b/lib/page/login/auto_parent/providers/auto_parent_first_login_provider.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/jnap/actions/better_action.dart';
 import 'package:privacy_gui/core/jnap/command/base_command.dart';
@@ -29,6 +27,9 @@ class AutoParentFirstLoginNotifier
     final fwUpdate = ref.read(firmwareUpdateProvider.notifier);
     logger.i('[FirstTime]: Do FW update check');
     await fwUpdate.fetchAvailableFirmwareUpdates();
+    if (fwUpdate.isFailedCheckFirmwareUpdate()) {
+      throw Exception('Failed to check firmware update');
+    }
     if (fwUpdate.getAvailableUpdateNumber() > 0) {
       logger.i('[FirstTime]: New Firmware available!');
       await fwUpdate.updateFirmware();
@@ -88,11 +89,11 @@ class AutoParentFirstLoginNotifier
   // Check internet connection via JNAP with 10 attempts retries
   Future<bool> checkInternetConnection() async {
     final repo = ref.read(routerRepositoryProvider);
-    // make up to 10 attempts to check internet connection
+    // make up to 5 attempts to check internet connection total 10 seconds
     final retryStrategy = ExponentialBackoffRetryStrategy(
-      maxRetries: 10,
-      initialDelay: const Duration(seconds: 3),
-      maxDelay: const Duration(seconds: 30),
+      maxRetries: 5,
+      initialDelay: const Duration(seconds: 2),
+      maxDelay: const Duration(seconds: 2),
     );
     return retryStrategy.execute<bool>(() async {
       final result = await repo.send(
@@ -109,11 +110,12 @@ class AutoParentFirstLoginNotifier
     });
   }
 
-  Future<void> finishFirstTimeLogin() async {
-    // Keep userAcknowledgedAutoConfiguration to false if no internet connection
-    final isConnected = await checkInternetConnection();
-    logger.i('[FirstTime]: Internet connection status: $isConnected');
-    if (isConnected) {
+  Future<void> finishFirstTimeLogin([bool failCheck = false]) async {
+    // Keep userAcknowledgedAutoConfiguration to false if check firmware failed
+    if (!failCheck) {
+      // wait for internet connection
+      final isConnected = await checkInternetConnection();
+      logger.i('[FirstTime]: Internet connection status: $isConnected');
       await setUserAcknowledgedAutoConfiguration();
     }
     // Set firmware update policy

--- a/lib/page/login/auto_parent/views/auto_parent_first_login_view.dart
+++ b/lib/page/login/auto_parent/views/auto_parent_first_login_view.dart
@@ -94,21 +94,27 @@ class _AutoParentFirstLoginViewState
 
   void _doFirmwareUpdateCheck() async {
     logger.i('[FirstTime]: Do Firmware Update Check');
+    bool failCheck = false;
     final isNewFwAvailable = await ref
         .read(autoParentFirstLoginProvider.notifier)
-        .checkAndAutoInstallFirmware();
+        .checkAndAutoInstallFirmware()
+        .onError((e, _) {
+      logger.e('[FirstTime]: Failed to check firmware update');
+      failCheck = true;
+      return false;
+    });
     if (isNewFwAvailable) {
       logger.i('[FirstTime]: Firmware Updateing...');
     } else {
-      logger.i('[FirstTime]: No available FW, ready to go');
-      _finishFirstTimeLogin();
+      logger.i('[FirstTime]: ${failCheck ? 'Fw check failed' : 'No available FW'}, ready to go.');
+      _finishFirstTimeLogin(failCheck);
     }
   }
 
-  void _finishFirstTimeLogin() async {
+  void _finishFirstTimeLogin([bool failCheck = false]) async {
     await ref
         .read(autoParentFirstLoginProvider.notifier)
-        .finishFirstTimeLogin();
+        .finishFirstTimeLogin(failCheck);
     Future.doWhile(() => !mounted).then((_) {
       context.goNamed(RouteNamed.dashboardHome);
     });


### PR DESCRIPTION
This PR fixes an issue where the user gets stuck on the 'Saving Configuration' page after logging in without a WAN connection. The changes include:

- Modified the firmware update check to handle failures gracefully.
- Adjusted the internet connection check retry strategy.
- Ensured the `userAcknowledgedAutoConfiguration` flag is not set if the firmware check fails.