### PR TITLE
feat: USP M2 documentation, SSE improvements & FW team request

### DIFF
--- a/doc/usp/integration/feature_roadmap.md
+++ b/doc/usp/integration/feature_roadmap.md
@@ -49,7 +49,7 @@
 |---------|-------------|--------|
 | 401 Auth Retry | Auto reauth on token expiry — two-stage (refreshToken → re-login), Completer lock, transparent to notifiers | Active |
 | SSE Connection Manager | Exponential backoff reconnection (1s → 60s), heartbeat watchdog (45s timeout), auto-reconnect | Active |
-| SSE Subscription Registry | Two-layer subscription (OBUSPA + bridge), `resubscribeAll()` on reconnect, lifecycle tracking | Active |
+| SSE Subscription Registry | Bridge-only subscription tracking (bridge auto-creates OBUSPA subs), `resubscribeAll()` on reconnect, idempotent | Active |
 | SSE Event Router | Demux by subscription_id, wildcard handlers for cross-cutting concerns, JSON parse + route | Active |
 | SSE Invalidation Provider | Path-based domain mapping, `.Stats.` noise filter, 11 invalidation domains for selective re-fetch | Active |
 | SSE Operation Awaiter | Async Operate commands (Ping/Traceroute) via OperationComplete, wildcard command_name matching, polling fallback | Active |
@@ -89,7 +89,7 @@
 | F-024: WiFi Performance Analytics | 3-tab card (Signal: per-client RSSI `AppBarChart` with tier coloring, Speed: DL/UL grouped `AppBarChart` per client, Channels: per-radio info + band distribution `AppPieChart` donut). Uses `WifiClient` signal/noise/speed + `connectionDetailMap` for AP→Radio band mapping. Files: `wifi_performance_helpers.dart` + `usp_wifi_performance_card.dart` | 2026-03-11 |
 | Bugfix: SliverDashboard crash | Fixed "Unexpected null value" at `sliver_dashboard.dart:621` — removed `optimizeLayout()` calls that mutated DashboardController after widget tree was built. Added stale layout validation (saved 15-item layout vs new 17-item spec). Files: `usp_layout_controller.dart` | 2026-03-11 |
 | F-021: System Performance Dashboard | 4-tab dashboard card (Monitor: CPU/Memory gauges + uptime, Trends: dual-line `AppLineChart` CPU+Memory, Distribution: 4-bucket CPU histogram `AppBarChart`, Correlation: dual-axis CPU vs WAN traffic). Statistics page with 4 sections (Gauges, Resource Trends, CPU Distribution, CPU-Traffic Correlation). 60-point ring buffer, configurable auto-refresh (Off/10s/30s/60s). Files: `usp_system_status_card.dart` + `system_monitor_state.dart` + `usp_system_monitor_notifier.dart` + `stats_*_section.dart` | 2026-03-13 (confirmed) |
-| SSE Infrastructure (Phases 1-4) | Full SSE pipeline: `SseConnectionManager` (backoff + heartbeat watchdog), `SseSubscriptionRegistry` (OBUSPA + bridge two-layer), `SseEventRouter` (demux + wildcard handlers), `SseInvalidationProvider` (path-based domain mapping, `.Stats.` filter), `SseOperationAwaiter` (OperationComplete for Ping/Traceroute, polling fallback), bootstrap purge for stale subscriptions. See `doc/usp/integration/sse_implementation.md` | 2026-03-13 |
+| SSE Infrastructure (Phases 1-4) | Full SSE pipeline: `SseConnectionManager` (backoff + heartbeat watchdog), `SseSubscriptionRegistry` (bridge-only, auto-creates OBUSPA subs), `SseEventRouter` (demux + wildcard handlers), `SseInvalidationProvider` (path-based domain mapping, `.Stats.` filter), `SseOperationAwaiter` (OperationComplete for Ping/Traceroute, polling fallback), bootstrap purge for stale subscriptions. See `doc/usp/integration/sse_implementation.md` | 2026-03-13 (updated 2026-03-16) |
 | SSE × Codegen Subscribe Alignment | YAML `subscribe:` array format (codegen v0.10.5), auto-generated `subscriptions.g.dart` replaces manual `subscription_config.dart`. 5 bootstrap subscriptions: Hosts (OC+OD+VC), DHCP Clients (OC), WiFi AP (OC). `UspService.subscribe<T>()` SSE delegate pattern, 11 invalidation domains | 2026-03-13 |
 | Bugfix: SSE Stats flooding | Removed WiFi SSID/Radio ValueChange from bootstrap subscriptions — `.Stats.*` counters fire every second. Path-based `_mapToDomain` replaces broken subscription_id matching | 2026-03-13 |
 | Bugfix: Stale OBUSPA subscriptions | `purgeAllSubscriptions()` via GET-based enumeration of `Device.LocalAgent.Subscription.` — clears subscriptions from previous sessions on browser refresh | 2026-03-13 |
@@ -110,11 +110,11 @@
 | Issue | Detail |
 |-------|--------|
 | VendorLogFile not supported | Router's USP agent (obuspa) does not implement `Device.DeviceInfo.VendorLogFile.{i}.` — syslog available via SSH (`logread`) but no HTTP/USP access |
-| WASM `add` returns empty for LocalAgent | `UspClientWeb.add('Device.LocalAgent.Subscription.')` returns empty — Rust WASM client bug. Workaround: GET-diff in `UspService.createNotifySubscription()` |
+| WASM `add` returns empty for LocalAgent | `UspClientWeb.add('Device.LocalAgent.Subscription.')` returns empty — Rust WASM client bug. No longer relevant: bridge handles OBUSPA subscription lifecycle. Legacy `createNotifySubscription()` retained for debug |
 | CPE subscription_id mismatch | CPE uses internal IDs (`cpe-3`, `cpe-15`) not client-assigned IDs. Affects both OperationComplete matching and invalidation routing. Workaround: wildcard handler + `command_name` / `param_path` matching |
 | WiFi Stats noise | `Device.WiFi.SSID.*.Stats.*` and `Device.WiFi.Radio.*.Stats.*` fire every second via ValueChange. Must NOT subscribe to broad WiFi ValueChange |
 | BUG-006: Operate results not in data model | `GET Device.IP.Diagnostics.IPPing.` returns empty after Operate — results only available via SSE OperationComplete |
-| Bridge subscribe doesn't create OBUSPA sub | `POST /api/v1/subscription` only registers bridge session mapping, does NOT create `Device.LocalAgent.Subscription.{i}`. Client must create OBUSPA subscriptions directly |
+| ~~Bridge subscribe doesn't create OBUSPA sub~~ | ~~`POST /api/v1/subscription` only registers bridge session mapping~~ — ✅ **FIXED** (2026-03-16): Bridge now auto-creates OBUSPA subscriptions with new API fields (`NotifType`/`ReferenceList`). Client simplified to bridge-only |
 
 ---
 

