### PR TITLE
[NOW-648] CLONE - Linksys Now GUI does not take the URL with embedded password after scanning the QR Code

### DIFF
--- a/lib/page/login/views/login_local_view.dart
+++ b/lib/page/login/views/login_local_view.dart
@@ -7,6 +7,8 @@ import 'package:privacy_gui/constants/error_code.dart';
 import 'package:privacy_gui/core/jnap/actions/better_action.dart';
 import 'package:privacy_gui/core/jnap/models/device_info.dart';
 import 'package:privacy_gui/core/jnap/providers/dashboard_manager_provider.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/page/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/page/components/styled/bottom_bar.dart';
 import 'package:privacy_gui/page/components/styled/consts.dart';
 import 'package:privacy_gui/page/components/views/arguments_view.dart';
@@ -45,13 +47,16 @@ class _LoginViewState extends ConsumerState<LoginLocalView> {
   NodeDeviceInfo? _deviceInfo;
 
   final TextEditingController _passwordController = TextEditingController();
+  String? _p;
 
   @override
   void initState() {
     super.initState();
     auth = ref.read(authProvider.notifier);
+    _p = widget.args['p'];
     //Use this to prevent errors from modifying the state during the init stage
-    Future.doWhile(() => !mounted).then((value) {
+    doSomethingWithSpinner(context, Future.doWhile(() => !mounted))
+        .then((value) {
       _getAdminPasswordHint();
       ref
           .read(dashboardManagerProvider.notifier)
@@ -59,7 +64,12 @@ class _LoginViewState extends ConsumerState<LoginLocalView> {
           .then((value) {
         _deviceInfo = value;
         buildBetterActions(value.services);
-        _getAdminPasswordAuthStatus(value.services);
+        if (_p != null) {
+          _passwordController.text = _p!;
+          _doLogin();
+        } else {
+          _getAdminPasswordAuthStatus(value.services);
+        }
       });
     });
   }
@@ -104,6 +114,7 @@ class _LoginViewState extends ConsumerState<LoginLocalView> {
   Widget build(BuildContext context) {
     final state = ref.watch(authProvider);
     return state.when(error: (error, stack) {
+      _p = null;
       //The countdown has been triggered and finished, but the error still exists in AsyncValue state
       //The error message should not be set again when countdown is terminated
       if (!isCountdownJustFinished) {
@@ -115,7 +126,7 @@ class _LoginViewState extends ConsumerState<LoginLocalView> {
     }, data: (state) {
       //Read password hint from the state
       _passwordHint = state.localPasswordHint;
-      return contentView();
+      return _p != null ? const AppFullScreenSpinner() : contentView();
     }, loading: () {
       return const AppFullScreenSpinner();
     });

--- a/lib/route/route_local_login.dart
+++ b/lib/route/route_local_login.dart
@@ -12,7 +12,9 @@ final localLoginRoute = LinksysRoute(
   path: RoutePath.localLoginPassword,
   config: LinksysRouteConfig(column: ColumnGrid(column: 12), noNaviRail: true),
   builder: (context, state) => LoginLocalView(
-    args: state.extra as Map<String, dynamic>? ?? {},
+    args: <String, dynamic>{}
+      ..addAll(state.extra as Map<String, dynamic>? ?? <String, dynamic>{})
+      ..addAll(state.uri.queryParameters),
   ),
   routes: [
     LinksysRoute(
@@ -31,6 +33,5 @@ final localLoginRoute = LinksysRoute(
         ),
       ],
     ),
-    
   ],
 );

--- a/lib/route/router_provider.dart
+++ b/lib/route/router_provider.dart
@@ -336,7 +336,7 @@ class RouterNotifier extends ChangeNotifier {
 
   String _home([String? query]) {
     return BuildConfig.forceCommandType == ForceCommand.local
-        ? RoutePath.localLoginPassword
+        ? '${RoutePath.localLoginPassword}?$query'
         : '${RoutePath.cloudLoginAuth}?$query';
   }
 


### PR DESCRIPTION
fix(login): [NOW-648] Support embedded password in URL for QR code login

- This change allows the login page to accept a password from a URL query parameter.
- This is necessary to support QR code-based login where the password is embedded in the scanned URL.
- The login page will now automatically attempt to log in if a password is provided in the URL.