### PR TITLE
Merge NOW-675 to dev-1.2.8

### DIFF
--- a/lib/page/wifi_settings/providers/wifi_bundle_provider.dart
+++ b/lib/page/wifi_settings/providers/wifi_bundle_provider.dart
@@ -182,16 +182,20 @@ class WifiBundleNotifier extends Notifier<WifiBundleState>
       numOfDevices: deviceManagerState.guestWifiDevices.length,
     );
 
-    final availableSecurityTypeList =
-        getSimpleModeAvailableSecurityTypeList(wifiItems);
+    // Use 2.4G band for primary security type list
+    final wifiForSecurityList = wifiItems.firstWhere(
+      (wifi) => wifi.radioID == WifiRadioBand.radio_24,
+      orElse: () => wifiItems.first, // Fallback, or handle error
+    );
+    final availableSecurityTypeList = getSimpleModeAvailableSecurityTypeList(
+        wifiForSecurityList != null ? [wifiForSecurityList] : wifiItems);
     final firstEnabledWifi =
         wifiItems.firstWhereOrNull((e) => e.isEnabled) ?? wifiItems.first;
 
     final isSimpleMode = wifiItems.every((wifi) =>
         wifi.isEnabled == firstEnabledWifi.isEnabled &&
         wifi.ssid == firstEnabledWifi.ssid &&
-        wifi.password == firstEnabledWifi.password &&
-        wifi.securityType == firstEnabledWifi.securityType);
+        wifi.password == firstEnabledWifi.password);
     final simpleModeWifi = firstEnabledWifi.copyWith(
       securityType: getSimpleModeAvailableSecurityType(
           firstEnabledWifi.securityType, availableSecurityTypeList),

--- a/lib/page/wifi_settings/providers/wifi_state.dart
+++ b/lib/page/wifi_settings/providers/wifi_state.dart
@@ -5,8 +5,6 @@ import 'package:equatable/equatable.dart';
 import 'package:privacy_gui/page/wifi_settings/_wifi_settings.dart';
 import 'package:privacy_gui/page/wifi_settings/providers/guest_wifi_item.dart';
 
-
-
 class WiFiListSettings extends Equatable {
   final List<WiFiItem> mainWiFi;
   final GuestWiFiItem guestWiFi;
@@ -68,14 +66,17 @@ class WiFiListSettings extends Equatable {
   List<WiFiItem> getMainWifiItemsWithSimpleSettings() {
     return mainWiFi.map((wifiItem) {
       final isEnabled = isSimpleMode ? true : wifiItem.isEnabled;
-      final ssid =
-          isSimpleMode ? simpleModeWifi.ssid : wifiItem.ssid;
+      final ssid = isSimpleMode ? simpleModeWifi.ssid : wifiItem.ssid;
       final security = isSimpleMode
-          ? simpleModeWifi.securityType
+          // Handle security type for 6G band
+          ? wifiItem.radioID == WifiRadioBand.radio_6
+              ? simpleModeWifi.securityType.isOpenVariant
+                  ? WifiSecurityType.enhancedOpenOnly
+                  : WifiSecurityType.wpa3Personal
+              : simpleModeWifi.securityType
           : wifiItem.securityType;
-      final password = isSimpleMode
-          ? simpleModeWifi.password
-          : wifiItem.password;
+      final password =
+          isSimpleMode ? simpleModeWifi.password : wifiItem.password;
 
       return wifiItem.copyWith(
         isEnabled: isEnabled,

--- a/lib/page/wifi_settings/views/wifi_list_view.dart
+++ b/lib/page/wifi_settings/views/wifi_list_view.dart
@@ -110,11 +110,6 @@ class WiFiListView extends ArgumentsConsumerStatelessView {
             value: isSimpleMode,
             onChanged: (value) {
               notifier.setSimpleMode(value);
-              if (value) {
-                // Logic to init simple mode settings if needed can be called here
-              } else {
-                // Logic to revert to advanced settings if needed
-              }
             },
           ),
         ],


### PR DESCRIPTION
### **User description**
Merge NOW-675 to dev-1.2.8


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed security type handling for 2.4G band in WiFi settings

- Added special handling for 6G band security type conversion

- Removed unnecessary security type comparison in simple mode detection

- Cleaned up unused conditional logic in WiFi mode switching


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WiFi Items"] -->|"Filter 2.4G band"| B["Security Type List"]
  C["Simple Mode Detection"] -->|"Remove security comparison"| D["Improved Logic"]
  E["6G Band WiFi"] -->|"Convert security type"| F["Enhanced/WPA3 Personal"]
  B --> G["WiFi Settings"]
  D --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wifi_bundle_provider.dart</strong><dd><code>Filter security types by 2.4G band</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/wifi_settings/providers/wifi_bundle_provider.dart

<ul><li>Modified security type list generation to use only 2.4G band WiFi <br>items<br> <li> Removed security type comparison from simple mode detection logic<br> <li> Added fallback handling when 2.4G band WiFi is not available</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/489/files#diff-efa7ce76c59bdb875760318bd0802cafd2a4f0fe02d201a7235e5c1b6acc1a3e">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wifi_state.dart</strong><dd><code>Add 6G band security type conversion logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/wifi_settings/providers/wifi_state.dart

<ul><li>Added special security type handling for 6G band in simple mode<br> <li> Converts open variants to Enhanced Open or WPA3 Personal for 6G<br> <li> Removed extra blank lines for code cleanup<br> <li> Improved code formatting consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/489/files#diff-9a7e6bf837331e8fbb6e8968c010e6fc2687e01f401a2ff4eb5482d5db07f2d6">+10/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Code cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wifi_list_view.dart</strong><dd><code>Remove unused WiFi mode switching logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/wifi_settings/views/wifi_list_view.dart

<ul><li>Removed unnecessary conditional logic in simple mode toggle handler<br> <li> Simplified onChanged callback for AppSwitch component</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/489/files#diff-3b8acc3caa3ad74fd8305726d5e7623f703285f55f01ea67c922639c0717b180">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