--- a/doc/usp/integration/roadmap_m2.md
+++ b/doc/usp/integration/roadmap_m2.md
@@ -1,0 +1,632 @@
+# USP Milestone 2 Roadmap — JNAP Migration Gap & Feasibility Analysis
+
+> Date: 2026-03-16 | Branch: `feat/usp-protocol-integration`
+> Based on: M1 Feature Roadmap, SSH Validation, USP Features Matrix, JNAP Alignment Analysis
+> Router: Linksys M60TB-EU (PINNACLE 2.0) | Firmware: 1.0.16.26013014
+
+---
+
+## Migration Goal
+
+**Fully eliminate JNAP dependency and migrate all features to USP protocol.**
+
+M1 completed USP migration for 45/72 (63%) features. This document tracks USP support gaps for the remaining 27 features, categorized by blocker type, to guide firmware team communication and development scheduling.
+
+All features still dependent on JNAP are considered **Migration Gaps**, requiring resolution or firmware team USP/vendor extension support.
+
+---
+
+## Scope
+
+1. Remaining M1 pending features (WiFi management, Diagnostics, Performance)
+2. Internet Settings write support (10 open issues)
+3. WiFi Settings TR-181 limitations (4 issues)
+4. DDNS, QoS, Parental Control feasibility (SSH-verified 2026-03-16)
+5. **JNAP dependencies requiring USP vendor extension support**
+
+---
+
+## Status Overview
+
+| Category | Total | ✅ USP Ready | 🔧 Needs Code Fix | 🏭 Needs FW Team | 🔴 USP Gap (JNAP dependency) |
+|----------|-------|-------------|-------------------|-----------------|-------------------------------|
+| M1 Pending Features | 8 | 6 | — | — | — |
+| Internet Settings | 10 | — | 5 | 4 | 1 |
+| WiFi Settings | 4 | — | 2 | 2 | — |
+| WiFi Advanced / Security | 3 | 1 | 1 | — | 1 |
+| DDNS | 1 | — | — | 1 | — |
+| QoS | 4 | — | — | 1 | 3 |
+| Parental Control | 3 | — | — | — | 2 |
+| Remaining JNAP Dependencies | 7 | — | — | — | 7 |
+| **Total** | **40** | **7** | **8** | **8** | **14** |
+
+> 🔴 **USP Gap** = Feature currently only supported by JNAP, no corresponding USP path. Requires firmware team to provide vendor extension or bbfdm plugin to complete migration.
+
+---
+
+## 1. M1 Pending Features
+
+These features have verified TR-181 support and are ready for implementation.
+
+### F-001: WiFi SSID / Password / Security Management
+
+**Priority:** P0 | **Effort:** Small | **Feasibility:** ✅ USP Ready (SSH-verified 2026-03-16)
+
+- `Device.WiFi.AccessPoint.{i}.Security.KeyPassphrase` — validated SET-able
+- `Device.WiFi.AccessPoint.{i}.Security.SAEPassphrase` — WPA3 password (writable)
+- `Device.WiFi.AccessPoint.{i}.Security.ModeEnabled` — writable, supports: `None, WPA2-Personal, WPA3-Personal, WPA3-Personal-Transition, Enhanced-Open`
+- `Device.WiFi.AccessPoint.{i}.Security.MFPConfig` — Management Frame Protection (writable)
+- `Device.WiFi.AccessPoint.{i}.Security.Reset()` — Operate command
+- Add `writable: true` to `wi_fi_access_points.yaml`, re-run codegen
+- New dialog: WiFi password edit per AP/SSID + security mode selector
+- **JNAP `setWPSServerSessionStatus` can be fully migrated to USP**
+
+### F-004: WiFi Channel Width Edit
+
+**Priority:** P1 | **Effort:** Small | **Feasibility:** ✅ USP Ready
+
+- `Device.WiFi.Radio.{i}.OperatingChannelBandwidth` — available in codegen
+- Mark as `writable` in `wi_fi_radios.yaml`
+- Expand `wifi_channel_dialog.dart` with bandwidth selector
+
+### F-007: Guest Network Management
+
+**Priority:** P1 | **Effort:** Medium | **Feasibility:** ✅ USP Ready (with heuristic)
+
+- BUG-001 fixed, WiFi SSID enumeration works
+- Guest AP identification: AP index-based or `SSIDAdvertisementEnabled` heuristic
+- See [wifi-settings-tr181-limitations.md ISS-4](../issues/wifi-settings-tr181-limitations.md) — reliable detection needs vendor extension
+
+### F-011: Network Diagnostics (Ping / Traceroute)
+
+**Priority:** P1 | **Effort:** Medium | **Feasibility:** ✅ SSE Infrastructure Ready
+
+- Backend complete: `SseOperationAwaiter`, `PingResult`, `TracerouteResult`
+- Remaining: UI page only (models, notifier, view, routing)
+- Plan file: `noble-tickling-pumpkin.md`
+
+### F-025: Historical Trend Analysis
+
+**Priority:** P2 | **Effort:** Large | **Feasibility:** ⚠️ Client-Side Only
+
+- No TR-181 historical storage — requires Hive local DB + background collection
+- Weekly/monthly trend charts, seasonal analysis
+
+### F-026: Dashboard Prefetch Cache
+
+**Priority:** P1 | **Effort:** Medium | **Feasibility:** ✅ USP Ready
+
+- Batch prefetch: 17 requests → 1 batch + 16 cache hits
+- Target: dashboard load <500ms in high-latency networks
+
+### F-027: WPS (Wi-Fi Protected Setup)
+
+**Priority:** P2 | **Effort:** Small | **Feasibility:** ✅ USP Ready (SSH-verified 2026-03-16)
+
+- `Device.WiFi.AccessPoint.{i}.WPS.Enable` — writable (toggle per AP)
+- `Device.WiFi.AccessPoint.{i}.WPS.ConfigMethodsEnabled` — writable (`"PushButton"`)
+- `Device.WiFi.AccessPoint.{i}.WPS.Status` — read-only (`Configured` / `Disabled`)
+- `Device.WiFi.AccessPoint.{i}.WPS.InitiateWPSPBC()` — async Operate command
+- Verified: AP.1 ✅ AP.2 ✅ AP.3 (guest, disabled) ✅ AP.4 ✅
+- **JNAP `setWPSServerSessionStatus` can be fully migrated to USP**
+
+### F-028: WiFi Advanced Radio Settings
+
+**Priority:** P2 | **Effort:** Medium | **Feasibility:** ✅ USP Ready (SSH-verified 2026-03-16)
+
+All 12 Radio parameters below are writable (schema `data:"1"`), partially replacing JNAP `setAdvancedRadioSettings`:
+
+| Parameter | Path | Current Value | Notes |
+|-----------|------|--------------|-------|
+| Transmit Power | `Radio.{i}.TransmitPower` | (supported: -1,25,50,75,100) | % or auto(-1) |
+| Guard Interval | `Radio.{i}.GuardInterval` | `"Auto"` | Auto/Short/Long |
+| Beacon Period | `Radio.{i}.BeaconPeriod` | 100 | ms |
+| DTIM Period | `Radio.{i}.DTIMPeriod` | 2 | beacon count |
+| RTS Threshold | `Radio.{i}.RTSThreshold` | 2347 | bytes |
+| Fragmentation | `Radio.{i}.FragmentationThreshold` | 2346 | bytes |
+| Preamble Type | `Radio.{i}.PreambleType` | `"long"` | long/short |
+| MCS Index | `Radio.{i}.MCS` | 0 | modulation scheme |
+| 802.11h (DFS) | `Radio.{i}.IEEE80211hEnabled` | | radar detection |
+| Extension Channel | `Radio.{i}.ExtensionChannel` | | HT40 secondary |
+| Operating Standards | `Radio.{i}.OperatingStandards` | | 802.11 a/b/g/n/ac/ax |
+| Auto Channel Refresh | `Radio.{i}.AutoChannelRefreshPeriod` | | seconds |
+
+**Most of JNAP `setAdvancedRadioSettings` can be migrated to USP.** Remaining JNAP-only items in §7.
+
+---
+
+## 2. Internet Settings — Write Support
+
+**Reference:** [internet-settings-set-validation.md](../issues/internet-settings-set-validation.md) | [internet-settings-jnap-vs-usp-comparison.md](../issues/internet-settings-jnap-vs-usp-comparison.md)
+
+### 🔧 Needs Code Fix (no FW dependency)
+
+| ID | Issue | Root Cause | Fix |
+|----|-------|-----------|-----|
+| ISS-3 | Gateway path non-writable | Standard path fault 9008 | Swap to `X_LINKSYS_DefaultGateway` vendor extension |
+| ISS-4 | DNS Server paths non-writable / missing | Standard paths fault 9008/9005 | Swap to `X_LINKSYS_DNSServers` (comma-separated) |
+| ISS-6 | LCPEcho marked writable but read-only | YAML error | Remove `writable: true` from `wan_settings.yaml` |
+| ISS-8 | VLANTermination no instances by default | Multi-instance lifecycle | Implement Add before Set, Delete when disabling |
+| ISS-2 | PPP.Interface missing in non-PPPoE mode | Multi-instance lifecycle | Implement Add before Set, Delete when leaving PPPoE |
+
+**Vendor Extension Paths (SSH-verified writable):**
+
+```
+Device.IP.Interface.2.IPv4Address.1.X_LINKSYS_DefaultGateway   → replaces Routing.Router.1.IPv4Forwarding.1.GatewayIPAddress
+Device.IP.Interface.2.IPv4Address.1.X_LINKSYS_DNSServers        → replaces DNS.Client.Server.{1,2,3}.DNSServer
+```
+
+### 🏭 Needs FW Team
+
+| ID | Issue | Problem | Impact |
+|----|-------|---------|--------|
+| ISS-1 | AddressingType set is no-op | Set accepted (`data:1`) but `modified_uci: []`, value unchanged | **Blocks all connection type switching** |
+| ISS-5 | MAC Clone non-writable | `Ethernet.Link.1.MACAddress` fault 9008 | MAC clone feature broken |
+| ISS-7 | PPPoE.ServiceName denied | fault 9001 even after PPP instance created | PPPoE service name can't be set |
+| ISS-9 | IPv6rd prefix format validation | fault 9007 pattern mismatch on `"2001:db8::"` | 6rd tunnel manual config may fail |
+| ISS-2b | Bandwidth Data Inconsistency | Radio.2 `CurrentOperatingChannelBandwidth`=160MHz but `SupportedOperatingChannelBandwidths` max 80MHz | UI bandwidth dropdown may be incomplete |
+
+### ⚠️ Suspect (needs re-test after ISS-1 fix)
+
+| ID | Issue | Symptom |
+|----|-------|---------|
+| ISS-10 | ConnectionTrigger / Bridge.Enable | Set returns `data:1` but `modified_uci: []` — may work at dmmap level or silently fail |
+
+### 🔴 USP Gap — Needs Vendor Extension
+
+| Feature | JNAP Action | TR-181 Gap | Required Extension |
+|---------|-------------|-----------|-------------------|
+| PPTP connection type | `setWANSettings` | No standard TR-181 path for PPTP | `X_LINKSYS_PPTPClient.*` or equivalent vendor object |
+| L2TP connection type | `setWANSettings` | No standard TR-181 path for L2TP | `X_LINKSYS_L2TPClient.*` or equivalent vendor object |
+
+### Recommended Fix Priority
+
+```
+Phase 1 — Code Fix (no FW dependency):
+  1. ISS-3 + ISS-4: Swap to X_LINKSYS_* vendor extensions
+  2. ISS-6: Remove LCPEcho writable flag
+  3. ISS-2 + ISS-8: Implement PPP/VLAN Add/Delete lifecycle
+
+Phase 2 — FW Team Resolution:
+  4. ISS-1: AddressingType switching mechanism (blocks everything)
+  5. ISS-5: MAC clone writable path
+  6. ISS-7: PPPoE.ServiceName denial
+  7. ISS-9: IPv6rd prefix format
+
+Phase 3 — Re-test:
+  8. ISS-10: Re-verify after ISS-1 resolved
+```
+
+---
+
+## 3. WiFi Settings — TR-181 Limitations
+
+**Reference:** [wifi-settings-tr181-limitations.md](../issues/wifi-settings-tr181-limitations.md)
+**SSH Re-verified:** 2026-03-16
+
+### 🔧 ISS-2: Channel Width — ✅ Standard Path Exists (Code Fix Only)
+
+**Original Assessment:** Vendor extension needed (`X_LINKSYS_PossibleChannelBandwidths`)
+**SSH Verification:** `Device.WiFi.Radio.{i}.SupportedOperatingChannelBandwidths` path exists and returns correct data
+
+```
+Radio.1 (2.4 GHz): "Auto,20MHz"
+Radio.2 (5 GHz):   "Auto,20MHz,40MHz,80MHz"    ← SupportedBandwidths max 80MHz
+```
+
+> ⚠️ **Data Inconsistency (2026-03-16):** Radio.2's `CurrentOperatingChannelBandwidth` reports `160MHz`, but `SupportedOperatingChannelBandwidths` only lists up to `80MHz`. This contradiction needs FW team clarification — `SupportedOperatingChannelBandwidths` return value may be incomplete, or `CurrentOperatingChannelBandwidth` is reporting incorrectly.
+
+**Fix:** Remove UI hardcoded values, read `SupportedOperatingChannelBandwidths` for dynamic rendering. Update `wifi-settings-tr181-limitations.md` accordingly.
+
+### 🔧 ISS-1: Channel-per-Width — Client-Side Computable (Code Fix)
+
+**Original Assessment:** Vendor extension needed (`X_LINKSYS_AvailableChannels`)
+**Revised Assessment:** **Client-side computable** — downgraded from FW Team dependency to Code Fix
+
+IEEE 802.11 channel bonding rules are spec-defined constants. The app can derive `Map<WifiChannelWidth, List<int>>` by combining:
+1. `Device.WiFi.Radio.{i}.PossibleChannels` — regulatory-filtered flat channel list from TR-181
+2. `Device.WiFi.Radio.{i}.SupportedOperatingChannelBandwidths` — supported widths per radio
+3. IEEE 802.11 bonding rules — deterministic primary channel selection per width
+
+**Existing App Code:**
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| Channel/frequency/DFS/UNII data | `lib/page/wifi_settings/models/channel_constants.dart` | 1302-line static table: 2.4GHz (14 ch), 5GHz (~60 ch), 6GHz (~90 ch) |
+| Mode → max width mapping | `lib/page/wifi_settings/models/wifi_enums.dart` `WifiWirelessMode.maxSupportedWidth` | e.g., ac→80MHz, ax→160MHz, be→320MHz |
+| JNAP channel-per-width mapping | `lib/page/wifi_settings/services/wifi_settings_mapper.dart:32-39` | Maps `supportedChannelsForChannelWidths` → `Map<WifiChannelWidth, List<int>>` |
+| Target data structure | `lib/page/wifi_settings/providers/wifi_item.dart:22` | `Map<WifiChannelWidth, List<int>> availableChannels` |
+| Channel selection by width | `lib/page/wifi_settings/providers/wifi_bundle_provider.dart:262` | `setChannelWidth` uses `availableChannels[channelWidth]` |
+
+**USP Migration Fix:** Implement a utility that parses `PossibleChannels` string → applies IEEE 802.11 bonding rules per width → produces `Map<WifiChannelWidth, List<int>>` to populate `WiFiItem.availableChannels`. This replaces the JNAP `supportedChannelsForChannelWidths` without FW dependency.
+
+### 🏭 Needs FW Team (1 item)
+
+| ID | Issue | Impact | Needed Extension |
+|----|-------|--------|-----------------|
+| ISS-4 | Guest network detection — no field distinguishes Guest/Primary | SSH verified 4 APs: SSIDReference/IsolationEnable/MultiAPMode identical across all, only Enable and Security.ModeEnabled differ (AP.3/4 disabled + None) | `X_LINKSYS_NetworkType` on `Device.WiFi.AccessPoint.{i}` |
+
+### 🏭 ISS-3: MAC Filtering — Issue More Severe Than Documented
+
+**Original Assessment:** TR-181 only supports allow-list, vendor extension needed for deny-list
+**SSH Verification Results:**
+
+| Path | Result | Issue |
+|------|--------|-------|
+| `MACAddressControlEnabled` | ✅ writable (modifies `/etc/config/trx69`) | Toggle works |
+| `AllowedMACAddress` (GET) | Returns flat string `"00:00:00:00:00:00"` | **Not a multi-instance table** |
+| `AllowedMACAddress.{i}.` (schema) | fault 7026: not in data model | **Multi-instance does not exist** |
+| `X_LINKSYS_DeniedMACAddress` | fault 9005 | Vendor extension does not exist |
+
+**Revised Assessment:** Not only is the deny-list missing, but the allow-list multi-instance table is also not implemented. The entire MAC address list mechanism is broken at the bbfdm level. FW team needs to fix `AllowedMACAddress.{i}` multi-instance support **and** add deny-list vendor extension.
+
+**Current Mitigations:**
+- ISS-1: ~~Hardcoded channel lists~~ → **Client-side computable** using `PossibleChannels` + `SupportedOperatingChannelBandwidths` + IEEE 802.11 bonding rules (see ISS-1 section above)
+- ISS-2: ~~Hardcoded width lists~~ → **Can use `SupportedOperatingChannelBandwidths` instead**
+- ISS-3: MAC Filtering tab removed from WiFi Settings page
+- ISS-4: Case-insensitive `"guest"` substring match on SSID name
+
+---
+
+## 3b. WiFi Features — JNAP Dependency Re-evaluation
+
+**SSH-verified:** 2026-03-16 — Multiple features originally marked "JNAP Required" actually have TR-181 paths
+
+### ✅ USP Ready (Moved from JNAP Required)
+
+| Feature | JNAP Action | USP Path | Status |
+|---------|-------------|----------|--------|
+| **WPS** | `setWPSServerSessionStatus` | `AP.{i}.WPS.Enable` + `InitiateWPSPBC()` | ✅ Full support (see §1 F-027) |
+| **Advanced Radio (partial)** | `setAdvancedRadioSettings` | 12 writable Radio parameters | ✅ Mostly migratable (see §1 F-028) |
+| **Security Mode** | `setWirelessNetworkSettings` | `AP.{i}.Security.ModeEnabled` + WPA3 | ✅ Includes WPA3 + MFP (see §1 F-001) |
+
+### 🔧 Code Fix (YAML/codegen update needed)
+
+| Feature | JNAP Action | USP Path | Fix |
+|---------|-------------|----------|-----|
+| **WiFi Scheduling** | `setWirelessSchedulerSettings` | `Radio.{i}.Enable` + client-side timer | No TR-181 scheduler — use Radio Enable + app scheduling workaround |
+
+### 🔴 USP Gap (Still needs vendor extension)
+
+| Feature | JNAP Action | TR-181 Gap | Required Extension |
+|---------|-------------|-----------|-------------------|
+| **Smart Connect** | `setSmartConnectSettings` | Linksys proprietary band steering algorithm | `X_LINKSYS_SmartConnect.*` |
+| **WiFi 6E/7 MLO** | `setMLOSettings` | Multi-Link Operation not standardized in TR-181 | `X_LINKSYS_MLO.*` |
+| **WiFi Optimization** | `setWiFiOptimizationSettings` | Linksys proprietary optimization | `X_LINKSYS_WiFiOptimization.*` |
+| **Channel Scanner** | `startChannelScan` | No standard Operate command | `X_LINKSYS_ChannelScan()` |
+
+---
+
+## 4. DDNS — SSH Verification Results
+
+**Verified:** 2026-03-16 | **Status:** 🔴 bbfdm plugin missing
+
+### TR-181 Path Test
+
+```bash
+ubus call bbfdm get '{"path":"Device.DynamicDNS."}'
+# → fault 9005: Invalid parameter name
+
+ubus call bbfdm get '{"path":"Device.DynamicDNS.Client."}'
+# → fault 9005: Invalid parameter name
+```
+
+### Router-Level Support
+
+| Layer | Status | Detail |
+|-------|--------|--------|
+| **OpenWrt packages** | ✅ Installed | `ddns-scripts` v2.8.2-42, `ddns-scripts-noip`, `ddns-scripts-services` |
+| **UCI config** | ✅ Exists | `/etc/config/ddns` — dyndns.org + NoIP templates (IPv4/IPv6) |
+| **Update scripts** | ✅ Available | `/usr/lib/ddns/update_no-ip_com.sh`, `dynamic_dns_updater.sh` |
+| **bbfdm plugin** | ❌ Missing | No DDNS module in `/usr/lib/bbfdm/`, no `bbfdm.ddnsmngr` daemon |
+| **TR-181 path** | ❌ Not exposed | `Device.DynamicDNS.*` returns fault 9005 |
+
+### Assessment
+
+DDNS functionality fully exists at the OpenWrt level (UCI + ddns-scripts), but firmware has not implemented a bbfdm plugin to map it to the TR-181 data model.
+
+**Action Required:** Firmware team to develop `bbfdm.ddnsmngr` plugin, mapping `/etc/config/ddns` UCI configuration to `Device.DynamicDNS.Client.{i}.*` TR-181 paths.
+
+**Expected TR-181 Mapping:**
+
+| TR-181 Path | UCI Path | Notes |
+|-------------|----------|-------|
+| `Device.DynamicDNS.Client.{i}.Enable` | `ddns.@service[i].enabled` | Service enable/disable |
+| `Device.DynamicDNS.Client.{i}.Server` | `ddns.@service[i].service_name` | Provider name (dyndns.org, no-ip.com) |
+| `Device.DynamicDNS.Client.{i}.Username` | `ddns.@service[i].username` | Provider login |
+| `Device.DynamicDNS.Client.{i}.Password` | `ddns.@service[i].password` | Provider password |
+| `Device.DynamicDNS.Client.{i}.HostnameList` | `ddns.@service[i].domain` | Hostname to update |
+| `Device.DynamicDNS.Client.{i}.Interface` | `ddns.@service[i].interface` | WAN interface |
+| `Device.DynamicDNS.Client.{i}.Status` | runtime | Current update status |
+
+**JNAP → USP Migration Mapping:**
+
+| JNAP Action (to eliminate) | USP Replacement (after bbfdm plugin) | Notes |
+|---------------------------|--------------------------------------|-------|
+| `getDDNSSettings` | `GET Device.DynamicDNS.Client.*` | Read all DDNS clients |
+| `setDDNSSettings` | `SET Device.DynamicDNS.Client.{i}.*` | Update provider config |
+| `getDDNSStatus2` | `GET Device.DynamicDNS.Client.{i}.Status` | Update status polling |
+| `getSupportedDDNSProviders` | `X_LINKSYS_SupportedDDNSProviders` | Need vendor extension — provider list not in TR-181 standard |
+
+---
+
+## 5. QoS — SSH Verification Results
+
+**Verified:** 2026-03-16 | **Status:** 🔴 bbfdm plugin missing + partially proprietary
+
+### TR-181 Path Test
+
+```bash
+ubus call bbfdm get '{"path":"Device.QoS."}'
+# → fault 9005: Invalid parameter name
+
+ubus call bbfdm get '{"path":"Device.QoS.Classification."}'
+# → fault 9005: Invalid parameter name
+```
+
+### Router-Level Support
+
+| Layer | Status | Detail |
+|-------|--------|--------|
+| **Hardware QoS** | ✅ Installed | `qca-sal-qos` (Qualcomm SAL hardware-level QoS) |
+| **ebtables rules** | ✅ Exists | `bridging.qos` / `bridging.qos_output` chains (broute + nat) |
+| **UCI config** | ❌ None | No `/etc/config/qos` file |
+| **init.d service** | ❌ None | No QoS service daemon |
+| **bbfdm plugin** | ❌ Missing | No QoS module in `/usr/lib/bbfdm/`, no `bbfdm.qosmngr` daemon |
+| **TR-181 path** | ❌ Not exposed | `Device.QoS.*` returns fault 9005 |
+
+### Feature Breakdown
+
+| Feature | JNAP Action | Feasibility | Blocker | Required Extension |
+|---------|-------------|------------|---------|-------------------|
+| **QoS Basic** (traffic classification) | `setQoSSettings` | 🏭 Needs FW | bbfdm plugin missing | `bbfdm.qosmngr` → `Device.QoS.Classification.{i}.*` |
+| **Adaptive QoS** (AI-based) | `setAdaptiveQoSSettings` | 🔴 USP Gap | Linksys proprietary AI algorithm | `X_LINKSYS_AdaptiveQoS.*` vendor extension |
+| **Express Forwarding** | `setExpressForwardingSettings` | 🔴 USP Gap | Qualcomm SAL hardware layer | `X_LINKSYS_ExpressForwarding.*` vendor extension |
+| **Gaming Prioritization** | `setGamePriority` | 🔴 USP Gap | Linksys proprietary feature | `X_LINKSYS_GamePriority.*` vendor extension |
+
+### Assessment
+
+QoS is implemented via Qualcomm hardware layer (SAL) + ebtables bridging rules. Firmware has not built a bbfdm plugin, TR-181 `Device.QoS.*` is completely unavailable.
+
+- **Basic QoS:** Can theoretically be mapped via bbfdm plugin to `Device.QoS.Classification.{i}.*`
+- **Advanced QoS:** Adaptive QoS / Gaming Prioritization / Express Forwarding are Linksys proprietary implementations, requiring firmware team vendor extensions to eliminate JNAP
+
+**Action Required — Firmware Team:**
+1. Evaluate `bbfdm.qosmngr` plugin feasibility (basic traffic classification)
+2. Confirm whether basic `Device.QoS.Classification.{i}.*` can map to ebtables rules
+3. Provide vendor extension paths or alternatives for Adaptive QoS / Gaming Prioritization / Express Forwarding
+4. If vendor extensions cannot be provided, please respond explicitly so we can plan alternative architecture
+
+---
+
+## 6. Parental Control — Feature Analysis
+
+**Status:** 🔴 Core features have no TR-181 standard path — requires firmware team vendor extension
+
+### Feature Breakdown
+
+| Feature | JNAP Action | Current Status | USP Gap | Required Extension |
+|---------|-------------|---------------|---------|-------------------|
+| **Safe Browsing (DNS)** | `setParentalControlSettings` | ✅ M1 implemented | ✅ Migrated | — (DNS override via `LanNetworkInfo.save()`) |
+| **Time-Based Controls** | `setParentalControlRules` | ❌ Not migrated | 🔴 USP Gap | `X_LINKSYS_ParentalControl.Rule.{i}.*` (device scheduling, time limits) |
+| **Content Filtering** | `setParentalControlRules` | ❌ Not migrated | 🔴 USP Gap | `X_LINKSYS_ContentFilter.*` (age-based filtering, website allow/block lists) |
+
+### USP Migration Path Analysis
+
+| Approach | Feasibility | Limitations |
+|----------|-------------|-------------|
+| **WiFi Radio Scheduling** | ⚠️ Partially viable | Too coarse-grained — affects all devices, no per-device control |
+| **MAC-based Firewall Rules** | ⚠️ Partially viable | `Device.Firewall.Chain.*.Rule.*` can block MAC, but no time-scheduled trigger mechanism |
+| **DNS Override** | ✅ Implemented | Safe Browsing already completed via USP |
+| **Vendor Extension** | 🏭 Best approach | Requires firmware team to map JNAP parental control features to TR-181 vendor extension |
+
+**Action Required — Firmware Team:**
+1. Provide `X_LINKSYS_ParentalControl.*` vendor extension, mapping JNAP `setParentalControlRules` functionality
+2. Must support at minimum: per-device time scheduling, enable/disable, rule CRUD
+3. Content filtering database access path (if feasible)
+
+---
+
+## 7. Remaining JNAP Dependencies — USP Migration Gaps
+
+The following features currently only have JNAP implementations, with no standard TR-181 paths. **Each requires firmware team vendor extension to complete migration.**
+
+> ~~WPS~~ — ✅ Confirmed USP Ready (2026-03-16), moved to §1 F-027
+> ~~WiFi Advanced Settings~~ — ✅ Mostly confirmed USP Ready, moved to §1 F-028 / §3b
+
+| Feature | JNAP Action | Category | Required Vendor Extension | Priority |
+|---------|-------------|----------|--------------------------|----------|
+| Smart Connect | `setSmartConnectSettings` | WiFi | `X_LINKSYS_SmartConnect.*` | P2 |
+| WiFi 6E/7 MLO | `setMLOSettings` | WiFi | `X_LINKSYS_MLO.*` | P3 |
+| WiFi Optimization | `setWiFiOptimizationSettings` | WiFi | `X_LINKSYS_WiFiOptimization.*` | P3 |
+| Channel Scanner | `startChannelScan` | WiFi | `X_LINKSYS_ChannelScan()` Operate command | P2 |
+| PPTP Connection | `setWANSettings` | Internet | `X_LINKSYS_PPTPClient.*` | P2 |
+| L2TP Connection | `setWANSettings` | Internet | `X_LINKSYS_L2TPClient.*` | P2 |
+| Speed Test | `runSpeedTest` | Diagnostics | `X_LINKSYS_SpeedTest()` Operate command | P2 |
+| Firmware Update | `setFirmwareUpdateSettings` | Admin | `Device.DeviceInfo.FirmwareImage.{i}.Download()` or `X_LINKSYS_FirmwareUpdate.*` | P1 |
+| Auto Firmware Update | `setAutoFirmwareUpdateSettings` | Admin | `X_LINKSYS_AutoFirmwareUpdate.*` (schedule + policy) | P2 |
+| Network Modes | `setNetworkModeSettings` | Advanced | `X_LINKSYS_NetworkMode.*` (Router/AP/Bridge) | P2 |
+
+> **Note:** Firmware Update has TR-181 `Device.DeviceInfo.FirmwareImage.{i}.Download()` standard Operate — needs SSH verification to confirm router implementation.
+
+**Action Required — Firmware Team:**
+1. Verify Firmware Update TR-181 standard path support
+2. Provide Smart Connect / Channel Scanner vendor extension
+3. Provide PPTP/L2TP vendor extension paths
+4. Provide Speed Test vendor extension (or Operate command)
+5. QoS-related vendor extensions (see §5)
+6. WiFi 6E/7 MLO / WiFi Optimization — low priority, pending hardware support confirmation
+
+---
+
+## 8. Dependency Map — JNAP Migration Path
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Layer 1: No Dependencies — Can develop immediately          │
+│                                                          │
+│  F-001 WiFi PW/Security  F-004 Channel Width             │
+│  F-011 Ping UI           F-026 Prefetch Cache            │
+│  F-027 WPS               F-028 Advanced Radio            │
+│  WiFi ISS-1 (channel-per-width client computation)       │
+│  WiFi ISS-2 (use SupportedBandwidths)                    │
+│  Internet ISS-3/4 Vendor Ext  ISS-6 YAML Fix            │
+│  Internet ISS-2/8 Add/Delete                             │
+└──────────────────────────────────────────────────────────┘
+                          │
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│  Layer 2: FW Team Bug Fix — Existing path repair             │
+│                                                          │
+│  ISS-1 AddressingType  → blocks connection type switch   │
+│  ISS-5 MAC Clone       → blocks MAC clone feature        │
+│  ISS-7 PPPoE.ServiceName → blocks PPPoE service name     │
+│  ISS-9 IPv6rd prefix   → blocks 6rd manual config        │
+│  ISS-10 re-test        → depends on ISS-1 resolution     │
+└──────────────────────────────────────────────────────────┘
+                          │
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│  Layer 3: FW Team bbfdm Plugin — New TR-181 paths            │
+│                                                          │
+│  DDNS (bbfdm.ddnsmngr)  → Device.DynamicDNS.*           │
+│  QoS Basic (bbfdm.qosmngr) → Device.QoS.*               │
+│  WiFi ISS-3 (MAC deny-list vendor ext)                   │
+│  WiFi ISS-4 (network type vendor ext)                    │
+└──────────────────────────────────────────────────────────┘
+                          │
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│  Layer 4: FW Team Vendor Extension — Eliminate JNAP dep      │
+│  ⚠️ Each item is a JNAP migration blocker, must request from FW│
+│                                                          │
+│  Smart Connect       → X_LINKSYS_SmartConnect.*          │
+│  Channel Scanner     → X_LINKSYS_ChannelScan()           │
+│  WiFi 6E/7 MLO       → X_LINKSYS_MLO.*                  │
+│  WiFi Optimization   → X_LINKSYS_WiFiOptimization.*      │
+│  Network Modes       → X_LINKSYS_NetworkMode.*           │
+│  Parental Control    → X_LINKSYS_ParentalControl.*       │
+│  Adaptive QoS        → X_LINKSYS_AdaptiveQoS.*          │
+│  Gaming Priority     → X_LINKSYS_GamePriority.*          │
+│  Express Forwarding  → X_LINKSYS_ExpressForwarding.*     │
+│  PPTP / L2TP         → X_LINKSYS_PPTPClient/L2TPClient.* │
+│  Speed Test          → X_LINKSYS_SpeedTest()             │
+│  Firmware Update     → Device.DeviceInfo.FirmwareImage.* │
+│  Auto FW Update      → X_LINKSYS_AutoFirmwareUpdate.*    │
+└──────────────────────────────────────────────────────────┘
+```
+
+> **Goal:** Complete all Layers 1-4 to achieve 100% USP migration and fully remove JNAP dependency.
+
+---
+
+## 9. Recommended Execution Order
+
+### Phase M2-A: Immediate (no external dependency)
+
+| # | Feature | Effort | Rationale |
+|---|---------|--------|-----------|
+| 1 | F-001 WiFi Password/Security | Small | P0 daily WiFi management + WPA3 security modes |
+| 2 | F-004 Channel Width | Small | P1 paired with WiFi, switch to `SupportedOperatingChannelBandwidths` |
+| 3 | WiFi ISS-1 fix | Medium | Channel-per-width client-side computation (IEEE 802.11 bonding rules + `PossibleChannels`) |
+| 4 | WiFi ISS-2 fix | Trivial | Remove hardcoded bandwidth, read from TR-181 |
+| 5 | F-027 WPS | Small | P2 ✅ SSH verified full support |
+| 6 | F-028 Advanced Radio | Medium | P2 12 writable parameters, partially replaces JNAP |
+| 7 | F-011 Ping/Traceroute UI | Medium | SSE infrastructure ready, UI only |
+| 8 | Internet ISS-3/4 | Small | Vendor extension path swap |
+| 9 | Internet ISS-6 | Trivial | YAML writable flag removal |
+| 10 | Internet ISS-2/8 | Medium | PPP/VLAN Add/Delete lifecycle |
+| 11 | F-026 Prefetch Cache | Medium | Dashboard performance optimization |
+
+### Phase M2-B: FW Team Coordination
+
+| # | Feature | Dependency | Priority |
+|---|---------|-----------|----------|
+| 8 | ISS-1 AddressingType | FW team confirms switching mechanism | **P0 Critical** |
+| 9 | ISS-5 MAC Clone | FW team provides vendor extension | P1 |
+| 10 | ISS-7 PPPoE ServiceName | FW team investigates fault 9001 | P1 |
+| 11 | ISS-9 IPv6rd Prefix | FW team confirms format specification | P2 |
+| 12 | F-007 Guest Network | Can use heuristic first, vendor extension later | P1 |
+
+### Phase M2-C: bbfdm Plugin Development
+
+| # | Feature | Plugin | Priority |
+|---|---------|--------|----------|
+| 13 | DDNS | `bbfdm.ddnsmngr` | P1 — UCI config already exists |
+| 14 | QoS Basic | `bbfdm.qosmngr` | P2 — needs feasibility assessment |
+| 15 | WiFi ISS-3 | MAC deny-list vendor extension | P3 |
+| 16 | WiFi ISS-4 | Network type vendor extension | P3 |
+
+### Phase M2-D: Vendor Extension — JNAP Dependency Elimination
+
+| # | Feature | Required from FW Team | Priority |
+|---|---------|----------------------|----------|
+| 18 | Firmware Update | Verify `Device.DeviceInfo.FirmwareImage.{i}.Download()` or provide vendor ext | P1 |
+| 19 | Smart Connect | Provide `X_LINKSYS_SmartConnect.*` vendor extension | P2 |
+| 20 | Channel Scanner | Provide `X_LINKSYS_ChannelScan()` Operate command | P2 |
+| 21 | Network Modes | Provide `X_LINKSYS_NetworkMode.*` (Router/AP/Bridge) | P2 |
+| 22 | Parental Control (time/content) | Provide `X_LINKSYS_ParentalControl.*` vendor extension | P2 |
+| 23 | PPTP / L2TP | Provide `X_LINKSYS_PPTPClient/L2TPClient.*` vendor extension | P2 |
+| 24 | Speed Test | Provide `X_LINKSYS_SpeedTest()` Operate command | P2 |
+| 25 | Auto Firmware Update | Provide `X_LINKSYS_AutoFirmwareUpdate.*` vendor extension | P2 |
+| 26 | Adaptive QoS / Gaming / Express FW | Provide vendor extensions (see §5) | P3 |
+| 27 | WiFi 6E/7 MLO / Optimization | Provide vendor extensions (pending hardware support) | P3 |
+| 28 | F-025 Historical Trends | Client-side Hive DB (no FW dependency) | P3 |
+
+---
+
+## 10. JNAP Migration Progress Tracker
+
+**Goal: 72/72 (100%) USP coverage, fully remove JNAP dependency.**
+
+Based on USP Features Matrix (72 features total):
+
+| Status | Count | Percentage | Description |
+|--------|-------|-----------|-------------|
+| ✅ USP Complete | 45 | 63% | M1 migration completed |
+| ✅ USP Ready (verified) | 3 | 4% | SSH verified available: WPS, Advanced Radio, Security Mode |
+| 🔧 Code Fix Only | 8 | 11% | Vendor extension path swap, YAML fix, bandwidth fix, channel-per-width computation, scheduling workaround |
+| 🏭 FW Bug Fix | 5 | 7% | Existing TR-181 paths need repair (ISS-1/5/7/9/10) |
+| 🏭 FW bbfdm Plugin | 2 | 3% | New bbfdm plugins needed (DDNS, QoS Basic) |
+| 🔴 FW Vendor Extension | 9 | 13% | FW team must provide new vendor extensions (JNAP migration blockers) |
+
+### Migration Milestones
+
+| Milestone | Scope | USP Coverage | JNAP Dependencies |
+|-----------|-------|-------------|-------------------|
+| **M1 Done** | 45 features implemented | 45/72 (63%) | 27 remaining |
+| **M2-A** (code fix) | F-001/004/011/026/027/028 + WiFi ISS-1/2 + Internet ISS-3/4/6/2/8 | 56/72 (78%) | 16 remaining |
+| **M2-B** (FW bug fix) | ISS-1/5/7/9/10 + F-007 | 61/72 (85%) | 11 remaining |
+| **M2-C** (bbfdm plugins) | DDNS, QoS Basic | 63/72 (88%) | 9 remaining |
+| **M2-D** (vendor extensions) | Smart Connect, Parental Control, PPTP/L2TP, FW Update, etc. | **72/72 (100%)** | **0 — JNAP migration complete** |
+
+### FW Team Request Summary
+
+Completing 100% migration requires the firmware team to provide:
+
+| Category | Items | Effort Estimate |
+|----------|-------|-----------------|
+| **Bug Fix** (existing path repair) | ISS-1, ISS-5, ISS-7, ISS-9 | Low — fix existing bbfdm behavior |
+| **bbfdm Plugin** (new standard paths) | DDNS (`bbfdm.ddnsmngr`), QoS (`bbfdm.qosmngr`), MAC Filter AllowedMACAddress.{i} multi-instance fix + deny-list | Medium — UCI config already exists, plugin development needed |
+| **Vendor Extension** (new proprietary paths) | Smart Connect, Channel Scanner, Network Modes, Parental Control, QoS Advanced, PPTP/L2TP, Speed Test, FW Update | High — map JNAP features to TR-181 vendor extensions |
+
+> ⚠️ **Vendor extensions are the biggest blocker to 100% migration.** If the firmware team cannot provide certain vendor extensions, those features cannot be decoupled from JNAP. Feasibility must be confirmed individually during M2-D phase.
+
+---
+
+## Related Documentation
+
+- [M1 Feature Roadmap](feature_roadmap.md) — Implemented features and infrastructure
+- [FW Team Request](../issues/fw-team-request.md) — All issues requiring firmware team action (26 items)
+- [Internet Settings Validation](../issues/internet-settings-set-validation.md) — SSH test results
+- [Internet Settings JNAP vs USP](../issues/internet-settings-jnap-vs-usp-comparison.md) — Field-by-field comparison
+- [WiFi Settings Limitations](../issues/wifi-settings-tr181-limitations.md) — TR-181 gaps
+- [Router Firmware Bugs](../issues/router-firmware-bugs.md) — All resolved
+- [USP Features Matrix](../USP_FEATURES_MATRIX.md) — Complete 72-feature coverage analysis
+- [JNAP USP Alignment](../archive/milestone1/JNAP_USP_ALIGNMENT.md) — Issue #641 (DDNS), #643 (Parental Control)
+- [SSE Implementation](sse_implementation.md) — Real-time notification infrastructure
+
+---
+
+**Last Updated:** 2026-03-16
+**Next Review:** After FW team response on ISS-1 / bbfdm plugin feasibility

--- a/doc/usp/integration/sse_implementation.md
+++ b/doc/usp/integration/sse_implementation.md
@@ -1,6 +1,6 @@
 # SSE (Server-Sent Events) Implementation Guide
 
-**Date:** 2026-03-13 | **Branch:** `feat/usp-protocol-integration`
+**Date:** 2026-03-13 (updated 2026-03-16) | **Branch:** `feat/usp-protocol-integration`
 **Firmware:** 1.0.16.26013014 | **usp-bridge:** v0.1.1
 
 ---
@@ -12,45 +12,41 @@ SSE provides real-time push notifications from the router to the Flutter web app
 ```
 Flutter App (WASM)
     │
