### PR TITLE
test: simple service layer tests — 5 services, 43 tests (93.4%)

### DIFF
--- a/test/page/admin/services/usp_admin_service_test.dart
+++ b/test/page/admin/services/usp_admin_service_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/services/usp_service.dart';
+import 'package:privacy_gui/generated/time_settings.g.dart';
+import 'package:privacy_gui/page/admin/services/usp_admin_service.dart';
+
+class MockUspService extends Mock implements UspService {}
+
+void main() {
+  late MockUspService mockUsp;
+  late UspAdminService service;
+
+  setUp(() {
+    mockUsp = MockUspService();
+    service = UspAdminService(mockUsp);
+  });
+
+  group('UspAdminService — fetchAdmin', () {
+    test('returns admin user when found by username', () async {
+      when(() => mockUsp.get(any())).thenAnswer((_) async => {
+            'Device.Users.User.1.Username': 'guest',
+            'Device.Users.User.1.Password': 'pass1',
+            'Device.Users.User.1.Enable': true,
+            'Device.Users.User.2.Username': 'admin',
+            'Device.Users.User.2.Password': 'pass2',
+            'Device.Users.User.2.Enable': true,
+          });
+
+      final result = await service.fetchAdmin();
+
+      expect(result.username, 'admin');
+      expect(result.instancePath, 'Device.Users.User.2.');
+      expect(result.enable, isTrue);
+    });
+
+    test('falls back to first user when no admin user exists', () async {
+      when(() => mockUsp.get(any())).thenAnswer((_) async => {
+            'Device.Users.User.1.Username': 'operator',
+            'Device.Users.User.1.Password': 'pass',
+            'Device.Users.User.1.Enable': true,
+          });
+
+      final result = await service.fetchAdmin();
+
+      expect(result.username, 'operator');
+      expect(result.instancePath, 'Device.Users.User.1.');
+    });
+  });
+
+  group('UspAdminService — updatePassword', () {
+    test('calls AdminUsers.update with correct params', () async {
+      when(() => mockUsp.set(any())).thenAnswer((_) async => {});
+
+      await service.updatePassword(
+        instancePath: 'Device.Users.User.2.',
+        newPassword: 'newSecret123',
+      );
+
+      final captured = verify(() => mockUsp.set(captureAny())).captured;
+      expect(captured, hasLength(1));
+      final params = captured.first as Map<String, dynamic>;
+      expect(params['Device.Users.User.2.Password'], 'newSecret123');
+    });
+  });
+
+  group('UspAdminService — buildTimeSettingsUIModel', () {
+    test('maps all TimeSettings fields to UIModel', () {
+      final ts = TimeSettings(
+        enable: true,
+        status: 'Synchronized',
+        ntpServer1: 'pool.ntp.org',
+        ntpServer2: 'time.google.com',
+        localTimeZone: 'CST-8',
+        currentLocalTime: '2026-03-23T10:30:00Z',
+      );
+
+      final model = service.buildTimeSettingsUIModel(ts);
+
+      expect(model.enable, isTrue);
+      expect(model.status, 'Synchronized');
+      expect(model.ntpServer1, 'pool.ntp.org');
+      expect(model.ntpServer2, 'time.google.com');
+      expect(model.localTimeZone, 'CST-8');
+      expect(model.currentLocalTime, '2026-03-23T10:30:00Z');
+      expect(model.isSynchronized, isTrue);
+    });
+
+    test('isSynchronized is false when status is not Synchronized', () {
+      final ts = TimeSettings(
+        enable: true,
+        status: 'Unsynchronized',
+        ntpServer1: '',
+        ntpServer2: '',
+        localTimeZone: '',
+        currentLocalTime: '',
+      );
+
+      final model = service.buildTimeSettingsUIModel(ts);
+
+      expect(model.isSynchronized, isFalse);
+    });
+  });
+}

