### PR TITLE
refactor: Unified NavigationExtra & navigateBack

### DIFF
--- a/lib/components/styled/menus/widgets/menu_holder.dart
+++ b/lib/components/styled/menus/widgets/menu_holder.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/styled/menus/menu_consts.dart';
 import 'package:privacy_gui/components/styled/menus/widgets/bottom_navigation_menu.dart';
 import 'package:privacy_gui/components/styled/menus/widgets/top_navigation_menu.dart';
+import 'package:privacy_gui/route/navigation_extra.dart';
 import 'package:privacy_gui/route/route_model.dart';
 import 'package:privacy_gui/route/router_provider.dart';
 import 'package:ui_kit_library/ui_kit.dart';
@@ -51,8 +52,8 @@ class MenuHolderState extends ConsumerState<MenuHolder> {
   void _updateMenuSelection() {
     if (_routerDelegate == null) return;
     final extra = _routerDelegate!.currentConfiguration.extra;
-    if (extra is NaviType) {
-      _controller.setTo(extra);
+    if (extra is NavigationExtra && extra.naviType != null) {
+      _controller.setTo(extra.naviType!);
     }
   }
 
@@ -151,7 +152,7 @@ class MenuController {
     final path = pathResolver?.call(type) ?? type.resolvePath();
     key.currentContext!.goNamed(
       path,
-      extra: type,
+      extra: NavigationExtra(naviType: type),
     );
   }
 

--- a/lib/components/ui_kit_page_view.dart
+++ b/lib/components/ui_kit_page_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/components/styled/top_bar.dart';
+import 'package:privacy_gui/route/navigation_extensions.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
 const double kDefaultToolbarHeight = kToolbarHeight; // 56
@@ -127,6 +128,7 @@ class UiKitPageView extends ConsumerStatefulWidget {
   final TabController? tabController;
   final void Function(int index)? onTabTap;
   final VoidCallback? onBackTap;
+  final String? backFallback; // Fallback route name for navigateBack when onBackTap is null
   final double?
       unboundedFallbackHeight; // Fallback height for unbounded content
   final bool isTabScrollable;
@@ -170,6 +172,7 @@ class UiKitPageView extends ConsumerStatefulWidget {
     this.tabController,
     this.onTabTap,
     this.onBackTap,
+    this.backFallback,
     this.unboundedFallbackHeight,
     this.isTabScrollable = true,
     this.showAppBarBorder = false,
@@ -249,6 +252,7 @@ class UiKitPageView extends ConsumerStatefulWidget {
     TabController? tabController,
     void Function(int index)? onTabTap,
     VoidCallback? onBackTap,
+    String? backFallback,
     double? unboundedFallbackHeight,
     TextStyle? selectedTabTextStyle,
     TextStyle? tabTextStyle,
@@ -289,6 +293,7 @@ class UiKitPageView extends ConsumerStatefulWidget {
       tabController: tabController,
       onTabTap: onTabTap,
       onBackTap: onBackTap,
+      backFallback: backFallback,
       unboundedFallbackHeight: unboundedFallbackHeight,
       isTabScrollable: isTabScrollable,
       showAppBarBorder: showAppBarBorder,
@@ -493,7 +498,11 @@ class _UiKitPageViewState extends ConsumerState<UiKitPageView> {
       title: widget.title,
       showBackButton: showBackButton,
       toolbarHeight: widget.toolbarHeight,
-      onBackTap: widget.onBackTap,
+      onBackTap: widget.onBackTap ??
+          (showBackButton
+              ? () => context.navigateBack(
+                  fallback: widget.backFallback)
+              : null),
       showBorder: widget.showAppBarBorder,
     );
   }

--- a/lib/components/ui_kit_page_view.dart
+++ b/lib/components/ui_kit_page_view.dart
@@ -128,7 +128,8 @@ class UiKitPageView extends ConsumerStatefulWidget {
   final TabController? tabController;
   final void Function(int index)? onTabTap;
   final VoidCallback? onBackTap;
-  final String? backFallback; // Fallback route name for navigateBack when onBackTap is null
+  final String?
+      backFallback; // Fallback route name for navigateBack when onBackTap is null
   final double?
       unboundedFallbackHeight; // Fallback height for unbounded content
   final bool isTabScrollable;
@@ -500,8 +501,7 @@ class _UiKitPageViewState extends ConsumerState<UiKitPageView> {
       toolbarHeight: widget.toolbarHeight,
       onBackTap: widget.onBackTap ??
           (showBackButton
-              ? () => context.navigateBack(
-                  fallback: widget.backFallback)
+              ? () => context.navigateBack(fallback: widget.backFallback)
               : null),
       showBorder: widget.showAppBarBorder,
     );

--- a/lib/page/admin/views/usp_admin_view.dart
+++ b/lib/page/admin/views/usp_admin_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/page/admin/providers/usp_admin_notifier.dart';
@@ -29,9 +28,7 @@ class UspAdminView extends ConsumerWidget {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspMenu),
+      backFallback: RouteNamed.uspMenu,
       onRefresh: () => ref.refresh(uspAdminProvider.future),
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: (childContext, constraints) {

--- a/lib/page/advanced_settings/views/usp_advanced_settings_view.dart
+++ b/lib/page/advanced_settings/views/usp_advanced_settings_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
+import 'package:privacy_gui/route/navigation_extensions.dart';
 import 'package:privacy_gui/components/composed/app_list_card.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/page/models/app_section_item_data.dart';
@@ -23,9 +24,7 @@ class UspAdvancedSettingsView extends StatelessWidget {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspMenu),
+      onBackTap: () => context.navigateBack(fallback: RouteNamed.uspMenu),
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: (childContext, constraints) {
         return AppResponsiveLayout(
@@ -73,27 +72,27 @@ class UspAdvancedSettingsView extends StatelessWidget {
       ),
       AppSectionItemData(
         title: loc(context).localNetwork,
-        onTap: () => context.goNamed(RouteNamed.uspLocalNetwork),
+        onTap: () => context.pushNamed(RouteNamed.uspLocalNetwork),
       ),
       AppSectionItemData(
         title: loc(context).firewall,
-        onTap: () => context.goNamed(RouteNamed.uspFirewall),
+        onTap: () => context.pushNamed(RouteNamed.uspFirewall),
       ),
       AppSectionItemData(
         title: loc(context).dmz,
-        onTap: () => context.goNamed(RouteNamed.uspDmz),
+        onTap: () => context.pushNamed(RouteNamed.uspDmz),
       ),
       AppSectionItemData(
         title: 'Port Forwarding',
-        onTap: () => context.goNamed(RouteNamed.uspPortForwardingDetail),
+        onTap: () => context.pushNamed(RouteNamed.uspPortForwardingDetail),
       ),
       AppSectionItemData(
         title: loc(context).staticRouting,
-        onTap: () => context.goNamed(RouteNamed.uspStaticRouting),
+        onTap: () => context.pushNamed(RouteNamed.uspStaticRouting),
       ),
       AppSectionItemData(
         title: 'Network Diagnostics',
-        onTap: () => context.goNamed(RouteNamed.uspNetworkDiagnostics),
+        onTap: () => context.pushNamed(RouteNamed.uspNetworkDiagnostics),
       ),
     ];
   }

--- a/lib/page/devices/views/usp_device_detail_view.dart
+++ b/lib/page/devices/views/usp_device_detail_view.dart
@@ -41,7 +41,8 @@ class UspDeviceDetailView extends ConsumerWidget {
                 AppGap.lg(),
                 AppButton.text(
                   label: 'Back to Devices',
-                  onTap: () => context.navigateBack(fallback: RouteNamed.uspDeviceList),
+                  onTap: () =>
+                      context.navigateBack(fallback: RouteNamed.uspDeviceList),
                 ),
               ],
             ),

--- a/lib/page/devices/views/usp_device_detail_view.dart
+++ b/lib/page/devices/views/usp_device_detail_view.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/route/navigation_extensions.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/_shared/models/device_ui_model.dart';
@@ -29,9 +29,7 @@ class UspDeviceDetailView extends ConsumerWidget {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspDeviceList),
+      backFallback: RouteNamed.uspDeviceList,
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: (childContext, constraints) {
         if (detail.device == null) {
@@ -43,9 +41,7 @@ class UspDeviceDetailView extends ConsumerWidget {
                 AppGap.lg(),
                 AppButton.text(
                   label: 'Back to Devices',
-                  onTap: () => context.canPop()
-                      ? context.pop()
-                      : context.goNamed(RouteNamed.uspDeviceList),
+                  onTap: () => context.navigateBack(fallback: RouteNamed.uspDeviceList),
                 ),
               ],
             ),

--- a/lib/page/devices/views/usp_device_list_view.dart
+++ b/lib/page/devices/views/usp_device_list_view.dart
@@ -41,9 +41,7 @@ class _UspDeviceListViewState extends ConsumerState<UspDeviceListView> {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspDashboard),
+      backFallback: RouteNamed.uspDashboard,
       onRefresh: () => ref.refresh(devicesDataProvider.future),
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: (childContext, constraints) {

--- a/lib/page/dhcp/views/usp_dhcp_detail_view.dart
+++ b/lib/page/dhcp/views/usp_dhcp_detail_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
@@ -36,9 +35,7 @@ class UspDhcpDetailView extends ConsumerWidget {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspMenu),
+      backFallback: RouteNamed.uspMenu,
       onRefresh: () async {
         ref.invalidate(dhcpDataProvider);
         ref.read(uspDhcpReservationsProvider.notifier).fetch(forceRemote: true);

--- a/lib/page/dmz/views/usp_dmz_view.dart
+++ b/lib/page/dmz/views/usp_dmz_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/dmz/models/dmz_feature_state.dart';
@@ -59,9 +58,7 @@ class _UspDmzViewState extends ConsumerState<UspDmzView> {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspMenu),
+      backFallback: RouteNamed.uspAdvancedSettings,
       onRefresh: () =>
           ref.read(uspDmzProvider.notifier).fetch(forceRemote: true),
       bottomBar: _buildBottomBar(context, ref, state),

--- a/lib/page/firewall/views/usp_firewall_view.dart
+++ b/lib/page/firewall/views/usp_firewall_view.dart
@@ -25,9 +25,7 @@ class UspFirewallView extends ConsumerWidget {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspMenu),
+      backFallback: RouteNamed.uspAdvancedSettings,
       onRefresh: () =>
           ref.read(uspFirewallProvider.notifier).fetch(forceRemote: true),
       bottomBar: _buildBottomBar(context, ref, state),

--- a/lib/page/instant_privacy/views/instant_privacy_view.dart
+++ b/lib/page/instant_privacy/views/instant_privacy_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/instant_privacy/models/instant_privacy_device_ui_model.dart';
@@ -27,9 +26,7 @@ class InstantPrivacyView extends ConsumerWidget {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspMenu),
+      backFallback: RouteNamed.uspMenu,
       onRefresh: () => ref.refresh(uspInstantPrivacyProvider.future),
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: (childContext, constraints) {

--- a/lib/page/instant_safety/views/instant_safety_view.dart
+++ b/lib/page/instant_safety/views/instant_safety_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/instant_safety/providers/instant_safety_provider.dart';
@@ -22,9 +21,7 @@ class UspInstantSafetyView extends ConsumerWidget {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspMenu),
+      backFallback: RouteNamed.uspMenu,
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: (childContext, constraints) {
         return asyncState.when(

--- a/lib/page/ipv6_port_service/views/usp_ipv6_port_service_view.dart
+++ b/lib/page/ipv6_port_service/views/usp_ipv6_port_service_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
@@ -27,9 +26,7 @@ class UspIpv6PortServiceView extends ConsumerWidget {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspMenu),
+      backFallback: RouteNamed.uspAdvancedSettings,
       onRefresh: () => ref
           .read(uspIpv6PortServiceProvider.notifier)
           .fetch(forceRemote: true),

--- a/lib/page/local_network/views/usp_local_network_view.dart
+++ b/lib/page/local_network/views/usp_local_network_view.dart
@@ -91,9 +91,7 @@ class _UspLocalNetworkViewState extends ConsumerState<UspLocalNetworkView> {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspMenu),
+      backFallback: RouteNamed.uspAdvancedSettings,
       onRefresh: () =>
           ref.read(uspLocalNetworkProvider.notifier).fetch(forceRemote: true),
       bottomBar: _buildBottomBar(context, ref, state),

--- a/lib/page/login/views/local_reset_router_password_view.dart
+++ b/lib/page/login/views/local_reset_router_password_view.dart
@@ -7,6 +7,7 @@ import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/components/views/arguments_view.dart';
 import 'package:privacy_gui/page/login/providers/router_password_provider.dart';
 import 'package:privacy_gui/route/constants.dart';
+import 'package:privacy_gui/route/navigation_extra.dart';
 import 'package:privacy_gui/validator_rules/rules.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
@@ -183,7 +184,8 @@ class _LocalResetRouterPasswordViewState
       dialogContent = loc(context).localResetRouterPasswordSuccessContent;
       actionTitle = loc(context).localResetRouterPasswordSuccessNext;
       action = () {
-        context.goNamed(RouteNamed.localLoginPassword, extra: {'reset': true});
+        context.goNamed(RouteNamed.localLoginPassword,
+            extra: NavigationExtra(data: {'reset': true}));
       };
     }).onError((error, stackTrace) {
       if (!mounted) return;

--- a/lib/page/login/views/local_router_recovery_view.dart
+++ b/lib/page/login/views/local_router_recovery_view.dart
@@ -6,6 +6,7 @@ import 'package:privacy_gui/components/styled/bottom_bar.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/page/login/providers/router_password_provider.dart';
 import 'package:privacy_gui/route/constants.dart';
+import 'package:privacy_gui/route/navigation_extra.dart';
 import 'package:privacy_gui/components/views/arguments_view.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
@@ -116,7 +117,7 @@ class _LocalRouterRecoveryViewState
         if (!mounted) return;
         context.pushNamed(
           RouteNamed.localPasswordReset,
-          extra: {'code': code},
+          extra: NavigationExtra(data: {'code': code}),
         );
       }
     });

--- a/lib/page/network_diagnostics/views/usp_network_diagnostics_view.dart
+++ b/lib/page/network_diagnostics/views/usp_network_diagnostics_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/core/usp/services/sse_operation_awaiter.dart';
@@ -38,9 +37,7 @@ class _UspNetworkDiagnosticsViewState
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspMenu),
+      backFallback: RouteNamed.uspAdvancedSettings,
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: (childContext, constraints) {
         return asyncState.when(

--- a/lib/page/port_forwarding/views/usp_port_forwarding_detail_view.dart
+++ b/lib/page/port_forwarding/views/usp_port_forwarding_detail_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
@@ -66,9 +65,7 @@ class _UspPortForwardingDetailViewState
         useMainPadding: false,
         showAppBarBorder: false,
         showTabBorder: false,
-        onBackTap: () => context.canPop()
-            ? context.pop()
-            : context.goNamed(RouteNamed.uspMenu),
+        backFallback: RouteNamed.uspAdvancedSettings,
         onRefresh: () => ref
             .read(uspPortForwardingPageProvider.notifier)
             .fetch(forceRemote: true),

--- a/lib/page/static_routing/views/usp_static_routing_view.dart
+++ b/lib/page/static_routing/views/usp_static_routing_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
@@ -27,9 +26,7 @@ class UspStaticRoutingView extends ConsumerWidget {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspMenu),
+      backFallback: RouteNamed.uspAdvancedSettings,
       onRefresh: () =>
           ref.read(uspStaticRoutingProvider.notifier).fetch(forceRemote: true),
       bottomBar: _buildBottomBar(context, ref, state),

--- a/lib/page/statistics/views/usp_statistics_view.dart
+++ b/lib/page/statistics/views/usp_statistics_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/shell/usp_top_bar.dart';
@@ -47,9 +46,7 @@ class _UspStatisticsViewState extends ConsumerState<UspStatisticsView>
         useMainPadding: false,
         showAppBarBorder: false,
         showTabBorder: false,
-        onBackTap: () => context.canPop()
-            ? context.pop()
-            : context.goNamed(RouteNamed.uspMenu),
+        backFallback: RouteNamed.uspMenu,
         tabs: const [
           Tab(text: 'Network'),
           Tab(text: 'Devices'),

--- a/lib/page/system_log/views/usp_system_log_view.dart
+++ b/lib/page/system_log/views/usp_system_log_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/shell/usp_top_bar.dart';
@@ -22,9 +21,7 @@ class UspSystemLogView extends ConsumerWidget {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspMenu),
+      backFallback: RouteNamed.uspMenu,
       onRefresh: () => ref.refresh(uspSystemLogProvider.future),
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: (childContext, constraints) {

--- a/lib/page/test_console/views/usp_test_console_view.dart
+++ b/lib/page/test_console/views/usp_test_console_view.dart
@@ -4,7 +4,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/route/navigation_extensions.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/core/usp/providers/sse_providers.dart';
@@ -639,9 +639,7 @@ class _UspTestConsoleViewState extends ConsumerState<UspTestConsoleView> {
         children: [
           AppIconButton(
             icon: AppIcon.font(Icons.arrow_back),
-            onTap: () => context.canPop()
-                ? context.pop()
-                : context.goNamed(RouteNamed.uspMenu),
+            onTap: () => context.navigateBack(fallback: RouteNamed.uspMenu),
           ),
           AppGap.md(),
           Expanded(

--- a/lib/page/topology/views/usp_node_detail_view.dart
+++ b/lib/page/topology/views/usp_node_detail_view.dart
@@ -42,7 +42,8 @@ class UspNodeDetailView extends ConsumerWidget {
                 AppGap.lg(),
                 AppButton.text(
                   label: 'Back to Topology',
-                  onTap: () => context.navigateBack(fallback: RouteNamed.uspTopology),
+                  onTap: () =>
+                      context.navigateBack(fallback: RouteNamed.uspTopology),
                 ),
               ],
             ),

--- a/lib/page/topology/views/usp_node_detail_view.dart
+++ b/lib/page/topology/views/usp_node_detail_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/route/navigation_extensions.dart';
 import 'package:privacy_gui/core/utils/device_image_helper.dart';
 import 'package:privacy_gui/core/utils/icon_rules.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
@@ -29,9 +30,7 @@ class UspNodeDetailView extends ConsumerWidget {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspTopology),
+      backFallback: RouteNamed.uspTopology,
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: (childContext, constraints) {
         if (detail.node == null) {
@@ -43,9 +42,7 @@ class UspNodeDetailView extends ConsumerWidget {
                 AppGap.lg(),
                 AppButton.text(
                   label: 'Back to Topology',
-                  onTap: () => context.canPop()
-                      ? context.pop()
-                      : context.goNamed(RouteNamed.uspTopology),
+                  onTap: () => context.navigateBack(fallback: RouteNamed.uspTopology),
                 ),
               ],
             ),

--- a/lib/page/topology/views/usp_topology_view.dart
+++ b/lib/page/topology/views/usp_topology_view.dart
@@ -28,9 +28,7 @@ class UspTopologyView extends ConsumerWidget {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      onBackTap: () => context.canPop()
-          ? context.pop()
-          : context.goNamed(RouteNamed.uspDashboard),
+      backFallback: RouteNamed.uspDashboard,
       onRefresh: () => ref.refresh(devicesDataProvider.future),
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: (childContext, constraints) {

--- a/lib/page/wifi_settings/views/usp_wifi_settings_view.dart
+++ b/lib/page/wifi_settings/views/usp_wifi_settings_view.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/route/navigation_extensions.dart';
 import 'package:privacy_gui/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/shell/usp_top_bar.dart';
@@ -116,9 +116,7 @@ class _UspWifiSettingsViewState extends ConsumerState<UspWifiSettingsView>
       children: [
         AppIconButton(
           icon: const AppIcon.font(Icons.arrow_back),
-          onTap: () => context.canPop()
-              ? context.pop()
-              : context.goNamed(RouteNamed.uspMenu),
+          onTap: () => context.navigateBack(fallback: RouteNamed.uspMenu),
         ),
         AppGap.md(),
         Expanded(

--- a/lib/route/navigation_extensions.dart
+++ b/lib/route/navigation_extensions.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/route/navigation_extra.dart';
+
+extension NavigationExtension on BuildContext {
+  void navigateBack({String? fallback}) {
+    if (canPop()) {
+      pop();
+      return;
+    }
+    final extra = GoRouterState.of(this).extra;
+    if (extra is NavigationExtra && extra.backDestination != null) {
+      goNamed(extra.backDestination!);
+      return;
+    }
+    if (fallback != null) {
+      goNamed(fallback);
+    }
+  }
+}

--- a/lib/route/navigation_extra.dart
+++ b/lib/route/navigation_extra.dart
@@ -1,0 +1,9 @@
+import 'package:privacy_gui/components/styled/menus/menu_consts.dart';
+
+class NavigationExtra {
+  final NaviType? naviType;
+  final String? backDestination;
+  final Map<String, dynamic>? data;
+
+  const NavigationExtra({this.naviType, this.backDestination, this.data});
+}

--- a/lib/route/route_local_login.dart
+++ b/lib/route/route_local_login.dart
@@ -13,7 +13,10 @@ final localLoginRoute = LinksysRoute(
   config: LinksysRouteConfig(column: ColumnGrid(column: 12), noNaviRail: true),
   builder: (context, state) => LoginLocalView(
     args: <String, dynamic>{}
-      ..addAll(state.extra as Map<String, dynamic>? ?? <String, dynamic>{})
+      ..addAll((state.extra is NavigationExtra
+              ? (state.extra as NavigationExtra).data
+              : state.extra as Map<String, dynamic>?) ??
+          <String, dynamic>{})
       ..addAll(state.uri.queryParameters),
   ),
   routes: [
@@ -28,7 +31,10 @@ final localLoginRoute = LinksysRoute(
           path: RoutePath.localPasswordReset,
           config: const LinksysRouteConfig(noNaviRail: true),
           builder: (context, state) => LocalResetRouterPasswordView(
-            args: state.extra as Map<String, dynamic>? ?? {},
+            args: (state.extra is NavigationExtra
+                    ? (state.extra as NavigationExtra).data
+                    : state.extra as Map<String, dynamic>?) ??
+                {},
           ),
         ),
       ],

--- a/lib/route/router_provider.dart
+++ b/lib/route/router_provider.dart
@@ -18,6 +18,7 @@ import 'package:privacy_gui/route/route_model.dart';
 import 'package:privacy_gui/route/router_logger.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'constants.dart';
+import 'navigation_extra.dart';
 
 // USP dashboard imports
 import 'package:privacy_gui/page/dashboard/views/usp_dashboard_view.dart';


### PR DESCRIPTION
## Summary
- Unified `extra` parameter type across all navigation calls into `NavigationExtra` (naviType + backDestination + data)
- Added `navigateBack()` extension with 3-tier priority: pop → backDestination → fallback
- Added `backFallback` parameter to `UiKitPageView` to centralize default back behavior
- Fixed Advanced Settings sub-pages to use `pushNamed` consistently, correcting fallback destinations

Closes #714

## Test plan
- [ ] Menu → Advanced Settings → Firewall → back → returns to Advanced Settings
- [ ] Menu → Advanced Settings → Internet Settings → back → returns to Advanced Settings
- [ ] Dashboard → Device List → Device Detail → back → returns to Device List
- [ ] Topology → Node Detail → back → returns to Topology
- [ ] Bottom tab switching → tab highlighting works correctly
- [ ] Login → Forgot Password → Recovery → Reset → flow works normally
- [ ] Deep link directly to a sub-page → back falls back to correct parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)