### PR TITLE
test: framework Preservable mixin 100% coverage

### DIFF
--- a/doc/usp/unit-test-coverage-plan.md
+++ b/doc/usp/unit-test-coverage-plan.md
@@ -1,0 +1,269 @@
+# Unit Test Coverage Expansion Plan
+
+## Context
+
+Issue #704 identifies critical test coverage gaps: **28 test files / ~223 testable source files = ~12% file coverage**. The project has well-structured, testable architecture (thin services over codegen, uniform notifier mixin, Riverpod DI) but most business logic is untested.
+
+**Already tested**: SSE module (#726, 179 tests), Dashboard Custom Layout (#724, 293 tests), WiFi/Internet settings services, Preservable framework basics, theme/validator utilities.
+
+**Goal**: Systematically cover all untested service, notifier, framework, and provider layers to reach **~60%+ file coverage** with ~446 new tests across ~42 new/modified test files.
+
+---
+
+## Current Coverage Snapshot
+
+| Layer | Total Files | Tested | Gap |
+|-------|:-----------:|:------:|:---:|
+| Core USP (SSE/Bridge) | 27 | 11 | Stubs/platform-only remaining |
+| Page Services | 18 | 2 | **16 untested** |
+| Notifiers (Pattern A: Preservable) | 9 | 0 | **9 untested** |
+| Notifiers (Pattern B: AsyncNotifier) | 7 | 0 | **7 untested** |
+| Shared Data Providers | 6 | 0 | **6 untested** |
+| Framework (Preservable mixin) | 5 | 1 (partial) | **4 missing paths** |
+| Auth System | 6 | 0 | **6 untested** |
+| Generated Transforms | 1 | 0 | **1 untested** |
+
+---
+
+## Architecture Quick Reference
+
+### Service Pattern (Layer 1)
+```dart
+class UspXxxService {
+  final UspService _usp;
+  Future<(XxxSettings, XxxStatus)> fetch() async {
+    final data = await XxxCodegen.fetch(_usp);  // codegen static call
+    return (buildSettings(data), buildStatus(data));
+  }
+  Future<void> save(...) async { ... }           // codegen CRUD
+  XxxUIModel buildUIModel(XxxCodegen data) { ... } // transform
+  Map<String, String> validateForm(...) { ... }    // validation
+}
+```
+
+### Notifier Pattern A: Preservable (Layer 2)
+```dart
+class UspXxxNotifier extends AutoDisposeNotifier<XxxFeatureState>
+    with PreservableAutoDisposeNotifierMixin<...> {
+  build() { listen(sseInvalidationProvider); Future.microtask(() => fetch()); }
+  performFetch() → calls service.fetch()
+  performSave() → calls service.save/add/update/delete
+  updateSetting() → synchronous UI mutation + validation
+}
+```
+
+### Notifier Pattern B: Simple AsyncNotifier (Layer 2)
+Direct `state = AsyncValue.data(...)`, no FeatureState/Preservable.
+
+---
+
+## Phases
+
+### Phase 0: Shared Test Infrastructure
+**Goal**: Consolidate reusable mocks and fixture factories.
+
+| File | Purpose |
+|------|---------|
+| `test/shared/mocks.dart` | Re-export `MockUspService` from `test/core/usp/mocks.dart`; add service mocks (`MockUspDmzService`, `MockUspFirewallService`, etc.) for notifier tests |
+| `test/shared/fixtures.dart` | Factory functions for codegen data classes with sensible defaults: `makeDmzEntry()`, `makeFirewallChainRule()`, `makeDhcpReservation()`, etc. |
+
+**Tests**: 0 (infrastructure only)
+
+---
+
+### Phase 1: Framework Mixin Gap Coverage
+**Goal**: Cover 4 missing `_PreservableDelegate` paths. Highest leverage — benefits all 9 Pattern A notifiers.
+
+**File**: `test/framework/preservable_test.dart` (modify existing)
+
+| # | Test | Target Code |
+|---|------|-------------|
+| 1-2 | `fetch(updateStatusOnly: true)` updates status only, settings unchanged | delegate:57-61 |
+| 3-4 | `onSseInvalidation()` skips fetch when dirty, fetches when clean | delegate:95-102 |
+| 5-6 | `performFetch` returns `(null, errorStatus)` — status updates, settings unchanged | delegate:72-74 |
+| 7-8 | `save()` re-fetch failure — save still marked clean, error propagated | delegate:84-88 |
+| 9-10 | `fetch(forceRemote: true)` with both settings+status returned | delegate:65-69 |
+
+**Tests**: ~10
+
+---
+
+### Phase 2: Simple Services (5 services, quick wins)
+
+| Service | File | Lines | Key Tests | Est. Tests |
+|---------|------|:-----:|-----------|:----------:|
+| **UspDmzService** | `test/page/dmz/services/usp_dmz_service_test.dart` | 117 | buildUIModel (empty/single/sourceType), validateForm (5 rules), add/update codegen calls | 12 |
+| **UspAdminService** | `test/page/admin/services/usp_admin_service_test.dart` | 66 | fetchAdmin (find admin user, fallback), updatePassword, buildTimeSettingsUIModel | 6 |
+| **UspSystemLogService** | `test/page/system_log/services/usp_system_log_service_test.dart` | 35 | fetch mapping, empty input, multiple items | 3 |
+| **UspInstantSafetyService** | `test/page/instant_safety/services/usp_instant_safety_service_test.dart` | 63 | detectType (openDNS/off), dnsValueForType, save | 6 |
+| **UspDhcpService** | `test/page/dhcp/services/usp_dhcp_service_test.dart` | 103 | fetchReservations mapping, saveBatch (delete/add/update/mixed/no-change) | 10 |
+
+**Tests**: ~37
+
+---
+
+### Phase 3: Medium Services (5 services, meaningful logic)
+
+| Service | File | Lines | Key Tests | Est. Tests |
+|---------|------|:-----:|-----------|:----------:|
+| **UspFirewallService** | `test/page/firewall/services/usp_firewall_service_test.dart` | 220 | parseFirewallRules (desc→key), buildUIModel (Accept inversion, Drop passthrough, missing rules), buildSetPayload (paired rules: SPI×2, IPSec×2; single rules; no-change) | 18 |
+| **UspStaticRoutingService** | `test/page/static_routing/services/usp_static_routing_service_test.dart` | 174 | buildRouteUIModels (origin filter, interface→display), validateRoute (7+ rules), saveBatch | 16 |
+| **UspIpv6PortServiceService** | `test/page/ipv6_port_service/services/usp_ipv6_port_service_service_test.dart` | 212 | buildRuleUIModels (ipVersion/target filter, IANA→display), validateRule (6+ rules), saveBatch | 18 |
+| **UspPortForwardingService** | `test/page/port_forwarding/services/usp_port_forwarding_service_test.dart` | 196 | saveForwardingBatch, saveTriggeringBatch (parent+child add ordering) | 12 |
+| **InstantPrivacyService** | `test/page/instant_privacy/services/instant_privacy_service_test.dart` | 230 | activeDevices filter, isEnabled logic, allowedDevices parsing, buildEnable/DisableUpdates, validateMac, normalizeMac | 16 |
+
+**Tests**: ~80
+
+---
+
+### Phase 4: Complex Services (3 large services)
+
+| Service | File | Lines | Key Tests | Est. Tests |
+|---------|------|:-----:|-----------|:----------:|
+| **UspLocalNetworkService** | `test/page/local_network/services/usp_local_network_service_test.dart` | 276 | DNS parsing, leaseTime conversion, 8+ validation methods, lockedOctetCount, syncPrefix, save diff logic | 30 |
+| **UspDeviceService** | `test/page/_shared/services/usp_device_service_test.dart` | 502 | 12+ build methods (systemInfo, firmwareImages, devices, wifiRadios, dhcpClients, dhcpReservations, portForwarding, lanInfo, wanStatus, ethernetPorts, nodes) | 35 |
+| **WiFiChannelBonding** | `test/page/wifi_settings/services/wifi_channel_bonding_test.dart` | 288 | computeChannelsPerBandwidth (2.4/5/6 GHz × each width), maxBandwidthForStandards, minStandardForBandwidth | 25 |
+
+**Tests**: ~90
+
+---
+
+### Phase 5: Generated Transforms
+**File**: `test/generated/transforms_test.dart`
+
+| Function | Tests |
+|----------|:-----:|
+| cidrToNetmask (bounds, edge cases) | 4 |
+| formatBandwidth (Mbps/Gbps transition) | 3 |
+| formatDuration (h+m+s combos) | 3 |
+| formatBytes (B→TB transitions) | 3 |
+| formatPercent, formatNumber, formatSpeed | 6 |
+| hexDecode, durationSeconds/Ms | 6 |
+
+**Tests**: ~25
+
+---
+
+### Phase 6: Auth System
+
+| File | Tests | Key Tests |
+|------|:-----:|-----------|
+| `test/providers/auth/auth_service_test.dart` | 10 | getStoredLocalPassword, getStoredLoginType, saveLocalPassword, clearAllCredentials (happy + error paths) |
+| `test/providers/auth/auth_result_test.dart` | 8 | AuthSuccess/AuthFailure when/map dispatch, isSuccess/isFailure, equality |
+| `test/providers/auth/auth_state_test.dart` | 6 | empty(), copyWith, fromJson, Equatable |
+
+**Tests**: ~24
+
+---
+
+### Phase 7: Notifiers — Pattern A (9 Preservable notifiers)
+
+Each notifier test follows a uniform template (~9 tests each):
+1. `build()` returns initial loading state
+2. `performFetch()` calls service.fetch(), maps result
+3. `performFetch()` error → `(null, errorStatus)` path
+4. `performSave()` calls correct service methods from current state
+5. `updateSetting()` mutations + validation wiring
+6. SSE invalidation domain wiring (correct domain triggers `onSseInvalidation`)
+7. Feature-specific mutations (add/edit/toggle/delete for list-based features)
+
+| Notifier | File | Differentiator |
+|----------|------|---------------|
+| UspDmzNotifier | `test/page/dmz/providers/usp_dmz_notifier_test.dart` | isNewEntry → add vs update |
+| UspFirewallNotifier | `test/page/firewall/providers/usp_firewall_notifier_test.dart` | reads from firewallDataProvider |
+| UspDhcpReservationsNotifier | `test/page/dhcp/providers/usp_dhcp_reservations_notifier_test.dart` | list add/edit/toggle/delete |
+| UspStaticRoutingNotifier | `test/page/static_routing/providers/usp_static_routing_notifier_test.dart` | list mutations |
+| UspIpv6PortServiceNotifier | `test/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier_test.dart` | list + validation |
+| UspLocalNetworkNotifier | `test/page/local_network/providers/usp_local_network_notifier_test.dart` | cascade validation |
+| UspPortForwardingNotifier | `test/page/port_forwarding/providers/usp_port_forwarding_notifier_test.dart` | forwarding + triggering tabs |
+| UspInternetSettingsNotifier | `test/page/internet_settings/providers/usp_internet_settings_notifier_test.dart` | WAN type switch |
+| UspWifiSettingsNotifier | `test/page/wifi_settings/providers/usp_wifi_settings_notifier_test.dart` | multi-AP config |
+
+**Tests**: ~85
+
+---
+
+### Phase 8: Notifiers — Pattern B (7 Simple AsyncNotifiers)
+
+| Notifier | File | Key Tests | Est. Tests |
+|----------|------|-----------|:----------:|
+| UspAdminNotifier | `test/page/admin/providers/usp_admin_notifier_test.dart` | fetch admin+time, setPassword, reboot | 8 |
+| InstantPrivacyNotifier | `test/page/instant_privacy/providers/instant_privacy_notifier_test.dart` | enable/disable/addMac, optimistic UI, error rollback | 10 |
+| NetworkDiagnosticsNotifier | `test/page/network_diagnostics/providers/usp_network_diagnostics_notifier_test.dart` | runPing/Traceroute with mock awaiter, timeout | 12 |
+| SystemLogNotifier | `test/page/system_log/providers/usp_system_log_notifier_test.dart` | simple fetch | 3 |
+| SystemMonitorNotifier | `test/page/_shared/providers/usp_system_monitor_notifier_test.dart` | ring buffer, CPU/memory %, timer lifecycle | 10 |
+| TrafficAnalysisNotifier | `test/page/_shared/providers/usp_traffic_analysis_notifier_test.dart` | rate from deltas, counter wraparound, ring buffer | 10 |
+| DeviceAnalyticsNotifier | `test/page/_shared/providers/usp_device_analytics_notifier_test.dart` | distribution, hourly aggregate, 24h pruning | 7 |
+
+**Tests**: ~60
+
+---
+
+### Phase 9: Shared Data Providers
+
+| Provider | File | Key Tests | Est. Tests |
+|----------|------|-----------|:----------:|
+| DhcpDataNotifier | `test/page/local_network/providers/dhcp_data_provider_test.dart` | dual fetch, hostname enrichment, mutations, SSE debounce | 10 |
+| LanDataNotifier | `test/page/local_network/providers/lan_data_provider_test.dart` | fetch + IPv6 fallback | 4 |
+| EthernetDataNotifier | `test/page/local_network/providers/ethernet_data_provider_test.dart` | bridge port classification | 5 |
+| TimeDataNotifier | `test/page/admin/providers/time_data_provider_test.dart` | fetch + updateTimezone | 5 |
+| SystemInfoDataNotifier | `test/page/admin/providers/system_info_data_provider_test.dart` | fetch + firmware assembly | 5 |
+| DevicesDataNotifier | `test/page/devices/providers/devices_data_provider_test.dart` | complex aggregation | 6 |
+
+**Tests**: ~35
+
+---
+
+## Summary
+
+| Phase | Scope | New Files | Tests | Dependency |
+|-------|-------|:---------:|:-----:|:----------:|
+| 0 | Shared infrastructure | 2 | 0 | — |
+| 1 | Framework mixin gaps | 0 (modify) | 10 | Phase 0 |
+| 2 | Simple services (5) | 5 | 37 | Phase 0 |
+| 3 | Medium services (5) | 5 | 80 | Phase 0 |
+| 4 | Complex services (3) | 3 | 90 | Phase 0 |
+| 5 | transforms.g.dart | 1 | 25 | — |
+| 6 | Auth system | 3 | 24 | Phase 0 |
+| 7 | Notifiers Pattern A (9) | 9 | 85 | Phase 2-4 |
+| 8 | Notifiers Pattern B (7) | 7 | 60 | Phase 0 |
+| 9 | Shared data providers | 6 | 35 | Phase 2-4 |
+| **Total** | | **~41 files** | **~446** | |
+
+### Execution Order (recommended)
+
+```
+Phase 0 → Phase 1 → Phase 2 → Phase 5 → Phase 3 → Phase 6 → Phase 4 → Phase 7 → Phase 8 → Phase 9
+```
+
+Phases 1-6 have no cross-dependencies (only depend on Phase 0). Phases 7-9 depend on service tests being established.
+
+### Parallelizable Groups
+- **Group A** (independent): Phase 1, Phase 5, Phase 6
+- **Group B** (sequential): Phase 2 → Phase 3 → Phase 4
+- **Group C** (after B): Phase 7 → Phase 9
+- **Group D** (after Phase 0): Phase 8
+
+---
+
+## Test Conventions
+
+- **Mocking**: `mocktail` exclusively (established pattern)
+- **Codegen data**: Construct directly (`DmzEntry(...)`) — no mocking
+- **Service tests**: `MockUspService` injected, no ProviderContainer needed
+- **Notifier tests**: `ProviderContainer` with service provider overrides
+- **Timer tests**: `fakeAsync` for SystemMonitor/TrafficAnalysis
+- **Directory mirroring**: `lib/page/xxx/` → `test/page/xxx/`
+- **Static codegen methods**: Mock at `UspService` level (codegen calls `client.get()` internally)
+
+## Verification
+
+```bash
+# Per-phase verification
+flutter test test/framework/                    # Phase 1
+flutter test test/page/dmz/                     # Phase 2 (per feature)
+flutter test test/generated/                    # Phase 5
+
+# Full regression
+./run_tests.sh
+```

--- a/test/framework/preservable_test.dart
+++ b/test/framework/preservable_test.dart
@@ -85,6 +85,54 @@ class TestStatusWithMessage extends Equatable {
       TestStatusWithMessage(map['message'] as String?);
 }
 
+class AutoDisposeTestNotifier extends AutoDisposeNotifier<TestState>
+    with
+        PreservableAutoDisposeNotifierMixin<TestSettings, TestStatus,
+            TestState> {
+  Future<(TestSettings?, TestStatus?)> Function({
+    bool forceRemote,
+    bool updateStatusOnly,
+  })? fetchOverride;
+  Future<void> Function()? saveOverride;
+  int fetchCallCount = 0;
+
+  @override
+  TestState build() {
+    return const TestState(
+      settings: Preservable(
+          original: TestSettings('initial'), current: TestSettings('initial')),
+      status: TestStatus(),
+    );
+  }
+
+  void updateValue(String newValue) {
+    state = state.copyWith(
+      settings: state.settings.update(TestSettings(newValue)),
+    );
+  }
+
+  @override
+  Future<(TestSettings?, TestStatus?)> performFetch(
+      {bool forceRemote = false, bool updateStatusOnly = false}) async {
+    fetchCallCount++;
+    if (fetchOverride != null) {
+      return fetchOverride!(
+          forceRemote: forceRemote, updateStatusOnly: updateStatusOnly);
+    }
+    if (updateStatusOnly) {
+      return (null, const TestStatus());
+    }
+    return (const TestSettings('fetched'), const TestStatus());
+  }
+
+  @override
+  Future<void> performSave() async {
+    if (saveOverride != null) {
+      return saveOverride!();
+    }
+  }
+}
+
 class TestNotifier extends Notifier<TestState>
     with PreservableNotifierMixin<TestSettings, TestStatus, TestState> {
   /// Hook to control performFetch behavior from tests.
@@ -456,6 +504,243 @@ void main() {
       // After fetch, original and current are both 'fetched' — clean
       expect(notifier.isDirty(), isFalse);
       expect(notifier.state.settings.current.value, 'fetched');
+    }, tags: 'dirty-guard-framework');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Line 68 coverage: fetch returns (settings, null) — status preserved
+  // ---------------------------------------------------------------------------
+
+  group('_PreservableDelegate — settings present, status null', () {
+    late ProviderContainer container;
+    late TestNotifier notifier;
+
+    setUp(() {
+      container = ProviderContainer();
+      final provider =
+          NotifierProvider<TestNotifier, TestState>(TestNotifier.new);
+      notifier = container.read(provider.notifier);
+    });
+
+    test('fetch() with (settings, null) updates settings and preserves status',
+        () async {
+      // First establish a known status via normal fetch
+      await notifier.fetch();
+      final statusBefore = notifier.state.status;
+
+      // Override: return new settings but null status
+      notifier.fetchOverride =
+          ({forceRemote = false, updateStatusOnly = false}) async {
+        return (const TestSettings('new-settings'), null);
+      };
+
+      await notifier.fetch();
+
+      // Settings updated
+      expect(notifier.state.settings.current.value, 'new-settings');
+      expect(notifier.state.settings.original.value, 'new-settings');
+      // Status preserved from before
+      expect(notifier.state.status, equals(statusBefore));
+      expect(notifier.isDirty(), isFalse);
+    }, tags: 'dirty-guard-framework');
+  });
+
+  // ---------------------------------------------------------------------------
+  // PreservableAutoDisposeNotifierMixin (lines 172-187)
+  // ---------------------------------------------------------------------------
+
+  group('PreservableAutoDisposeNotifierMixin', () {
+    late ProviderContainer container;
+    late AutoDisposeTestNotifier notifier;
+
+    setUp(() {
+      container = ProviderContainer();
+      final provider =
+          AutoDisposeNotifierProvider<AutoDisposeTestNotifier, TestState>(
+              AutoDisposeTestNotifier.new);
+      // Keep alive so we can test
+      container.listen(provider, (_, __) {});
+      notifier = container.read(provider.notifier);
+    });
+
+    test('isDirty() is false initially', () {
+      expect(notifier.isDirty(), isFalse);
+    }, tags: 'dirty-guard-framework');
+
+    test('isDirty() is true after updating state', () {
+      notifier.updateValue('new value');
+      expect(notifier.isDirty(), isTrue);
+    }, tags: 'dirty-guard-framework');
+
+    test('revert() restores original value', () {
+      notifier.updateValue('new value');
+      expect(notifier.isDirty(), isTrue);
+
+      notifier.revert();
+
+      expect(notifier.isDirty(), isFalse);
+      expect(notifier.state.settings.current.value, 'initial');
+    }, tags: 'dirty-guard-framework');
+
+    test('fetch() updates both original and current', () async {
+      await notifier.fetch();
+
+      expect(notifier.isDirty(), isFalse);
+      expect(notifier.state.settings.original.value, 'fetched');
+      expect(notifier.state.settings.current.value, 'fetched');
+    }, tags: 'dirty-guard-framework');
+
+    test('save() calls performSave then re-fetches', () async {
+      notifier.updateValue('edited');
+      expect(notifier.isDirty(), isTrue);
+
+      await notifier.save();
+
+      expect(notifier.isDirty(), isFalse);
+      expect(notifier.state.settings.original.value, 'fetched');
+    }, tags: 'dirty-guard-framework');
+
+    test('markAsSaved() updates original to current', () {
+      notifier.updateValue('new value');
+      notifier.markAsSaved();
+
+      expect(notifier.isDirty(), isFalse);
+      expect(notifier.state.settings.original.value, 'new value');
+    }, tags: 'dirty-guard-framework');
+
+    test('onSseInvalidation() skips fetch when dirty', () async {
+      notifier.updateValue('unsaved');
+      final countBefore = notifier.fetchCallCount;
+
+      notifier.onSseInvalidation();
+      await Future.delayed(Duration.zero);
+
+      expect(notifier.fetchCallCount, equals(countBefore));
+    }, tags: 'dirty-guard-framework');
+
+    test('onSseInvalidation() triggers fetch when clean', () async {
+      final countBefore = notifier.fetchCallCount;
+
+      notifier.onSseInvalidation();
+      await Future.delayed(Duration.zero);
+
+      expect(notifier.fetchCallCount, greaterThan(countBefore));
+      expect(notifier.state.settings.current.value, 'fetched');
+    }, tags: 'dirty-guard-framework');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Preservable serialization (fromMap, fromJson, toMap, toJson)
+  // ---------------------------------------------------------------------------
+
+  group('Preservable serialization', () {
+    const original = TestSettings('orig');
+    const current = TestSettings('curr');
+
+    test('toMap() produces correct structure', () {
+      final p = Preservable(original: original, current: current);
+      final map = p.toMap((v) => v.toMap());
+
+      expect(map['original'], equals({'value': 'orig'}));
+      expect(map['current'], equals({'value': 'curr'}));
+    }, tags: 'dirty-guard-framework');
+
+    test('fromMap() round-trips correctly', () {
+      final p = Preservable(original: original, current: current);
+      final map = p.toMap((v) => v.toMap());
+      final restored =
+          Preservable.fromMap(map, (m) => TestSettings.fromMap(m));
+
+      expect(restored.original, equals(original));
+      expect(restored.current, equals(current));
+    }, tags: 'dirty-guard-framework');
+
+    test('toJson()/fromJson() round-trips correctly', () {
+      final p = Preservable(original: original, current: current);
+      final json = p.toJson((v) => v.toMap());
+      final restored =
+          Preservable.fromJson(json, (m) => TestSettings.fromMap(m));
+
+      expect(restored.original, equals(original));
+      expect(restored.current, equals(current));
+    }, tags: 'dirty-guard-framework');
+
+    test('props contains original and current for Equatable comparison', () {
+      final p1 =
+          Preservable(original: const TestSettings('a'), current: const TestSettings('b'));
+      final p2 =
+          Preservable(original: const TestSettings('a'), current: const TestSettings('b'));
+      final p3 =
+          Preservable(original: const TestSettings('a'), current: const TestSettings('c'));
+
+      expect(p1, equals(p2));
+      expect(p1, isNot(equals(p3)));
+      expect(p1.props, hasLength(2));
+    }, tags: 'dirty-guard-framework');
+
+    test('copyWith() creates copy with overrides', () {
+      final p = Preservable(original: original, current: current);
+
+      final updated = p.copyWith(original: const TestSettings('new-orig'));
+      expect(updated.original.value, 'new-orig');
+      expect(updated.current.value, 'curr');
+
+      final updatedCurrent =
+          p.copyWith(current: const TestSettings('new-curr'));
+      expect(updatedCurrent.original.value, 'orig');
+      expect(updatedCurrent.current.value, 'new-curr');
+    }, tags: 'dirty-guard-framework');
+  });
+
+  // ---------------------------------------------------------------------------
+  // FeatureState properties (current, toJson, props)
+  // ---------------------------------------------------------------------------
+
+  group('FeatureState properties', () {
+    test('current getter returns settings.current', () {
+      const state = TestState(
+        settings: Preservable(
+            original: TestSettings('a'), current: TestSettings('b')),
+        status: TestStatus(),
+      );
+      expect(state.current, equals(const TestSettings('b')));
+    }, tags: 'dirty-guard-framework');
+
+    test('toJson() returns valid JSON string', () {
+      const state = TestState(
+        settings: Preservable(
+            original: TestSettings('a'), current: TestSettings('b')),
+        status: TestStatus(),
+      );
+      final json = state.toJson();
+      expect(json, isA<String>());
+      expect(json, contains('"value":"a"'));
+      expect(json, contains('"value":"b"'));
+    }, tags: 'dirty-guard-framework');
+
+    test('props includes settings and status', () {
+      const state = TestState(
+        settings: Preservable(
+            original: TestSettings('a'), current: TestSettings('a')),
+        status: TestStatus(),
+      );
+      expect(state.props, hasLength(2));
+      expect(state.props[0], isA<Preservable<TestSettings>>());
+      expect(state.props[1], isA<TestStatus>());
+    }, tags: 'dirty-guard-framework');
+
+    test('equality based on settings and status', () {
+      const state1 = TestState(
+        settings: Preservable(
+            original: TestSettings('a'), current: TestSettings('a')),
+        status: TestStatus(),
+      );
+      const state2 = TestState(
+        settings: Preservable(
+            original: TestSettings('a'), current: TestSettings('a')),
+        status: TestStatus(),
+      );
+      expect(state1, equals(state2));
     }, tags: 'dirty-guard-framework');
   });
 }

--- a/test/framework/preservable_test.dart
+++ b/test/framework/preservable_test.dart
@@ -457,8 +457,7 @@ void main() {
       };
 
       // save() should propagate the error
-      expect(() => notifier.save(), throwsA(isA<Exception>()));
-      await Future.delayed(Duration.zero);
+      await expectLater(notifier.save(), throwsA(isA<Exception>()));
 
       expect(saveCalled, isTrue);
       // markAsSaved() was called before the re-fetch, so isDirty should be false

--- a/test/framework/preservable_test.dart
+++ b/test/framework/preservable_test.dart
@@ -648,8 +648,7 @@ void main() {
     test('fromMap() round-trips correctly', () {
       final p = Preservable(original: original, current: current);
       final map = p.toMap((v) => v.toMap());
-      final restored =
-          Preservable.fromMap(map, (m) => TestSettings.fromMap(m));
+      final restored = Preservable.fromMap(map, (m) => TestSettings.fromMap(m));
 
       expect(restored.original, equals(original));
       expect(restored.current, equals(current));
@@ -666,12 +665,12 @@ void main() {
     }, tags: 'dirty-guard-framework');
 
     test('props contains original and current for Equatable comparison', () {
-      final p1 =
-          Preservable(original: const TestSettings('a'), current: const TestSettings('b'));
-      final p2 =
-          Preservable(original: const TestSettings('a'), current: const TestSettings('b'));
-      final p3 =
-          Preservable(original: const TestSettings('a'), current: const TestSettings('c'));
+      final p1 = Preservable(
+          original: const TestSettings('a'), current: const TestSettings('b'));
+      final p2 = Preservable(
+          original: const TestSettings('a'), current: const TestSettings('b'));
+      final p3 = Preservable(
+          original: const TestSettings('a'), current: const TestSettings('c'));
 
       expect(p1, equals(p2));
       expect(p1, isNot(equals(p3)));

--- a/test/framework/preservable_test.dart
+++ b/test/framework/preservable_test.dart
@@ -71,8 +71,34 @@ class TestState extends FeatureState<TestSettings, TestStatus> {
   }
 }
 
+/// A status that carries an optional message for testing error display paths.
+class TestStatusWithMessage extends Equatable {
+  final String? message;
+  const TestStatusWithMessage([this.message]);
+
+  @override
+  List<Object?> get props => [message];
+
+  Map<String, dynamic> toMap() => {'message': message};
+
+  factory TestStatusWithMessage.fromMap(Map<String, dynamic> map) =>
+      TestStatusWithMessage(map['message'] as String?);
+}
+
 class TestNotifier extends Notifier<TestState>
     with PreservableNotifierMixin<TestSettings, TestStatus, TestState> {
+  /// Hook to control performFetch behavior from tests.
+  Future<(TestSettings?, TestStatus?)> Function({
+    bool forceRemote,
+    bool updateStatusOnly,
+  })? fetchOverride;
+
+  /// Hook to control performSave behavior from tests.
+  Future<void> Function()? saveOverride;
+
+  /// Tracks how many times performFetch was actually called.
+  int fetchCallCount = 0;
+
   @override
   TestState build() {
     return const TestState(
@@ -91,16 +117,22 @@ class TestNotifier extends Notifier<TestState>
   @override
   Future<(TestSettings?, TestStatus?)> performFetch(
       {bool forceRemote = false, bool updateStatusOnly = false}) async {
+    fetchCallCount++;
+    if (fetchOverride != null) {
+      return fetchOverride!(
+          forceRemote: forceRemote, updateStatusOnly: updateStatusOnly);
+    }
     if (updateStatusOnly) {
-      return (null, const TestStatus()); // Return a new status object
+      return (null, const TestStatus());
     }
     return (const TestSettings('fetched'), const TestStatus());
   }
 
   @override
   Future<void> performSave() async {
-    // Do nothing, just simulate a successful save.
-    return;
+    if (saveOverride != null) {
+      return saveOverride!();
+    }
   }
 }
 
@@ -196,6 +228,234 @@ void main() {
       expect(notifier.isDirty(), isFalse);
       // The final state should be the one from fetch(), not the one from markAsSaved()
       expect(notifier.state.settings.original.value, 'fetched');
+    }, tags: 'dirty-guard-framework');
+  });
+
+  // ---------------------------------------------------------------------------
+  // _PreservableDelegate gap coverage
+  // ---------------------------------------------------------------------------
+
+  group('_PreservableDelegate — updateStatusOnly path', () {
+    late ProviderContainer container;
+    late TestNotifier notifier;
+
+    setUp(() {
+      container = ProviderContainer();
+      final provider =
+          NotifierProvider<TestNotifier, TestState>(TestNotifier.new);
+      notifier = container.read(provider.notifier);
+    });
+
+    test('fetch(updateStatusOnly: true) updates status only', () async {
+      // Start with known state
+      await notifier.fetch();
+      expect(notifier.state.settings.current.value, 'fetched');
+
+      // Override fetch to return only a new status
+      notifier.fetchOverride =
+          ({forceRemote = false, updateStatusOnly = false}) async {
+        return (null, const TestStatus());
+      };
+
+      await notifier.fetch(updateStatusOnly: true);
+
+      // Settings should remain 'fetched', not be overwritten
+      expect(notifier.state.settings.current.value, 'fetched');
+      expect(notifier.state.settings.original.value, 'fetched');
+      expect(notifier.isDirty(), isFalse);
+    }, tags: 'dirty-guard-framework');
+
+    test('fetch(updateStatusOnly: true) with null status is no-op', () async {
+      await notifier.fetch();
+      final stateBefore = notifier.state;
+
+      notifier.fetchOverride =
+          ({forceRemote = false, updateStatusOnly = false}) async {
+        return (null, null);
+      };
+
+      await notifier.fetch(updateStatusOnly: true);
+
+      // State unchanged when both returns are null
+      expect(notifier.state, equals(stateBefore));
+    }, tags: 'dirty-guard-framework');
+  });
+
+  group('_PreservableDelegate — onSseInvalidation', () {
+    late ProviderContainer container;
+    late TestNotifier notifier;
+
+    setUp(() {
+      container = ProviderContainer();
+      final provider =
+          NotifierProvider<TestNotifier, TestState>(TestNotifier.new);
+      notifier = container.read(provider.notifier);
+    });
+
+    test('onSseInvalidation() skips fetch when dirty', () async {
+      notifier.updateValue('unsaved edit');
+      expect(notifier.isDirty(), isTrue);
+
+      final countBefore = notifier.fetchCallCount;
+      notifier.onSseInvalidation();
+      await Future.delayed(Duration.zero);
+
+      // performFetch should NOT have been called
+      expect(notifier.fetchCallCount, equals(countBefore));
+      // Unsaved edit preserved
+      expect(notifier.state.settings.current.value, 'unsaved edit');
+    }, tags: 'dirty-guard-framework');
+
+    test('onSseInvalidation() triggers fetch when clean', () async {
+      expect(notifier.isDirty(), isFalse);
+
+      final countBefore = notifier.fetchCallCount;
+      notifier.onSseInvalidation();
+      await Future.delayed(Duration.zero);
+
+      // performFetch SHOULD have been called
+      expect(notifier.fetchCallCount, greaterThan(countBefore));
+      expect(notifier.state.settings.current.value, 'fetched');
+    }, tags: 'dirty-guard-framework');
+
+    test('onSseInvalidation() fetch error is caught gracefully', () async {
+      expect(notifier.isDirty(), isFalse);
+
+      notifier.fetchOverride =
+          ({forceRemote = false, updateStatusOnly = false}) async {
+        throw Exception('network error');
+      };
+
+      // Should not throw — error is caught by catchError in delegate
+      notifier.onSseInvalidation();
+      await Future.delayed(Duration.zero);
+
+      // State should remain as initial (error was caught, not propagated)
+      expect(notifier.state.settings.current.value, 'initial');
+    }, tags: 'dirty-guard-framework');
+  });
+
+  group('_PreservableDelegate — error display path', () {
+    late ProviderContainer container;
+    late TestNotifier notifier;
+
+    setUp(() {
+      container = ProviderContainer();
+      final provider =
+          NotifierProvider<TestNotifier, TestState>(TestNotifier.new);
+      notifier = container.read(provider.notifier);
+    });
+
+    test(
+        'performFetch returns (null, status) — settings unchanged, status updated',
+        () async {
+      // Set initial state via a normal fetch
+      await notifier.fetch();
+      expect(notifier.state.settings.current.value, 'fetched');
+
+      // Override: simulate an error — settings null, only status returned
+      notifier.fetchOverride =
+          ({forceRemote = false, updateStatusOnly = false}) async {
+        return (null, const TestStatus());
+      };
+
+      await notifier.fetch();
+
+      // Settings should be unchanged (still 'fetched')
+      expect(notifier.state.settings.current.value, 'fetched');
+      expect(notifier.state.settings.original.value, 'fetched');
+    }, tags: 'dirty-guard-framework');
+
+    test('performFetch returns (null, null) — state completely unchanged',
+        () async {
+      await notifier.fetch();
+      final stateBefore = notifier.state;
+
+      notifier.fetchOverride =
+          ({forceRemote = false, updateStatusOnly = false}) async {
+        return (null, null);
+      };
+
+      await notifier.fetch();
+
+      expect(notifier.state, equals(stateBefore));
+    }, tags: 'dirty-guard-framework');
+  });
+
+  group('_PreservableDelegate — save re-fetch failure', () {
+    late ProviderContainer container;
+    late TestNotifier notifier;
+
+    setUp(() {
+      container = ProviderContainer();
+      final provider =
+          NotifierProvider<TestNotifier, TestState>(TestNotifier.new);
+      notifier = container.read(provider.notifier);
+    });
+
+    test('save() re-fetch failure still leaves state as saved (not dirty)',
+        () async {
+      notifier.updateValue('edited');
+      expect(notifier.isDirty(), isTrue);
+
+      // Save succeeds, but subsequent fetch throws
+      bool saveCalled = false;
+      notifier.saveOverride = () async {
+        saveCalled = true;
+      };
+      notifier.fetchOverride =
+          ({forceRemote = false, updateStatusOnly = false}) async {
+        throw Exception('re-fetch failed');
+      };
+
+      // save() should propagate the error
+      expect(() => notifier.save(), throwsA(isA<Exception>()));
+      await Future.delayed(Duration.zero);
+
+      expect(saveCalled, isTrue);
+      // markAsSaved() was called before the re-fetch, so isDirty should be false
+      expect(notifier.isDirty(), isFalse);
+      // Original should have been updated to the edited value by markAsSaved
+      expect(notifier.state.settings.original.value, 'edited');
+    }, tags: 'dirty-guard-framework');
+  });
+
+  group('_PreservableDelegate — fetch with forceRemote', () {
+    late ProviderContainer container;
+    late TestNotifier notifier;
+
+    setUp(() {
+      container = ProviderContainer();
+      final provider =
+          NotifierProvider<TestNotifier, TestState>(TestNotifier.new);
+      notifier = container.read(provider.notifier);
+    });
+
+    test('fetch(forceRemote: true) updates both settings and status', () async {
+      bool forceRemoteReceived = false;
+      notifier.fetchOverride =
+          ({forceRemote = false, updateStatusOnly = false}) async {
+        forceRemoteReceived = forceRemote;
+        return (const TestSettings('remote'), const TestStatus());
+      };
+
+      await notifier.fetch(forceRemote: true);
+
+      expect(forceRemoteReceived, isTrue);
+      expect(notifier.state.settings.current.value, 'remote');
+      expect(notifier.state.settings.original.value, 'remote');
+      expect(notifier.isDirty(), isFalse);
+    }, tags: 'dirty-guard-framework');
+
+    test('fetch() with settings resets dirty state', () async {
+      notifier.updateValue('dirty edit');
+      expect(notifier.isDirty(), isTrue);
+
+      await notifier.fetch();
+
+      // After fetch, original and current are both 'fetched' — clean
+      expect(notifier.isDirty(), isFalse);
+      expect(notifier.state.settings.current.value, 'fetched');
     }, tags: 'dirty-guard-framework');
   });
 }


### PR DESCRIPTION
## Summary

- Covers all `_PreservableDelegate` code paths (fetch, save, revert, SSE invalidation, error display)
- Adds `PreservableAutoDisposeNotifierMixin` test variant (the mixin used by all 9 settings pages)
- Adds `Preservable` serialization round-trip tests (toMap, fromMap, toJson, fromJson)
- Adds `FeatureState` property tests (current getter, toJson, props, equality)

## Coverage

| File | Before | After |
|------|--------|-------|
| `preservable_notifier_mixin.dart` | 80.0% (40/50) | **100.0% (55/55)** |
| `feature_state.dart` | 33.3% (2/6) | **100.0% (6/6)** |
| `preservable.dart` | 36.4% (8/22) | **100.0% (22/22)** |
| **Framework total** | **64.1% (50/78)** | **100.0% (83/83)** |

## Test breakdown

- **37 tests total** (9 original + 28 new)
- All 403 project tests pass

## Test plan

- [x] `flutter test test/framework/preservable_test.dart` — 37/37 pass
- [x] `flutter test --exclude-tags 'golden,loc,ui'` — 403/403 pass
- [x] Coverage verified at 100% for all 3 framework files

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Qodo Review Fix (2026-03-24)
- **fix**: `expect(() => notifier.save(), throwsA(...))` → `await expectLater(notifier.save(), throwsA(...))` for async Future error assertion