### PR TITLE
fix: use ceil() for grid height calculation in dashboard menu

### DIFF
--- a/lib/page/dashboard/views/dashboard_menu_view.dart
+++ b/lib/page/dashboard/views/dashboard_menu_view.dart
@@ -66,7 +66,8 @@ class _DashboardMenuViewState extends ConsumerState<DashboardMenuView> {
     return Scrollbar(
       thickness: 0,
       child: SizedBox(
-        height: (items.length / (isDesktop ? 3 : 1)) * (isDesktop ? 152 : 112) +
+        height: (items.length / (isDesktop ? 3 : 1)).ceil() *
+                (isDesktop ? 152 : 112) +
             kDefaultToolbarHeight,
         child: GridView.builder(
           controller: Scrollable.maybeOf(context)?.widget.controller,


### PR DESCRIPTION
### **User description**
## Problem
The dashboard menu grid view was cutting off content at the bottom. The height calculation was truncating rows when item count is not divisible by column count.

## Solution
Use `.ceil()` to round up the row count, ensuring all rows are fully visible.

## Changes
- Modified `_buildMenuGridView` in `dashboard_menu_view.dart` to use `.ceil()` for height calculation

## Testing
- Verified menu items are now fully visible without truncation


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed grid height calculation using `.ceil()` to prevent content truncation

- Ensures all menu items are fully visible when count not divisible by columns

- Applies to both desktop (3 columns) and mobile (1 column) layouts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Grid Height Calculation"] -->|"Apply ceil() to row count"| B["Prevent Row Truncation"]
  B -->|"Ensures all items visible"| C["Fixed Menu Display"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard_menu_view.dart</strong><dd><code>Apply ceil() to grid row count calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/dashboard/views/dashboard_menu_view.dart

<ul><li>Modified <code>_buildMenuGridView</code> method to apply <code>.ceil()</code> to the row count <br>calculation<br> <li> Changed from <code>(items.length / columnCount) * itemHeight</code> to <br><code>(items.length / columnCount).ceil() * itemHeight</code><br> <li> Ensures proper height allocation for grid when item count is not <br>evenly divisible by column count<br> <li> Fixes content cutoff issue in both desktop and mobile layouts</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/532/files#diff-3d4fd1fcaa85451d010536aa0c247fc262e96d9c990d581ad0a7e421a2b6bb25">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

