### PR TITLE
[NOW-622]: IPv6 input field revise

### DIFF
--- a/lib/page/advanced_settings/firewall/views/ipv6_port_service_list_view.dart
+++ b/lib/page/advanced_settings/firewall/views/ipv6_port_service_list_view.dart
@@ -7,7 +7,6 @@ import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/advanced_settings/_advanced_settings.dart';
 import 'package:privacy_gui/page/components/settings_view/editable_card_list_settings_view.dart';
 import 'package:privacy_gui/page/components/settings_view/editable_table_settings_view.dart';
-import 'package:privacy_gui/page/components/settings_view/editable_table_settings_view.dart';
 import 'package:privacy_gui/page/components/styled/styled_page_view.dart';
 import 'package:privacy_gui/page/components/views/arguments_view.dart';
 import 'package:privacy_gui/page/instant_device/providers/device_list_state.dart';
@@ -18,7 +17,6 @@ import 'package:privacygui_widgets/widgets/card/setting_card.dart';
 import 'package:privacygui_widgets/widgets/container/responsive_layout.dart';
 import 'package:privacygui_widgets/widgets/dropdown/dropdown_button.dart';
 import 'package:privacygui_widgets/widgets/gap/const/spacing.dart';
-import 'package:privacygui_widgets/widgets/input_field/ip_form_field_display_type.dart';
 import 'package:privacygui_widgets/widgets/input_field/ipv6_form_field.dart';
 import 'package:privacygui_widgets/widgets/page/layout/basic_layout.dart';
 
@@ -229,9 +227,29 @@ class _Ipv6PortServiceListViewState
               children: [
                 Expanded(
                   child: AppIPv6FormField(
-                    displayType: AppIpFormFieldDisplayType.tight,
                     controller: ipAddressTextController,
                     border: const OutlineInputBorder(),
+                    autovalidateMode: AutovalidateMode.disabled,
+                    suffixIcon: AppIconButton.noPadding(
+                      icon: LinksysIcons.devices,
+                      onTap: () async {
+                        final result =
+                            await context.pushNamed<List<DeviceListItem>?>(
+                          RouteNamed.devicePicker,
+                          extra: {'type': 'ipv6', 'selectMode': 'single'},
+                        );
+                        if (result != null) {
+                          final selectedIpv6Address = result.first.ipv6Address;
+                          ipAddressTextController.text = selectedIpv6Address;
+                          ref
+                              .read(ipv6PortServiceRuleProvider.notifier)
+                              .updateRule(stateRule?.copyWith(
+                                  ipv6Address: selectedIpv6Address));
+                          _validateInputData();
+                        }
+                        controller.validate(index);
+                      },
+                    ),
                     onChanged: (value) {
                       ref
                           .read(ipv6PortServiceRuleProvider.notifier)
@@ -239,25 +257,6 @@ class _Ipv6PortServiceListViewState
                       _validateInputData();
                     },
                   ),
-                ),
-                AppIconButton.noPadding(
-                  icon: LinksysIcons.devices,
-                  onTap: () async {
-                    final result =
-                        await context.pushNamed<List<DeviceListItem>?>(
-                      RouteNamed.devicePicker,
-                      extra: {'type': 'ipv6', 'selectMode': 'single'},
-                    );
-                    if (result != null) {
-                      final selectedIpv6Address = result.first.ipv6Address;
-                      ipAddressTextController.text = selectedIpv6Address;
-                      ref.read(ipv6PortServiceRuleProvider.notifier).updateRule(
-                          stateRule?.copyWith(
-                              ipv6Address: selectedIpv6Address));
-                      _validateInputData();
-                    }
-                    controller.validate(index);
-                  },
                 ),
               ],
             ),

--- a/lib/page/advanced_settings/firewall/views/ipv6_port_service_rule_view.dart
+++ b/lib/page/advanced_settings/firewall/views/ipv6_port_service_rule_view.dart
@@ -49,7 +49,6 @@ class _AddRuleContentViewState
   final TextEditingController _ipAddressController = TextEditingController();
   String? _portError;
   String? _descriptionError;
-  String? _ipError;
 
   bool _isEdit = false;
 
@@ -155,17 +154,14 @@ class _AddRuleContentViewState
       AppTextField.outline(
         headerText: loc(context).ruleName,
         controller: _ruleNameController,
-        onFocusChanged: (focus) {
+        onChanged: (value) {
+          _notifier.updateRule(state.rule?.copyWith(description: value));
           setState(() {
-            _descriptionError = focus
-                ? null
-                : _notifier.isRuleNameValidate(_ruleNameController.text)
+            _descriptionError =
+                _notifier.isRuleNameValidate(_ruleNameController.text)
                     ? null
                     : loc(context).notBeEmptyAndLessThanThirtyThree;
           });
-        },
-        onChanged: (value) {
-          _notifier.updateRule(state.rule?.copyWith(description: value));
         },
         errorText: _descriptionError,
       ),
@@ -188,41 +184,34 @@ class _AddRuleContentViewState
         },
       ),
       const AppGap.large2(),