-    ├── UspService ──→ OBUSPA (via usp-bridge proxy)
-    │     │                │
-    │     │    USP Add/Delete Device.LocalAgent.Subscription.{i}
-    │     │                │
-    │     │                ▼
+    ├── UspBridgeClient ──→ usp-bridge HTTP API
+    │     │                      │
+    │     │    POST /api/v1/subscription
+    │     │      → Bridge auto-creates OBUSPA Subscription.{i}
+    │     │      → Bridge registers SSE session mapping
+    │     │                      │
+    │     │    GET /api/v1/notifications (SSE stream)
+    │     │                      │
     │     │         OBUSPA monitors TR-181 data model
     │     │                │
     │     │         Change detected → USP Notify (protobuf)
     │     │                │
-    │     │                ▼
-    │     │         UDS socket → usp-bridge
-    │     │
-    ├── UspBridgeClient ──→ usp-bridge HTTP API
-    │     │                      │
-    │     │    POST /api/v1/subscription (register SSE session)
-    │     │                      │
-    │     │    GET /api/v1/notifications (SSE stream)
-    │     │                      │
-    │     │                      ▼
-    │     │              Bridge routes Notify → SSE event
+    │     │         UDS socket → bridge → SSE event
     │     │
     └── SseManager (facade)
           ├── SseConnectionManager   — SSE stream lifecycle
