### PR TITLE
NOW-640: Instant-Verify: The parent and wired child node should not show the mesh health status in the printed device info

### DIFF
--- a/lib/page/instant_verify/views/instant_verify_view.dart
+++ b/lib/page/instant_verify/views/instant_verify_view.dart
@@ -1195,14 +1195,15 @@ class _InstantVerifyViewState extends ConsumerState<InstantVerifyView>
                   ? loc(context).wired
                   : loc(context).wireless),
         ]),
-        pw.TableRow(children: [
-          pw.Text('${loc(context).meshHealth}:'),
-          pw.Text(
-            node.data.isOnline
-                ? '${signalLevel.resolveLabel(context)}(${node.data.signalStrength})'
-                : loc(context).offline,
-          ),
-        ]),
+        if (!(node.data.isMaster || node.data.isWiredConnection))
+          pw.TableRow(children: [
+            pw.Text('${loc(context).meshHealth}:'),
+            pw.Text(
+              node.data.isOnline
+                  ? '${signalLevel.resolveLabel(context)}(${node.data.signalStrength})'
+                  : loc(context).offline,
+            ),
+          ]),
         pw.TableRow(children: [
           pw.Text('${loc(context).ipAddress}:'),
           pw.Text(node.data.isOnline ? node.data.ipAddress : '--'),


### PR DESCRIPTION
This PR resolves NOW-640. Changes include:\n- Updated Instant Verify View to hide mesh health status for the master and wired child nodes in the printed device info.\n- Updated widgets plugin.