### PR TITLE
NOW-639: Instant-Topology: The wired child node info should not show the mesh health status

### DIFF
--- a/lib/page/instant_topology/views/widgets/tree_node_item.dart
+++ b/lib/page/instant_topology/views/widgets/tree_node_item.dart
@@ -286,7 +286,8 @@ class _TreeNodeItemState extends State<TreeNodeItem> {
                     ? loc(context).wired
                     : loc(context).wireless),
           ]),
-          if (!node.data.isMaster)
+          if (!node.data.isMaster &&
+              (!node.data.isOnline || !node.data.isWiredConnection))
             TableRow(children: [
               AppText.labelLarge('${loc(context).meshHealth}:'),
               AppText.labelLarge(


### PR DESCRIPTION
- Hide mesh health if the node is wired connection.