-          ├── SseSubscriptionRegistry — OBUSPA + bridge subscription tracking
+          ├── SseSubscriptionRegistry — bridge-only subscription tracking
           └── SseEventRouter          — event demux by subscription_id + wildcard
 ```
 
-### Two-Layer Subscription Architecture
+### Bridge-Managed Subscription Architecture
 
-Two independent subscription systems exist:
+The bridge `POST /api/v1/subscription` handles the full OBUSPA lifecycle automatically:
 
-| Layer | Purpose | Persistence | Creation |
-|-------|---------|-------------|----------|
-| **OBUSPA** | Tells router to generate USP Notify messages | Survives SSE disconnect, browser refresh | `UspService.createNotifySubscription()` (5-step workaround) |
-| **Bridge** | Routes notifications to the correct SSE session | Destroyed on SSE disconnect | `UspBridgeClient.subscribe()` HTTP POST |
+| Action | Bridge Behavior | OBUSPA Effect |
+|--------|----------------|---------------|
+| **register** | Creates OBUSPA `Subscription.{i}` + SSE session mapping | Router generates Notify for matching events |
+| **unregister** | Deletes OBUSPA `Subscription.{i}` + SSE session mapping | Router stops generating Notify |
+| **re-register** (same ID) | Idempotent — reuses existing OBUSPA subscription | No duplicate subscriptions |
 
-Key insight: OBUSPA subscriptions persist on the router even after the browser disconnects. Bridge subscriptions are ephemeral — they only exist while the SSE connection is active.
+Key insight: OBUSPA subscriptions persist on the router even after the browser disconnects. Bridge session mappings are ephemeral.
 
-On SSE reconnect, only bridge subscriptions need re-registration (`SseSubscriptionRegistry.resubscribeAll()`).
+On SSE reconnect, `SseSubscriptionRegistry.resubscribeAll()` re-registers all subscriptions on the bridge. Since the bridge is idempotent by `subscription_id`, this safely handles both scenarios (OBUSPA subs survived or were cleaned up).
+
+**Session expiry caveat:** Bridge session timeout does NOT clean up OBUSPA subscriptions — they become orphans. Bootstrap `purgeAllSubscriptions()` cleans these up on app startup.
 
 ---
 
@@ -61,7 +57,7 @@ On SSE reconnect, only bridge subscriptions need re-registration (`SseSubscripti
 | File | Class | Responsibility |
 |------|-------|----------------|
 | `sse_connection_manager.dart` | `SseConnectionManager` | SSE stream lifecycle, exponential backoff (1s → 60s), heartbeat watchdog (45s = 30s heartbeat + 15s grace) |
-| `sse_subscription_registry.dart` | `SseSubscriptionRegistry` | Two-layer subscription tracking, `register()` / `unregister()` / `resubscribeAll()` |
+| `sse_subscription_registry.dart` | `SseSubscriptionRegistry` | Bridge-only subscription tracking, `register()` / `unregister()` / `resubscribeAll()` |
 | `sse_event_router.dart` | `SseEventRouter` | JSON parse → route by `subscription_id`, wildcard handlers for cross-cutting concerns |
 | `sse_manager.dart` | `SseManager` | Facade composing the above three. Primary API for Riverpod providers |
 | `sse_operation_awaiter.dart` | `SseOperationAwaiter` | Async Operate commands (Ping/Traceroute) via OperationComplete, polling fallback |
@@ -135,8 +131,8 @@ Used for async Operate commands where the SSE notification IS the result.
 ```
 SseOperationAwaiter.execute()
     │
-    ├── Create OBUSPA subscription (OperationComplete)
-    ├── Add wildcard handler (match by command_name)
+    ├── Register subscription via bridge (OperationComplete)
+    ├── Add wildcard handler (match by commandKey or command_name)
     ├── Fire operate command
     │
     ▼
@@ -282,37 +278,37 @@ Sent every 30s by the bridge. Watchdog timeout: 45s.
 
 ---
 
-## 6. OBUSPA Subscription Creation (5-Step Workaround)
+## 6. Subscription Creation — Bridge API
 
-`UspService.createNotifySubscription()` performs the full OBUSPA subscription lifecycle:
+The bridge handles OBUSPA subscription lifecycle automatically via `POST /api/v1/subscription`:
 
 ```dart
-// Step 1: GET Device.LocalAgent.Subscription. — snapshot existing IDs
-final before = await get(['Device.LocalAgent.Subscription.']);
-final idsBefore = _extractInstanceIds(before);
-
-// Step 2: USP Add Device.LocalAgent.Subscription. — create instance
-await add('Device.LocalAgent.Subscription.', {});
-
-// Step 3: GET again — diff to find new instance ID
-final after = await get(['Device.LocalAgent.Subscription.']);
-final idsAfter = _extractInstanceIds(after);
-final newId = idsAfter.difference(idsBefore).first;
-
-// Step 4: USP SetMultiple — configure the subscription
-await setMultiple({
-  'Device.LocalAgent.Subscription.$newId.Enable': 'true',
-  'Device.LocalAgent.Subscription.$newId.NotifType': notifType,
-  'Device.LocalAgent.Subscription.$newId.ReferenceList': referenceList,
-});
-
-// Step 5: Verify Recipient points to UDS controller
-final recipient = await get([
-  'Device.LocalAgent.Subscription.$newId.Recipient'
-]);
+// SseSubscriptionRegistry.register() — single bridge call
+await _bridge.subscribe(
+  subscriptionId: 'connected-devices-objectcreation',
+  path: 'Device.Hosts.Host.',
+  notifType: 2, // ObjectCreation — converted to string internally
+);
+// Bridge internally: creates OBUSPA Subscription.{i} + SSE session mapping
 ```
 
-**Why 5 steps?** WASM `add('Device.LocalAgent.Subscription.')` returns empty (Rust bug — `wasm/mod.rs:435-441` doesn't parse `AddResp.updated_inst_results`). The GET-diff workaround finds the new instance ID.
+### Bridge API Format
+
+```http
+POST /api/v1/subscription
+{
+  "action": "register",
+  "subscription_id": "connected-devices-objectcreation",
+  "NotifType": "ObjectCreation",
+  "ReferenceList": "Device.Hosts.Host."
+}
+```
+
+> **Note:** The bridge API uses `NotifType` (string) and `ReferenceList` — not the old `type` (int) and `path` fields. `UspBridgeClient.subscribe()` handles the int→string conversion internally.
+
+### Legacy: 5-Step OBUSPA Workaround (deprecated)
+
+`UspService.createNotifySubscription()` previously performed direct OBUSPA manipulation (Add + GET-diff + SetMultiple). This is retained for debug/legacy use only — bridge now handles this automatically.
 
 ---
 
@@ -341,11 +337,11 @@ Core subscriptions are auto-generated from YAML `subscribe:` blocks by `usp-code
 
 | Event | Connection Manager | Registry | Router |
 |-------|-------------------|----------|--------|
-| SSE stream error | Auto-reconnect (exp backoff) | `resubscribeAll()` on reconnect | OBUSPA subscriptions survive |
+| SSE stream error | Auto-reconnect (exp backoff) | `resubscribeAll()` on reconnect (bridge is idempotent) | OBUSPA subscriptions survive |
 | Heartbeat timeout (45s) | Close stream → reconnect | Same as above | Same as above |
-| Browser refresh | New session starts | Bootstrap purges old OBUSPA subs, creates new | Old subscriptions purged |
+| Browser refresh | New session starts | Bootstrap purges stale OBUSPA subs, creates new via bridge | Old subscriptions purged |
 | Intentional disconnect | No reconnect | Subscriptions retained in memory | OBUSPA subscriptions survive |
-| Logout / dispose | Stop and clean | `unregisterAll()` deletes OBUSPA + bridge | Subscriptions deleted |
+| Logout / dispose | Stop and clean | `unregisterAll()` calls bridge unsubscribe for each | Bridge deletes OBUSPA subs |
 
 ---
 
@@ -354,8 +350,8 @@ Core subscriptions are auto-generated from YAML `subscribe:` blocks by `usp-code
 | Issue | Impact | Workaround | Status |
 |-------|--------|------------|--------|
 | **CPE subscription_id mismatch** | Per-subscription handlers never fire | Wildcard handlers + path/command_name matching | Permanent workaround |
-| **WASM `add` returns empty for LocalAgent** | Can't get new subscription instance path | GET-diff in `createNotifySubscription()` | Permanent workaround (Rust bug) |
-| **Bridge subscribe doesn't create OBUSPA** | Client must manage OBUSPA subscriptions | 5-step workaround in `UspService` | Enhancement request filed (`subscription-notify-blocked.md`) |
+| **WASM `add` returns empty for LocalAgent** | Can't get new subscription instance path | N/A — bridge handles OBUSPA lifecycle (legacy `createNotifySubscription()` retained for debug) | Bypassed by bridge auto-creation |
+| ~~**Bridge subscribe doesn't create OBUSPA**~~ | ~~Client must manage OBUSPA subscriptions~~ | ~~5-step workaround~~ | ✅ **FIXED** (2026-03-16) — bridge auto-creates OBUSPA subs with new API fields (`NotifType`/`ReferenceList`) |
 | **WiFi Stats noise** | 50+ events/s from `.Stats.*` counters | Removed WiFi ValueChange from bootstrap + `.Stats.` filter | Fixed |
 | **Stale subscriptions on refresh** | Duplicate notifications | Bootstrap purge via `purgeAllSubscriptions()` | Fixed |
 | **BUG-006: Operate results not in data model** | Polling fallback returns empty | SSE OperationComplete is primary delivery (Direct Data Delivery pattern) | By design |
@@ -450,7 +446,7 @@ All SSE components use structured logging with `[SSE]` prefix:
 [SSE] Connected (event: heartbeat)
 [SSE Router] Routing: SseNotification(sub=cpe-3, type=OperationComplete)
 [SSE Operate] Matched OperationComplete for IPPing() (from sub=cpe-3)
-[SSE Registry] Registered connected-devices-objectcreation → Device.LocalAgent.Subscription.5.
+[SSE Registry] Registered connected-devices-objectcreation (type=ObjectCreation, ref=Device.Hosts.Host.)
 [SSE Bootstrap] Purged 2 stale OBUSPA subscriptions
 [SSE Bootstrap] Complete — 5 core subscriptions registered
 ```

--- a/doc/usp/issues/INDEX.md
+++ b/doc/usp/issues/INDEX.md
@@ -1,6 +1,6 @@
 # USP Issues & Documentation Index
 
-**Last Updated:** 2026-03-13
+**Last Updated:** 2026-03-16
 **Scope:** USP Protocol Integration - Issues, Bugs, and Technical Analyses
 
 ---
@@ -12,8 +12,10 @@
 | **Router Firmware Bugs** | 6 | 6 | 0 | 0 | [router-firmware-bugs.md](router-firmware-bugs.md) |
 | **SSE/Notification Pipeline** | 2 | 2 | 0 | 0 | [subscription-notify-blocked.md](subscription-notify-blocked.md) |
 | **Internet Settings** | 3 | 0 | 3 | 0 | Multiple files |
+| **WiFi Settings** | 4 | 1 | 0 | 3 | [wifi-settings-tr181-limitations.md](wifi-settings-tr181-limitations.md) |
+| **FW Team Requests** | 26 | 0 | 0 | 26 | [fw-team-request.md](fw-team-request.md) |
 | **Performance Issues** | 1 | 1 | 0 | 0 | [usp-add-latency.md](usp-add-latency.md) |
-| **Total** | **12** | **9** | **3** | **0** | **6 documents** |
+| **Total** | **42** | **9** | **3** | **29** | **8 documents** |
 
 ---
 
@@ -49,13 +51,33 @@ Detailed analysis of SSE notification pipeline with end-to-end validation.
 
 | Issue | Description | Status | Date |
 |-------|-------------|--------|------|
-| **Issue 1** | Bridge HTTP API does not create OBUSPA Subscription | 🟡 **WORKAROUND** | 2026-03-09 |
+| **Issue 1** | Bridge HTTP API does not create OBUSPA Subscription | ✅ **FIXED** | 2026-03-16 |
 | **Issue 2** | usp-bridge does not forward OBUSPA Notify → SSE | ✅ **FIXED** | 2026-03-12 |
 
 **Verification Results:**
 - ✅ End-to-end TraceRoute → OperationComplete via SSE
 - ✅ Complete notification payload with hop-by-hop results
-- 🟡 Enhancement request: auto-register bridge subscriptions
+- ✅ Bridge auto-creates OBUSPA subscriptions with new API fields (`NotifType`/`ReferenceList`)
+
+---
+
+### 🏭 **Firmware Team Requests**
+
+#### [fw-team-request.md](fw-team-request.md)
+**Firmware Team Request — USP/TR-181 Support Issues**
+
+Consolidated list of all issues requiring firmware team action, organized by priority tier.
+
+| Tier | Type | Items | Description |
+|------|------|-------|-------------|
+| **Tier 1** | Bug Fix | 6 | Existing TR-181 paths with broken Set behavior |
+| **Tier 2** | bbfdm Plugin / Extension | 5 | Missing bbfdm plugins or multi-instance support |
+| **Tier 3** | Vendor Extension | 15 | JNAP features needing `X_LINKSYS_*` TR-181 mapping |
+
+**Key Blockers:**
+- 🔴 FW-001: AddressingType Set no-op (P0 — blocks all WAN type switching)
+- 🔴 FW-010: DDNS bbfdm plugin missing (P1)
+- 🔴 FW-007: MAC Filtering completely broken (P2)
 
 ---
 
@@ -134,6 +156,7 @@ Analysis of configuration commit performance bottleneck affecting USP Set operat
 | **2026-03-09** | BUG-001, BUG-003 documented | WiFi + SSE infrastructure |
 | **2026-03-12** | BUG-005 verified fixed | Complete notification pipeline |
 | **2026-03-13** | All router bugs status confirmed | 100% functionality achieved |
+| **2026-03-16** | Issue 1 fixed — bridge auto-creates OBUSPA subs | Full SSE pipeline operational, client simplified |
 
 ### **Ongoing Work (Internet Settings)**
 
@@ -160,7 +183,7 @@ Analysis of configuration commit performance bottleneck affecting USP Set operat
 - ✅ USP Add latency (documented, mitigated)
 
 ### **Low (P3) - Enhancement Requests**
-- 🟡 Bridge subscription auto-registration
+- ✅ Bridge subscription auto-registration — **FIXED** (2026-03-16)
 - 🟡 Internet Settings feature parity gaps
 
 ---

