### PR TITLE
NOW-635: [Instant-Action] should be hidden when an IM router is used as a child node.

### DIFF
--- a/lib/page/instant_topology/views/instant_topology_view.dart
+++ b/lib/page/instant_topology/views/instant_topology_view.dart
@@ -196,34 +196,12 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
   }
 
   Widget _buildNode(BuildContext context, WidgetRef ref, RouterTreeNode node) {
-    final autoOnboarding = serviceHelper.isSupportAutoOnboarding();
-    final hasBlinkFunction = serviceHelper.isSupportLedBlinking();
     final supportChildReboot = serviceHelper.isSupportChildReboot();
-    final supportChildFactoryReset = serviceHelper.isSupportChildFactoryReset();
 
     return ResponsiveLayout.isMobileLayout(context)
         ? TopologyNodeItem.simple(
             node: node,
-            actions: node.data.isMaster
-                ? [
-                    if (hasBlinkFunction &&
-                        isCognitiveMeshRouter(
-                            modelNumber: node.data.model,
-                            hardwareVersion: node.data.hardwareVersion))
-                      NodeInstantActions.blink,
-                    NodeInstantActions.reboot,
-                    if (autoOnboarding) NodeInstantActions.pair,
-                    NodeInstantActions.reset,
-                  ]
-                : [
-                    if (hasBlinkFunction &&
-                        isCognitiveMeshRouter(
-                            modelNumber: node.data.model,
-                            hardwareVersion: node.data.hardwareVersion))
-                      NodeInstantActions.blink,
-                    if (supportChildReboot) NodeInstantActions.reboot,
-                    if (supportChildFactoryReset) NodeInstantActions.reset,
-                  ],
+            actions: _buildActions(node),
             onTap: () {
               onNodeTap(context, ref, node);
             },
@@ -233,26 +211,7 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
           )
         : TopologyNodeItem(
             node: node,
-            actions: node.data.isMaster
-                ? [
-                    if (hasBlinkFunction &&
-                        isCognitiveMeshRouter(
-                            modelNumber: node.data.model,
-                            hardwareVersion: node.data.hardwareVersion))
-                      NodeInstantActions.blink,
-                    NodeInstantActions.reboot,
-                    if (autoOnboarding) NodeInstantActions.pair,
-                    NodeInstantActions.reset,
-                  ]
-                : [
-                    if (hasBlinkFunction &&
-                        isCognitiveMeshRouter(
-                            modelNumber: node.data.model,
-                            hardwareVersion: node.data.hardwareVersion))
-                      NodeInstantActions.blink,
-                    if (supportChildReboot) NodeInstantActions.reboot,
-                    if (supportChildFactoryReset) NodeInstantActions.reset,
-                  ],
+            actions: _buildActions(node),
             onTap: () {
               onNodeTap(context, ref, node);
             },
@@ -260,6 +219,42 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
               _handleSelectedNodeAction(action, node, supportChildReboot);
             },
           );
