### PR TITLE
feat(settings): always show advanced routing

### DIFF
--- a/lib/core/utils/nodes.dart
+++ b/lib/core/utils/nodes.dart
@@ -336,7 +336,6 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'SPNM60',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
-    'isHidingRipRouting': true,
     'pattern': '^spnm60',
   },
   {
@@ -345,7 +344,6 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'SPNM61',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
-    'isHidingRipRouting': true,
     'pattern': '^spnm61',
   },
   {
@@ -354,7 +352,6 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'SPNM62',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
-    'isHidingRipRouting': true,
     'pattern': '^spnm62',
   },
   {
@@ -363,7 +360,6 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'M60',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
-    'isHidingRipRouting': true,
     'pattern': '^m60',
   },
   {
@@ -372,7 +368,6 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'M61',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
-    'isHidingRipRouting': true,
     'pattern': '^m61',
   },
   {
@@ -381,7 +376,6 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'M62',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
-    'isHidingRipRouting': true,
     'pattern': '^m62',
   },
   {
@@ -512,14 +506,4 @@ bool isHorizontalPorts({
         modelNumber: modelNumber,
         hardwareVersion: hardwareVersion,
         paramName: 'isHorizontalPorts') ??
-    false;
-
-bool isHidingRipRouting({
-  required String modelNumber,
-  required String hardwareVersion,
-}) =>
-    doVelopModelTests(
-        modelNumber: modelNumber,
-        hardwareVersion: hardwareVersion,
-        paramName: 'isHidingRipRouting') ??
     false;

--- a/lib/page/advanced_settings/advanced_settings_view.dart
+++ b/lib/page/advanced_settings/advanced_settings_view.dart
@@ -87,12 +87,11 @@ class _AdvancedSettingsViewState extends ConsumerState<AdvancedSettingsView> {
           title: loc(context).localNetwork,
           onTap: () => context.goNamed(RouteNamed.settingsLocalNetwork),
           disabledOnBridge: true),
-      if (!_isHidingRipRouting)
-        AppSectionItemData(
-          title: loc(context).advancedRouting,
-          onTap: () => context.goNamed(RouteNamed.settingsStaticRouting),
-          disabledOnBridge: true,
-        ),
+      AppSectionItemData(
+        title: loc(context).advancedRouting,
+        onTap: () => context.goNamed(RouteNamed.settingsStaticRouting),
+        disabledOnBridge: true,
+      ),
       AppSectionItemData(
         title: loc(context).administration,
         onTap: () => context.goNamed(RouteNamed.settingsAdministration),
@@ -127,12 +126,5 @@ class _AdvancedSettingsViewState extends ConsumerState<AdvancedSettingsView> {
         onTap: disabled ? null : item.onTap,
       ),
     );
-  }
-
-  bool get _isHidingRipRouting {
-    final deviceInfo = ref.read(dashboardManagerProvider).deviceInfo;
-    return isHidingRipRouting(
-        modelNumber: deviceInfo?.modelNumber ?? '',
-        hardwareVersion: deviceInfo?.hardwareVersion ?? '1');
   }
 }


### PR DESCRIPTION
### **User description**
Removes the logic that was hiding the "Advanced Routing" option for certain device models. This makes the feature consistently visible across all devices.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove device-specific hiding logic for Advanced Routing

- Make Advanced Routing consistently visible across all devices

- Clean up unused `isHidingRipRouting` function and properties


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Device Model Map"] -- "Remove isHidingRipRouting flags" --> B["Updated Model Definitions"]
  C["Advanced Settings View"] -- "Remove conditional logic" --> D["Always Show Advanced Routing"]
  E["Utility Functions"] -- "Delete isHidingRipRouting function" --> F["Cleaned Up Code"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nodes.dart</strong><dd><code>Remove routing visibility flags and utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/core/utils/nodes.dart

<ul><li>Remove <code>isHidingRipRouting: true</code> property from 6 device models (SPNM60, <br>SPNM61, SPNM62, M60, M61, M62)<br> <li> Delete entire <code>isHidingRipRouting</code> utility function</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/466/files#diff-f44dd38ade0c0dfde2e4e4dfb3082fa80ffe91a11b3cf052dfe1d6ee864ecae4">+0/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>advanced_settings_view.dart</strong><dd><code>Always show Advanced Routing in settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/advanced_settings/advanced_settings_view.dart

<ul><li>Remove conditional logic that hides Advanced Routing option<br> <li> Delete <code>_isHidingRipRouting</code> getter method<br> <li> Make Advanced Routing always visible in settings</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/466/files#diff-c33c8a805897a28b7edfcd941825dc3dd2e78efcaec5faee488619c4474b2912">+5/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