--- a/doc/usp/issues/fw-team-request.md
+++ b/doc/usp/issues/fw-team-request.md
@@ -1,0 +1,515 @@
+# Firmware Team Request — USP/TR-181 Support Issues
+
+> **Date:** 2026-03-16
+> **From:** App Team (PrivacyGUI)
+> **Branch:** `feat/usp-protocol-integration`
+> **Router:** Linksys M60TB-EU (PINNACLE 2.0) | **FW:** 1.0.16.26013014
+> **Test Method:** `ubus call bbfdm {get|set|schema|instances|add|del}` via SSH
+
+---
+
+## Objective
+
+The app team is migrating all features from JNAP protocol to USP/TR-181. M1 has completed 45/72 (63%) features. This document lists all issues requiring firmware team support, organized into three tiers by priority.
+
+**Completing all items below achieves 100% USP migration and fully eliminates JNAP dependency.**
+
+---
+
+## Overview
+
+| Tier | Type | Count | Description |
+|------|------|-------|-------------|
+| **Tier 1** | Bug Fix — Existing Path Repair | 6 | Path exists but Set behavior is broken |
+| **Tier 2** | bbfdm Plugin / Path Extension | 5 | New bbfdm plugin or multi-instance fix needed |
+| **Tier 3** | Vendor Extension — New Proprietary Paths | 15 | Map JNAP features to `X_LINKSYS_*` TR-181 paths |
+| | **Total** | **26** | |
+
+---
+
+## Tier 1: Bug Fix — Existing TR-181 Path Repair
+
+> These paths already exist in the TR-181 data model, but Set operations behave incorrectly. Once fixed, the app can use them directly.
+
+### FW-001: AddressingType Set No-Op ⭐ P0 Critical
+
+| Field | Value |
+|-------|-------|
+| **TR-181 Path** | `Device.IP.Interface.2.IPv4Address.1.AddressingType` |
+| **Operation** | SET `value: "Static"` |
+| **Result** | Returns `data:1` (appears successful), but `modified_uci: []` (empty), value unchanged |
+| **Impact** | **Blocks all WAN connection type switching** (DHCP ↔ Static ↔ PPPoE ↔ Bridge) |
+| **Related** | Internet Settings ISS-1 |
+
+**SSH Reproduction:**
+```bash
+# Read current value
+ubus call bbfdm get '{"path":"Device.IP.Interface.2.IPv4Address.1.AddressingType"}'
+# → "DHCP"
+
+# Attempt to set
+ubus call bbfdm set '{"path":"Device.IP.Interface.2.IPv4Address.1.AddressingType","value":"Static"}'
+# → data:1, modified_uci: []   ← No effect!
+
+# Read again — value unchanged
+ubus call bbfdm get '{"path":"Device.IP.Interface.2.IPv4Address.1.AddressingType"}'
+# → "DHCP"  ← Still DHCP
+```
+
+**Please confirm:** What is the correct mechanism for WAN protocol switching? Is a different path or Operate command required?
+
+---
+
+### FW-002: MAC Clone Path Non-Writable — P1
+
+| Field | Value |
+|-------|-------|
+| **TR-181 Path** | `Device.Ethernet.Link.1.MACAddress` |
+| **Operation** | SET `value: "AA:BB:CC:DD:EE:FF"` |
+| **Result** | fault 9008: non-writable |
+| **Schema** | `data: "0"` (read-only) |
+| **Impact** | MAC address clone feature unusable |
+| **Related** | Internet Settings ISS-5 |
+
+**SSH Reproduction:**
+```bash
+ubus call bbfdm set '{"path":"Device.Ethernet.Link.1.MACAddress","value":"AA:BB:CC:DD:EE:FF"}'
+# → fault 9008
+```
+
+**Please provide:** A vendor extension path for MAC clone (e.g., `X_LINKSYS_MACClone.Enable` + `X_LINKSYS_MACClone.MACAddress`), or make `Ethernet.Link.1.MACAddress` writable.
+
+---
+
+### FW-003: PPPoE.ServiceName Set Denied — P1
+
+| Field | Value |
+|-------|-------|
+| **TR-181 Path** | `Device.PPP.Interface.1.PPPoE.ServiceName` |
+| **Operation** | SET `value: "myservice"` |
+| **Result** | fault 9001: Request denied |
+| **Schema** | `data: "1"` (marked as writable) |
+| **Precondition** | PPP.Interface.1 created via Add |
+| **Impact** | PPPoE service name cannot be set |
+| **Related** | Internet Settings ISS-7 |
+
+**SSH Reproduction:**
+```bash
+# Create PPP instance first
+ubus call bbfdm add '{"path":"Device.PPP.Interface."}'
+# → instance created
+
+# Attempt to set ServiceName
+ubus call bbfdm set '{"path":"Device.PPP.Interface.1.PPPoE.ServiceName","value":"myservice"}'
+# → fault 9001: Request denied
+
+# PPPoE.ACName also denied
+ubus call bbfdm set '{"path":"Device.PPP.Interface.1.PPPoE.ACName","value":"test"}'
+# → fault 9001: Request denied
+```
+
+**Please confirm:** Does the PPPoE sub-object require specific preconditions (e.g., `Enable=true` or `LowerLayers` configured) before allowing Set?
+
+---
+
+### FW-004: IPv6rd Prefix Format Validation Failure — P1
+
+| Field | Value |
+|-------|-------|
+| **TR-181 Path** | `Device.IPv6rd.InterfaceSetting.1.SPIPv6Prefix` |
+| **Operation** | SET `value: "2001:db8::"` |
+| **Result** | fault 9007: List patterns did not match |
+| **Impact** | Cannot set prefix field for 6rd tunnel manual configuration |
+| **Related** | Internet Settings ISS-9 |
+
+**SSH Reproduction:**
+```bash
+ubus call bbfdm set '{"path":"Device.IPv6rd.InterfaceSetting.1.SPIPv6Prefix","value":"2001:db8::"}'
+# → fault 9007
+```
+
+**Please confirm:** What is the expected format for this field? Does it require prefix length (e.g., `"2001:db8::/32"`) or a fully expanded IPv6 address?
+
+---
+
+### FW-005: Bandwidth Data Inconsistency — P1
+
+| Field | Value |
+|-------|-------|
+| **TR-181 Path (A)** | `Device.WiFi.Radio.2.SupportedOperatingChannelBandwidths` |
+| **TR-181 Path (B)** | `Device.WiFi.Radio.2.CurrentOperatingChannelBandwidth` |
+| **Path A returns** | `"Auto,20MHz,40MHz,80MHz"` — max 80MHz |
+| **Path B returns** | `"160MHz"` — currently using 160MHz |
+| **Contradiction** | Current bandwidth exceeds the Supported list |
+| **Impact** | UI bandwidth dropdown may be incomplete (missing 160MHz) |
+| **Related** | WiFi ISS-2b |
+
+**SSH Reproduction:**
+```bash
+ubus call bbfdm get '{"path":"Device.WiFi.Radio.2.SupportedOperatingChannelBandwidths"}'
+# → "Auto,20MHz,40MHz,80MHz"
+
+ubus call bbfdm get '{"path":"Device.WiFi.Radio.2.CurrentOperatingChannelBandwidth"}'
+# → "160MHz"
+```
+
+**Please confirm:** Is the `SupportedOperatingChannelBandwidths` return value incomplete (should include 160MHz), or is `CurrentOperatingChannelBandwidth` reporting incorrectly?
+
+---
+
+### FW-006: ConnectionTrigger / Bridge.Enable Set Suspected No-Op — P3 (Pending Observation)
+
+| Field | Value |
+|-------|-------|
+| **TR-181 Path** | `Device.PPP.Interface.1.ConnectionTrigger` / `Device.Bridging.Bridge.1.Enable` |
+| **Operation** | SET |
+| **Result** | Returns `data:1` but `modified_uci: []` |
+| **Possible Cause** | May operate at dmmap level rather than UCI, or same issue as FW-001 (AddressingType) |
+| **Impact** | PPPoE connection mode and Bridge mode switching may not take effect |
+| **Related** | Internet Settings ISS-10 |
+
+**Please re-verify after FW-001 is fixed.** If these paths still return `modified_uci: []` after AddressingType is fixed, further investigation is needed.
+
+---
+
+## Tier 2: bbfdm Plugin / Path Extension
+
+> These features have partial support at the OpenWrt level (UCI config or kernel module), but bbfdm has not mapped them to TR-181. New bbfdm plugins or multi-instance support fixes are needed.
+
+### FW-007: MAC Filtering — AllowedMACAddress Multi-Instance Missing + Deny-List Missing — P1
+
+| Field | Value |
+|-------|-------|
+| **TR-181 Path** | `Device.WiFi.AccessPoint.{i}.AllowedMACAddress.{i}.*` |
+| **Expected Behavior** | `AllowedMACAddress` should be a multi-instance table (one MAC address per entry) |
+| **Actual Behavior** | GET returns flat string `"00:00:00:00:00:00"`; schema query on `AllowedMACAddress.{i}.` returns fault 7026 (not in data model) |
+| **JNAP Equivalent** | JNAP MAC Filtering uses a **deny-list** (block specific devices) |
+| **Impact** | MAC Filtering feature completely unusable |
+| **Related** | WiFi ISS-3 |
+
+**SSH Reproduction:**
+```bash
+# AllowedMACAddress returns flat string instead of multi-instance
+ubus call bbfdm get '{"path":"Device.WiFi.AccessPoint.1.AllowedMACAddress"}'
+# → "00:00:00:00:00:00"
+
+# Multi-instance schema does not exist
+ubus call bbfdm schema '{"path":"Device.WiFi.AccessPoint.{i}.AllowedMACAddress.{i}."}'
+# → fault 7026: not in data model
+
+# Deny-list vendor extension does not exist
+ubus call bbfdm get '{"path":"Device.WiFi.AccessPoint.1.X_LINKSYS_DeniedMACAddress"}'
+# → fault 9005
+```
+
+**Required:**
+1. Fix `AllowedMACAddress.{i}` multi-instance table support (TR-181 standard)
+2. Add deny-list vendor extension: `X_LINKSYS_DeniedMACAddress.{i}.*` or `X_LINKSYS_MACFilterMode` (allow/deny toggle)
+
+---
+
+### FW-008: PossibleChannels Not Grouped by Channel Width — P2 (Downgraded)
+
+| Field | Value |
+|-------|-------|
+| **TR-181 Path** | `Device.WiFi.Radio.{i}.PossibleChannels` |
+| **Actual Behavior** | Returns flat list, e.g., `"36,40,44,48,52,56,60,64,100-140"` |
+| **Original Problem** | Cannot determine which channels are available at 40MHz/80MHz/160MHz |
+| **Revised Assessment** | **Client-side computable** — IEEE 802.11 channel bonding rules are spec-defined constants; app can derive channel-per-width mapping without vendor extension |
+| **Related** | WiFi ISS-1 |
+
+**SSH Verification Data:**
+```bash
+ubus call bbfdm get '{"path":"Device.WiFi.Radio.1.PossibleChannels"}'
+# → "1-13"  (2.4 GHz)
+
+ubus call bbfdm get '{"path":"Device.WiFi.Radio.2.PossibleChannels"}'
+# → "36,40,44,48,52,56,60,64,100-140"  (5 GHz, flat list)
+
+ubus call bbfdm get '{"path":"Device.WiFi.Radio.2.SupportedOperatingChannelBandwidths"}'
+# → "Auto,20MHz,40MHz,80MHz"
+```
+
+**Existing App Implementation (JNAP):**
+
+The current JNAP implementation receives `supportedChannelsForChannelWidths` directly from the router, mapped to `Map<WifiChannelWidth, List<int>>` in `WiFiItem.availableChannels`:
+
+- `wifi_settings_mapper.dart:32-39` — Maps JNAP `radio.supportedChannelsForChannelWidths` to `availableChannels`
+- `wifi_item.dart:22` — `Map<WifiChannelWidth, List<int>> availableChannels` data structure
+- `wifi_bundle_provider.dart:262` — `setChannelWidth` uses `availableChannels[channelWidth]` to filter channel list
+
+**Client-Side Computation Approach (USP):**
+
+Channel-per-width grouping can be computed using:
+1. `Device.WiFi.Radio.{i}.PossibleChannels` — regulatory-filtered flat channel list
+2. `Device.WiFi.Radio.{i}.SupportedOperatingChannelBandwidths` — supported widths for this radio
+3. IEEE 802.11 bonding rules (spec-defined constants, already partially in app code):
+
+| Source | Location | Data |
+|--------|----------|------|
+| Channel/frequency/DFS/UNII mapping | `channel_constants.dart` (1302 lines) | 2.4GHz (ch 1-14), 5GHz (ch 32-196), 6GHz (ch 1-233) |
+| Mode → max channel width | `wifi_enums.dart` `WifiWirelessMode.maxSupportedWidth` | e.g., 802.11ac→80MHz, 802.11ax→160MHz, 802.11be→320MHz |
+
+IEEE 802.11 bonding rules (deterministic, per spec):
+- **20MHz**: All channels in `PossibleChannels` are valid
+- **40MHz (5GHz)**: Primary channel must be lower of bonded pair (36,44,52,60,100,108,116,124,132,149,157)
+- **80MHz (5GHz)**: Valid primary channels: 36,52,100,116,132,149
+- **160MHz (5GHz)**: Valid primary channels: 36,100 (contiguous) or 80+80 combinations (non-contiguous)
+- **320MHz (6GHz)**: Valid primary channels per Wi-Fi 7 spec
+
+**Conclusion:** Vendor extension is **nice-to-have** but not required. App can compute `Map<WifiChannelWidth, List<int>>` client-side by intersecting `PossibleChannels` with IEEE bonding rules, filtered by `SupportedOperatingChannelBandwidths`. Priority downgraded from P1 to P2.
+
+**If vendor extension is provided:** Use `X_LINKSYS_AvailableChannelsByBandwidth` as authoritative source (preferred, accounts for DFS/regulatory edge cases the spec-based computation might miss).
+
+---
+
+### FW-009: Guest Network Indistinguishable — P1
+
+| Field | Value |
+|-------|-------|
+| **TR-181 Path** | `Device.WiFi.AccessPoint.{i}.*` |
+| **Problem** | No field can distinguish Guest AP from Primary AP |
+| **Impact** | App can only rely on unreliable heuristic of SSID name containing "guest" |
+| **Related** | WiFi ISS-4 |
+
+**SSH Verification — All 4 APs Compared:**
+
+| Field | AP.1 (Primary) | AP.2 (Primary) | AP.3 (Guest) | AP.4 (Guest) |
+|-------|---------------|---------------|--------------|--------------|
+| `Enable` | `true` | `true` | `false` | `false` |
+| `SSIDReference` | `""` | `""` | `""` | `""` |
+| `SSIDAdvertisementEnabled` | `true` | `true` | `true` | `true` |
+| `IsolationEnable` | `false` | `false` | `false` | `false` |
+| `MaxAllowedAssociations` | `32` | `32` | `32` | `32` |
+| `X_LINKSYS_MultiAPMode` | `0` | `0` | `0` | `0` |
+| `Security.ModeEnabled` | `WPA2-Personal` | `WPA2-Personal` | `None` | `None` |
+
+> All structural fields (SSIDReference, IsolationEnable, MaxAllowedAssociations, X_LINKSYS_MultiAPMode) are identical across all 4 APs. Only `Enable` and `Security.ModeEnabled` differ, but these are not reliable identifiers (users can enable Guest AP and set a password).
+
+**Required:** Add vendor extension on `Device.WiFi.AccessPoint.{i}`:
+```
+X_LINKSYS_NetworkType   → "primary" | "guest" | "iot"
+```
+
+---
+
+### FW-010: DDNS — bbfdm Plugin Missing — P1
+
+| Field | Value |
+|-------|-------|
+| **TR-181 Path** | `Device.DynamicDNS.*` |
+| **Current Status** | fault 9005 (Invalid parameter name) |
+| **OpenWrt Support** | ✅ `ddns-scripts` v2.8.2-42 installed, `/etc/config/ddns` UCI config exists |
+| **Missing** | No `bbfdm.ddnsmngr` plugin — UCI config not mapped to TR-181 |
+| **JNAP Equivalent** | `getDDNSSettings` / `setDDNSSettings` / `getDDNSStatus2` |
+
+**SSH Reproduction:**
+```bash
+ubus call bbfdm get '{"path":"Device.DynamicDNS."}'
+# → fault 9005
+
+ubus call bbfdm get '{"path":"Device.DynamicDNS.Client."}'
+# → fault 9005
+
+# But UCI config exists
+cat /etc/config/ddns
+# → Contains dyndns.org + NoIP configuration templates
+```
+
+**Required:** Develop `bbfdm.ddnsmngr` plugin, mapping the following paths:
+
+| TR-181 Path | UCI Path | R/W |
+|-------------|----------|-----|
+| `Device.DynamicDNS.Client.{i}.Enable` | `ddns.@service[i].enabled` | R/W |
+| `Device.DynamicDNS.Client.{i}.Server` | `ddns.@service[i].service_name` | R/W |
+| `Device.DynamicDNS.Client.{i}.Username` | `ddns.@service[i].username` | R/W |
+| `Device.DynamicDNS.Client.{i}.Password` | `ddns.@service[i].password` | R/W |
+| `Device.DynamicDNS.Client.{i}.HostnameList` | `ddns.@service[i].domain` | R/W |
+| `Device.DynamicDNS.Client.{i}.Interface` | `ddns.@service[i].interface` | R/W |
+| `Device.DynamicDNS.Client.{i}.Status` | runtime | R |
+
+Additional vendor extension needed:
+- `X_LINKSYS_SupportedDDNSProviders` — supported DDNS provider list (no standard TR-181 path)
+
+---
+
+### FW-011: QoS Basic — bbfdm Plugin Missing — P3
+
+| Field | Value |
+|-------|-------|
+| **TR-181 Path** | `Device.QoS.*` |
+| **Current Status** | fault 9005 (Invalid parameter name) |
+| **Hardware Support** | ✅ `qca-sal-qos` (Qualcomm SAL) installed, ebtables QoS chains exist |
+| **Missing** | No `bbfdm.qosmngr` plugin, no `/etc/config/qos` UCI config |
+| **JNAP Equivalent** | `setQoSSettings` |
+
+**SSH Reproduction:**
+```bash
+ubus call bbfdm get '{"path":"Device.QoS."}'
+# → fault 9005
+
+ubus call bbfdm get '{"path":"Device.QoS.Classification."}'
+# → fault 9005
+```
+
+**Required:**
+1. Evaluate `bbfdm.qosmngr` plugin feasibility
+2. Map basic traffic classification to `Device.QoS.Classification.{i}.*`
+3. Confirm whether ebtables rules can be managed via bbfdm
+
+---
+
+## Tier 3: Vendor Extension — New Proprietary Paths
+
+> These features have no corresponding TR-181 standard paths and currently only have JNAP implementations. The firmware team needs to map JNAP features to `X_LINKSYS_*` vendor extensions to complete USP migration.
+
+### WiFi Related
+
+| ID | Feature | JNAP Action | Suggested Vendor Extension | Priority |
+|----|---------|-------------|----------------------|----------|
+| FW-012 | Smart Connect | `setSmartConnectSettings` | `X_LINKSYS_SmartConnect.Enable`, `X_LINKSYS_SmartConnect.Mode` | P3 |
+| FW-013 | Channel Scanner | `startChannelScan` | `X_LINKSYS_ChannelScan()` Operate command + `X_LINKSYS_ChannelScanResult.{i}.*` | P3 |
+| FW-014 | WiFi 6E/7 MLO | `setMLOSettings` | `X_LINKSYS_MLO.Enable`, `X_LINKSYS_MLO.Mode` | P2 |
+| FW-015 | WiFi Optimization | `setWiFiOptimizationSettings` | `X_LINKSYS_WiFiOptimization.Enable`, `X_LINKSYS_WiFiOptimization.Mode` | P2 |
+
+### Internet Related
+
+| ID | Feature | JNAP Action | Suggested Vendor Extension | Priority |
+|----|---------|-------------|----------------------|----------|
+| FW-016 | PPTP Connection | `setWANSettings` | `X_LINKSYS_PPTPClient.{i}.Server`, `.Username`, `.Password` | P1 |
+| FW-017 | L2TP Connection | `setWANSettings` | `X_LINKSYS_L2TPClient.{i}.Server`, `.Username`, `.Password` | P1 |
+
+### QoS Advanced
+
+| ID | Feature | JNAP Action | Suggested Vendor Extension | Priority |
+|----|---------|-------------|----------------------|----------|
+| FW-018 | Adaptive QoS | `setAdaptiveQoSSettings` | `X_LINKSYS_AdaptiveQoS.Enable`, `X_LINKSYS_AdaptiveQoS.Mode` | P3 |
+| FW-019 | Gaming Prioritization | `setGamePriority` | `X_LINKSYS_GamePriority.Enable`, `X_LINKSYS_GamePriority.DeviceList` | P3 |
+| FW-020 | Express Forwarding | `setExpressForwardingSettings` | `X_LINKSYS_ExpressForwarding.Enable` | P3 |
+
+### Parental Control
+
+| ID | Feature | JNAP Action | Suggested Vendor Extension | Priority |
+|----|---------|-------------|---------------------------|----------|
+| FW-021 | Time-Based Controls | `setParentalControlRules` | `X_LINKSYS_ParentalControl.Rule.{i}.Enable`, `.MACAddress`, `.Schedule`, `.Action` | P3 |
+| FW-022 | Content Filtering | `setParentalControlRules` | `X_LINKSYS_ContentFilter.Enable`, `X_LINKSYS_ContentFilter.Category.{i}.*` | P3 |
+
+### Admin / Diagnostics
+
+| ID | Feature | JNAP Action | Suggested Vendor Extension | Priority |
+|----|---------|-------------|---------------------------|----------|
+| FW-023 | Firmware Update | `setFirmwareUpdateSettings` | First verify `Device.DeviceInfo.FirmwareImage.{i}.Download()` standard path; if unavailable, use `X_LINKSYS_FirmwareUpdate.*` | P1 |
+| FW-024 | Auto Firmware Update | `setAutoFirmwareUpdateSettings` | `X_LINKSYS_AutoFirmwareUpdate.Enable`, `.Schedule`, `.Policy` | P2 |
+| FW-025 | Speed Test | `runSpeedTest` | `X_LINKSYS_SpeedTest()` Operate command + `X_LINKSYS_SpeedTestResult.*` | P2 |
+| FW-026 | Network Modes | `setNetworkModeSettings` | `X_LINKSYS_NetworkMode.Mode` (Router / AP / Bridge) | P1 |
+
+---
+
+## Priority Summary
+
+### P0 Critical — Blocks Core Functionality
+| ID | Issue | Category | Status |
+|----|-------|----------|--------|
+| FW-001 | AddressingType Set No-Op | Internet | 🔴 Blocks all WAN connection switching |
+
+### P1 High — WiFi / Internet Settings Core
+| ID | Issue | Category | Status |
+|----|-------|----------|--------|
+| FW-002 | MAC Clone Non-Writable | Internet | 🔴 MAC clone feature broken |
+| FW-003 | PPPoE.ServiceName Denied | Internet | 🔴 PPPoE configuration incomplete |
+| FW-004 | IPv6rd Prefix Format | Internet | 🟡 6rd manual configuration blocked |
+| FW-005 | Bandwidth Data Inconsistency | WiFi | 🟡 UI bandwidth dropdown may be incomplete |
+| FW-007 | MAC Filtering Completely Unusable | WiFi | 🔴 Needs multi-instance fix + deny-list |
+| FW-009 | Guest AP Indistinguishable | WiFi | 🟡 Relies on unreliable heuristic |
+| FW-010 | DDNS bbfdm Plugin Missing | Internet | 🔴 DDNS feature cannot be migrated |
+| FW-016 | PPTP Connection | Internet | 🔴 JNAP dependency |
+| FW-017 | L2TP Connection | Internet | 🔴 JNAP dependency |
+| FW-023 | Firmware Update Path Verification | Admin | 🟡 Standard path pending verification |
+| FW-026 | Network Modes | Internet | 🔴 JNAP dependency |
+
+### P2 Medium — Secondary Features
+| ID | Issue | Category | Status |
+|----|-------|----------|--------|
+| FW-008 | Channel-per-Width Grouping | WiFi | 🟢 Client-side computable (nice-to-have vendor ext) |
+| FW-014 | WiFi 6E/7 MLO | WiFi | 🔴 Pending hardware support confirmation |
+| FW-015 | WiFi Optimization | WiFi | 🔴 JNAP dependency |
+| FW-024 | Auto FW Update | Admin | 🔴 JNAP dependency |
+| FW-025 | Speed Test | Diagnostics | 🔴 JNAP dependency |
+
+### P3 Low — QoS / Parental Control / Pending Observation
+| ID | Issue | Category | Status |
+|----|-------|----------|--------|
+| FW-006 | ConnectionTrigger/Bridge.Enable | Internet | 🟡 Pending re-verification after FW-001 fix |
+| FW-011 | QoS Basic bbfdm Plugin | QoS | 🔴 QoS cannot be migrated |
+| FW-012 | Smart Connect | WiFi | 🔴 JNAP dependency |
+| FW-013 | Channel Scanner | WiFi | 🔴 JNAP dependency |
+| FW-018 | Adaptive QoS | QoS | 🔴 JNAP dependency |
+| FW-019 | Gaming Prioritization | QoS | 🔴 JNAP dependency |
+| FW-020 | Express Forwarding | QoS | 🔴 JNAP dependency |
+| FW-021 | Parental Control (Time) | Parental | 🔴 JNAP dependency |
+| FW-022 | Content Filtering | Parental | 🔴 JNAP dependency |
+
+---
+
+## Expected Delivery and Schedule Suggestion
+
+| Phase | Content | Priority | App-Side Blockers Resolved |
+|-------|---------|----------|---------------------------|
+| **Phase A** (urgent) | FW-001 AddressingType fix | P0 | WAN connection type switching — unlocks Internet Settings core |
+| **Phase B** | FW-002/003/004/005/006 Internet + WiFi bug fix | P1 | MAC clone, full PPPoE config, IPv6rd, Bandwidth correction |
+| **Phase C** | FW-007/009 WiFi bbfdm extension | P1 | MAC Filtering, Guest AP identification (FW-008 channel-per-width moved to client-side computation) |
+| **Phase D** | FW-010/016/017/026 Internet vendor ext | P1 | DDNS, PPTP/L2TP, Network Modes |
+| **Phase E** | FW-014/015/023/024/025 Secondary features | P2 | MLO, WiFi Optimization, FW Update, Speed Test |
+| **Phase F** | FW-011/012/013/018/019/020/021/022 QoS + Parental Control + Advanced WiFi | P3 | Full QoS suite, Parental Control, Smart Connect, Channel Scanner |
+
+---
+
+## Test Environment
+
+| Field | Value |
+|-------|-------|
+| Router Model | Linksys M60TB-EU (PINNACLE 2.0) |
+| Firmware | 1.0.16.26013014 |
+| OpenWrt | 23.05-SNAPSHOT, r0-225ad95 |
+| bbfdm Agent | bbfdm (via ubus) |
+| WAN Mode | DHCP (`network.wan.proto='dhcp'`) |
+| SSH Access | `root@192.168.1.1` |
+| Test Date | 2026-03-16 |
+
+---
+
+## Appendix: bbfdm CLI Quick Reference
+
+```bash
+# Get parameter value
+ubus call bbfdm get '{"path":"Device.WiFi.Radio.1.PossibleChannels"}'
+
+# Set parameter value
+ubus call bbfdm set '{"path":"Device.PPP.Interface.1.Username","value":"myuser"}'
+
+# Get schema (writable check: data:"1"=writable, data:"0"=read-only)
+ubus call bbfdm schema '{"path":"Device.PPP.Interface.{i}."}'
+
+# List instances
+ubus call bbfdm instances '{"path":"Device.PPP.Interface."}'
+
+# Add instance
+ubus call bbfdm add '{"path":"Device.PPP.Interface."}'
+
+# Delete instance
+ubus call bbfdm del '{"path":"Device.PPP.Interface.1."}'
+```
+
+---
+
+## Related Documentation
+
+- [Internet Settings — Set Validation Report](internet-settings-set-validation.md)
+- [Internet Settings — JNAP vs USP Comparison](internet-settings-jnap-vs-usp-comparison.md)
+- [WiFi Settings — TR-181 Limitations](wifi-settings-tr181-limitations.md)
+- [M2 Roadmap — Full Migration Gap Analysis](../integration/roadmap_m2.md)
+
+---
+
+**Last Updated:** 2026-03-16
+**Contact:** App Team — Austin Chang

