### PR TITLE
NOW-711: Remove Speedtest widget from Pinnacle 2.2 until performance is as expected

### DIFF
--- a/lib/core/utils/nodes.dart
+++ b/lib/core/utils/nodes.dart
@@ -352,6 +352,8 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'SPNM62',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
+    'noSpeedTest':
+        true, // @2025/12/03 SPNM62 does not support speed test for now
     'pattern': '^spnm62',
   },
   {
@@ -376,6 +378,7 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'M62',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
+    'noSpeedTest': true, // @2025/12/03 M62 does not support speed test for now
     'pattern': '^m62',
   },
   {
@@ -507,3 +510,14 @@ bool isHorizontalPorts({
         hardwareVersion: hardwareVersion,
         paramName: 'isHorizontalPorts') ??
     false;
+
+bool isShowSpeedTest({
+  required String modelNumber,
+  String hardwareVersion = '1',
+}) {
+  return !(doVelopModelTests(
+          modelNumber: modelNumber,
+          hardwareVersion: hardwareVersion,
+          paramName: 'noSpeedTest') ??
+      false);
+}

--- a/lib/page/dashboard/views/components/port_and_speed.dart
+++ b/lib/page/dashboard/views/components/port_and_speed.dart
@@ -10,6 +10,7 @@ import 'package:privacy_gui/core/jnap/providers/polling_provider.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/dashboard/providers/dashboard_home_provider.dart';
 import 'package:privacy_gui/page/dashboard/providers/dashboard_home_state.dart';
+import 'package:privacy_gui/page/health_check/providers/speed_test_display.dart';
 import 'package:privacy_gui/page/instant_verify/views/components/speed_test_widget.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/dashboard/views/components/loading_tile.dart';
@@ -276,14 +277,17 @@ class DashboardHomePortAndSpeed extends ConsumerWidget {
       DashboardHomeState state, bool hasLanPort,
       [bool mobile = false]) {
     final isRemote = BuildConfig.isRemote();
-    return state.isHealthCheckSupported
+    final showSpeedTest = isDisplaySpeedTest(ref);
+    if (!showSpeedTest) {
+      return const SizedBox.shrink();
+    }
+    return state.isHealthCheckSupported && showSpeedTest
         ? hasLanPort
             ? Column(
                 children: const [
                   Divider(),
                   SpeedTestWidget(
-                      showDetails: false,
-                      layout: SpeedTestLayout.vertical),
+                      showDetails: false, layout: SpeedTestLayout.vertical),
                   AppGap.large2(),
                 ],
               )

--- a/lib/page/dashboard/views/dashboard_menu_view.dart
+++ b/lib/page/dashboard/views/dashboard_menu_view.dart
@@ -16,6 +16,7 @@ import 'package:privacy_gui/page/components/styled/menus/widgets/menu_holder.dar
 import 'package:privacy_gui/page/components/styled/status_label.dart';
 import 'package:privacy_gui/page/components/styled/styled_page_view.dart';
 import 'package:privacy_gui/page/dashboard/_dashboard.dart';
+import 'package:privacy_gui/page/health_check/providers/speed_test_display.dart';
 import 'package:privacy_gui/page/instant_privacy/providers/instant_privacy_provider.dart';
 import 'package:privacy_gui/page/instant_privacy/providers/instant_privacy_state.dart';
 import 'package:privacy_gui/page/instant_safety/providers/_providers.dart';
@@ -145,6 +146,8 @@ class _DashboardMenuViewState extends ConsumerState<DashboardMenuView> {
     final isSupportHealthCheck =
         ref.watch(dashboardHomeProvider).isHealthCheckSupported;
     final isSupportVPN = getIt.get<ServiceHelper>().isSupportVPN();
+    final showSpeedTest = isDisplaySpeedTest(ref);
+    
     return [
       AppSectionItemData(
           title: loc(context).incredibleWiFi,
@@ -213,22 +216,24 @@ class _DashboardMenuViewState extends ConsumerState<DashboardMenuView> {
             onTap: () {
               _navigateTo(RouteNamed.settingsVPN);
             }),
-      if (!isSupportHealthCheck && isBehindRouter)
-        AppSectionItemData(
-            title: loc(context).externalSpeedText,
-            description: loc(context).speedTestInternetToDeviceDesc,
-            iconData: LinksysIcons.networkCheck,
-            onTap: () {
-              _navigateTo(RouteNamed.speedTestExternal);
-            }),
-      if (isSupportHealthCheck)
-        AppSectionItemData(
-            title: loc(context).speedTest,
-            description: loc(context).speedTestInternetToRouterDesc,
-            iconData: LinksysIcons.networkCheck,
-            onTap: () {
-              _navigateTo(RouteNamed.dashboardSpeedTest);
-            }),
+      if (showSpeedTest) ...[
+        if (!isSupportHealthCheck && isBehindRouter)
+          AppSectionItemData(
+              title: loc(context).externalSpeedText,
+              description: loc(context).speedTestInternetToDeviceDesc,
+              iconData: LinksysIcons.networkCheck,
+              onTap: () {
+                _navigateTo(RouteNamed.speedTestExternal);
+              }),
+        if (isSupportHealthCheck)
+          AppSectionItemData(
+              title: loc(context).speedTest,
+              description: loc(context).speedTestInternetToRouterDesc,
+              iconData: LinksysIcons.networkCheck,
+              onTap: () {
+                _navigateTo(RouteNamed.dashboardSpeedTest);
+              }),
+      ],
     ];
   }
 

--- a/lib/page/health_check/providers/speed_test_display.dart
+++ b/lib/page/health_check/providers/speed_test_display.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/jnap/providers/dashboard_manager_provider.dart';
+import 'package:privacy_gui/core/utils/nodes.dart';
+
+bool isDisplaySpeedTest(WidgetRef ref) {
+  final modelNumber =
+      ref.watch(dashboardManagerProvider).deviceInfo?.modelNumber ?? '';
+  final hardwareVersion =
+      ref.watch(dashboardManagerProvider).deviceInfo?.hardwareVersion ?? '1';
+  return isShowSpeedTest(
+      modelNumber: modelNumber, hardwareVersion: hardwareVersion);
+}

--- a/lib/page/health_check/views/speed_test_view.dart
+++ b/lib/page/health_check/views/speed_test_view.dart
@@ -11,6 +11,7 @@ import 'package:privacy_gui/page/dashboard/_dashboard.dart';
 import 'package:privacy_gui/page/health_check/providers/health_check_provider.dart';
 import 'package:privacy_gui/page/health_check/providers/health_check_state.dart';
 import 'package:privacy_gui/page/components/customs/animated_digital_text.dart';
+import 'package:privacy_gui/page/health_check/providers/speed_test_display.dart';
 import 'package:privacy_gui/utils.dart';
 import 'package:privacygui_widgets/icons/linksys_icons.dart';
 import 'package:privacygui_widgets/theme/_theme.dart';
@@ -46,60 +47,64 @@ class _SpeedTestViewState extends ConsumerState<SpeedTestView> {
     final state = ref.watch(healthCheckProvider);
     final supportedBy = ref.watch(dashboardHomeProvider).healthCheckModule;
 
-    return StyledAppPageView(
-      scrollable: true,
-      title: loc(context).speedTest,
-      bottomBar: state.status == 'COMPLETE'
-          ? PageBottomBar(
-              positiveLabel: loc(context).testAgain,
-              isPositiveEnabled: true,
-              onPositiveTap: () {
-                ref
-                    .read(healthCheckProvider.notifier)
-                    .runHealthCheck(Module.speedtest);
-              },
-            )
-          : null,
-      child: (context, constraints) => switch (state.status) {
-        'RUNNING' => ResponsiveLayout(
-            desktop: Container(
-              margin: const EdgeInsets.fromLTRB(0, 0, 0, 40),
-              child: Center(
-                child: _runningView(
-                  state,
+    final isSpeedTestSupported = isDisplaySpeedTest(ref);
+
+    return isSpeedTestSupported
+        ? StyledAppPageView(
+            scrollable: true,
+            title: loc(context).speedTest,
+            bottomBar: state.status == 'COMPLETE'
+                ? PageBottomBar(
+                    positiveLabel: loc(context).testAgain,
+                    isPositiveEnabled: true,
+                    onPositiveTap: () {
+                      ref
+                          .read(healthCheckProvider.notifier)
+                          .runHealthCheck(Module.speedtest);
+                    },
+                  )
+                : null,
+            child: (context, constraints) => switch (state.status) {
+              'RUNNING' => ResponsiveLayout(
+                  desktop: Container(
+                    margin: const EdgeInsets.fromLTRB(0, 0, 0, 40),
+                    child: Center(
+                      child: _runningView(
+                        state,
+                      ),
+                    ),
+                  ),
+                  mobile: _runningView(state),
                 ),
-              ),
-            ),
-            mobile: _runningView(state),
-          ),
-        'COMPLETE' => ResponsiveLayout(
-            desktop: Container(
-              margin: const EdgeInsets.fromLTRB(0, 0, 0, 40),
-              child: Container(
-                alignment: state.step != 'error'
-                    ? Alignment.topCenter
-                    : Alignment.topLeft,
-                child: _finishView(
-                  state,
+              'COMPLETE' => ResponsiveLayout(
+                  desktop: Container(
+                    margin: const EdgeInsets.fromLTRB(0, 0, 0, 40),
+                    child: Container(
+                      alignment: state.step != 'error'
+                          ? Alignment.topCenter
+                          : Alignment.topLeft,
+                      child: _finishView(
+                        state,
+                      ),
+                    ),
+                  ),
+                  mobile: _finishView(
+                    state,
+                  ),
                 ),
-              ),
-            ),
-            mobile: _finishView(
-              state,
-            ),
-          ),
-        _ => ResponsiveLayout(
-            desktop: AppCard(
-              showBorder: false,
-              margin: const EdgeInsets.fromLTRB(0, 0, 0, 40),
-              padding: EdgeInsets.zero,
-              clipBehavior: Clip.antiAlias,
-              child: _initView(supportedBy),
-            ),
-            mobile: _initView(supportedBy),
-          ),
-      },
-    );
+              _ => ResponsiveLayout(
+                  desktop: AppCard(
+                    showBorder: false,
+                    margin: const EdgeInsets.fromLTRB(0, 0, 0, 40),
+                    padding: EdgeInsets.zero,
+                    clipBehavior: Clip.antiAlias,
+                    child: _initView(supportedBy),
+                  ),
+                  mobile: _initView(supportedBy),
+                ),
+            },
+          )
+        : const SizedBox.shrink();
   }
 
   Widget _gradientBackground() {


### PR DESCRIPTION
### **User description**
- Add noSpeedTest attr on nodes.dart
- Hide SpeedTest on DashboardHome, DashboardMenu, and Instant-Verify
- Display empty view on speed test view if noSpeedTest flag is true


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add `noSpeedTest` flag to SPNM62 and M62 router models

- Create centralized `isShowSpeedTest()` utility function for speed test visibility

- Hide speed test UI across dashboard, menu, and instant verify pages

- Display empty view when speed test unsupported on dedicated speed test page

- Add `_portsCardVertical()` layout fallback when speed test hidden


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["nodes.dart<br/>Add noSpeedTest flag"] --> B["speed_test_display.dart<br/>isShowSpeedTest utility"]
  B --> C["Dashboard Pages<br/>Hide speed test UI"]
  B --> D["Speed Test View<br/>Show empty state"]
  C --> E["port_and_speed.dart<br/>Dashboard Home"]
  C --> F["dashboard_menu_view.dart<br/>Dashboard Menu"]
  C --> G["instant_verify_view.dart<br/>Instant Verify"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nodes.dart</strong><dd><code>Add noSpeedTest flag and utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/core/utils/nodes.dart

<ul><li>Add <code>noSpeedTest: true</code> flag to SPNM62 model configuration<br> <li> Add <code>noSpeedTest: true</code> flag to M62 model configuration<br> <li> Create new <code>isShowSpeedTest()</code> function that checks model support and <br>returns inverse of <code>noSpeedTest</code> flag</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/492/files#diff-f44dd38ade0c0dfde2e4e4dfb3082fa80ffe91a11b3cf052dfe1d6ee864ecae4">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>speed_test_display.dart</strong><dd><code>New speed test display provider utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/health_check/providers/speed_test_display.dart

<ul><li>New file providing centralized <code>isDisplaySpeedTest()</code> helper function<br> <li> Retrieves model number and hardware version from dashboard manager <br>provider<br> <li> Calls <code>isShowSpeedTest()</code> utility to determine speed test visibility</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/492/files#diff-514f4b6d79f7619dcb3cb86f50b27dc89559790260574d943ae7221d01153ffa">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>port_and_speed.dart</strong><dd><code>Hide speed test tile on dashboard home</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/dashboard/views/components/port_and_speed.dart

<ul><li>Import new <code>speed_test_display</code> provider<br> <li> Check <code>isDisplaySpeedTest()</code> in <code>_createSpeedTestTile()</code> method<br> <li> Return empty <code>SizedBox.shrink()</code> when speed test not supported<br> <li> Add conditional check to speed test tile creation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/492/files#diff-dcdb0feea2dd4792c04cb2e28fa4fe4d35b60d13b2217c6d0f47a2562728f0a3">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dashboard_menu_view.dart</strong><dd><code>Hide speed test menu items conditionally</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/dashboard/views/dashboard_menu_view.dart

<ul><li>Import new <code>speed_test_display</code> provider<br> <li> Add <code>showSpeedTest</code> variable using <code>isDisplaySpeedTest()</code> check<br> <li> Wrap external and internal speed test menu items in conditional <code>if </code><br><code>(showSpeedTest)</code> block<br> <li> Prevent speed test menu options from appearing for unsupported models</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/492/files#diff-3d4fd1fcaa85451d010536aa0c247fc262e96d9c990d581ad0a7e421a2b6bb25">+21/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>speed_test_view.dart</strong><dd><code>Display empty view for unsupported models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/health_check/views/speed_test_view.dart

<ul><li>Import new <code>speed_test_display</code> provider<br> <li> Add <code>isSpeedTestSupported</code> check using <code>isDisplaySpeedTest()</code><br> <li> Wrap entire <code>StyledAppPageView</code> in conditional ternary operator<br> <li> Return empty <code>SizedBox.shrink()</code> when speed test not supported</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/492/files#diff-d9320c8433932d4e5d555a4e28b78f1812a17f5c186306dd36d337a704de81eb">+57/-52</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>instant_verify_view.dart</strong><dd><code>Hide speed test and add ports fallback layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/instant_verify/views/instant_verify_view.dart

<ul><li>Import new <code>speed_test_display</code> provider<br> <li> Add <code>showSpeedTest</code> variable using <code>isDisplaySpeedTest()</code> check<br> <li> Conditionally render speed test content in mobile layout<br> <li> Replace speed test content with <code>_portsCardVertical()</code> fallback on <br>desktop when unsupported<br> <li> Add new <code>_portsCardVertical()</code> method to display ports in vertical <br>layout as alternative to speed test</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/492/files#diff-89a27bc23912ba8a8ca137fb8d3c411f12536cc76bfd1b809ee24ed276a8e556">+72/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

