### PR TITLE
fix: dashboard loading resilience, edit mode resize & SSE banner

### DIFF
--- a/lib/demo/providers/demo_overrides.dart
+++ b/lib/demo/providers/demo_overrides.dart
@@ -92,12 +92,15 @@ class _DemoAuthNotifier extends AuthNotifier {
   @override
   Future<AuthState?> init() async {
     debugPrint('Demo: Auth init called - preserving local login');
-    final demoState = AuthState(
-      loginType: LoginType.local,
-      localPassword: 'demo-password',
-    );
-    state = AsyncValue.data(demoState);
-    return demoState;
+    // Use AsyncValue.guard to match base class pattern — the `await` ensures
+    // the state assignment happens after a microtask boundary, avoiding the
+    // "Tried to modify a provider while the widget tree was building" error
+    // when init() is called from go_router redirect during build phase.
+    state = await AsyncValue.guard(() async => AuthState(
+          loginType: LoginType.local,
+          localPassword: 'demo-password',
+        ));
+    return state.value;
   }
 
   @override

--- a/lib/page/_shared/components/sse_connection_banner.dart
+++ b/lib/page/_shared/components/sse_connection_banner.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/usp/providers/sse_providers.dart';
@@ -11,27 +13,84 @@ import 'package:ui_kit_library/ui_kit.dart';
 /// - **suspended / disconnected** (non-intentional): danger banner with
 ///   a "Reconnect" button that calls [SseConnectionManager.tryReconnect]
 ///
+/// Uses a grace period ([_graceDelay]) before showing the banner to avoid
+/// flickering during brief reconnection cycles.
+///
 /// Place this at the top of [UspDashboardShell] body so it spans all pages.
-class SseConnectionBanner extends ConsumerWidget {
+class SseConnectionBanner extends ConsumerStatefulWidget {
   const SseConnectionBanner({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final stateAsync = ref.watch(sseConnectionStateProvider);
+  ConsumerState<SseConnectionBanner> createState() =>
+      _SseConnectionBannerState();
+}
 
-    return stateAsync.when(
-      data: (state) => _buildBanner(context, ref, state),
-      loading: () => const SizedBox.shrink(),
-      error: (_, __) => const SizedBox.shrink(),
-    );
+class _SseConnectionBannerState extends ConsumerState<SseConnectionBanner> {
+  /// Grace period before showing the banner. If SSE reconnects within this
+  /// window the banner never appears, preventing visual flickering.
+  static const _graceDelay = Duration(seconds: 3);
+
+  /// The state currently displayed in the banner (null = hidden).
+  SseConnectionState? _visibleState;
+  Timer? _graceTimer;
+
+  @override
+  void dispose() {
+    _graceTimer?.cancel();
+    super.dispose();
   }
 
-  Widget _buildBanner(
-      BuildContext context, WidgetRef ref, SseConnectionState state) {
-    if (state == SseConnectionState.connected) {
-      return const SizedBox.shrink();
+  @override
+  Widget build(BuildContext context) {
+    final stateAsync = ref.watch(sseConnectionStateProvider);
+
+    stateAsync.whenData((realState) {
+      _reconcile(realState);
+    });
+
+    final state = _visibleState;
+    if (state == null) return const SizedBox.shrink();
+    return _buildBanner(context, state);
+  }
+
+  /// Reconciles the real SSE state with what the banner displays, applying
+  /// the grace period for non-connected states.
+  void _reconcile(SseConnectionState realState) {
+    if (realState == SseConnectionState.connected) {
+      // Recovered — hide immediately and cancel any pending show.
+      _graceTimer?.cancel();
+      _graceTimer = null;
+      if (_visibleState != null) {
+        setState(() => _visibleState = null);
+      }
+      return;
     }
 
+    // Non-connected state: start grace timer if not already ticking.
+    // Suspended/disconnected bypass the grace period (already severe).
+    final isSevere = realState == SseConnectionState.suspended ||
+        realState == SseConnectionState.disconnected;
+
+    if (isSevere) {
+      _graceTimer?.cancel();
+      _graceTimer = null;
+      if (_visibleState != realState) {
+        setState(() => _visibleState = realState);
+      }
+      return;
+    }
+
+    // connecting / reconnecting — wait for grace period before showing.
+    if (_graceTimer != null) return; // already waiting
+    _graceTimer = Timer(_graceDelay, () {
+      _graceTimer = null;
+      if (mounted) {
+        setState(() => _visibleState = realState);
+      }
+    });
+  }
+
+  Widget _buildBanner(BuildContext context, SseConnectionState state) {
     final appColors = Theme.of(context).extension<AppColorScheme>();
     final isSevere = state == SseConnectionState.suspended ||
         state == SseConnectionState.disconnected;

--- a/lib/page/_shared/components/sse_connection_banner.dart
+++ b/lib/page/_shared/components/sse_connection_banner.dart
@@ -35,6 +35,15 @@ class _SseConnectionBannerState extends ConsumerState<SseConnectionBanner> {
   Timer? _graceTimer;
 
   @override
+  void initState() {
+    super.initState();
+    // Listen outside build() so setState() never fires during the build phase.
+    ref.listenManual(sseConnectionStateProvider, (prev, next) {
+      next.whenData(_reconcile);
+    });
+  }
+
+  @override
   void dispose() {
     _graceTimer?.cancel();
     super.dispose();
@@ -42,11 +51,9 @@ class _SseConnectionBannerState extends ConsumerState<SseConnectionBanner> {
 
   @override
   Widget build(BuildContext context) {
-    final stateAsync = ref.watch(sseConnectionStateProvider);
-
-    stateAsync.whenData((realState) {
-      _reconcile(realState);
-    });
+    // Keep the watch so the widget rebuilds when the provider emits, but
+    // all state reconciliation happens in the listenManual callback above.
+    ref.watch(sseConnectionStateProvider);
 
     final state = _visibleState;
     if (state == null) return const SizedBox.shrink();

--- a/lib/page/dashboard/orchestrator/dashboard_orchestrator.dart
+++ b/lib/page/dashboard/orchestrator/dashboard_orchestrator.dart
@@ -9,6 +9,7 @@ import 'package:privacy_gui/page/_shared/models/system_monitor_state.dart';
 import 'package:privacy_gui/page/_shared/providers/usp_system_monitor_notifier.dart';
 import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
 import 'package:privacy_gui/page/local_network/providers/ethernet_data_provider.dart';
+import 'package:privacy_gui/page/wifi_settings/providers/wifi_data_provider.dart';
 import 'package:privacy_gui/core/usp/providers/sse_providers.dart';
 import 'package:privacy_gui/core/usp/providers/usp_auth_coordinator.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
@@ -132,8 +133,40 @@ class DashboardOrchestrator extends AsyncNotifier<DashboardOrchestratorState> {
       }),
     );
 
+    // Delayed retry: if domain providers failed (e.g. bridge 503 on startup),
+    // invalidate them after a delay so they re-fetch once the bridge is ready.
+    _scheduleProviderRetry();
+
     return DashboardOrchestratorState(
       isAuthenticated: usp.isAuthenticated,
     );
+  }
+
+  /// Checks domain providers after a delay and invalidates any that are in
+  /// error state. This handles the startup race where the bridge is
+  /// temporarily unavailable (503) and providers fail before SSE connects.
+  void _scheduleProviderRetry() {
+    const retryDelay = Duration(seconds: 5);
+    final providers = [
+      ('systemInfo', systemInfoDataProvider),
+      ('devices', devicesDataProvider),
+      ('ethernet', ethernetDataProvider),
+      ('wifi', wifiDataProvider),
+    ];
+
+    Future.delayed(retryDelay, () {
+      final failed = <String>[];
+      for (final (name, provider) in providers) {
+        final state = ref.read(provider);
+        if (state.hasError) {
+          failed.add(name);
+          ref.invalidate(provider);
+        }
+      }
+      if (failed.isNotEmpty) {
+        logger.d('[USP][Orchestrator] Retrying failed providers: '
+            '${failed.join(', ')}');
+      }
+    });
   }
 }

--- a/lib/page/dashboard/orchestrator/dashboard_orchestrator.dart
+++ b/lib/page/dashboard/orchestrator/dashboard_orchestrator.dart
@@ -9,7 +9,6 @@ import 'package:privacy_gui/page/_shared/models/system_monitor_state.dart';
 import 'package:privacy_gui/page/_shared/providers/usp_system_monitor_notifier.dart';
 import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
 import 'package:privacy_gui/page/local_network/providers/ethernet_data_provider.dart';
-import 'package:privacy_gui/page/wifi_settings/providers/wifi_data_provider.dart';
 import 'package:privacy_gui/core/usp/providers/sse_providers.dart';
 import 'package:privacy_gui/core/usp/providers/usp_auth_coordinator.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
@@ -56,8 +55,12 @@ final dashboardOrchestratorProvider =
 );
 
 class DashboardOrchestrator extends AsyncNotifier<DashboardOrchestratorState> {
+  Timer? _retryTimer;
+
   @override
   Future<DashboardOrchestratorState> build() async {
+    ref.onDispose(() => _retryTimer?.cancel());
+
     try {
       return await _buildImpl();
     } catch (e, st) {
@@ -146,15 +149,21 @@ class DashboardOrchestrator extends AsyncNotifier<DashboardOrchestratorState> {
   /// error state. This handles the startup race where the bridge is
   /// temporarily unavailable (503) and providers fail before SSE connects.
   void _scheduleProviderRetry() {
+    // Cancel any previously scheduled retry (e.g. from refreshAll re-build).
+    _retryTimer?.cancel();
+
     const retryDelay = Duration(seconds: 5);
+    // Only retry providers that were already triggered in _buildImpl().
+    // wifiDataProvider is not eagerly triggered here — it starts lazily via
+    // devicesDataProvider's soft dependency or the WiFi settings page.
     final providers = [
       ('systemInfo', systemInfoDataProvider),
       ('devices', devicesDataProvider),
       ('ethernet', ethernetDataProvider),
-      ('wifi', wifiDataProvider),
     ];
 
-    Future.delayed(retryDelay, () {
+    _retryTimer = Timer(retryDelay, () {
+      _retryTimer = null;
       final failed = <String>[];
       for (final (name, provider) in providers) {
         final state = ref.read(provider);

--- a/lib/page/dashboard/views/usp_sliver_dashboard_view.dart
+++ b/lib/page/dashboard/views/usp_sliver_dashboard_view.dart
@@ -431,8 +431,8 @@ class _UspSliverDashboardViewState
           fit: StackFit.expand,
           clipBehavior: Clip.none,
           children: [
-            AbsorbPointer(
-              absorbing: true,
+            IgnorePointer(
+              ignoring: true,
               child: displayedWidget,
             ),
             if (canHide)

--- a/lib/page/devices/providers/devices_data_provider.dart
+++ b/lib/page/devices/providers/devices_data_provider.dart
@@ -134,8 +134,19 @@ class DevicesDataNotifier extends AsyncNotifier<DevicesData> {
       }
     }
 
-    // Read WiFi enrichment data from domain provider
-    final wifiData = await ref.read(wifiDataProvider.future);
+    // Read WiFi enrichment data — soft dependency with timeout.
+    // If wifiDataProvider is in error (e.g. bridge 503 on startup), use
+    // fallback empty data so devices still load. The WiFi listener in build()
+    // will rebuild deviceModels when WiFi data arrives later.
+    WifiData wifiData;
+    try {
+      wifiData = await ref
+          .read(wifiDataProvider.future)
+          .timeout(const Duration(seconds: 10));
+    } catch (e) {
+      logger.w('[USP][DevicesData] WiFi data unavailable, using fallback: $e');
+      wifiData = const WifiData.empty();
+    }
 
     // Read system info for gateway name + node model building
     final sysData = ref.read(systemInfoDataProvider).valueOrNull;

--- a/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
+++ b/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
@@ -78,8 +78,20 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
 
     logger.d('[USP][WiFi]Fetching WiFi data...');
 
-    // Read from WiFi Data Provider (Layer 1) to avoid duplicate fetch
-    final wifiData = await ref.read(wifiDataProvider.future);
+    // Read from WiFi Data Provider (Layer 1) to avoid duplicate fetch.
+    // wifiDataProvider may throw (e.g. TimeoutException when the bridge is
+    // temporarily unavailable). Catch and return error status so the UI exits
+    // loading and displays the error instead of hanging.
+    final WifiData wifiData;
+    try {
+      wifiData = await ref.read(wifiDataProvider.future);
+    } catch (e) {
+      logger.w('[USP][WiFi] WiFi data fetch failed: $e');
+      return (
+        null,
+        WifiSettingsStatus(errorMessage: 'WiFi data unavailable'),
+      );
+    }
     final (:radios, :ssids, :accessPoints) = wifiData.codegenContext.raw;
 
     final networks = _svc.buildWifiNetworks(

--- a/lib/page/wifi_settings/providers/wifi_data_provider.dart
+++ b/lib/page/wifi_settings/providers/wifi_data_provider.dart
@@ -119,13 +119,14 @@ class WifiDataNotifier extends AsyncNotifier<WifiData> {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) throw StateError('USP service not available');
 
-    // Parallel fetch all WiFi data
+    // Parallel fetch all WiFi data (15s timeout prevents indefinite hang
+    // when the bridge is temporarily unavailable, e.g. 503 on startup)
     final results = await Future.wait([
       WiFiRadios.fetch(usp),
       WiFiSsids.fetch(usp),
       WiFiAccessPoints.fetch(usp),
       fetchWifiClients(usp),
-    ]);
+    ]).timeout(const Duration(seconds: 15));
 
     final radios = results[0] as WiFiRadios;
     final ssids = results[1] as WiFiSsids;


### PR DESCRIPTION
## Summary
- **Edit mode resize**: `AbsorbPointer` → `IgnorePointer` so `DashboardOverlay` receives pointer move/up events for resize handles
- **Dashboard skeleton stuck**: `devicesDataProvider` no longer hard-blocks on `wifiDataProvider.future`; uses 10s timeout + fallback empty data. WiFi listener rebuilds models when data arrives later
- **WiFi fetch timeout**: `Future.wait` in `wifiDataProvider` now has 15s timeout to prevent indefinite hang on bridge 503
- **Orchestrator retry**: 5s delayed check invalidates domain providers stuck in error state after bridge startup race
- **SSE banner grace period**: 3s debounce before showing connecting/reconnecting banner, preventing flicker during brief reconnection cycles. Severe states (suspended/disconnected) still show immediately

## Test plan
- [ ] Hot restart with bridge temporarily unavailable → dashboard cards load progressively instead of staying skeleton
- [ ] Edit mode → drag resize handle on card → card resizes correctly
- [ ] SSE brief disconnect/reconnect → banner does not flicker
- [ ] SSE suspended (bridge down >30s) → banner appears immediately with Reconnect button
- [ ] Pull-to-refresh → all cards reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)