--- a/doc/usp/issues/router-firmware-bugs.md
+++ b/doc/usp/issues/router-firmware-bugs.md
@@ -18,8 +18,8 @@
 This document tracks known bugs and limitations in the router firmware's USP/TR-181 implementation. Most critical bugs affecting functionality have been resolved through workarounds or firmware fixes.
 
 **Status Overview:**
-- ✅ **2 bugs fixed** (BUG-001, BUG-003)
-- ✅ **2 bugs with complete workarounds** (BUG-002, BUG-005)
+- ✅ **3 bugs fixed** (BUG-001, BUG-003, BUG-005)
+- ✅ **1 bug with complete workaround** (BUG-002)
 - 🟢 **1 behavior change** (BUG-004)
 - ✅ **1 design feature, not a bug** (BUG-006)
 

--- a/doc/usp/issues/subscription-notify-blocked.md
+++ b/doc/usp/issues/subscription-notify-blocked.md
@@ -7,19 +7,19 @@
 | Device | Linksys M60TB-EU (PINNACLE 2.0) |
 | Firmware | 1.0.16.26013014 |
 | usp-bridge | v0.1.1 |
-| Date | 2026-03-09 (updated 2026-03-12) |
+| Date | 2026-03-09 (updated 2026-03-16) |
 | Method | Flutter WASM client + SSH + OBUSPA prototrace |
 
 ---
 
 ## Summary
 
-The notification pipeline has two issues. **Issue 2 is now fixed** in FW 1.0.16. Issue 1 remains open.
+Both issues are now resolved. The full end-to-end notification pipeline is operational.
 
 ```
 Flutter App (WASM client)
     │
-    ├── subscribe() ──→ bridge HTTP API ──→ ❌ No OBUSPA Subscription created (Issue 1)
+    ├── subscribe() ──→ bridge HTTP API ──→ ✅ Bridge auto-creates OBUSPA Subscription (Issue 1 — FIXED)
     │
     ├── operate()   ──→ bridge ──→ OBUSPA ──→ bbfdm ──→ execution completes
     │                                            │
@@ -29,41 +29,66 @@ Flutter App (WASM client)
     │                                            │
     │                               bridge ──→ SSE ✅                  (Issue 2 — FIXED)
     │
-    └── SSE stream ──→ heartbeat + notification events ✅ (when subscription exists)
+    └── SSE stream ──→ heartbeat + notification events ✅
 ```
 
 ---
 
-## Issue 1: WASM client subscribe does not create an OBUSPA Subscription
+## Issue 1: Bridge subscribe now auto-creates OBUSPA Subscription — ✅ FIXED
 
-### Symptom
+> **Status**: Fixed in FW 1.0.16.26013014 (bridge v0.1.1 with updated API). Verified 2026-03-16.
+>
+> **Resolution**: The bridge API field names changed from `type`/`path` (int/string) to `NotifType`/`ReferenceList` (string/string). With the correct field names, `POST /api/v1/subscription` now automatically creates `Device.LocalAgent.Subscription.{i}` in OBUSPA with the correct Recipient (Controller.3/UDS).
 
-When the WASM client calls `subscribe(id, path, notifType)`, it issues an HTTP request to the bridge's `POST /api/v1/subscription` endpoint instead of sending a USP Add to create a `Device.LocalAgent.Subscription.{i}` object in OBUSPA.
+### Original Symptom (now resolved)
 
-### Impact
+When the WASM client called `subscribe(id, path, notifType)` with the **old** field names (`type`/`path`), the bridge only recorded the subscription internally — OBUSPA was unaware and would not generate Notify messages.
 
-- The bridge only records the subscription internally — **OBUSPA is completely unaware** that a subscription exists
-- OBUSPA will not generate USP Notify messages for any events
-- The bridge itself has no polling or listening mechanism to detect data model changes
-- The SSE stream only contains heartbeats and will never deliver notification events
+### Root Cause
 
-### Architecture Analysis
+The bridge API expected new field names that were not documented:
+- **Old (broken)**: `{ "type": 1, "path": "Device.Hosts.Host." }`
+- **New (working)**: `{ "NotifType": "ValueChange", "ReferenceList": "Device.Hosts.Host." }`
 
-Two independent subscription systems currently exist with no interoperation:
+### Verification (2026-03-16)
 
-| Layer | Mechanism | Creation Method | Notification Path |
-|-------|-----------|-----------------|-------------------|
-| **OBUSPA** | `Device.LocalAgent.Subscription.{i}` | USP Add / OBUSPA CLI | OBUSPA detects change → Notify → UDS → bridge |
-| **usp-bridge** | `/api/v1/subscription` HTTP API | HTTP POST register | bridge self-managed (no detection mechanism) |
+SSH verification confirmed bridge creates OBUSPA subscription with correct Recipient:
 
-### Expected Behavior
+```bash
+# Register via bridge with NEW field names
+$ curl -s -X POST http://127.0.0.1:8083/api/v1/subscription \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"action":"register","subscription_id":"test-vc","NotifType":"ValueChange","ReferenceList":"Device.Hosts.Host."}'
+{"status":"success"}
 
-The WASM client's subscribe should create a `Device.LocalAgent.Subscription.{i}` via USP protobuf, or the bridge should translate the request:
-
+# Verify OBUSPA subscription was created
+$ obuspa -s /tmp/usp_cli -c 'dump' 'subscriptions'
+enable=1
+instance=1
+cont_instance=3        # ← Controller.3 (UDS/bridge) — correct!
+subscription_id=test-vc
+notify_type=ValueChange
+path[0]=Device.Hosts.Host.
 ```
