### PR TITLE
[NOW-688]: [Pinnacle 2.2] Incredible-WiFi: Unknown error appears when using quick setup WiFi with WPA2 security mode

### DIFF
--- a/lib/page/wifi_settings/views/wifi_list_simple_mode_view.dart
+++ b/lib/page/wifi_settings/views/wifi_list_simple_mode_view.dart
@@ -41,13 +41,7 @@ class _SimpleModeViewState extends ConsumerState<SimpleModeView>
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(wifiListProvider);
-    Set<WifiSecurityType> securityTypeSet =
-        state.mainWiFi.first.availableSecurityTypes.toSet();
-    for (var e in state.mainWiFi) {
-      final availableSecurityTypesSet = e.availableSecurityTypes.toSet();
-      securityTypeSet = securityTypeSet.intersection(availableSecurityTypesSet);
-    }
-    final securityTypeList = securityTypeSet.toList();
+    final securityTypeList = state.simpleModeWifi.availableSecurityTypes;
 
     final isMobile = ResponsiveLayout.isMobileLayout(context);
 

--- a/test/page/wifi_settings/providers/wifi_list_provider_test.dart
+++ b/test/page/wifi_settings/providers/wifi_list_provider_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/wifi_settings/_wifi_settings.dart';
+import 'package:privacy_gui/page/wifi_settings/providers/wifi_state.dart';
+
+import '../../../test_data/wifi_list_test_state.dart';
+
+// A testable version of WifiListNotifier that allows setting state.
+class TestableWifiListNotifier extends WifiListNotifier {
+  @override
+  WiFiState build() {
+    // Do nothing, state will be set manually.
+    return WiFiState.fromMap(wifiListTestState);
+  }
+
+  void setState(WiFiState newState) {
+    state = newState;
+  }
+}
+
+void main() {
+  final defaultWifiItem = WiFiItem(
+    radioID: WifiRadioBand.radio_24,
+    ssid: 'test',
+    password: 'test',
+    securityType: WifiSecurityType.wpa2Personal,
+    wirelessMode: WifiWirelessMode.bgn,
+    channelWidth: WifiChannelWidth.auto,
+    channel: 1,
+    isBroadcast: false,
+    isEnabled: true,
+    availableSecurityTypes: const [
+      WifiSecurityType.wpa2Personal,
+      WifiSecurityType.wpa3Personal,
+      WifiSecurityType.wpa2Or3MixedPersonal,
+    ],
+    availableWirelessModes: const [WifiWirelessMode.bgn],
+    availableChannels: const {WifiChannelWidth.auto: [1, 2, 3]},
+    numOfDevices: 0,
+  );
+  group('WifiListNotifier - Testable Methods', () {
+    
+    group('getSimpleModeAvailableSecurityTypeList', () {
+      final notifier = TestableWifiListNotifier();
+
+      test('should return intersection of security types', () {
+        final wifiItem1 = defaultWifiItem.copyWith(
+          radioID: WifiRadioBand.radio_24,
+          availableSecurityTypes: const [
+            WifiSecurityType.wpa2Personal,
+            WifiSecurityType.wpa3Personal,
+            WifiSecurityType.wpa2Or3MixedPersonal,
+          ],
+        );
+        final wifiItem2 = defaultWifiItem.copyWith(
+          radioID: WifiRadioBand.radio_5_1,
+          availableSecurityTypes: const [
+            WifiSecurityType.wpa2Personal,
+            WifiSecurityType.wpa3Personal,
+          ],
+        );
+
+        final result = notifier.getSimpleModeAvailableSecurityTypeList([wifiItem1, wifiItem2]);
+
+        expect(result,
+            containsAll([WifiSecurityType.wpa2Personal, WifiSecurityType.wpa3Personal]));
+        expect(result.length, 2);
+      });
+
+      test('should return empty list for no common types', () {
+        final wifiItem1 = defaultWifiItem.copyWith(
+          radioID: WifiRadioBand.radio_24,
+          availableSecurityTypes: const [WifiSecurityType.wpa2Personal],
+        );
+        final wifiItem2 = defaultWifiItem.copyWith(
+          radioID: WifiRadioBand.radio_5_1,
+          availableSecurityTypes: const [WifiSecurityType.wpa3Personal],
+        );
+
+        final result = notifier.getSimpleModeAvailableSecurityTypeList([wifiItem1, wifiItem2]);
+
+        expect(result, isEmpty);
+      });
+
+      test('should return full list for a single wifi item', () {
+        final wifiItem1 = defaultWifiItem.copyWith(
+          radioID: WifiRadioBand.radio_24,
+          availableSecurityTypes: const [
+            WifiSecurityType.wpa2Personal,
+            WifiSecurityType.wpa3Personal,
+          ],
+        );
+
+        final result = notifier.getSimpleModeAvailableSecurityTypeList([wifiItem1]);
+
+        expect(result, [WifiSecurityType.wpa2Personal, WifiSecurityType.wpa3Personal]);
+      });
+
+      test('should return empty list when mainWiFi is empty', () {
+        final result = notifier.getSimpleModeAvailableSecurityTypeList([]);
+        expect(result, isEmpty);
+      });
+    });
+
+    group('getSimpleModeAvailableSecurityType', () {
+      final notifier = TestableWifiListNotifier();
+      final availableList = [
+        WifiSecurityType.wpa2Personal,
+        WifiSecurityType.wpa3Personal,
+        WifiSecurityType.wpa2Or3MixedPersonal,
+        WifiSecurityType.wep,
+      ];
+
+      test('should return current type if it is in the available list', () {
+        const current = WifiSecurityType.wpa2Personal;
+        final result = notifier.getSimpleModeAvailableSecurityType(current, availableList);
+        expect(result, current);
+      });
+
+      test('should return wpa3Personal if current is not available but wpa3Personal is', () {
+        const current = WifiSecurityType.wpaPersonal;
+        final result = notifier.getSimpleModeAvailableSecurityType(current, availableList);
+        expect(result, WifiSecurityType.wpa3Personal);
+      });
+
+      test('should return wpa2Or3MixedPersonal if wpa3Personal is not available', () {
+        const current = WifiSecurityType.wpaPersonal;
+        final listWithoutWpa3 = [
+          WifiSecurityType.wpa2Personal,
+          WifiSecurityType.wpa2Or3MixedPersonal,
+          WifiSecurityType.wep,
+        ];
+        final result = notifier.getSimpleModeAvailableSecurityType(current, listWithoutWpa3);
+        expect(result, WifiSecurityType.wpa2Or3MixedPersonal);
+      });
+
+      test('should return wpa2Personal if wpa3 and mixed are not available', () {
+        const current = WifiSecurityType.wpaPersonal;
+        final listWithoutWpa3AndMixed = [
+          WifiSecurityType.wpa2Personal,
+          WifiSecurityType.wep,
+        ];
+        final result = notifier.getSimpleModeAvailableSecurityType(current, listWithoutWpa3AndMixed);
+        expect(result, WifiSecurityType.wpa2Personal);
+      });
+
+      test('should return the first item if no preferred types are available', () {
+        const current = WifiSecurityType.wpaPersonal;
+        final listWithoutPreferred = [
+          WifiSecurityType.wep,
+          WifiSecurityType.open,
+        ];
+        final result = notifier.getSimpleModeAvailableSecurityType(current, listWithoutPreferred);
+        expect(result, WifiSecurityType.wep);
+      });
+
+      test('should return current type if available list is empty', () {
+        const current = WifiSecurityType.wpaPersonal;
+        final emptyList = <WifiSecurityType>[];
+        final result = notifier.getSimpleModeAvailableSecurityType(current, emptyList);
+        expect(result, current);
+      });
+    });
+  });
+}


