### PR TITLE
[Instant Admin Testing] Updated the test case

### DIFF
--- a/integration_test/config/integration_test_config.dart
+++ b/integration_test/config/integration_test_config.dart
@@ -4,7 +4,7 @@ class IntegrationTestConfig {
   static const String recoveryCode =
       String.fromEnvironment('recoveryCode', defaultValue: '00000');
   static const String newPassword =
-      String.fromEnvironment('newAdminPassword', defaultValue: 'Linksys123!');
+      String.fromEnvironment('newPassword', defaultValue: 'Linksys123!');
   static const String passwordHint =
       String.fromEnvironment('passwordHint', defaultValue: 'Password hint');
   static const String wifiBands =

--- a/integration_test/instant_admin_test.dart
+++ b/integration_test/instant_admin_test.dart
@@ -76,6 +76,7 @@ void main() {
     // Hide&Show password
     await adminActions.tapPasswordEyeButton();
     await adminActions.tapPasswordEyeButton();
+    
     // Start changing admin password
     // Open the edit password dialog
     await adminActions.tapEditPasswordTappableArea();
@@ -89,6 +90,13 @@ void main() {
     await adminActions.inputPasswordHint(IntegrationTestConfig.passwordHint);
     // Save the new password
     await adminActions.tapEditPasswordSaveButton();
+    // Now we have to change the password back
+    await adminActions.tapEditPasswordTappableArea();
+    await adminActions.inputNewPassword(IntegrationTestConfig.password);
+    await adminActions.inputConfirmPassword(IntegrationTestConfig.password);
+    await adminActions.inputPasswordHint("");
+    await adminActions.tapEditPasswordSaveButton();
+
     // Enter time zone selection screen
     await adminActions.tapTimezoneTappableArea();
     // Record the current status of auto daylight saving

--- a/integration_test/shell_scripts/reset_password.sh
+++ b/integration_test/shell_scripts/reset_password.sh
@@ -19,7 +19,7 @@ if [ $status -ne 0 ]; then
   exit $status
 fi
 
-new_admin_password=$(get_config_value '.newAdminPassword')
+new_admin_password=$(get_config_value '.newPassword')
 # if new_admin_password is empty, exit
 if [ -z "$new_admin_password" ]; then
   echo "Error: newAdminPassword is empty. This reset password can only using for set new admin password case"

--- a/integration_test/test_meta/instant_admin_test.json
+++ b/integration_test/test_meta/instant_admin_test.json
@@ -3,10 +3,10 @@
     "target": "integration_test/instant_admin_test.dart",
     "description": "Execute all the functions on the page and verify that the new data has been synced",
     "setUp":  ["factory_reset", "skip_setup"],
-    "tearDown": ["reset_password"],
+    "tearDown": [],
     "tags": ["admin", "menu"],
     "config": {
-        "newAdminPassword": "Linksys123!",
+        "newPassword": "Linksys123!",
         "passwordHint": "Linksys"
     }
 }

--- a/integration_test/test_meta/recovery_and_login_test.json
+++ b/integration_test/test_meta/recovery_and_login_test.json
@@ -6,7 +6,7 @@
     "tearDown": ["reset_password", "factory_reset"],
     "tags": ["login", "recovery"],
     "config": {
-        "newAdminPassword": "Linksys123!",
+        "newPassword": "Linksys123!",
         "passwordHint": "Linksys"
     }
 }


### PR DESCRIPTION
Updated the integration testing of Instant Admin:
Reset the admin password to the original one during the testing rather than in the teardown