### PR TITLE
Cannot set /31 subnet on Pinnacle 2.0 and 2.2

### DIFF
--- a/lib/page/advanced_settings/internet_settings/views/internet_settings_view.dart
+++ b/lib/page/advanced_settings/internet_settings/views/internet_settings_view.dart
@@ -1179,7 +1179,8 @@ class _InternetSettingsViewState extends ConsumerState<InternetSettingsView>
           errorText: subnetMaskErrorText,
           border: const OutlineInputBorder(),
           onChanged: (value) {
-            final subnetMaskValidator = SubnetMaskValidator();
+            // override default of 30 for WAN Static IP settings (QUALITY-439)
+            final subnetMaskValidator = SubnetMaskValidator(max: 31);
             final isValidSubnetMask = subnetMaskValidator.validate(value);
             if (isValidSubnetMask) {
               _notifier.updateIpv4Settings(ipv4Setting.copyWith(

--- a/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_static_ip_view.dart
+++ b/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_static_ip_view.dart
@@ -29,7 +29,8 @@ class _PnpStaticIpViewState extends ConsumerState<PnpStaticIpView> {
   final _dns2Controller = TextEditingController();
   var _hasExtraDNS = false;
 
-  final subnetMaskValidator = SubnetMaskValidator();
+  // override default of 30 for WAN Static IP settings (QUALITY-439)
+  final subnetMaskValidator = SubnetMaskValidator(max: 31);
   final ipAddressValidator = IpAddressValidator();
   final requiredIpAddressValidator = IpAddressRequiredValidator();
   String? _ipError;


### PR DESCRIPTION
### **User description**
Set SubnetMaskValidator max to 31 for Internet settings to align LSWF.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Override SubnetMaskValidator default max from 30 to 31

- Allow /31 subnet configuration for WAN Static IP settings

- Applied consistently across internet and ISP settings views


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SubnetMaskValidator<br/>default max: 30"] -->|"override to max: 31"| B["WAN Static IP<br/>Settings Support"]
  C["internet_settings_view.dart"] -->|"apply validator"| B
  D["pnp_static_ip_view.dart"] -->|"apply validator"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>internet_settings_view.dart</strong><dd><code>Override subnet validator max to 31 in internet settings</code>&nbsp; </dd></summary>
<hr>

lib/page/advanced_settings/internet_settings/views/internet_settings_view.dart

<ul><li>Modified <code>SubnetMaskValidator</code> instantiation to override max parameter <br>to 31<br> <li> Added comment referencing QUALITY-439 ticket<br> <li> Allows /31 subnet masks in WAN Static IP configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/555/files#diff-1d4a7507d03c495a249458fe0eb66b7c183ec6bc632825081623412175759880">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pnp_static_ip_view.dart</strong><dd><code>Override subnet validator max to 31 in ISP settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_static_ip_view.dart

<ul><li>Changed <code>SubnetMaskValidator</code> initialization to include max: 31 <br>parameter<br> <li> Added comment referencing QUALITY-439 ticket<br> <li> Enables /31 subnet support in PnP static IP configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/555/files#diff-6278a9194355d14b55277fcffe71143e046a5289762c0722c6a5d9bde658ec23">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