### PR DESCRIPTION
### **User description**
Refactor: Extract logic for simple mode WiFi security

Refactored the `_checkMode` method into `_setupSimpleMode` to improve clarity and separation of concerns.

Extracted the logic for determining the available security types in simple mode into a new method, `getSimpleModeAvailableSecurityTypeList`. This method now calculates the intersection of available security types across all main WiFi networks.

A new method, `getSimpleModeAvailableSecurityType`, has been added to determine the default security type for simple mode. It prioritizes WPA3, then WPA2/WPA3 Mixed, and then WPA2, if available.

Added unit tests for the new methods to ensure their correctness.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Refactored WiFi security mode logic into dedicated methods for clarity

- Extracted security type intersection calculation into `getSimpleModeAvailableSecurityTypeList`

- Added security type prioritization in `getSimpleModeAvailableSecurityType` (WPA3 > WPA2/3 Mixed > WPA2)

- Added comprehensive unit tests for new security type methods

- Simplified view logic by using pre-calculated security types from state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_checkMode<br/>old logic"] -->|refactored| B["_setupSimpleMode<br/>new method"]
  B --> C["getSimpleModeAvailableSecurityTypeList<br/>calculate intersection"]
  B --> D["getSimpleModeAvailableSecurityType<br/>prioritize security type"]
  C --> E["WiFiState<br/>availableSecurityTypes"]
  D --> E
  E --> F["SimpleModeView<br/>simplified logic"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wifi_list_provider.dart</strong><dd><code>Extract and refactor WiFi security type logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/wifi_settings/providers/wifi_list_provider.dart

<ul><li>Renamed <code>_checkMode</code> to <code>_setupSimpleMode</code> for clarity<br> <li> Extracted security type intersection logic into <br><code>getSimpleModeAvailableSecurityTypeList</code> method<br> <li> Added <code>getSimpleModeAvailableSecurityType</code> method with WPA3 > WPA2/3 <br>Mixed > WPA2 prioritization<br> <li> Updated <code>_setupSimpleMode</code> to use new methods and populate <br><code>availableSecurityTypes</code> in state<br> <li> Added <code>@visibleForTesting</code> annotations for testable methods</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/474/files#diff-d9462fc7de4a31f2891d6daca3da161397a1cf499b59d952d8bd72251a5c9176">+53/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wifi_list_simple_mode_view.dart</strong><dd><code>Simplify view by using state security types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/wifi_settings/views/wifi_list_simple_mode_view.dart

<ul><li>Removed inline security type intersection calculation logic<br> <li> Simplified view to use pre-calculated <code>availableSecurityTypes</code> from <br><code>simpleModeWifi</code> state<br> <li> Reduced code complexity by delegating calculation to provider</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/474/files#diff-d05b20d9e294af4dd3f26107bd473da964eafb0797b89732815f68f86a7c3dc5">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wifi_list_provider_test.dart</strong><dd><code>Add unit tests for WiFi security methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/page/wifi_settings/providers/wifi_list_provider_test.dart

<ul><li>Added comprehensive unit tests for <br><code>getSimpleModeAvailableSecurityTypeList</code> method<br> <li> Added comprehensive unit tests for <code>getSimpleModeAvailableSecurityType</code> <br>method<br> <li> Created <code>TestableWifiListNotifier</code> class for testing private methods<br> <li> Tested security type intersection, prioritization, and edge cases</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/474/files#diff-804964c213e6a6e2a1f0e506c07c56d7ea667077b508442b97a04c1ce75c0e3b">+164/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