-Option A: WASM subscribe → USP Add(Device.LocalAgent.Subscription.) → OBUSPA manages
-Option B: WASM subscribe → bridge API → bridge proxies USP Add → OBUSPA manages
+
+Additional SSH verification:
+- **Idempotency**: Re-subscribing same ID 3 times → only 1 OBUSPA subscription created (safe for reconnect)
+- **Session expiry**: Bridge session timeout (36s) does NOT clean up OBUSPA subscriptions (orphan risk → bootstrap purge kept as safety net)
+
+### Flutter Client Update
+
+`UspBridgeClient.subscribe()` updated to use new field names:
+```dart
+body: jsonEncode({
+  'action': 'register',
+  'subscription_id': subscriptionId,
+  'NotifType': notifTypeNames[notifType] ?? 'ValueChange',  // was 'type': notifType
+  'ReferenceList': path,                                      // was 'path': path
+}),
 ```
+
+`SseSubscriptionRegistry` simplified to bridge-only (removed 5-step OBUSPA workaround — bridge handles OBUSPA lifecycle automatically).
 
 ---
 
@@ -105,53 +130,31 @@ All notification types now expected to work:
 
 ---
 
-## Fix Dependencies
+## Fix Dependencies — ✅ All Resolved
 
 ```
-Issue 2 (bridge does not forward Notify to SSE) ── ✅ FIXED in FW 1.0.16
+Issue 2 (bridge does not forward Notify to SSE) ── ✅ FIXED in FW 1.0.16 (2026-03-12)
    │
    ▼
-Issue 1 (subscribe does not create OBUSPA Subscription) ── ❌ OPEN
-   │
-   │  After fix → End-to-end notifications working
+Issue 1 (bridge subscribe creates OBUSPA sub)   ── ✅ FIXED in FW 1.0.16 (2026-03-16, new API fields)
    │
    ▼
-End-to-end notifications working ✅
+End-to-end notifications working ✅ (verified Ping OperationComplete via SSE)
 ```
 
-**Issue 2 is fixed.** Issue 1 remains — the bridge subscribe API must be enhanced to create OBUSPA subscriptions.
+**Both issues are fixed.** The full SSE notification pipeline is operational.
 
-### Current Workaround (Dart client-side)
+### Previous Workaround (now deprecated)
 
-`UspService.createNotifySubscription()` performs the full flow from the Dart client:
-
-```
-Step 1: GET Device.LocalAgent.Subscription. (snapshot existing IDs)
-Step 2: USP Add Device.LocalAgent.Subscription. (create instance)
-Step 3: GET Device.LocalAgent.Subscription. (diff to find new instance ID)*
-Step 4: USP SetMultiple Enable=true, NotifType=..., ReferenceList=...
-Step 5: GET verify Recipient points to UDS controller
-```
-
-> *Step 3 is needed because the WASM client's `add()` returns empty for `Device.LocalAgent.Subscription.` — OBUSPA's AddResp has no `updated_inst_results`. This is a Rust WASM client bug (`wasm/mod.rs:435-441`).
-
-**Problems with the workaround:**
-- 5 round-trips instead of 1
-- Client must know OBUSPA internals (`Device.LocalAgent.Subscription.` schema)
-- GET-diff is fragile under concurrent access
-- WASM `add` return value bug requires extra GET
+`UspService.createNotifySubscription()` performed a 5-step OBUSPA workaround (Add + GET-diff + SetMultiple). This is no longer needed for production — bridge handles OBUSPA lifecycle automatically. The method is retained in `UspService` for legacy/debug purposes only.
 
 ---
 
-## Enhancement Request: Bridge Auto-Register OBUSPA Subscription
+## Bridge Subscription API — Current Working Format (✅ Implemented)
 
-### Goal
+The bridge `POST /api/v1/subscription` endpoint now auto-creates OBUSPA subscriptions.
 
-The bridge `POST /api/v1/subscription` endpoint should create a proper `Device.LocalAgent.Subscription.{i}` instance in OBUSPA, not just register an internal session mapping.
-
-### Proposed API
-
-**Request** (same endpoint, enhanced behavior):
+### Request Format
 
 ```http
 POST /api/v1/subscription
@@ -161,45 +164,26 @@ Authorization: Bearer <token>
 {
   "action": "register",
   "subscription_id": "client-sub-1",
-  "path": "Device.IP.Diagnostics.TraceRoute()",
-  "type": "OperationComplete"
+  "NotifType": "OperationComplete",
+  "ReferenceList": "Device.IP.Diagnostics.TraceRoute()"
 }
 ```
 
-`type` field should accept string names (preferred) or numeric values:
+| Field | Type | Description |
+|-------|------|-------------|
+| `action` | string | `"register"` or `"unregister"` |
+| `subscription_id` | string | Client-assigned unique ID |
+| `NotifType` | string | `ValueChange`, `ObjectCreation`, `ObjectDeletion`, `OperationComplete`, `Event` |
+| `ReferenceList` | string | TR-181 path to monitor |
 
-| type (string) | type (numeric) | Description |
-|---------------|----------------|-------------|
-| `ValueChange` | 1 | Parameter value changed |
-| `ObjectCreation` | 2 | Object instance created |
-| `ObjectDeletion` | 3 | Object instance deleted |
-| `OperationComplete` | 4 | Async Operate completed |
-| `Event` | 5 | Custom event |
+### Bridge Internal Behavior
 
-**Bridge internal flow:**
+- **register**: Creates OBUSPA `Device.LocalAgent.Subscription.{i}` with correct Recipient (Controller.3/UDS) + SSE session mapping
+- **unregister**: Deletes OBUSPA subscription + SSE session mapping
+- **Idempotent**: Re-registering same `subscription_id` reuses existing OBUSPA subscription (safe for reconnect)
+- **Session expiry caveat**: Bridge session timeout does NOT clean up OBUSPA subscriptions — client should purge on app startup
 
-```
-1. Receive POST /api/v1/subscription
-2. USP Add → Device.LocalAgent.Subscription.    (create OBUSPA instance)
-3. USP Set → Enable=true, NotifType=<type>, ReferenceList=<path>
-4. Verify Recipient → must point to bridge's own UDS controller
-5. Register SSE session mapping (existing behavior)
-6. Return response with instance details
-```
-
-**Response** (enhanced):
-
-```json
-{
-  "status": "success",
-  "instance_path": "Device.LocalAgent.Subscription.3.",
-  "recipient": "Device.LocalAgent.Controller.3",
-  "notif_type": "OperationComplete",
-  "reference_list": "Device.IP.Diagnostics.TraceRoute()"
-}
-```
-
-**Unregister** should also clean up the OBUSPA instance:
+### Unregister
 
 ```http
 POST /api/v1/subscription
@@ -208,16 +192,6 @@ POST /api/v1/subscription
   "subscription_id": "client-sub-1"
 }
 ```
-
-Bridge internal: USP Delete `Device.LocalAgent.Subscription.{i}.` + remove SSE mapping.
-
-### Benefits
-
-- Single round-trip from client
-- Client doesn't need to know OBUSPA `Device.LocalAgent.` schema
-- Bridge controls the full lifecycle (create + cleanup)
-- No dependency on WASM `add` return value bug
-- Atomic operation — no race conditions from GET-diff
 
 ---
 

--- a/doc/usp/issues/wifi-settings-tr181-limitations.md
+++ b/doc/usp/issues/wifi-settings-tr181-limitations.md
@@ -9,7 +9,7 @@
 
 ## Summary
 
-Four limitations discovered during WiFi Settings page implementation that cannot be fully resolved with standard TR-181 paths. Items 1 and 2 require a vendor extension from the firmware team; items 3 and 4 are descoped pending further investigation.
+Four limitations discovered during WiFi Settings page implementation. **ISS-2 resolved** (2026-03-16): `SupportedOperatingChannelBandwidths` standard path exists. Items 1, 3, and 4 require vendor extensions from the firmware team.
 
 ---
 
@@ -19,31 +19,45 @@ Four limitations discovered during WiFi Settings page implementation that cannot
 
 TR-181 provides a flat, comma-separated list of all channels available on the radio — it does not group channels by channel width. As a result, the UI cannot automatically derive which channels are valid for a given bandwidth selection (e.g., which channels support 80 MHz vs. 160 MHz).
 
+**SSH Verification (2026-03-16):**
+
+| Radio | PossibleChannels | SupportedBandwidths | CurrentBandwidth |
+|-------|-----------------|---------------------|------------------|
+| Radio.1 (2.4 GHz) | `1-13` | `Auto,20MHz` | `20MHz` |
+| Radio.2 (5 GHz) | `36,40,44,48,52,56,60,64,100-140` | `Auto,20MHz,40MHz,80MHz` | `160MHz` ⚠️ |
+
+> **Data inconsistency:** Radio.2 reports `CurrentOperatingChannelBandwidth` = `160MHz`, but `SupportedOperatingChannelBandwidths` only lists up to `80MHz`. This firmware data contradiction needs clarification from the FW team.
+
 Additional factors that affect channel availability at runtime:
 
 - **Regulatory domain** — legal channels differ by country (e.g., Japan, Taiwan, and the EU each permit different channel sets).
 - **DFS channels (52–144)** — require active radar detection before use in most regions. The router may dynamically exclude them depending on detected radar activity or regional restrictions.
 
-**Impact:** The current implementation cannot build an accurate "channels available for this width" dropdown from TR-181 data alone.
+**Impact:** The current implementation cannot build an accurate "channels available for this width" dropdown from TR-181 data alone. The flat `PossibleChannels` list (e.g., `36,40,44,48,52-64,100-140`) does not indicate which channels are valid for 40 MHz vs. 80 MHz vs. 160 MHz bonding.
 
 **Workaround needed:** A firmware vendor extension that exposes a pre-filtered `AvailableChannels` map keyed by channel width, taking regulatory domain and DFS state into account, so the router provides the correct list directly.
 
 ---
 
-## ISS-2: Channel width options are hardcoded
+## ISS-2: Channel width options are hardcoded — ✅ RESOLVED (2026-03-16)
 
-**Path:** `Device.WiFi.Radio.{i}.OperatingChannelBandwidth` / `PossibleChannelBandwidths` (non-standard)
+**Path:** `Device.WiFi.Radio.{i}.OperatingChannelBandwidth` / `SupportedOperatingChannelBandwidths`
 
-TR-181 does not define a `PossibleChannelBandwidths` equivalent to `PossibleChannels`. The current UI hardcodes the available options:
+~~TR-181 does not define a `PossibleChannelBandwidths` equivalent to `PossibleChannels`.~~ **Update (2026-03-16):** The standard path `Device.WiFi.Radio.{i}.SupportedOperatingChannelBandwidths` exists and returns correct data:
 
-| Band | Options |
-|------|---------|
-| 2.4 GHz | Auto / 20 MHz / 40 MHz |
-| 5 GHz / 6 GHz | Auto / 20 MHz / 40 MHz / 80 MHz / 160 MHz |
+```
+Radio.1 (2.4 GHz): "Auto,20MHz"
+Radio.2 (5 GHz):   "Auto,20MHz,40MHz,80MHz"   ← hardware does not support 160MHz
+```
 
-These options may not reflect what the actual hardware supports (e.g., a radio that does not support 160 MHz would still show it in the list).
+The current UI hardcodes the available options (incorrect):
 
-**Workaround needed:** A vendor extension path that returns the supported bandwidths per radio, or a firmware-side filtering mechanism that rejects unsupported values with a clear fault code.
+| Band | Hardcoded Options | Actual Support |
+|------|-------------------|----------------|
+| 2.4 GHz | Auto / 20 MHz / 40 MHz | Auto / 20 MHz |
+| 5 GHz / 6 GHz | Auto / 20 MHz / 40 MHz / 80 MHz / 160 MHz | Auto / 20 MHz / 40 MHz / 80 MHz |
+
+**Fix:** Remove hardcoded options. Read `SupportedOperatingChannelBandwidths` per radio and dynamically build the dropdown. No vendor extension needed.
 
 ---
 
@@ -65,8 +79,27 @@ Enabling `MACAddressControlEnabled` with an `AllowedMACAddress` list would block
 
 TR-181 does not provide a property on `Device.WiFi.Radio.{i}` or `Device.WiFi.AccessPoint.{i}` to distinguish a guest network from a primary network. The `WiFiRadio`, `WiFiAccessPoint`, and `WiFiSsid` objects have no `IsGuest` or `NetworkRole` field in the standard data model.
 
+**SSH Verification (2026-03-16) — All 4 AccessPoint profiles compared:**
+
+| Field | AP.1 (Primary 2.4G) | AP.2 (Primary 5G) | AP.3 (Guest 2.4G) | AP.4 (Guest 5G) |
+|-------|---------------------|--------------------|--------------------|------------------|
+| `Enable` | `true` | `true` | **`false`** | **`false`** |
+| `SSIDReference` | `""` | `""` | `""` | `""` |
+| `SSIDAdvertisementEnabled` | `true` | `true` | `true` | `true` |
+| `IsolationEnable` | `false` | `false` | `false` | `false` |
+| `MaxAllowedAssociations` | `32` | `32` | `32` | `32` |
+| `X_LINKSYS_MultiAPMode` | `0` | `0` | `0` | `0` |
+| `Security.ModeEnabled` | `WPA2-Personal` | `WPA2-Personal` | **`None`** | **`None`** |
+
+**Findings:**
+- **No field distinguishes guest from primary.** All structural/policy fields (`SSIDReference`, `IsolationEnable`, `MaxAllowedAssociations`, `X_LINKSYS_MultiAPMode`) are identical across all 4 APs.
+- AP.3/4 can only be inferred as "guest" by convention: disabled by default + `Security.ModeEnabled = "None"`. This is unreliable — user could enable a guest AP and set security, making it indistinguishable from a primary AP.
+- `SSIDReference` is empty for all APs (no cross-reference to `Device.WiFi.SSID.{i}`), so SSID-based lookup is also unavailable via this field.
+
 **Current workaround:** Guest networks are identified by checking whether the SSID string contains `"guest"` (case-insensitive). This heuristic fails for:
 - Guest networks with custom names (e.g., `"Linksys-Visitors"`)
 - Primary networks that happen to include `"guest"` in the name
+
+**Alternative heuristic considered:** AP index-based (AP.3/4 = guest). This is fragile and hardware-dependent.
 
 **Workaround needed:** A vendor extension property on `Device.WiFi.AccessPoint.{i}` (e.g., `X_LINKSYS_NetworkType`) that explicitly marks the network role (primary / guest / iot).

--- a/doc/usp/router/USP-CLIENT_USP-BRIDGE_ARCHITECTURE.md
+++ b/doc/usp/router/USP-CLIENT_USP-BRIDGE_ARCHITECTURE.md
@@ -117,7 +117,7 @@ The bridge is structured around a central `bridge_context_t` that owns all sub-s
 | **UDS Client** | `uds_client.h` | Maintains persistent connection to OBUSPA's UDS socket |
 | **Session Manager** | `session_manager.h` | Tracks active sessions by session ID (from JWT) |
 | **Router** | `router.h` | Correlates outbound USP requests with inbound responses by request ID |
-| **Subscription Manager** | `subscription.h` | Maps SSE subscriptions to data model paths for targeted notification delivery |
+| **Subscription Manager** | `subscription.h` | Maps SSE subscriptions to data model paths; auto-creates OBUSPA `Device.LocalAgent.Subscription.{i}` instances |
 | **Channel Manager** | `channel.h` | Manages exclusive streaming channel (for firmware upgrade, speed test, etc.) |
 | **JWT Util** | `jwt_util.h` | Validates incoming JWTs using the shared signing key |
 
@@ -128,7 +128,7 @@ The bridge is structured around a central `bridge_context_t` that owns all sub-s
 | `GET` | `/api/v1/health` | No | Health check + performance metrics |
 | `POST` | `/api/v1/usp` | Yes | Forward a USP protobuf message to OBUSPA and return the response |
 | `GET` | `/api/v1/notifications` | Yes | SSE stream — real-time notifications from OBUSPA |
-| `POST` | `/api/v1/subscription` | Yes | Register/unregister notification subscriptions |
+| `POST` | `/api/v1/subscription` | Yes | Register/unregister notification subscriptions (auto-creates OBUSPA `Subscription.{i}`). Fields: `NotifType` (string), `ReferenceList` (string) |
 | `POST` | `/api/v1/turbo/start` | Yes | Acquire the exclusive streaming channel |
 | `POST` | `/api/v1/turbo/heartbeat` | Yes | Keep the streaming channel alive |
 | `POST` | `/api/v1/turbo/release` | Yes | Release the streaming channel |