--- a/test/page/dhcp/services/usp_dhcp_service_test.dart
+++ b/test/page/dhcp/services/usp_dhcp_service_test.dart
@@ -1,0 +1,274 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/services/usp_service.dart';
+import 'package:privacy_gui/page/_shared/models/dhcp_reservation_ui_model.dart';
+import 'package:privacy_gui/page/dhcp/services/usp_dhcp_service.dart';
+
+class MockUspService extends Mock implements UspService {}
+
+void main() {
+  late MockUspService mockUsp;
+  late UspDhcpService service;
+
+  setUp(() {
+    mockUsp = MockUspService();
+    service = UspDhcpService(mockUsp);
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetchReservations
+  // ---------------------------------------------------------------------------
+
+  group('UspDhcpService — fetchReservations', () {
+    test('returns empty list when no reservations', () async {
+      when(() => mockUsp.get(any()))
+          .thenAnswer((_) async => <String, dynamic>{});
+
+      final result = await service.fetchReservations();
+
+      expect(result, isEmpty);
+    });
+
+    test('maps chaddr→mac and yiaddr→ip correctly', () async {
+      when(() => mockUsp.get(any())).thenAnswer((_) async => {
+            'Device.DHCPv4.Server.Pool.1.StaticAddress.1.Enable': true,
+            'Device.DHCPv4.Server.Pool.1.StaticAddress.1.Chaddr':
+                'AA:BB:CC:DD:EE:FF',
+            'Device.DHCPv4.Server.Pool.1.StaticAddress.1.Yiaddr':
+                '192.168.1.100',
+          });
+
+      final result = await service.fetchReservations();
+
+      expect(result, hasLength(1));
+      expect(result[0].mac, 'AA:BB:CC:DD:EE:FF');
+      expect(result[0].ip, '192.168.1.100');
+      expect(result[0].enable, isTrue);
+      expect(
+        result[0].instancePath,
+        'Device.DHCPv4.Server.Pool.1.StaticAddress.1.',
+      );
+    });
+
+    test('maps multiple reservations in order', () async {
+      when(() => mockUsp.get(any())).thenAnswer((_) async => {
+            'Device.DHCPv4.Server.Pool.1.StaticAddress.1.Enable': true,
+            'Device.DHCPv4.Server.Pool.1.StaticAddress.1.Chaddr':
+                'AA:BB:CC:DD:EE:01',
+            'Device.DHCPv4.Server.Pool.1.StaticAddress.1.Yiaddr':
+                '192.168.1.101',
+            'Device.DHCPv4.Server.Pool.1.StaticAddress.2.Enable': false,
+            'Device.DHCPv4.Server.Pool.1.StaticAddress.2.Chaddr':
+                'AA:BB:CC:DD:EE:02',
+            'Device.DHCPv4.Server.Pool.1.StaticAddress.2.Yiaddr':
+                '192.168.1.102',
+          });
+
+      final result = await service.fetchReservations();
+
+      expect(result, hasLength(2));
+      expect(result[0].mac, 'AA:BB:CC:DD:EE:01');
+      expect(result[1].mac, 'AA:BB:CC:DD:EE:02');
+      expect(result[1].enable, isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // saveBatch
+  // ---------------------------------------------------------------------------
+
+  group('UspDhcpService — saveBatch', () {
+    test('no-op when original and current are identical', () async {
+      final original = [
+        DhcpReservationUIModel(
+          instancePath: 'Device.DHCPv4.Server.Pool.1.StaticAddress.1.',
+          mac: 'AA:BB:CC:DD:EE:FF',
+          ip: '192.168.1.100',
+          enable: true,
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: original,
+        current: List.of(original),
+      );
+
+      expect(result.added, 0);
+      expect(result.updated, 0);
+      expect(result.deleted, 0);
+      verifyNever(() => mockUsp.delete(any()));
+      verifyNever(() => mockUsp.add(any(), any()));
+      verifyNever(() => mockUsp.set(any()));
+    });
+
+    test('delete removes items missing from current', () async {
+      when(() => mockUsp.delete(any())).thenAnswer((_) async {});
+
+      final original = [
+        DhcpReservationUIModel(
+          instancePath: 'Device.DHCPv4.Server.Pool.1.StaticAddress.1.',
+          mac: 'AA:BB:CC:DD:EE:FF',
+          ip: '192.168.1.100',
+          enable: true,
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: original,
+        current: [],
+      );
+
+      expect(result.deleted, 1);
+      verify(() => mockUsp.delete(
+            'Device.DHCPv4.Server.Pool.1.StaticAddress.1.',
+          )).called(1);
+    });
+
+    test('multiple deletes use sequential delay', () async {
+      when(() => mockUsp.delete(any())).thenAnswer((_) async {});
+
+      final original = [
+        DhcpReservationUIModel(
+          instancePath: 'path.1.',
+          mac: 'AA:AA:AA:AA:AA:01',
+          ip: '192.168.1.1',
+          enable: true,
+        ),
+        DhcpReservationUIModel(
+          instancePath: 'path.2.',
+          mac: 'AA:AA:AA:AA:AA:02',
+          ip: '192.168.1.2',
+          enable: true,
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: original,
+        current: [],
+      );
+
+      expect(result.deleted, 2);
+      verify(() => mockUsp.delete('path.1.')).called(1);
+      verify(() => mockUsp.delete('path.2.')).called(1);
+    });
+
+    test('add creates items with null instancePath', () async {
+      when(() => mockUsp.add(any(), any())).thenAnswer((_) async => '');
+
+      final current = [
+        DhcpReservationUIModel(
+          mac: '11:22:33:44:55:66',
+          ip: '192.168.1.200',
+          enable: true,
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: [],
+        current: current,
+      );
+
+      expect(result.added, 1);
+      final captured =
+          verify(() => mockUsp.add(captureAny(), captureAny())).captured;
+      final params = captured[1] as Map<String, dynamic>;
+      expect(params['Chaddr'], '11:22:33:44:55:66');
+      expect(params['Yiaddr'], '192.168.1.200');
+    });
+
+    test('update detects changed content on same path', () async {
+      when(() => mockUsp.set(any())).thenAnswer((_) async => {});
+
+      final original = [
+        DhcpReservationUIModel(
+          instancePath: 'Device.DHCPv4.Server.Pool.1.StaticAddress.1.',
+          mac: 'AA:BB:CC:DD:EE:FF',
+          ip: '192.168.1.100',
+          enable: true,
+        ),
+      ];
+      final current = [
+        DhcpReservationUIModel(
+          instancePath: 'Device.DHCPv4.Server.Pool.1.StaticAddress.1.',
+          mac: 'AA:BB:CC:DD:EE:FF',
+          ip: '192.168.1.200', // changed IP
+          enable: true,
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: original,
+        current: current,
+      );
+
+      expect(result.updated, 1);
+    });
+
+    test('mixed batch: delete + add + update', () async {
+      when(() => mockUsp.delete(any())).thenAnswer((_) async {});
+      when(() => mockUsp.add(any(), any())).thenAnswer((_) async => '');
+      when(() => mockUsp.set(any())).thenAnswer((_) async => {});
+
+      final original = [
+        DhcpReservationUIModel(
+          instancePath: 'path.1.',
+          mac: 'AA:AA:AA:AA:AA:01',
+          ip: '192.168.1.1',
+          enable: true,
+        ),
+        DhcpReservationUIModel(
+          instancePath: 'path.2.',
+          mac: 'AA:AA:AA:AA:AA:02',
+          ip: '192.168.1.2',
+          enable: true,
+        ),
+      ];
+      final current = [
+        // path.1. removed (delete)
+        DhcpReservationUIModel(
+          instancePath: 'path.2.',
+          mac: 'AA:AA:AA:AA:AA:02',
+          ip: '192.168.1.20', // changed (update)
+          enable: true,
+        ),
+        DhcpReservationUIModel(
+          // new entry (add)
+          mac: 'BB:BB:BB:BB:BB:03',
+          ip: '192.168.1.3',
+          enable: true,
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: original,
+        current: current,
+      );
+
+      expect(result.deleted, 1);
+      expect(result.added, 1);
+      expect(result.updated, 1);
+    });
+
+    test('multiple adds use sequential delay', () async {
+      final addTimes = <DateTime>[];
+      when(() => mockUsp.add(any(), any())).thenAnswer((_) async {
+        addTimes.add(DateTime.now());
+        return '';
+      });
+
+      final current = [
+        DhcpReservationUIModel(
+            mac: '11:11:11:11:11:01', ip: '10.0.0.1', enable: true),
+        DhcpReservationUIModel(
+            mac: '11:11:11:11:11:02', ip: '10.0.0.2', enable: true),
+      ];
+
+      await service.saveBatch(original: [], current: current);
+
+      expect(addTimes, hasLength(2));
+      // Second add should be at least 200ms after first (300ms delay, allow margin)
+      final gap = addTimes[1].difference(addTimes[0]);
+      expect(gap.inMilliseconds, greaterThanOrEqualTo(200));
+    });
+  });
+}

--- a/test/page/dmz/services/usp_dmz_service_test.dart
+++ b/test/page/dmz/services/usp_dmz_service_test.dart
@@ -1,0 +1,323 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/services/usp_service.dart';
+import 'package:privacy_gui/generated/dmz.g.dart';
+import 'package:privacy_gui/page/dmz/models/dmz_ui_model.dart';
+import 'package:privacy_gui/page/dmz/services/usp_dmz_service.dart';
+
+class MockUspService extends Mock implements UspService {}
+
+void main() {
+  late MockUspService mockUsp;
+  late UspDmzService service;
+
+  setUp(() {
+    mockUsp = MockUspService();
+    service = UspDmzService(mockUsp);
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildUIModel — pure transform
+  // ---------------------------------------------------------------------------
+
+  group('UspDmzService — buildUIModel', () {
+    test('returns disabled model when items list is empty', () {
+      const data = Dmz(items: []);
+
+      final model = service.buildUIModel(data);
+
+      expect(model.isEnabled, isFalse);
+      expect(model.destIp, '');
+      expect(model.sourceType, DmzSourceType.any);
+      expect(model.sourcePrefix, '');
+    });
+
+    test('maps single enabled entry correctly', () {
+      final data = Dmz(items: [
+        DmzEntry(
+          instancePath: 'Device.Firewall.DMZ.1.',
+          enable: true,
+          destIp: '192.168.1.50',
+          sourcePrefix: '0.0.0.0/0',
+          interface_: '',
+          description: 'DMZ',
+          status: 'Enabled',
+        ),
+      ]);
+
+      final model = service.buildUIModel(data);
+
+      expect(model.isEnabled, isTrue);
+      expect(model.destIp, '192.168.1.50');
+      expect(model.sourceType, DmzSourceType.any);
+      expect(model.sourcePrefix, '0.0.0.0/0');
+    });
+
+    test('detects CIDR source type for non-any prefix', () {
+      final data = Dmz(items: [
+        DmzEntry(
+          instancePath: 'Device.Firewall.DMZ.1.',
+          enable: true,
+          destIp: '192.168.1.50',
+          sourcePrefix: '10.0.0.0/8',
+          interface_: '',
+          description: 'DMZ',
+          status: 'Enabled',
+        ),
+      ]);
+
+      final model = service.buildUIModel(data);
+
+      expect(model.sourceType, DmzSourceType.cidr);
+      expect(model.sourcePrefix, '10.0.0.0/8');
+    });
+
+    test('detects any source type for empty prefix', () {
+      final data = Dmz(items: [
+        DmzEntry(
+          instancePath: 'Device.Firewall.DMZ.1.',
+          enable: false,
+          destIp: '192.168.1.50',
+          sourcePrefix: '',
+          interface_: '',
+          description: 'DMZ',
+          status: 'Disabled',
+        ),
+      ]);
+
+      final model = service.buildUIModel(data);
+
+      expect(model.sourceType, DmzSourceType.any);
+      expect(model.isEnabled, isFalse);
+    });
+
+    test('uses only the first entry when multiple exist', () {
+      final data = Dmz(items: [
+        DmzEntry(
+          instancePath: 'Device.Firewall.DMZ.1.',
+          enable: true,
+          destIp: '192.168.1.10',
+          sourcePrefix: '0.0.0.0/0',
+          interface_: '',
+          description: 'DMZ',
+          status: 'Enabled',
+        ),
+        DmzEntry(
+          instancePath: 'Device.Firewall.DMZ.2.',
+          enable: true,
+          destIp: '192.168.1.20',
+          sourcePrefix: '0.0.0.0/0',
+          interface_: '',
+          description: 'DMZ2',
+          status: 'Enabled',
+        ),
+      ]);
+
+      final model = service.buildUIModel(data);
+
+      expect(model.destIp, '192.168.1.10');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateForm — pure validation
+  // ---------------------------------------------------------------------------
+
+  group('UspDmzService — validateForm', () {
+    test('returns no errors when disabled', () {
+      const model = DmzUIModel(
+        isEnabled: false,
+        destIp: '',
+        sourceType: DmzSourceType.any,
+        sourcePrefix: '',
+      );
+
+      final errors = service.validateForm(model);
+
+      expect(errors, isEmpty);
+    });
+
+    test('returns error when enabled with empty destIp', () {
+      const model = DmzUIModel(
+        isEnabled: true,
+        destIp: '',
+        sourceType: DmzSourceType.any,
+        sourcePrefix: '',
+      );
+
+      final errors = service.validateForm(model);
+
+      expect(errors, contains('destIp'));
+      expect(errors['destIp'], 'Destination IP is required');
+    });
+
+    test('returns error when destIp is invalid', () {
+      const model = DmzUIModel(
+        isEnabled: true,
+        destIp: 'not-an-ip',
+        sourceType: DmzSourceType.any,
+        sourcePrefix: '',
+      );
+
+      final errors = service.validateForm(model);
+
+      expect(errors, contains('destIp'));
+      expect(errors['destIp'], 'Invalid IP address');
+    });
+
+    test('returns no errors for valid enabled configuration', () {
+      const model = DmzUIModel(
+        isEnabled: true,
+        destIp: '192.168.1.50',
+        sourceType: DmzSourceType.any,
+        sourcePrefix: '',
+      );
+
+      final errors = service.validateForm(model);
+
+      expect(errors, isEmpty);
+    });
+
+    test('returns error when sourceType is cidr with empty prefix', () {
+      const model = DmzUIModel(
+        isEnabled: true,
+        destIp: '192.168.1.50',
+        sourceType: DmzSourceType.cidr,
+        sourcePrefix: '',
+      );
+
+      final errors = service.validateForm(model);
+
+      expect(errors, contains('sourcePrefix'));
+      expect(errors['sourcePrefix'], 'CIDR range is required');
+    });
+
+    test('returns no error when sourceType is cidr with valid prefix', () {
+      const model = DmzUIModel(
+        isEnabled: true,
+        destIp: '192.168.1.50',
+        sourceType: DmzSourceType.cidr,
+        sourcePrefix: '10.0.0.0/8',
+      );
+
+      final errors = service.validateForm(model);
+
+      expect(errors, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetch — async with mock
+  // ---------------------------------------------------------------------------
+
+  group('UspDmzService — fetch', () {
+    test('returns settings with instancePath when entry exists', () async {
+      when(() => mockUsp.get(any())).thenAnswer((_) async => {
+            'Device.Firewall.DMZ.1.Enable': true,
+            'Device.Firewall.DMZ.1.DestIP': '192.168.1.50',
+            'Device.Firewall.DMZ.1.SourcePrefix': '0.0.0.0/0',
+            'Device.Firewall.DMZ.1.Interface': '',
+            'Device.Firewall.DMZ.1.Description': 'DMZ',
+            'Device.Firewall.DMZ.1.Status': 'Enabled',
+          });
+
+      final (settings, status) = await service.fetch();
+
+      expect(settings.instancePath, 'Device.Firewall.DMZ.1.');
+      expect(settings.model.isEnabled, isTrue);
+      expect(settings.model.destIp, '192.168.1.50');
+      expect(settings.isNewEntry, isFalse);
+      expect(status.isLoading, isFalse);
+    });
+
+    test('returns settings with null instancePath when empty', () async {
+      when(() => mockUsp.get(any()))
+          .thenAnswer((_) async => <String, dynamic>{});
+
+      final (settings, status) = await service.fetch();
+
+      expect(settings.instancePath, isNull);
+      expect(settings.isNewEntry, isTrue);
+      expect(settings.model.isEnabled, isFalse);
+      expect(status.isLoading, isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // add / update — async with mock
+  // ---------------------------------------------------------------------------
+
+  group('UspDmzService — add', () {
+    test('add with sourceType.any sends 0.0.0.0/0', () async {
+      when(() => mockUsp.add(any(), any())).thenAnswer((_) async => '');
+
+      await service.add(
+        model: DmzUIModel(
+          isEnabled: true,
+          destIp: '192.168.1.50',
+          sourceType: DmzSourceType.any,
+          sourcePrefix: '',
+        ),
+      );
+
+      final captured =
+          verify(() => mockUsp.add(captureAny(), captureAny())).captured;
+      final params = captured[1] as Map<String, dynamic>;
+      expect(params['SourcePrefix'], '0.0.0.0/0');
+      expect(params['DestIP'], '192.168.1.50');
+    });
+
+    test('add with sourceType.cidr sends the CIDR value', () async {
+      when(() => mockUsp.add(any(), any())).thenAnswer((_) async => '');
+
+      await service.add(
+        model: DmzUIModel(
+          isEnabled: true,
+          destIp: '192.168.1.50',
+          sourceType: DmzSourceType.cidr,
+          sourcePrefix: '10.0.0.0/8',
+        ),
+      );
+
+      final captured =
+          verify(() => mockUsp.add(captureAny(), captureAny())).captured;
+      final params = captured[1] as Map<String, dynamic>;
+      expect(params['SourcePrefix'], '10.0.0.0/8');
+    });
+  });
+
+  group('UspDmzService — update', () {
+    test('update with sourceType.any sends 0.0.0.0/0', () async {
+      when(() => mockUsp.set(any())).thenAnswer((_) async => {});
+
+      await service.update(
+        instancePath: 'Device.Firewall.DMZ.1.',
+        model: DmzUIModel(
+          isEnabled: false,
+          destIp: '192.168.1.100',
+          sourceType: DmzSourceType.any,
+          sourcePrefix: '',
+        ),
+      );
+
+      final captured = verify(() => mockUsp.set(captureAny())).captured;
+      expect(captured, hasLength(1));
+    });
+
+    test('update with sourceType.cidr sends the CIDR value', () async {
+      when(() => mockUsp.set(any())).thenAnswer((_) async => {});
+
+      await service.update(
+        instancePath: 'Device.Firewall.DMZ.1.',
+        model: DmzUIModel(
+          isEnabled: true,
+          destIp: '192.168.1.100',
+          sourceType: DmzSourceType.cidr,
+          sourcePrefix: '10.0.0.0/8',
+        ),
+      );
+
+      verify(() => mockUsp.set(captureAny())).called(1);
+    });
+  });
+}

--- a/test/page/instant_safety/services/usp_instant_safety_service_test.dart
+++ b/test/page/instant_safety/services/usp_instant_safety_service_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/services/usp_service.dart';
+import 'package:privacy_gui/generated/lan_network_info.g.dart';
+import 'package:privacy_gui/page/instant_safety/models/safe_browsing_ui_model.dart';
+import 'package:privacy_gui/page/instant_safety/services/instant_safety_service.dart';
+
+class MockUspService extends Mock implements UspService {}
+
+void main() {
+  late MockUspService mockUsp;
+  late UspInstantSafetyService service;
+
+  setUp(() {
+    mockUsp = MockUspService();
+    service = UspInstantSafetyService(mockUsp);
+  });
+
+  group('UspInstantSafetyService — buildUIModel', () {
+    test('detects OpenDNS from matching first DNS entry', () {
+      final data = LanNetworkInfo(
+        ipAddress: '192.168.1.1',
+        subnetMask: '255.255.255.0',
+        dhcpEnabled: true,
+        minAddress: '192.168.1.100',
+        maxAddress: '192.168.1.200',
+        leaseTime: 86400,
+        dnsServers: '208.67.222.222,208.67.220.220',
+        hostName: 'router',
+      );
+
+      final model = service.buildUIModel(data);
+
+      expect(model.type, SafeBrowsingType.openDNS);
+      expect(model.isEnabled, isTrue);
+      expect(model.currentDnsServers, '208.67.222.222,208.67.220.220');
+    });
+
+    test('detects off when DNS is different', () {
+      final data = LanNetworkInfo(
+        ipAddress: '192.168.1.1',
+        subnetMask: '255.255.255.0',
+        dhcpEnabled: true,
+        minAddress: '192.168.1.100',
+        maxAddress: '192.168.1.200',
+        leaseTime: 86400,
+        dnsServers: '8.8.8.8,8.8.4.4',
+        hostName: 'router',
+      );
+
+      final model = service.buildUIModel(data);
+
+      expect(model.type, SafeBrowsingType.off);
+      expect(model.isEnabled, isFalse);
+    });
+
+    test('detects off when DNS is empty', () {
+      final data = LanNetworkInfo(
+        ipAddress: '192.168.1.1',
+        subnetMask: '255.255.255.0',
+        dhcpEnabled: true,
+        minAddress: '192.168.1.100',
+        maxAddress: '192.168.1.200',
+        leaseTime: 86400,
+        dnsServers: '',
+        hostName: 'router',
+      );
+
+      final model = service.buildUIModel(data);
+
+      expect(model.type, SafeBrowsingType.off);
+    });
+  });
+
+  group('UspInstantSafetyService — dnsValueForType', () {
+    test('openDNS returns full DNS string', () {
+      expect(
+        service.dnsValueForType(SafeBrowsingType.openDNS),
+        '208.67.222.222,208.67.220.220',
+      );
+    });
+
+    test('off returns empty string', () {
+      expect(service.dnsValueForType(SafeBrowsingType.off), '');
+    });
+  });
+
+  group('UspInstantSafetyService — fetch', () {
+    test('fetch returns SafeBrowsingUIModel from router data', () async {
+      when(() => mockUsp.get(any())).thenAnswer((_) async => {
+            'Device.IP.Interface.1.IPv4Address.1.IPAddress': '192.168.1.1',
+            'Device.IP.Interface.1.IPv4Address.1.SubnetMask': '255.255.255.0',
+            'Device.DHCPv4.Server.Pool.1.Enable': true,
+            'Device.DHCPv4.Server.Pool.1.MinAddress': '192.168.1.100',
+            'Device.DHCPv4.Server.Pool.1.MaxAddress': '192.168.1.200',
+            'Device.DHCPv4.Server.Pool.1.LeaseTime': '86400',
+            'Device.DHCPv4.Server.Pool.1.DNSServers':
+                '208.67.222.222,208.67.220.220',
+            'Device.DeviceInfo.HostName': 'router',
+          });
+
+      final model = await service.fetch();
+
+      expect(model.type, SafeBrowsingType.openDNS);
+      expect(model.isEnabled, isTrue);
+    });
+  });
+
+  group('UspInstantSafetyService — save', () {
+    test('save(openDNS) writes OpenDNS values', () async {
+      when(() => mockUsp.set(any())).thenAnswer((_) async => {});
+
+      await service.save(SafeBrowsingType.openDNS);
+
+      final captured = verify(() => mockUsp.set(captureAny())).captured;
+      expect(captured, hasLength(1));
+      final params = captured.first as Map<String, dynamic>;
+      expect(
+        params['Device.DHCPv4.Server.Pool.1.DNSServers'],
+        '208.67.222.222,208.67.220.220',
+      );
+    });
+
+    test('save(off) writes empty string', () async {
+      when(() => mockUsp.set(any())).thenAnswer((_) async => {});
+
+      await service.save(SafeBrowsingType.off);
+
+      final captured = verify(() => mockUsp.set(captureAny())).captured;
+      final params = captured.first as Map<String, dynamic>;
+      expect(params['Device.DHCPv4.Server.Pool.1.DNSServers'], '');
+    });
+  });
+}

--- a/test/page/system_log/services/usp_system_log_service_test.dart
+++ b/test/page/system_log/services/usp_system_log_service_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/services/usp_service.dart';
+import 'package:privacy_gui/page/system_log/services/usp_system_log_service.dart';
+
+class MockUspService extends Mock implements UspService {}
+
+void main() {
+  late MockUspService mockUsp;
+  late UspSystemLogService service;
+
+  setUp(() {
+    mockUsp = MockUspService();
+    service = UspSystemLogService(mockUsp);
+  });
+
+  group('UspSystemLogService — fetch', () {
+    test('returns empty list when no log files exist', () async {
+      when(() => mockUsp.get(any()))
+          .thenAnswer((_) async => <String, dynamic>{});
+
+      final result = await service.fetch();
+
+      expect(result, isEmpty);
+    });
+
+    test('maps single vendor log file correctly', () async {
+      when(() => mockUsp.get(any())).thenAnswer((_) async => {
+            'Device.DeviceInfo.VendorLogFile.1.Name': 'syslog',
+            'Device.DeviceInfo.VendorLogFile.1.MaximumSize': '524288',
+            'Device.DeviceInfo.VendorLogFile.1.Persistent': true,
+          });
+
+      final result = await service.fetch();
+
+      expect(result, hasLength(1));
+      expect(result[0].name, 'syslog');
+      expect(result[0].maximumSize, 524288);
+      expect(result[0].persistent, isTrue);
+      expect(
+        result[0].instancePath,
+        'Device.DeviceInfo.VendorLogFile.1.',
+      );
+    });
+
+    test('maps multiple vendor log files in order', () async {
+      when(() => mockUsp.get(any())).thenAnswer((_) async => {
+            'Device.DeviceInfo.VendorLogFile.1.Name': 'syslog',
+            'Device.DeviceInfo.VendorLogFile.1.MaximumSize': '524288',
+            'Device.DeviceInfo.VendorLogFile.1.Persistent': true,
+            'Device.DeviceInfo.VendorLogFile.2.Name': 'crashlog',
+            'Device.DeviceInfo.VendorLogFile.2.MaximumSize': '65536',
+            'Device.DeviceInfo.VendorLogFile.2.Persistent': false,
+          });
+
+      final result = await service.fetch();
+
+      expect(result, hasLength(2));
+      expect(result[0].name, 'syslog');
+      expect(result[1].name, 'crashlog');
+      expect(result[1].maximumSize, 65536);
+      expect(result[1].persistent, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Unit tests for 5 simple page services — thin wrappers over codegen with transform + validation logic.

- **UspDmzService** (17 tests): buildUIModel (empty/single/CIDR/any/multi), validateForm (disabled/empty destIp/invalid IP/valid/CIDR required/CIDR valid), fetch, add (any/cidr), update (any/cidr)
- **UspAdminService** (5 tests): fetchAdmin (admin found/fallback), updatePassword, buildTimeSettingsUIModel (sync/unsync)
- **UspSystemLogService** (3 tests): fetch (empty/single/multiple)
- **UspInstantSafetyService** (8 tests): buildUIModel (OpenDNS/other/empty), dnsValueForType (openDNS/off), fetch, save (openDNS/off)
- **UspDhcpService** (10 tests): fetchReservations (empty/single/multiple), saveBatch (no-op/delete/multi-delete/add/update/mixed/sequential delay)

## Coverage

| Service | Lines Covered | Coverage | Uncovered |
|---------|:------------:|:--------:|-----------|
| UspDmzService | 39/41 | **95.1%** | Provider boilerplate |
| UspAdminService | 24/26 | **92.3%** | Provider boilerplate |
| UspSystemLogService | 13/15 | **86.7%** | Provider boilerplate |
| UspInstantSafetyService | 17/19 | **89.5%** | Provider boilerplate |
| UspDhcpService | 48/50 | **96.0%** | Provider boilerplate |
| **Total** | **141/151** | **93.4%** | |

> Remaining uncovered lines are all Riverpod `Provider(...)` definitions — app-container boilerplate not reachable in unit tests.

## Test plan

- [x] `flutter test test/page/dmz/services/` — 17/17 pass
- [x] `flutter test test/page/admin/services/` — 5/5 pass
- [x] `flutter test test/page/system_log/services/` — 3/3 pass
- [x] `flutter test test/page/instant_safety/services/` — 8/8 pass
- [x] `flutter test test/page/dhcp/services/` — 10/10 pass
- [x] `flutter test --exclude-tags 'golden,loc,ui'` — 418/418 pass
- [x] `dart format .` — clean

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)