### PR TITLE
feat(speed-test): add latency check animation

### DIFF
--- a/lib/page/components/customs/animated_digital_text.dart
+++ b/lib/page/components/customs/animated_digital_text.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'dart:async'; // Required for Timer
+
+/// A widget that shows a continuously rolling digit, like a slot machine.
+/// It uses a [ListWheelScrollView] to create an infinite looping effect of digits 0-9.
+class ContinuousRollingDigit extends StatefulWidget {
+  /// The interval at which the digit changes.
+  final Duration changeInterval;
+
+  /// The duration of the animation when rolling to the next digit.
+  /// This should be less than or equal to [changeInterval].
+  final Duration animationDuration;
+
+  final double fontSize;
+  final Color? fontColor;
+
+  const ContinuousRollingDigit({
+    Key? key,
+    this.changeInterval = const Duration(milliseconds: 100),
+    this.animationDuration = const Duration(milliseconds: 80),
+    this.fontSize = 16,
+    this.fontColor,
+  })  : assert(animationDuration <= changeInterval,
+            'animationDuration must be less than or equal to changeInterval'),
+        super(key: key);
+
+  @override
+  State<ContinuousRollingDigit> createState() => _ContinuousRollingDigitState();
+}
+
+class _ContinuousRollingDigitState extends State<ContinuousRollingDigit> {
+  late FixedExtentScrollController _scrollController;
+  Timer? _timer;
+  int _currentItem = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = FixedExtentScrollController();
+    // Start the timer to continuously scroll through digits.
+    _timer = Timer.periodic(widget.changeInterval, (Timer timer) {
+      if (_scrollController.hasClients) {
+        _currentItem++;
+        _scrollController.animateToItem(
+          _currentItem,
+          duration: widget.animationDuration,
+          curve: Curves.linear,
+        );
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final digitStyle = Theme.of(context).textTheme.bodyLarge?.copyWith(
+          fontSize: widget.fontSize,
+          fontWeight: FontWeight.bold,
+          color: widget.fontColor,
+        );
+
+    return SizedBox(
+      width: widget.fontSize * 1,
+      height: widget.fontSize * 1.2,
+      child: IgnorePointer(
+        // Disable user interaction
+        child: ListWheelScrollView.useDelegate(
+          controller: _scrollController,
+          itemExtent: widget.fontSize * 1.2,
+          physics: const NeverScrollableScrollPhysics(),
+          childDelegate: ListWheelChildLoopingListDelegate(
+            children: List<Widget>.generate(10, (index) {
+              return Text(
+                index.toString(),
+                style: digitStyle,
+                textAlign: TextAlign.center,
+              );
+            }),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A widget that displays two continuously and independently rolling digits.
+class AnimatedDigitalText extends StatelessWidget {
+  const AnimatedDigitalText({super.key, this.fontSize = 16, this.fontColor});
+
+  final double fontSize;
+  final Color? fontColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          // First digit, rolling at its own pace.
+          ContinuousRollingDigit(
+            changeInterval: const Duration(milliseconds: 80),
+            animationDuration: const Duration(milliseconds: 40),
+            fontSize: fontSize,
+            fontColor: fontColor,
+          ),
+          // Second digit, rolling at a different pace to appear independent.
+          ContinuousRollingDigit(
+            changeInterval: const Duration(milliseconds: 60),
+            animationDuration: const Duration(milliseconds: 40),
+            fontSize: fontSize,
+            fontColor: fontColor,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/page/health_check/views/speed_test_view.dart
+++ b/lib/page/health_check/views/speed_test_view.dart
@@ -10,6 +10,7 @@ import 'package:privacy_gui/page/components/views/arguments_view.dart';
 import 'package:privacy_gui/page/dashboard/_dashboard.dart';
 import 'package:privacy_gui/page/health_check/providers/health_check_provider.dart';
 import 'package:privacy_gui/page/health_check/providers/health_check_state.dart';
+import 'package:privacy_gui/page/components/customs/animated_digital_text.dart';
 import 'package:privacy_gui/utils.dart';
 import 'package:privacygui_widgets/icons/linksys_icons.dart';
 import 'package:privacygui_widgets/theme/_theme.dart';
@@ -241,7 +242,8 @@ class _SpeedTestViewState extends ConsumerState<SpeedTestView> {
             }),
             AppText.displayLarge(
                 step == 'latency' ? '—' : (value).toStringAsFixed(1)),
-            AppText.bodyMedium(unit),
+            if (step == 'downloadBandwidth' || step == 'uploadBandwidth')
+              AppText.bodyMedium(unit),
           ],
         );
       },
@@ -252,6 +254,7 @@ class _SpeedTestViewState extends ConsumerState<SpeedTestView> {
   }
 
   Widget _pingView(String step, String latency) {
+    final isLatencyStep = step == 'latency' || latency == '0';
     return Column(
       mainAxisAlignment:
           step != 'success' ? MainAxisAlignment.end : MainAxisAlignment.center,
@@ -269,15 +272,26 @@ class _SpeedTestViewState extends ConsumerState<SpeedTestView> {
                 borderColor: Theme.of(context).colorScheme.primary,
                 size: 12,
                 dotSize: 6,
-                animated: latency == '—',
+                animated: isLatencyStep,
               ),
             ),
             AppText.titleSmall(
-              step == 'latency' ? 'Ping: —' : 'Ping: ',
+              'Ping: ',
               color: Theme.of(context).colorScheme.primary,
             ),
+            if (isLatencyStep)
+              AnimatedDigitalText(
+                fontSize: 12,
+                fontColor: Theme.of(context).colorScheme.primary,
+              ),
+            if (!isLatencyStep) ...[
+              AppText.bodyMedium(
+                latency,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+            ],
             AppText.bodyMedium(
-              step == 'latency' ? 'ms' : '${latency}ms',
+              'ms',
               color: Theme.of(context).colorScheme.primary,
             ),
           ],


### PR DESCRIPTION
Implements a rolling number animation during the speed test's latency check phase to provide users with clear visual feedback that the test is in progress.

This addresses the issue where the UI appeared static, causing confusion about whether the latency check was running.

- Creates a new `AnimatedDigitalText` widget with a "slot machine" style continuous rolling effect.
- Integrates this animation into the Speed Test page and the dashboard's Speed Test widget.
- The animation displays while ping is being measured and is replaced by the final value upon completion.

NOW-664