### PR TITLE
[PINN-497]

### DIFF
--- a/lib/page/instant_device/views/instant_device_view.dart
+++ b/lib/page/instant_device/views/instant_device_view.dart
@@ -211,12 +211,10 @@ class _InstantDeviceViewState extends ConsumerState<InstantDeviceView> {
   Widget _editButton(
       bool isOnlineFilter, List<DeviceListItem> filteredDeviceList) {
     return AppTextButton.noPadding(
-      filteredDeviceList.length == _selectedList.length
-          ? loc(context).deselectAll
-          : loc(context).selectAll,
+      loc(context).selectAll,
       icon: filteredDeviceList.length == _selectedList.length
-          ? LinksysIcons.checkBoxOutlineBlank
-          : LinksysIcons.checkBox,
+          ? LinksysIcons.checkBox
+          : LinksysIcons.checkBoxOutlineBlank,
       color: isOnlineFilter
           ? Theme.of(context).colorScheme.onSurface.withOpacity(0.12)
           : Theme.of(context).colorScheme.primary,

--- a/lib/page/login/views/login_local_view.dart
+++ b/lib/page/login/views/login_local_view.dart
@@ -7,12 +7,10 @@ import 'package:privacy_gui/constants/error_code.dart';
 import 'package:privacy_gui/core/jnap/actions/better_action.dart';
 import 'package:privacy_gui/core/jnap/models/device_info.dart';
 import 'package:privacy_gui/core/jnap/providers/dashboard_manager_provider.dart';
-import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/page/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/page/components/styled/bottom_bar.dart';
 import 'package:privacy_gui/page/components/styled/consts.dart';
 import 'package:privacy_gui/page/components/views/arguments_view.dart';
-import 'package:privacy_gui/providers/auth/_auth.dart';
 import 'package:privacy_gui/providers/auth/auth_provider.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/core/jnap/result/jnap_result.dart';
@@ -271,7 +269,7 @@ class _LoginViewState extends ConsumerState<LoginLocalView> {
                         ),
                       ),
                     ),
-                  const AppGap.large3(),
+                  const AppGap.small3(),
                   AppTextButton.noPadding(
                     loc(context).forgotPassword,
                     onTap: () {

--- a/lib/providers/auth/auth_provider.dart
+++ b/lib/providers/auth/auth_provider.dart
@@ -165,6 +165,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
       logger.d(
           '[Auth]: Existence: cloud user name: ${username != null}, cloud pwd: ${password != null}, admin password: ${localPassword != null}. Login type = $loginType');
       return AuthState(
+        localPasswordHint: state.value?.localPasswordHint,
         username: username ?? '',
         loginType: loginType,
         sessionToken: sessionToken,


### PR DESCRIPTION
### **User description**
1. Fixed the "Show hint" disappears after shortly being displayed on the local login screen
2. Updated the "select all" UX on the instant device screen

<img width="1552" height="987" alt="Screenshot 2025-10-23 at 11 06 35 AM" src="https://github.com/user-attachments/assets/1065ddaf-5349-4465-904a-fdeab22bde47" />
<img width="1552" height="987" alt="Screenshot 2025-10-23 at 11 06 19 AM" src="https://github.com/user-attachments/assets/b18ef1b8-e0bf-406a-ab95-e0fadd18f070" />
<img width="1552" height="987" alt="Screenshot 2025-10-23 at 11 06 23 AM" src="https://github.com/user-attachments/assets/31749506-4cdd-46ee-82c5-5f90a8018194" />


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed "Show hint" disappearing after brief display on login screen

- Improved "select all" button UX on instant device screen

- Adjusted spacing and icon logic for better visual consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Login Local View"] -->|"Preserve hint state"| B["Auth Provider"]
  C["Instant Device View"] -->|"Update button logic"| D["Select All Button"]
  D -->|"Swap icon states"| E["Visual Consistency"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>instant_device_view.dart</strong><dd><code>Simplify select all button label and icon logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/instant_device/views/instant_device_view.dart

<ul><li>Changed button label to always display "Select All" instead of <br>toggling between "Select All" and "Deselect All"<br> <li> Swapped checkbox icon logic: now shows filled checkbox when all items <br>are selected, empty checkbox otherwise<br> <li> Maintains consistent button behavior while improving UX clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/472/files#diff-d9984308cb2d8a8b6592073b3bc8305892622920b2a3b376d43945abebfafa22">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>login_local_view.dart</strong><dd><code>Remove unused imports and adjust spacing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/login/views/login_local_view.dart

<ul><li>Removed unused imports for logger and auth module<br> <li> Changed spacing from <code>AppGap.large3()</code> to <code>AppGap.small3()</code> between <br>password field and forgot password button<br> <li> Reduces vertical gap for better visual layout</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/472/files#diff-d7009ad5c64e6130285654ed37195f77a5d46f99aa58cd46f2b100269eb465af">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>auth_provider.dart</strong><dd><code>Preserve password hint in auth state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/providers/auth/auth_provider.dart

<ul><li>Added <code>localPasswordHint</code> preservation in <code>AuthState</code> initialization<br> <li> Ensures password hint persists across auth state updates instead of <br>disappearing<br> <li> Fixes the issue where hint text was lost after brief display on login <br>screen</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/472/files#diff-fbbd209dc411451dc15ccee61ff2fc7e7d1e57bd1a09740e1d750a9d13503986">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