+  }
+
+  List<NodeInstantActions> _buildActions(RouterTreeNode node) {
+    final autoOnboarding = serviceHelper.isSupportAutoOnboarding();
+    final hasBlinkFunction = serviceHelper.isSupportLedBlinking();
+    final supportChildReboot = serviceHelper.isSupportChildReboot();
+    final supportChildFactoryReset = serviceHelper.isSupportChildFactoryReset();
+
+    return node.data.isMaster
+        ? [
+            if (hasBlinkFunction &&
+                isCognitiveMeshRouter(
+                    modelNumber: node.data.model,
+                    hardwareVersion: node.data.hardwareVersion))
+              NodeInstantActions.blink,
+            NodeInstantActions.reboot,
+            if (autoOnboarding) NodeInstantActions.pair,
+            NodeInstantActions.reset,
+          ]
+        : [
+            if (hasBlinkFunction &&
+                isCognitiveMeshRouter(
+                    modelNumber: node.data.model,
+                    hardwareVersion: node.data.hardwareVersion))
+              NodeInstantActions.blink,
+            if (supportChildReboot &&
+                isCognitiveMeshRouter(
+                    modelNumber: node.data.model,
+                    hardwareVersion: node.data.hardwareVersion))
+              NodeInstantActions.reboot,
+            if (supportChildFactoryReset &&
+                isCognitiveMeshRouter(
+                    modelNumber: node.data.model,
+                    hardwareVersion: node.data.hardwareVersion))
+              NodeInstantActions.reset,
+          ];
   }
 
   _handleSelectedNodeAction(

--- a/test/page/instant_topology/localizations/instant_topology_view_test.dart
+++ b/test/page/instant_topology/localizations/instant_topology_view_test.dart
@@ -7,6 +7,7 @@ import 'package:privacy_gui/page/instant_topology/_instant_topology.dart';
 import 'package:mockito/mockito.dart';
 import 'package:privacy_gui/page/instant_topology/views/model/node_instant_actions.dart';
 import 'package:privacy_gui/page/instant_topology/views/widgets/tree_node_item.dart';
+import 'package:privacygui_widgets/theme/custom_theme.dart';
 
 import '../../../common/config.dart';
 import '../../../common/di.dart';
@@ -154,6 +155,38 @@ void main() async {
         skipOffstage: false,
       );
       await tester.tap(instantActionFinder);
+      await tester.pumpAndSettle();
+    });
+
+    testLocalizations(
+        'Instant-Topology view - instant-action popup - legacy child node',
+        (tester, locale) async {
+      when(mockTopologyNotifier.build())
+          .thenReturn(TopologyTestData().testTopologyLegacySlavesDaisyState);
+
+      final widget = testableSingleRoute(
+        overrides: [
+          instantTopologyProvider.overrideWith(() => mockTopologyNotifier),
+        ],
+        locale: locale,
+        child: const InstantTopologyView(),
+      );
+      await tester.pumpWidget(widget);
+      await tester.runAsync(() async {
+        final context = tester.element(find.byType(InstantTopologyView));
+        await precacheImage(
+            CustomTheme.of(context).images.devices.routerMx5300, context);
+        await precacheImage(
+            CustomTheme.of(context).images.devices.routerLn12, context);
+        await precacheImage(
+            CustomTheme.of(context).images.devices_xl.routerLn12, context);
+        await tester.pumpAndSettle();
+      });
+      await tester.pumpAndSettle();
+      final treeNodeItemFinder =
+          find.byType(TopologyNodeItem, skipOffstage: false);
+      await tester.scrollUntilVisible(treeNodeItemFinder.last, 10,
+          scrollable: find.byType(Scrollable).last);
       await tester.pumpAndSettle();
     });
 

--- a/test/test_data/topology_data.dart
+++ b/test/test_data/topology_data.dart
@@ -141,6 +141,21 @@ final _slaveNode5 = RouterTopologyNode(
   ),
   children: [],
 );
+final _slaveLegacyNode1 = RouterTopologyNode(
+  data: TopologyModel.fromMap(topologyModelJsonTemplate).copyWith(
+    deviceId: 'ROUTER-LEGACY-SLAVE-DEVICEID-000005',
+    location: 'Mx4200 Node 1',
+    isMaster: false,
+    isOnline: true,
+    isWiredConnection: false,
+    signalStrength: -70,
+    isRouter: true,
+    icon: 'routerMx5300',
+    model: 'Mx4200',
+    connectedDeviceCount: 999,
+  ),
+  children: [],
+);
 
 final _slaveOfflineNode1 = RouterTopologyNode(
   data: TopologyModel.fromMap(topologyModelJsonTemplate).copyWith(
@@ -585,6 +600,24 @@ get testTopologyPinnacleSlavesDaisyState => InstantTopologyState(
       ])),
 );
 
+get testTopologyLegacySlavesDaisyState => InstantTopologyState(
+  root: _onlineRoot
+    ..children.clear()
+    ..children.add(_masterNode
+      ..parent = _onlineRoot
+      ..children.clear()
+      ..children.addAll([
+        _slaveNode1
+          ..children.clear()
+          ..parent = _masterNode
+          ..children.addAll([
+            _slaveLegacyNode1
+              ..children.clear()
+              ..parent = _slaveNode1
+          ]),
+      ])),
+);
+
 void cleanup() {
   _onlineRoot.children.clear();
   _slaveOfflineNode1.children.clear();
@@ -599,6 +632,7 @@ void cleanup() {
   _slaveNode3.children.clear();
   _slaveNode4.children.clear();
   _slaveNode5.children.clear();
+  _slaveLegacyNode1.children.clear();
   _slaveGoodNode.children.clear();
   _slaveFairNode.children.clear();
 }


### PR DESCRIPTION
NOW-635: [Instant-Action] should be hidden when an IM router is used as a child node. - Prevent display actions on non-cognitive routers - Add a screenshot test case for legacy child node