### PR TITLE
fix: enable speed test for SPNM62 and M62 models

### DIFF
--- a/lib/core/utils/nodes.dart
+++ b/lib/core/utils/nodes.dart
@@ -352,8 +352,6 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'SPNM62',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
-    'noSpeedTest':
-        true, // @2025/12/03 SPNM62 does not support speed test for now
     'pattern': '^spnm62',
   },
   {
@@ -378,7 +376,6 @@ const List<Map<String, dynamic>> _velopModelMap = [
     'seriesModel': 'M62',
     'isMeshRouter': false,
     'isCognitiveMesh': true,
-    'noSpeedTest': true, // @2025/12/03 M62 does not support speed test for now
     'pattern': '^m62',
   },
   {


### PR DESCRIPTION
### **User description**
## Summary
- Enable speed test functionality for SPNM62 and M62 models
- Remove `noSpeedTest` flag that was previously disabling speed test for these models

## Related Issue
#586


___

### **PR Type**
Bug fix


___

### **Description**
- Remove `noSpeedTest` flag from SPNM62 model configuration

- Remove `noSpeedTest` flag from M62 model configuration

- Enable speed test functionality for both models


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SPNM62 & M62<br/>Model Config"] -- "Remove noSpeedTest flag" --> B["Speed Test<br/>Enabled"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nodes.dart</strong><dd><code>Remove noSpeedTest flags from model configs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/core/utils/nodes.dart

<ul><li>Removed <code>noSpeedTest: true</code> flag from SPNM62 model entry<br> <li> Removed <code>noSpeedTest: true</code> flag from M62 model entry<br> <li> Deleted associated comments indicating speed test was not supported</ul>


</details>


  </td>
  <td><a href="https://github.com/linksys/PrivacyGUI/pull/587/files#diff-f44dd38ade0c0dfde2e4e4dfb3082fa80ffe91a11b3cf052dfe1d6ee864ecae4">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