-      AppText.labelMedium(loc(context).ipAddress),
-      const AppGap.medium(),
       AppIPv6FormField(
         semanticLabel: 'ip address',
+        title: loc(context).ipAddress,
         controller: _ipAddressController,
         border: const OutlineInputBorder(),
         onChanged: (value) {
           _notifier.updateRule(state.rule?.copyWith(ipv6Address: value));
         },
-        onFocusChanged: (focus) {
-          setState(() {
-            _ipError = focus
-                ? null
-                : _notifier.isDeviceIpValidate(_ipAddressController.text)
-                    ? null
-                    : loc(context).invalidIpAddress;
-          });
+        validator: (value) {
+          return _notifier.isDeviceIpValidate(value ?? '')
+              ? null
+              : loc(context).invalidIpAddress;
         },
-        errorText: _ipError,
-      ),
-      const AppGap.small3(),
-      AppIconButton.noPadding(
-        icon: LinksysIcons.devices,
-        onTap: () async {
-          final result = await context.pushNamed<List<DeviceListItem>?>(
-              RouteNamed.devicePicker,
-              extra: {'type': 'ipv6', 'selectMode': 'single'});
-          if (result != null) {
-            final device = result.first;
-            _ipAddressController.text = device.ipv6Address;
-            _notifier.updateRule(
-              state.rule?.copyWith(ipv6Address: device.ipv6Address),
-            );
-          }
-        },
+        suffixIcon: AppIconButton.noPadding(
+          icon: LinksysIcons.devices,
+          onTap: () async {
+            final result = await context.pushNamed<List<DeviceListItem>?>(
+                RouteNamed.devicePicker,
+                extra: {'type': 'ipv6', 'selectMode': 'single'});
+            if (result != null) {
+              final device = result.first;
+              _ipAddressController.text = device.ipv6Address;
+              _notifier.updateRule(
+                state.rule?.copyWith(ipv6Address: device.ipv6Address),
+              );
+            }
+          },
+        ),
       ),
       const AppGap.large2(),
       Row(

--- a/lib/validator_rules/rules.dart
+++ b/lib/validator_rules/rules.dart
@@ -158,11 +158,10 @@ class MACAddressRule extends RegExValidationRule {
   RegExp get _rule => RegExp(r"^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$");
 }
 
-class IPv6Rule extends RegExValidationRule {
+class IPv6Rule extends ValidationRule {
   @override
   String get name => 'IPv6Rule';
 
-  @override
   RegExp get _rule => RegExp(
       r'^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|' // 1:2:3:4:5:6:7:8
       r'([0-9a-fA-F]{1,4}:){1,7}:|' // 1::, 1:2:3:4:5:6:7::
@@ -179,6 +178,17 @@ class IPv6Rule extends RegExValidationRule {
       r'([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}'
       r'(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$' // IPv4-embedded IPv6 (2001:db8::192.168.0.1)
       );
+
+  @override
+  bool validate(String input) {
+    try {
+      // Uri.parseIPv6Address will throw a FormatException if the address is invalid.
+      Uri.parseIPv6Address(input);
+      return true;
+    } catch (e) {
+      return false || _rule.hasMatch(input);
+    }
+  }
 }
 
 class IPv6WithReservedRule extends ValidationRule {

--- a/lib/validator_rules/rules.dart
+++ b/lib/validator_rules/rules.dart
@@ -158,10 +158,11 @@ class MACAddressRule extends RegExValidationRule {
   RegExp get _rule => RegExp(r"^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$");
 }
 
-class IPv6Rule extends ValidationRule {
+class IPv6Rule extends RegExValidationRule {
   @override
   String get name => 'IPv6Rule';
 
+  @override
   RegExp get _rule => RegExp(
       r'^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|' // 1:2:3:4:5:6:7:8
       r'([0-9a-fA-F]{1,4}:){1,7}:|' // 1::, 1:2:3:4:5:6:7::


### PR DESCRIPTION
This pull request addresses the IPv6 input field revisions outlined in NOW-622.

Key changes include:
- Refactored the IPv6 port service rule view to use real-time form field validators, improving user feedback.
- Updated the IPv6 validation regex to correctly handle various abbreviated address formats.
- Integrated the device picker icon directly into the IPv6 form field as a suffix icon for a more intuitive UI.
- Removed unused properties and imports to streamline the code.