@@ -385,7 +385,8 @@ sequenceDiagram
     Note over Bridge: Create subscription
     Bridge-->>Client: SSE stream opened
 
-    Client->>Bridge: POST /api/v1/subscription { action: "register", subscription_id: "..." }
+    Client->>Bridge: POST /api/v1/subscription { action: "register", subscription_id: "...", NotifType: "ValueChange", ReferenceList: "Device.Hosts.Host." }
+    Note over Bridge: Auto-create OBUSPA Subscription.{i}
     Bridge-->>Client: 200 { status: "success" }
 
     Note over Client, Agent: ...time passes...

--- a/lib/usp/models/sse_subscription_record.dart
+++ b/lib/usp/models/sse_subscription_record.dart
@@ -1,10 +1,10 @@
-/// A registered subscription record tracking both OBUSPA and bridge layers.
+/// A registered subscription record managed by the bridge.
+///
+/// The bridge handles the full OBUSPA `Device.LocalAgent.Subscription.{i}`
+/// lifecycle automatically — the client only tracks logical state.
 class SseSubscriptionRecord {
   /// Client-assigned ID (e.g., "connected-devices-objectcreation").
   final String subscriptionId;
-
-  /// OBUSPA instance path (e.g., "Device.LocalAgent.Subscription.3.").
-  final String obuspaInstancePath;
 
   /// Notification type: "ValueChange", "ObjectCreation", "ObjectDeletion",
   /// "OperationComplete", "Event".
@@ -18,7 +18,6 @@ class SseSubscriptionRecord {
 
   const SseSubscriptionRecord({
     required this.subscriptionId,
-    required this.obuspaInstancePath,
     required this.notifType,
     required this.referenceList,
     required this.createdAt,

--- a/lib/usp/services/sse_manager.dart
+++ b/lib/usp/services/sse_manager.dart
@@ -44,7 +44,7 @@ class SseManager {
     required UspBridgeClient bridge,
   })  : _usp = usp,
         connection = SseConnectionManager(bridge),
-        registry = SseSubscriptionRegistry(usp, bridge),
+        registry = SseSubscriptionRegistry(bridge),
         router = SseEventRouter() {
     // Wire connection events to router
     connection.onEvent = router.routeEvent;

--- a/lib/usp/services/sse_subscription_registry.dart
+++ b/lib/usp/services/sse_subscription_registry.dart
@@ -2,24 +2,24 @@ import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/usp/models/sse_subscription_record.dart';
 
 import 'usp_bridge_client.dart';
-import 'usp_service.dart';
 
 export 'package:privacy_gui/usp/models/sse_subscription_record.dart';
 
-/// Tracks active SSE subscriptions and manages two-layer creation:
+/// Tracks active SSE subscriptions via the bridge API.
 ///
-/// 1. **OBUSPA Layer**: Creates `Device.LocalAgent.Subscription.{i}` via
-///    [UspService.createNotifySubscription] (5-step workaround).
-/// 2. **Bridge Layer**: Registers with bridge via
-///    [UspBridgeClient.subscribe] for SSE session routing.
+/// The bridge handles the full OBUSPA `Device.LocalAgent.Subscription.{i}`
+/// lifecycle automatically:
+/// - **register** → bridge creates OBUSPA subscription + SSE session mapping
+/// - **unregister** → bridge deletes OBUSPA subscription + SSE session mapping
+/// - **re-register** (same ID) → bridge is idempotent, reuses existing OBUSPA
 ///
-/// On SSE reconnect, only the bridge layer needs re-registration (OBUSPA
-/// subscriptions persist on the router independently of SSE connections).
+/// On SSE reconnect, [resubscribeAll] re-registers all tracked subscriptions
+/// on the bridge. Since bridge is idempotent by subscription_id, this is safe
+/// even if the OBUSPA subscriptions persist from the previous session.
 class SseSubscriptionRegistry {
-  final UspService _usp;
   final UspBridgeClient _bridge;
 
-  SseSubscriptionRegistry(this._usp, this._bridge);
+  SseSubscriptionRegistry(this._bridge);
 
   final Map<String, SseSubscriptionRecord> _subscriptions = {};
 
@@ -29,15 +29,10 @@ class SseSubscriptionRegistry {
   /// All current subscription records.
   Iterable<SseSubscriptionRecord> get records => _subscriptions.values;
 
-  /// Creates a subscription at both OBUSPA and bridge layers.
+  /// Registers a subscription via the bridge API.
   ///
-  /// Steps:
-  /// 1. Create OBUSPA subscription (5-step workaround via UspService)
-  /// 2. Register with bridge for SSE routing
-  /// 3. Store record for tracking
-  ///
-  /// Throws if either step fails. On bridge registration failure, the OBUSPA
-  /// subscription is cleaned up.
+  /// The bridge creates the OBUSPA subscription and SSE routing in one call.
+  /// Throws on failure.
   Future<SseSubscriptionRecord> register({
     required String subscriptionId,
     required String notifType,
@@ -53,53 +48,27 @@ class SseSubscriptionRegistry {
     logger.d('[SSE Registry] Registering $subscriptionId '
         '(type=$notifType, ref=$referenceList)');
 
-    // Step 1: Create OBUSPA subscription
-    final obuspaResult = await _usp.createNotifySubscription(
-      notifType: notifType,
-      referenceList: referenceList,
+    await _bridge.subscribe(
+      subscriptionId: subscriptionId,
+      path: referenceList,
+      notifType: _notifTypeToInt(notifType),
     );
-    final instancePath = obuspaResult['instancePath'] ?? '';
 
-    if (instancePath.isEmpty) {
-      throw StateError(
-          'OBUSPA subscription creation returned empty instancePath '
-          'for $subscriptionId');
-    }
-
-    // Step 2: Register with bridge for SSE routing
-    try {
-      await _bridge.subscribe(
-        subscriptionId: subscriptionId,
-        path: referenceList,
-        notifType: _notifTypeToInt(notifType),
-      );
-    } catch (e) {
-      // Cleanup OBUSPA subscription on bridge failure
-      logger.w('[SSE Registry] Bridge registration failed for '
-          '$subscriptionId, cleaning up OBUSPA subscription: $e');
-      try {
-        await _usp.deleteNotifySubscription(instancePath);
-      } catch (cleanupError) {
-        logger.w('[SSE Registry] OBUSPA cleanup also failed: $cleanupError');
-      }
-      rethrow;
-    }
-
-    // Step 3: Store record
     final record = SseSubscriptionRecord(
       subscriptionId: subscriptionId,
-      obuspaInstancePath: instancePath,
       notifType: notifType,
       referenceList: referenceList,
       createdAt: DateTime.now(),
     );
     _subscriptions[subscriptionId] = record;
 
-    logger.d('[SSE Registry] Registered $subscriptionId → $instancePath');
+    logger.d('[SSE Registry] Registered $subscriptionId');
     return record;
   }
 
-  /// Removes a subscription from both OBUSPA and bridge layers.
+  /// Unregisters a subscription via the bridge API.
+  ///
+  /// The bridge deletes the OBUSPA subscription and SSE routing.
   Future<void> unregister(String subscriptionId) async {
     final record = _subscriptions.remove(subscriptionId);
     if (record == null) {
@@ -110,28 +79,19 @@ class SseSubscriptionRegistry {
 
     logger.d('[SSE Registry] Unregistering $subscriptionId');
 
-    // Unregister from bridge (non-fatal if fails)
     try {
       await _bridge.unsubscribe(subscriptionId: subscriptionId);
     } catch (e) {
       logger.w('[SSE Registry] Bridge unsubscribe failed for '
           '$subscriptionId: $e');
     }
-
-    // Delete OBUSPA subscription (non-fatal if fails)
-    try {
-      await _usp.deleteNotifySubscription(record.obuspaInstancePath);
-    } catch (e) {
-      logger.w('[SSE Registry] OBUSPA delete failed for '
-          '$subscriptionId (${record.obuspaInstancePath}): $e');
-    }
   }
 
-  /// Re-registers ALL tracked subscriptions on the bridge layer only.
+  /// Re-registers ALL tracked subscriptions on the bridge.
   ///
-  /// Called after SSE reconnect. OBUSPA subscriptions persist on the router
-  /// across SSE disconnects, so only the bridge session mapping needs
-  /// re-registration — this avoids the expensive 5-step OBUSPA workaround.
+  /// Called after SSE reconnect. Bridge is idempotent by subscription_id,
+  /// so this safely reuses any OBUSPA subscriptions that persist from the
+  /// previous session.
   Future<void> resubscribeAll() async {
     if (_subscriptions.isEmpty) {
       logger
@@ -153,12 +113,11 @@ class SseSubscriptionRegistry {
       } catch (e) {
         logger.w('[SSE Registry] Failed to re-register '
             '${record.subscriptionId}: $e');
-        // Non-fatal: continue with remaining subscriptions
       }
     }
   }
 
-  /// Removes all subscriptions (both OBUSPA and bridge).
+  /// Removes all subscriptions (bridge unregister for each).
   /// Used during logout / dispose.
   Future<void> unregisterAll() async {
     final ids = _subscriptions.keys.toList();

--- a/lib/usp/services/usp_bridge_client_web.dart
+++ b/lib/usp/services/usp_bridge_client_web.dart
@@ -260,12 +260,23 @@ class UspBridgeClient {
 
   /// Registers a subscription for parameter change notifications.
   ///
-  /// [notifType]: 1=ValueChange, 2=ObjectCreation, 3=ObjectDeletion
+  /// The bridge creates an OBUSPA `Device.LocalAgent.Subscription.{i}`
+  /// instance automatically and routes notifications to the SSE stream.
+  ///
+  /// [notifType]: 1=ValueChange, 2=ObjectCreation, 3=ObjectDeletion,
+  ///              4=OperationComplete, 5=Event
   Future<Map<String, dynamic>> subscribe({
     required String subscriptionId,
     required String path,
     required int notifType,
   }) async {
+    const notifTypeNames = {
+      1: 'ValueChange',
+      2: 'ObjectCreation',
+      3: 'ObjectDeletion',
+      4: 'OperationComplete',
+      5: 'Event',
+    };
     return _withAuthRetry(
       () => http.post(
         Uri.parse('$_baseUrl/api/v1/subscription'),
@@ -273,8 +284,8 @@ class UspBridgeClient {
         body: jsonEncode({
           'action': 'register',
           'subscription_id': subscriptionId,
-          'path': path,
-          'type': notifType,
+          'NotifType': notifTypeNames[notifType] ?? 'ValueChange',
+          'ReferenceList': path,
         }),
       ),
       (r) => jsonDecode(r.body) as Map<String, dynamic>,

--- a/lib/usp_page/test_console/views/usp_test_console_view.dart
+++ b/lib/usp_page/test_console/views/usp_test_console_view.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/page/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
+import 'package:privacy_gui/usp/providers/sse_providers.dart';
 import 'package:privacy_gui/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/usp/services/usp_bridge_client.dart';
 import 'package:privacy_gui/usp/services/usp_service.dart';
@@ -49,8 +50,8 @@ class _UspTestConsoleViewState extends ConsumerState<UspTestConsoleView> {
   bool _showManualOverride = false;
   final List<String> _logs = [];
 
-  // SSE state
-  StreamSubscription<SseEvent>? _sseSub;
+  // SSE state — taps into SseManager's wildcard handler
+  VoidCallback? _sseRemoveHandler;
   bool _sseConnected = false;
 
   // Subscription notif type
@@ -157,8 +158,8 @@ class _UspTestConsoleViewState extends ConsumerState<UspTestConsoleView> {
     }
     _log('Logout...');
     try {
-      await _sseSub?.cancel();
-      _sseSub = null;
+      _sseRemoveHandler?.call();
+      _sseRemoveHandler = null;
       setState(() => _sseConnected = false);
       await _service!.logout();
       setState(() => _isConnected = false);
@@ -302,43 +303,30 @@ class _UspTestConsoleViewState extends ConsumerState<UspTestConsoleView> {
   // ════════════════════════════════════════════════════════════════════════════
 
   void _sseConnect() {
-    if (_bridgeClient == null) return;
     if (_sseConnected) {
-      _log('SSE already connected');
+      _log('SSE already listening');
       return;
     }
-    _log('SSE connecting...');
-    try {
-      final stream = _bridgeClient!.notifications();
-      _sseSub = stream.listen(
-        (event) {
-          if (event.event == '_debug') {
-            _log('SSE [debug] ${event.data}');
-          } else {
-            _log('SSE [${event.event}] ${event.data}');
-          }
-        },
-        onError: (e) {
-          _log('SSE ERROR: $e');
-          setState(() => _sseConnected = false);
-        },
-        onDone: () {
-          _log('SSE stream closed');
-          setState(() => _sseConnected = false);
-        },
-      );
-      setState(() => _sseConnected = true);
-      _log('SSE listener attached');
-    } catch (e) {
-      _log('ERROR SSE connect: $e');
+    final manager = ref.read(sseManagerProvider);
+    if (manager == null) {
+      _log('SSE ERROR: SseManager not available');
+      return;
     }
+    _log('SSE attaching wildcard handler to SseManager...');
+    _sseRemoveHandler = manager.addWildcardHandler((notification) {
+      _log('SSE [${notification.type}] sub=${notification.subscriptionId} '
+          '${jsonEncode(notification.payload)}');
+    });
+    final state = manager.connection.connectionState.value;
+    setState(() => _sseConnected = true);
+    _log('SSE listener attached (connection: ${state.name})');
   }
 
   Future<void> _sseDisconnect() async {
     if (!_sseConnected) return;
-    _log('SSE disconnecting...');
-    await _sseSub?.cancel();
-    _sseSub = null;
+    _log('SSE removing wildcard handler...');
+    _sseRemoveHandler?.call();
+    _sseRemoveHandler = null;
     setState(() => _sseConnected = false);
     _log('SSE disconnected');
   }
@@ -497,7 +485,7 @@ class _UspTestConsoleViewState extends ConsumerState<UspTestConsoleView> {
 
   @override
   void dispose() {
-    _sseSub?.cancel();
+    _sseRemoveHandler?.call();
     // Only dispose self-created services, NOT the shared singleton.
     if (!_usingSharedSession) {
       _service?.dispose();


### PR DESCRIPTION
## Summary

- **SSE subscription registry**: Simplified to bridge-only flow — bridge auto-creates OBUSPA `Device.LocalAgent.Subscription.{i}`, removing the previous 5-step client-side workaround (USP Add + 4x Set)
- **Bridge API contract update**: `POST /api/v1/subscription` now uses string-based `NotifType` + `ReferenceList` (replaced old `type` int + `path` string)
- **USP test console**: Updated subscription UI to use new bridge API format
- **M2 Roadmap** (`roadmap_m2.md`): Comprehensive gap analysis for remaining 27/72 JNAP features — prioritized across 4 phases (M2-A through M2-D) with dependency map
- **FW Team Request** (`fw-team-request.md`): 26 issues across 3 tiers (Bug Fix / bbfdm Plugin / Vendor Extension) for firmware team action
- **WiFi channel-per-width**: Downgraded FW-008 from P1→P2 — client-side computable using IEEE 802.11 bonding rules + existing `channel_constants.dart` logic
- **Doc updates**: Translated all documentation to English, updated SSE implementation guide, issue index, and cross-references

## Changed Files

### Code (5 files)
- `lib/usp/models/sse_subscription_record.dart` — Model field updates
- `lib/usp/services/sse_manager.dart` — Manager wiring fix
- `lib/usp/services/sse_subscription_registry.dart` — Bridge-only subscription flow
- `lib/usp/services/usp_bridge_client_web.dart` — String-based API contract
- `lib/page/usp_test/test_console/views/usp_test_console_view.dart` — Test UI updates

### Documentation (9 files)
- `doc/usp/integration/roadmap_m2.md` — **NEW**: M2 migration gap analysis (40 items, 10 sections)
- `doc/usp/issues/fw-team-request.md` — **NEW**: FW team request (26 issues, 3 tiers)
- `doc/usp/integration/sse_implementation.md` — Updated for bridge-only subscription
- `doc/usp/issues/INDEX.md` — Added new doc references
- `doc/usp/issues/wifi-settings-tr181-limitations.md` — ISS-1 channel-per-width update
- Plus 4 other doc files with minor updates

## Test plan

- [x] SSE subscription register/unregister verified on `_bridge_sub_fixed.img`
- [x] OperationComplete (Ping/TraceRoute) via SSE verified
- [x] ValueChange notification via SSE verified
- [x] Bootstrap purge cleans orphaned OBUSPA subscriptions
- [x] Idempotent re-register on reconnect verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)