### PR TITLE
test: add medium service layer tests (#730)

### DIFF
--- a/test/page/firewall/services/usp_firewall_service_test.dart
+++ b/test/page/firewall/services/usp_firewall_service_test.dart
@@ -1,0 +1,317 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/services/usp_service.dart';
+import 'package:privacy_gui/generated/firewall_chain_rules.g.dart';
+import 'package:privacy_gui/page/firewall/models/firewall_ui_model.dart';
+import 'package:privacy_gui/page/firewall/services/usp_firewall_service.dart';
+
+class MockUspService extends Mock implements UspService {}
+
+// Helper to build a FirewallChainRule with the given fields.
+FirewallChainRule _rule(
+  String instancePath, {
+  required bool enable,
+  required String description,
+  String target = 'Accept',
+}) =>
+    FirewallChainRule(
+      instancePath: instancePath,
+      enable: enable,
+      description: description,
+      target: target,
+    );
+
+void main() {
+  late MockUspService mockUsp;
+  late UspFirewallService service;
+
+  setUp(() {
+    mockUsp = MockUspService();
+    service = UspFirewallService(mockUsp);
+  });
+
+  // ---------------------------------------------------------------------------
+  // parseFirewallRules
+  // ---------------------------------------------------------------------------
+
+  group('UspFirewallService — parseFirewallRules', () {
+    test('maps known descriptions to feature keys', () {
+      final rules = FirewallChainRules(items: [
+        _rule('p.10.', enable: true, description: 'RULE_SPI_IPV4_INPUT'),
+        _rule('p.11.', enable: true, description: 'RULE_SPI_IPV4_FORWARD'),
+        _rule('p.21.', enable: false, description: 'RULE_LAN2WAN_IPSEC'),
+      ]);
+
+      final map = UspFirewallService.parseFirewallRules(rules);
+
+      expect(map, hasLength(3));
+      expect(map['spiV4Input']!.instancePath, 'p.10.');
+      expect(map['spiV4Forward']!.instancePath, 'p.11.');
+      expect(map['ipsec1']!.instancePath, 'p.21.');
+    });
+
+    test('skips unknown descriptions', () {
+      final rules = FirewallChainRules(items: [
+        _rule('p.1.', enable: true, description: 'RULE_SPI_IPV4_INPUT'),
+        _rule('p.99.', enable: true, description: 'UNKNOWN_RULE'),
+      ]);
+
+      final map = UspFirewallService.parseFirewallRules(rules);
+
+      expect(map, hasLength(1));
+      expect(map.containsKey('spiV4Input'), isTrue);
+    });
+
+    test('empty rules returns empty map', () {
+      final map = UspFirewallService.parseFirewallRules(
+        FirewallChainRules(items: []),
+      );
+      expect(map, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildUIModel
+  // ---------------------------------------------------------------------------
+
+  group('UspFirewallService — buildUIModel', () {
+    test('accept rules: feature ON when rule disabled', () {
+      final rules = {
+        'spiV4Input': _rule('p.10.', enable: false, description: ''),
+        'spiV6Input': _rule('p.12.', enable: false, description: ''),
+        'anonymousRequests': _rule('p.19.', enable: false, description: ''),
+        'multicast': _rule('p.18.', enable: false, description: ''),
+        'ident': _rule('p.20.', enable: false, description: ''),
+      };
+
+      final model = UspFirewallService.buildUIModel(rules: rules);
+
+      expect(model.isIPv4FirewallEnabled, isTrue);
+      expect(model.isIPv6FirewallEnabled, isTrue);
+      expect(model.blockAnonymousRequests, isTrue);
+      expect(model.blockMulticast, isTrue);
+      expect(model.blockIDENT, isTrue);
+    });
+
+    test('accept rules: feature OFF when rule enabled', () {
+      final rules = {
+        'spiV4Input': _rule('p.10.', enable: true, description: ''),
+        'spiV6Input': _rule('p.12.', enable: true, description: ''),
+      };
+
+      final model = UspFirewallService.buildUIModel(rules: rules);
+
+      expect(model.isIPv4FirewallEnabled, isFalse);
+      expect(model.isIPv6FirewallEnabled, isFalse);
+    });
+
+    test('drop rules: block ON when rule enabled', () {
+      final rules = {
+        'ipsec1': _rule('p.21.', enable: true, description: ''),
+        'pptp': _rule('p.23.', enable: true, description: ''),
+        'l2tp': _rule('p.24.', enable: true, description: ''),
+      };
+
+      final model = UspFirewallService.buildUIModel(rules: rules);
+
+      expect(model.blockIPSec, isTrue);
+      expect(model.blockPPTP, isTrue);
+      expect(model.blockL2TP, isTrue);
+    });
+
+    test('drop rules: block OFF when rule disabled', () {
+      final rules = {
+        'ipsec1': _rule('p.21.', enable: false, description: ''),
+        'pptp': _rule('p.23.', enable: false, description: ''),
+        'l2tp': _rule('p.24.', enable: false, description: ''),
+      };
+
+      final model = UspFirewallService.buildUIModel(rules: rules);
+
+      expect(model.blockIPSec, isFalse);
+      expect(model.blockPPTP, isFalse);
+      expect(model.blockL2TP, isFalse);
+    });
+
+    test('missing rules default to false', () {
+      final model = UspFirewallService.buildUIModel(rules: {});
+
+      // Accept rules with missing key: !(null?.enable ?? false) → !false → true
+      expect(model.isIPv4FirewallEnabled, isTrue);
+      // Drop rules with missing key: null?.enable ?? false → false
+      expect(model.blockIPSec, isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildSetPayload
+  // ---------------------------------------------------------------------------
+
+  group('UspFirewallService — buildSetPayload', () {
+    test('no changes returns empty list', () {
+      final model = FirewallUIModel();
+      final updates = service.buildSetPayload(
+        original: model,
+        pending: model,
+        rules: {},
+      );
+      expect(updates, isEmpty);
+    });
+
+    test('IPv4 SPI toggle generates paired updates', () {
+      final rules = {
+        'spiV4Input': _rule('p.10.', enable: false, description: ''),
+        'spiV4Forward': _rule('p.11.', enable: false, description: ''),
+      };
+
+      final updates = service.buildSetPayload(
+        original: FirewallUIModel(isIPv4FirewallEnabled: true),
+        pending: FirewallUIModel(isIPv4FirewallEnabled: false),
+        rules: rules,
+      );
+
+      expect(updates, hasLength(2));
+      expect(updates[0].instancePath, 'p.10.');
+      // Feature OFF → accept rule enabled
+      expect(updates[0].enable, isTrue);
+      expect(updates[1].instancePath, 'p.11.');
+      expect(updates[1].enable, isTrue);
+    });
+
+    test('IPv6 SPI toggle generates paired updates', () {
+      final rules = {
+        'spiV6Input': _rule('p.12.', enable: true, description: ''),
+        'spiV6Forward': _rule('p.13.', enable: true, description: ''),
+      };
+
+      final updates = service.buildSetPayload(
+        original: FirewallUIModel(isIPv6FirewallEnabled: false),
+        pending: FirewallUIModel(isIPv6FirewallEnabled: true),
+        rules: rules,
+      );
+
+      expect(updates, hasLength(2));
+      // Feature ON → accept rule disabled
+      expect(updates[0].enable, isFalse);
+    });
+
+    test('IPSec toggle generates paired updates', () {
+      final rules = {
+        'ipsec1': _rule('p.21.', enable: false, description: ''),
+        'ipsec2': _rule('p.22.', enable: false, description: ''),
+      };
+
+      final updates = service.buildSetPayload(
+        original: FirewallUIModel(blockIPSec: false),
+        pending: FirewallUIModel(blockIPSec: true),
+        rules: rules,
+      );
+
+      expect(updates, hasLength(2));
+      // Block ON → drop rule enabled
+      expect(updates[0].enable, isTrue);
+      expect(updates[1].enable, isTrue);
+    });
+
+    test('single rule toggles (PPTP, L2TP, anonymous, multicast, IDENT)', () {
+      final rules = {
+        'pptp': _rule('p.23.', enable: false, description: ''),
+        'l2tp': _rule('p.24.', enable: false, description: ''),
+        'anonymousRequests': _rule('p.19.', enable: true, description: ''),
+        'multicast': _rule('p.18.', enable: true, description: ''),
+        'ident': _rule('p.20.', enable: true, description: ''),
+      };
+
+      final updates = service.buildSetPayload(
+        original: FirewallUIModel(),
+        pending: FirewallUIModel(
+          blockPPTP: true,
+          blockL2TP: true,
+          blockAnonymousRequests: true,
+          blockMulticast: true,
+          blockIDENT: true,
+        ),
+        rules: rules,
+      );
+
+      // 5 single-rule toggles
+      expect(updates, hasLength(5));
+    });
+
+    test('missing rule in map is silently skipped', () {
+      // Change IPv4 SPI but only one of the paired rules exists
+      final rules = {
+        'spiV4Input': _rule('p.10.', enable: false, description: ''),
+        // spiV4Forward missing
+      };
+
+      final updates = service.buildSetPayload(
+        original: FirewallUIModel(isIPv4FirewallEnabled: true),
+        pending: FirewallUIModel(isIPv4FirewallEnabled: false),
+        rules: rules,
+      );
+
+      // Only the existing rule is updated
+      expect(updates, hasLength(1));
+      expect(updates[0].instancePath, 'p.10.');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildFromChainRules (integration)
+  // ---------------------------------------------------------------------------
+
+  group('UspFirewallService — buildFromChainRules', () {
+    test('returns UI model and context from chain rules', () {
+      final rules = FirewallChainRules(items: [
+        _rule('p.10.', enable: false, description: 'RULE_SPI_IPV4_INPUT'),
+        _rule('p.11.', enable: false, description: 'RULE_SPI_IPV4_FORWARD'),
+        _rule('p.21.', enable: true, description: 'RULE_LAN2WAN_IPSEC'),
+      ]);
+
+      final (model, context) = service.buildFromChainRules(rules);
+
+      expect(model.isIPv4FirewallEnabled, isTrue);
+      expect(model.blockIPSec, isTrue);
+      expect(context, isNot(FirewallRuleContext.empty));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // save
+  // ---------------------------------------------------------------------------
+
+  group('UspFirewallService — save', () {
+    test('no changes returns 0 and makes no USP call', () async {
+      final model = FirewallUIModel();
+      final context = FirewallRuleContext.fromMap({});
+
+      final count = await service.save(
+        original: model,
+        pending: model,
+        context: context,
+      );
+
+      expect(count, 0);
+      verifyNever(() => mockUsp.set(any()));
+    });
+
+    test('changed toggles call updateMany and return count', () async {
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => {});
+
+      final rules = {
+        'pptp': _rule('p.23.', enable: false, description: 'RULE_LAN2WAN_PPTP'),
+      };
+      final context = FirewallRuleContext.fromMap(rules);
+
+      final count = await service.save(
+        original: FirewallUIModel(blockPPTP: false),
+        pending: FirewallUIModel(blockPPTP: true),
+        context: context,
+      );
+
+      expect(count, 1);
+    });
+  });
+}

--- a/test/page/instant_privacy/services/usp_instant_privacy_service_test.dart
+++ b/test/page/instant_privacy/services/usp_instant_privacy_service_test.dart
@@ -1,0 +1,455 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/services/usp_service.dart';
+import 'package:privacy_gui/generated/connected_devices.g.dart';
+import 'package:privacy_gui/generated/mac_filter_access_points.g.dart';
+import 'package:privacy_gui/page/instant_privacy/models/instant_privacy_device_ui_model.dart';
+import 'package:privacy_gui/page/instant_privacy/services/instant_privacy_service.dart';
+
+class MockUspService extends Mock implements UspService {}
+
+ConnectedDevice _device({
+  String instancePath = 'Device.Hosts.Host.1.',
+  String macAddress = 'AA:BB:CC:DD:EE:FF',
+  String ipAddress = '192.168.1.100',
+  String hostName = 'MyDevice',
+  bool isActive = true,
+  String interface_ = 'Device.Ethernet.Interface.1',
+  String addressSource = 'DHCP',
+}) =>
+    ConnectedDevice(
+      instancePath: instancePath,
+      macAddress: macAddress,
+      ipAddress: ipAddress,
+      hostName: hostName,
+      isActive: isActive,
+      interface_: interface_,
+      addressSource: addressSource,
+      ipv6Addresses: const [],
+    );
+
+MacFilterAccessPoint _ap({
+  String instancePath = 'Device.WiFi.AccessPoint.1.',
+  String ssidReference = 'Device.WiFi.SSID.1',
+  bool macAddressControlEnabled = false,
+  String allowedMACAddress = '',
+}) =>
+    MacFilterAccessPoint(
+      instancePath: instancePath,
+      ssidReference: ssidReference,
+      macAddressControlEnabled: macAddressControlEnabled,
+      allowedMACAddress: allowedMACAddress,
+    );
+
+void main() {
+  late MockUspService mockUsp;
+  late UspInstantPrivacyService service;
+
+  setUp(() {
+    mockUsp = MockUspService();
+    service = UspInstantPrivacyService(mockUsp);
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateMac
+  // ---------------------------------------------------------------------------
+
+  group('UspInstantPrivacyService — validateMac', () {
+    test('valid colon-separated MAC', () {
+      expect(UspInstantPrivacyService.validateMac('AA:BB:CC:DD:EE:FF'), isTrue);
+    });
+
+    test('valid hyphen-separated MAC', () {
+      expect(UspInstantPrivacyService.validateMac('AA-BB-CC-DD-EE-FF'), isTrue);
+    });
+
+    test('valid lowercase MAC', () {
+      expect(UspInstantPrivacyService.validateMac('aa:bb:cc:dd:ee:ff'), isTrue);
+    });
+
+    test('trims whitespace', () {
+      expect(UspInstantPrivacyService.validateMac('  AA:BB:CC:DD:EE:FF  '),
+          isTrue);
+    });
+
+    test('rejects empty string', () {
+      expect(UspInstantPrivacyService.validateMac(''), isFalse);
+    });
+
+    test('rejects too few octets', () {
+      expect(UspInstantPrivacyService.validateMac('AA:BB:CC:DD:EE'), isFalse);
+    });
+
+    test('rejects non-hex characters', () {
+      expect(
+          UspInstantPrivacyService.validateMac('GG:BB:CC:DD:EE:FF'), isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // normalizeMac
+  // ---------------------------------------------------------------------------
+
+  group('UspInstantPrivacyService — normalizeMac', () {
+    test('uppercases and replaces hyphens', () {
+      expect(UspInstantPrivacyService.normalizeMac('aa-bb-cc-dd-ee-ff'),
+          'AA:BB:CC:DD:EE:FF');
+    });
+
+    test('trims whitespace', () {
+      expect(UspInstantPrivacyService.normalizeMac('  aa:bb:cc:dd:ee:ff  '),
+          'AA:BB:CC:DD:EE:FF');
+    });
+
+    test('idempotent for already normalized', () {
+      expect(UspInstantPrivacyService.normalizeMac('AA:BB:CC:DD:EE:FF'),
+          'AA:BB:CC:DD:EE:FF');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // activeDevices
+  // ---------------------------------------------------------------------------
+
+  group('UspInstantPrivacyService — activeDevices', () {
+    test('returns only active devices with non-empty interface', () {
+      final data = ConnectedDevices(items: [
+        _device(
+            isActive: true,
+            interface_: 'eth0',
+            macAddress: 'AA:BB:CC:DD:EE:01'),
+        _device(
+          instancePath: 'p.2.',
+          isActive: false,
+          interface_: 'eth0',
+          macAddress: 'AA:BB:CC:DD:EE:02',
+        ),
+        _device(
+          instancePath: 'p.3.',
+          isActive: true,
+          interface_: '',
+          macAddress: 'AA:BB:CC:DD:EE:03',
+        ),
+      ]);
+
+      final result = service.activeDevices(data);
+
+      expect(result, hasLength(1));
+      expect(result[0].mac, 'AA:BB:CC:DD:EE:01');
+    });
+
+    test('uses hostname as displayName when available', () {
+      final data = ConnectedDevices(items: [
+        _device(hostName: 'Laptop', macAddress: 'AA:BB:CC:DD:EE:FF'),
+      ]);
+
+      final result = service.activeDevices(data);
+
+      expect(result[0].displayName, 'Laptop');
+    });
+
+    test('uses MAC as displayName when hostname empty', () {
+      final data = ConnectedDevices(items: [
+        _device(hostName: '', macAddress: 'aa:bb:cc:dd:ee:ff'),
+      ]);
+
+      final result = service.activeDevices(data);
+
+      expect(result[0].displayName, 'AA:BB:CC:DD:EE:FF');
+    });
+
+    test('empty devices returns empty list', () {
+      final result = service.activeDevices(ConnectedDevices(items: []));
+      expect(result, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // isEnabled
+  // ---------------------------------------------------------------------------
+
+  group('UspInstantPrivacyService — isEnabled', () {
+    test('returns true when any AP has MAC filter enabled', () {
+      final data = MacFilterAccessPoints(items: [
+        _ap(macAddressControlEnabled: false),
+        _ap(instancePath: 'p.2.', macAddressControlEnabled: true),
+      ]);
+
+      expect(service.isEnabled(data), isTrue);
+    });
+
+    test('returns false when all APs disabled', () {
+      final data = MacFilterAccessPoints(items: [
+        _ap(macAddressControlEnabled: false),
+      ]);
+
+      expect(service.isEnabled(data), isFalse);
+    });
+
+    test('returns false when no APs', () {
+      final data = MacFilterAccessPoints(items: []);
+      expect(service.isEnabled(data), isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // allowedDevices
+  // ---------------------------------------------------------------------------
+
+  group('UspInstantPrivacyService — allowedDevices', () {
+    test('parses comma-separated MAC list', () {
+      final data = MacFilterAccessPoints(items: [
+        _ap(allowedMACAddress: 'AA:BB:CC:DD:EE:01,AA:BB:CC:DD:EE:02'),
+      ]);
+
+      final result = service.allowedDevices(data);
+
+      expect(result, hasLength(2));
+      expect(result[0].mac, 'AA:BB:CC:DD:EE:01');
+      expect(result[1].mac, 'AA:BB:CC:DD:EE:02');
+    });
+
+    test('deduplicates MACs', () {
+      final data = MacFilterAccessPoints(items: [
+        _ap(allowedMACAddress: 'AA:BB:CC:DD:EE:01,AA:BB:CC:DD:EE:01'),
+      ]);
+
+      final result = service.allowedDevices(data);
+
+      expect(result, hasLength(1));
+    });
+
+    test('trims whitespace in MAC entries', () {
+      final data = MacFilterAccessPoints(items: [
+        _ap(allowedMACAddress: ' AA:BB:CC:DD:EE:01 , AA:BB:CC:DD:EE:02 '),
+      ]);
+
+      final result = service.allowedDevices(data);
+
+      expect(result, hasLength(2));
+    });
+
+    test('empty allowedMACAddress returns empty list', () {
+      final data = MacFilterAccessPoints(items: [
+        _ap(allowedMACAddress: ''),
+      ]);
+
+      final result = service.allowedDevices(data);
+
+      expect(result, isEmpty);
+    });
+
+    test('empty AP list returns empty', () {
+      final result = service.allowedDevices(MacFilterAccessPoints(items: []));
+      expect(result, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildEnableUpdates
+  // ---------------------------------------------------------------------------
+
+  group('UspInstantPrivacyService — buildEnableUpdates', () {
+    test('creates update for each AP with enabled + MAC list', () {
+      final data = MacFilterAccessPoints(items: [
+        _ap(instancePath: 'ap.1.'),
+        _ap(instancePath: 'ap.2.'),
+      ]);
+
+      final updates = service.buildEnableUpdates(
+        ['AA:BB:CC:DD:EE:01', 'AA:BB:CC:DD:EE:02'],
+        data,
+      );
+
+      expect(updates, hasLength(2));
+      expect(updates[0].macAddressControlEnabled, isTrue);
+      expect(
+          updates[0].allowedMACAddress, 'AA:BB:CC:DD:EE:01,AA:BB:CC:DD:EE:02');
+      expect(updates[1].instancePath, 'ap.2.');
+    });
+
+    test('empty MAC list creates update with empty string', () {
+      final data = MacFilterAccessPoints(items: [_ap()]);
+
+      final updates = service.buildEnableUpdates([], data);
+
+      expect(updates[0].allowedMACAddress, '');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildDisableUpdates
+  // ---------------------------------------------------------------------------
+
+  group('UspInstantPrivacyService — buildDisableUpdates', () {
+    test('creates disable update for each AP', () {
+      final data = MacFilterAccessPoints(items: [
+        _ap(instancePath: 'ap.1.'),
+        _ap(instancePath: 'ap.2.'),
+      ]);
+
+      final updates = service.buildDisableUpdates(data);
+
+      expect(updates, hasLength(2));
+      expect(updates[0].macAddressControlEnabled, isFalse);
+      expect(updates[0].allowedMACAddress, '');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildAddMacUpdates
+  // ---------------------------------------------------------------------------
+
+  group('UspInstantPrivacyService — buildAddMacUpdates', () {
+    test('appends new MAC to existing list', () {
+      final data = MacFilterAccessPoints(items: [
+        _ap(
+          instancePath: 'ap.1.',
+          allowedMACAddress: 'AA:BB:CC:DD:EE:01',
+        ),
+      ]);
+
+      final updates = service.buildAddMacUpdates('AA:BB:CC:DD:EE:02', data);
+
+      expect(updates, hasLength(1));
+      expect(
+          updates[0].allowedMACAddress, 'AA:BB:CC:DD:EE:01,AA:BB:CC:DD:EE:02');
+    });
+
+    test('returns empty when MAC already present', () {
+      final data = MacFilterAccessPoints(items: [
+        _ap(allowedMACAddress: 'AA:BB:CC:DD:EE:01'),
+      ]);
+
+      final updates = service.buildAddMacUpdates('AA:BB:CC:DD:EE:01', data);
+
+      expect(updates, isEmpty);
+    });
+
+    test('returns empty when no APs', () {
+      final data = MacFilterAccessPoints(items: []);
+
+      final updates = service.buildAddMacUpdates('AA:BB:CC:DD:EE:01', data);
+
+      expect(updates, isEmpty);
+    });
+
+    test('adds first MAC to empty list', () {
+      final data = MacFilterAccessPoints(items: [
+        _ap(instancePath: 'ap.1.', allowedMACAddress: ''),
+      ]);
+
+      final updates = service.buildAddMacUpdates('AA:BB:CC:DD:EE:01', data);
+
+      expect(updates, hasLength(1));
+      expect(updates[0].allowedMACAddress, 'AA:BB:CC:DD:EE:01');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // High-level CRUD (fetchAll, enable, disable, addMac)
+  // ---------------------------------------------------------------------------
+
+  group('UspInstantPrivacyService — fetchAll', () {
+    test('returns enriched result with active devices and allowed list',
+        () async {
+      // Mock USP get to return connected devices + AP data in sequence
+      var callCount = 0;
+      when(() => mockUsp.get(any())).thenAnswer((_) async {
+        callCount++;
+        if (callCount <= 1) {
+          // ConnectedDevices response
+          return {
+            'Device.Hosts.Host.1.PhysAddress': 'AA:BB:CC:DD:EE:01',
+            'Device.Hosts.Host.1.IPAddress': '192.168.1.10',
+            'Device.Hosts.Host.1.HostName': 'Laptop',
+            'Device.Hosts.Host.1.Active': true,
+            'Device.Hosts.Host.1.Layer1Interface':
+                'Device.Ethernet.Interface.1',
+            'Device.Hosts.Host.1.AddressSource': 'DHCP',
+          };
+        }
+        // MacFilterAccessPoints response
+        return {
+          'Device.WiFi.AccessPoint.1.SSIDReference': 'Device.WiFi.SSID.1',
+          'Device.WiFi.AccessPoint.1.MACAddressControlEnabled': true,
+          'Device.WiFi.AccessPoint.1.AllowedMACAddress': 'AA:BB:CC:DD:EE:01',
+        };
+      });
+
+      final result = await service.fetchAll();
+
+      expect(result.isEnabled, isTrue);
+      expect(result.connectedDevices, hasLength(1));
+      expect(result.allowedDevices, hasLength(1));
+      // Allowed device should be enriched with hostname from devices
+      expect(result.allowedDevices[0].displayName, 'Laptop');
+    });
+  });
+
+  group('UspInstantPrivacyService — enable', () {
+    test('calls updateMany with enable updates', () async {
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => {});
+
+      // Build context from AP data
+      when(() => mockUsp.get(any())).thenAnswer((_) async => {
+            'Device.WiFi.AccessPoint.1.SSIDReference': 'Device.WiFi.SSID.1',
+            'Device.WiFi.AccessPoint.1.MACAddressControlEnabled': false,
+            'Device.WiFi.AccessPoint.1.AllowedMACAddress': '',
+          });
+
+      // We need a real context — fetchAll uses codegen which is mocked via UspService
+      // Instead, test via buildEnableUpdates + verify set is called
+      final data = MacFilterAccessPoints(items: [
+        _ap(instancePath: 'ap.1.'),
+      ]);
+      final updates = service.buildEnableUpdates(['AA:BB:CC:DD:EE:01'], data);
+
+      expect(updates, hasLength(1));
+      expect(updates[0].macAddressControlEnabled, isTrue);
+    });
+  });
+
+  group('UspInstantPrivacyService — disable', () {
+    test('builds correct disable updates', () {
+      final data = MacFilterAccessPoints(items: [
+        _ap(instancePath: 'ap.1.', macAddressControlEnabled: true),
+      ]);
+
+      final updates = service.buildDisableUpdates(data);
+
+      expect(updates, hasLength(1));
+      expect(updates[0].macAddressControlEnabled, isFalse);
+      expect(updates[0].allowedMACAddress, '');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // MacFilterContext
+  // ---------------------------------------------------------------------------
+
+  group('MacFilterContext', () {
+    test('empty context is constant', () {
+      expect(MacFilterContext.empty, MacFilterContext.empty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // InstantPrivacyDeviceUIModel
+  // ---------------------------------------------------------------------------
+
+  group('InstantPrivacyDeviceUIModel', () {
+    test('toMap / fromMap round-trip', () {
+      final model = InstantPrivacyDeviceUIModel(
+        mac: 'AA:BB:CC:DD:EE:FF',
+        displayName: 'Laptop',
+      );
+
+      final map = model.toMap();
+      final restored = InstantPrivacyDeviceUIModel.fromMap(map);
+
+      expect(restored, model);
+    });
+  });
+}

--- a/test/page/instant_privacy/services/usp_instant_privacy_service_test.dart
+++ b/test/page/instant_privacy/services/usp_instant_privacy_service_test.dart
@@ -350,32 +350,41 @@ void main() {
   // High-level CRUD (fetchAll, enable, disable, addMac)
   // ---------------------------------------------------------------------------
 
-  group('UspInstantPrivacyService — fetchAll', () {
-    test('returns enriched result with active devices and allowed list',
-        () async {
-      // Mock USP get to return connected devices + AP data in sequence
-      var callCount = 0;
-      when(() => mockUsp.get(any())).thenAnswer((_) async {
-        callCount++;
-        if (callCount <= 1) {
-          // ConnectedDevices response
-          return {
-            'Device.Hosts.Host.1.PhysAddress': 'AA:BB:CC:DD:EE:01',
-            'Device.Hosts.Host.1.IPAddress': '192.168.1.10',
-            'Device.Hosts.Host.1.HostName': 'Laptop',
-            'Device.Hosts.Host.1.Active': true,
-            'Device.Hosts.Host.1.Layer1Interface':
-                'Device.Ethernet.Interface.1',
-            'Device.Hosts.Host.1.AddressSource': 'DHCP',
-          };
-        }
-        // MacFilterAccessPoints response
-        return {
+  /// Standard path-based mock for fetchAll: routes ConnectedDevices vs
+  /// MacFilterAccessPoints based on requested paths.
+  void stubFetchAll(
+    MockUspService mock, {
+    Map<String, dynamic>? devicesResponse,
+    Map<String, dynamic>? apResponse,
+  }) {
+    final devices = devicesResponse ??
+        {
+          'Device.Hosts.Host.1.PhysAddress': 'AA:BB:CC:DD:EE:01',
+          'Device.Hosts.Host.1.IPAddress': '192.168.1.10',
+          'Device.Hosts.Host.1.HostName': 'Laptop',
+          'Device.Hosts.Host.1.Active': true,
+          'Device.Hosts.Host.1.Layer1Interface': 'Device.Ethernet.Interface.1',
+          'Device.Hosts.Host.1.AddressSource': 'DHCP',
+        };
+    final aps = apResponse ??
+        {
           'Device.WiFi.AccessPoint.1.SSIDReference': 'Device.WiFi.SSID.1',
           'Device.WiFi.AccessPoint.1.MACAddressControlEnabled': true,
           'Device.WiFi.AccessPoint.1.AllowedMACAddress': 'AA:BB:CC:DD:EE:01',
         };
-      });
+    when(() => mock.get(any())).thenAnswer((_) async {
+      final paths = _.positionalArguments[0] as List;
+      if (paths.any((p) => p.toString().contains('Hosts.Host'))) {
+        return devices;
+      }
+      return aps;
+    });
+  }
+
+  group('UspInstantPrivacyService — fetchAll', () {
+    test('returns enriched result with active devices and allowed list',
+        () async {
+      stubFetchAll(mockUsp);
 
       final result = await service.fetchAll();
 
@@ -385,43 +394,119 @@ void main() {
       // Allowed device should be enriched with hostname from devices
       expect(result.allowedDevices[0].displayName, 'Laptop');
     });
+
+    test('allowed device uses Unknown Device when no host match', () async {
+      stubFetchAll(mockUsp, apResponse: {
+        'Device.WiFi.AccessPoint.1.SSIDReference': 'Device.WiFi.SSID.1',
+        'Device.WiFi.AccessPoint.1.MACAddressControlEnabled': true,
+        'Device.WiFi.AccessPoint.1.AllowedMACAddress': 'FF:FF:FF:FF:FF:FF',
+      });
+
+      final result = await service.fetchAll();
+
+      // FF:FF:FF:FF:FF:FF is not in connected devices → "Unknown Device"
+      expect(result.allowedDevices[0].displayName, 'Unknown Device');
+    });
   });
 
   group('UspInstantPrivacyService — enable', () {
-    test('calls updateMany with enable updates', () async {
+    test('calls set via updateMany with enable updates', () async {
+      // Stub fetchAll to get a real MacFilterContext
+      stubFetchAll(mockUsp, apResponse: {
+        'Device.WiFi.AccessPoint.1.SSIDReference': 'Device.WiFi.SSID.1',
+        'Device.WiFi.AccessPoint.1.MACAddressControlEnabled': false,
+        'Device.WiFi.AccessPoint.1.AllowedMACAddress': '',
+      });
       when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
           .thenAnswer((_) async => {});
 
-      // Build context from AP data
-      when(() => mockUsp.get(any())).thenAnswer((_) async => {
-            'Device.WiFi.AccessPoint.1.SSIDReference': 'Device.WiFi.SSID.1',
-            'Device.WiFi.AccessPoint.1.MACAddressControlEnabled': false,
-            'Device.WiFi.AccessPoint.1.AllowedMACAddress': '',
-          });
+      final result = await service.fetchAll();
 
-      // We need a real context — fetchAll uses codegen which is mocked via UspService
-      // Instead, test via buildEnableUpdates + verify set is called
-      final data = MacFilterAccessPoints(items: [
-        _ap(instancePath: 'ap.1.'),
-      ]);
-      final updates = service.buildEnableUpdates(['AA:BB:CC:DD:EE:01'], data);
+      await service.enable(['AA:BB:CC:DD:EE:01'], result.macFilterContext);
 
-      expect(updates, hasLength(1));
-      expect(updates[0].macAddressControlEnabled, isTrue);
+      final captured = verify(
+        () =>
+            mockUsp.set(captureAny(), allowPartial: any(named: 'allowPartial')),
+      ).captured;
+      final params = captured.first as Map<String, dynamic>;
+      expect(
+          params,
+          containsPair(
+            'Device.WiFi.AccessPoint.1.MACAddressControlEnabled',
+            true,
+          ));
+      expect(
+          params,
+          containsPair(
+            'Device.WiFi.AccessPoint.1.AllowedMACAddress',
+            'AA:BB:CC:DD:EE:01',
+          ));
     });
   });
 
   group('UspInstantPrivacyService — disable', () {
-    test('builds correct disable updates', () {
-      final data = MacFilterAccessPoints(items: [
-        _ap(instancePath: 'ap.1.', macAddressControlEnabled: true),
-      ]);
+    test('calls set via updateMany with disable updates', () async {
+      stubFetchAll(mockUsp);
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => {});
 
-      final updates = service.buildDisableUpdates(data);
+      final result = await service.fetchAll();
 
-      expect(updates, hasLength(1));
-      expect(updates[0].macAddressControlEnabled, isFalse);
-      expect(updates[0].allowedMACAddress, '');
+      await service.disable(result.macFilterContext);
+
+      final captured = verify(
+        () =>
+            mockUsp.set(captureAny(), allowPartial: any(named: 'allowPartial')),
+      ).captured;
+      final params = captured.first as Map<String, dynamic>;
+      expect(
+          params,
+          containsPair(
+            'Device.WiFi.AccessPoint.1.MACAddressControlEnabled',
+            false,
+          ));
+      expect(
+          params,
+          containsPair(
+            'Device.WiFi.AccessPoint.1.AllowedMACAddress',
+            '',
+          ));
+    });
+  });
+
+  group('UspInstantPrivacyService — addMac', () {
+    test('adds new MAC and calls set', () async {
+      stubFetchAll(mockUsp);
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => {});
+
+      final result = await service.fetchAll();
+
+      final added = await service.addMac(
+        'FF:FF:FF:FF:FF:FF',
+        result.macFilterContext,
+      );
+
+      expect(added, isTrue);
+      verify(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .called(1);
+    });
+
+    test('returns false when MAC already present', () async {
+      stubFetchAll(mockUsp);
+
+      final result = await service.fetchAll();
+
+      // AA:BB:CC:DD:EE:01 is already in the allowed list
+      final added = await service.addMac(
+        'AA:BB:CC:DD:EE:01',
+        result.macFilterContext,
+      );
+
+      expect(added, isFalse);
+      verifyNever(
+        () => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')),
+      );
     });
   });
 
@@ -432,6 +517,15 @@ void main() {
   group('MacFilterContext', () {
     test('empty context is constant', () {
       expect(MacFilterContext.empty, MacFilterContext.empty);
+    });
+
+    test('props uses item count for equality', () async {
+      stubFetchAll(mockUsp);
+      final result = await service.fetchAll();
+
+      // Same item count → equal props
+      expect(result.macFilterContext.props, isNotEmpty);
+      expect(MacFilterContext.empty.props, isNotEmpty);
     });
   });
 

--- a/test/page/ipv6_port_service/services/usp_ipv6_port_service_service_test.dart
+++ b/test/page/ipv6_port_service/services/usp_ipv6_port_service_service_test.dart
@@ -1,0 +1,421 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/services/usp_service.dart';
+import 'package:privacy_gui/generated/ipv6port_service.g.dart';
+import 'package:privacy_gui/page/ipv6_port_service/models/ipv6_port_service_ui_model.dart';
+import 'package:privacy_gui/page/ipv6_port_service/services/usp_ipv6_port_service_service.dart';
+
+class MockUspService extends Mock implements UspService {}
+
+Ipv6PortServiceRule _rule({
+  String instancePath = 'Device.Firewall.Chain.1.Rule.26.',
+  bool enable = true,
+  String description = 'WebServer',
+  int ipVersion = 6,
+  String destIp = '2001:db8::1',
+  int destPort = 80,
+  int destPortRangeMax = 80,
+  int protocol = 6,
+  String target = 'Accept',
+  String creationDate = '2026-01-15T12:00:00Z',
+}) =>
+    Ipv6PortServiceRule(
+      instancePath: instancePath,
+      enable: enable,
+      description: description,
+      ipVersion: ipVersion,
+      destIp: destIp,
+      destPort: destPort,
+      destPortRangeMax: destPortRangeMax,
+      protocol: protocol,
+      target: target,
+      creationDate: creationDate,
+    );
+
+void main() {
+  late MockUspService mockUsp;
+  late UspIpv6PortServiceService service;
+
+  setUp(() {
+    mockUsp = MockUspService();
+    service = UspIpv6PortServiceService(mockUsp);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Protocol mapping
+  // ---------------------------------------------------------------------------
+
+  group('UspIpv6PortServiceService — protocol mapping', () {
+    test('mapIanaToDisplay maps known protocols', () {
+      expect(service.mapIanaToDisplay(6), 'TCP');
+      expect(service.mapIanaToDisplay(17), 'UDP');
+      expect(service.mapIanaToDisplay(255), 'Both');
+    });
+
+    test('mapIanaToDisplay defaults unknown to Both', () {
+      expect(service.mapIanaToDisplay(99), 'Both');
+    });
+
+    test('mapDisplayToIana maps known names', () {
+      expect(service.mapDisplayToIana('TCP'), 6);
+      expect(service.mapDisplayToIana('UDP'), 17);
+      expect(service.mapDisplayToIana('Both'), 255);
+    });
+
+    test('mapDisplayToIana defaults unknown to 255', () {
+      expect(service.mapDisplayToIana('SCTP'), 255);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildRuleUIModels
+  // ---------------------------------------------------------------------------
+
+  group('UspIpv6PortServiceService — buildRuleUIModels', () {
+    test('filters to IPv6 Accept user rules only', () {
+      final data = Ipv6PortService(items: [
+        _rule(ipVersion: 6, target: 'Accept'),
+        _rule(
+          instancePath: 'p.27.',
+          ipVersion: 4,
+          target: 'Accept',
+        ), // filtered: not IPv6
+        _rule(
+          instancePath: 'p.28.',
+          ipVersion: 6,
+          target: 'Drop',
+        ), // filtered: not Accept
+        _rule(
+          instancePath: 'p.29.',
+          ipVersion: 6,
+          target: 'Accept',
+          creationDate: '0001-01-01T00:00:00Z',
+        ), // filtered: system rule
+      ]);
+
+      final result = service.buildRuleUIModels(data);
+
+      expect(result, hasLength(1));
+    });
+
+    test('maps all fields correctly', () {
+      final data = Ipv6PortService(items: [
+        _rule(
+          instancePath: 'path.26.',
+          enable: true,
+          description: 'SSH',
+          destIp: '2001:db8::1',
+          destPort: 22,
+          destPortRangeMax: 22,
+          protocol: 6,
+        ),
+      ]);
+
+      final result = service.buildRuleUIModels(data);
+
+      expect(result[0].instancePath, 'path.26.');
+      expect(result[0].enabled, isTrue);
+      expect(result[0].description, 'SSH');
+      expect(result[0].ipv6Address, '2001:db8::1');
+      expect(result[0].startPort, 22);
+      expect(result[0].endPort, 22);
+      expect(result[0].protocol, 'TCP');
+    });
+
+    test('maps protocol 17 to UDP display', () {
+      final data = Ipv6PortService(items: [
+        _rule(protocol: 17),
+      ]);
+
+      final result = service.buildRuleUIModels(data);
+
+      expect(result[0].protocol, 'UDP');
+    });
+
+    test('empty items returns empty list', () {
+      final result = service.buildRuleUIModels(Ipv6PortService(items: []));
+      expect(result, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateRule
+  // ---------------------------------------------------------------------------
+
+  group('UspIpv6PortServiceService — validateRule', () {
+    test('valid rule returns empty errors', () {
+      final errors = UspIpv6PortServiceService.validateRule(
+        description: 'WebServer',
+        ipv6Address: '2001:db8::1',
+        startPort: '80',
+        endPort: '443',
+      );
+      expect(errors, isEmpty);
+    });
+
+    test('empty description returns error', () {
+      final errors = UspIpv6PortServiceService.validateRule(
+        description: '',
+        ipv6Address: '2001:db8::1',
+        startPort: '80',
+        endPort: '80',
+      );
+      expect(errors['description'], 'Name is required');
+    });
+
+    test('description with leading space returns error', () {
+      final errors = UspIpv6PortServiceService.validateRule(
+        description: ' WebServer',
+        ipv6Address: '2001:db8::1',
+        startPort: '80',
+        endPort: '80',
+      );
+      expect(errors['description'],
+          'Name must not have leading or trailing spaces');
+    });
+
+    test('description over 32 chars returns error', () {
+      final errors = UspIpv6PortServiceService.validateRule(
+        description: 'A' * 33,
+        ipv6Address: '2001:db8::1',
+        startPort: '80',
+        endPort: '80',
+      );
+      expect(errors['description'], 'Name must be 32 characters or less');
+    });
+
+    test('empty IPv6 address returns error', () {
+      final errors = UspIpv6PortServiceService.validateRule(
+        description: 'Rule1',
+        ipv6Address: '',
+        startPort: '80',
+        endPort: '80',
+      );
+      expect(errors['ipv6Address'], 'IPv6 address is required');
+    });
+
+    test('invalid IPv6 format returns error', () {
+      final errors = UspIpv6PortServiceService.validateRule(
+        description: 'Rule1',
+        ipv6Address: 'not-an-ipv6',
+        startPort: '80',
+        endPort: '80',
+      );
+      expect(errors['ipv6Address'], 'Invalid IPv6 address format');
+    });
+
+    test('empty start port returns error', () {
+      final errors = UspIpv6PortServiceService.validateRule(
+        description: 'Rule1',
+        ipv6Address: '2001:db8::1',
+        startPort: '',
+        endPort: '80',
+      );
+      expect(errors['startPort'], 'Start port is required');
+    });
+
+    test('port out of range returns error', () {
+      final errors = UspIpv6PortServiceService.validateRule(
+        description: 'Rule1',
+        ipv6Address: '2001:db8::1',
+        startPort: '0',
+        endPort: '65536',
+      );
+      expect(errors['startPort'], 'Port must be 1-65535');
+      expect(errors['endPort'], 'Port must be 1-65535');
+    });
+
+    test('end port less than start port returns error', () {
+      final errors = UspIpv6PortServiceService.validateRule(
+        description: 'Rule1',
+        ipv6Address: '2001:db8::1',
+        startPort: '443',
+        endPort: '80',
+      );
+      expect(errors['endPort'], 'End port must be >= start port');
+    });
+
+    test('multiple errors returned simultaneously', () {
+      final errors = UspIpv6PortServiceService.validateRule(
+        description: '',
+        ipv6Address: '',
+        startPort: '',
+        endPort: '',
+      );
+      expect(errors.length, greaterThanOrEqualTo(4));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // saveBatch
+  // ---------------------------------------------------------------------------
+
+  group('UspIpv6PortServiceService — saveBatch', () {
+    test('no-op when lists identical', () async {
+      final rules = [
+        Ipv6PortServiceRuleUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          description: 'SSH',
+          ipv6Address: '2001:db8::1',
+          protocol: 'TCP',
+          startPort: 22,
+          endPort: 22,
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: rules,
+        current: List.of(rules),
+      );
+
+      expect(result.added, 0);
+      expect(result.updated, 0);
+      expect(result.deleted, 0);
+    });
+
+    test('delete removes missing items', () async {
+      when(() => mockUsp.delete(any())).thenAnswer((_) async {});
+
+      final original = [
+        Ipv6PortServiceRuleUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          description: 'SSH',
+          ipv6Address: '2001:db8::1',
+          protocol: 'TCP',
+          startPort: 22,
+          endPort: 22,
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: original,
+        current: [],
+      );
+
+      expect(result.deleted, 1);
+      verify(() => mockUsp.delete('path.1.')).called(1);
+    });
+
+    test('add creates items with null instancePath', () async {
+      when(() => mockUsp.add(any(), any())).thenAnswer((_) async => '');
+
+      final current = [
+        Ipv6PortServiceRuleUIModel(
+          enabled: true,
+          description: 'Web',
+          ipv6Address: '2001:db8::2',
+          protocol: 'TCP',
+          startPort: 80,
+          endPort: 443,
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: [],
+        current: current,
+      );
+
+      expect(result.added, 1);
+      final captured =
+          verify(() => mockUsp.add(captureAny(), captureAny())).captured;
+      final params = captured[1] as Map<String, dynamic>;
+      expect(params['DestIP'], '2001:db8::2');
+      expect(params['Protocol'], 6); // TCP → IANA 6
+      expect(params['IPVersion'], 6);
+      expect(params['Target'], 'Accept');
+    });
+
+    test('update detects changed content', () async {
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => {});
+
+      final original = [
+        Ipv6PortServiceRuleUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          description: 'SSH',
+          ipv6Address: '2001:db8::1',
+          protocol: 'TCP',
+          startPort: 22,
+          endPort: 22,
+        ),
+      ];
+      final current = [
+        Ipv6PortServiceRuleUIModel(
+          instancePath: 'path.1.',
+          enabled: false, // changed
+          description: 'SSH',
+          ipv6Address: '2001:db8::1',
+          protocol: 'TCP',
+          startPort: 22,
+          endPort: 22,
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: original,
+        current: current,
+      );
+
+      expect(result.updated, 1);
+    });
+
+    test('mixed batch: delete + add + update', () async {
+      when(() => mockUsp.delete(any())).thenAnswer((_) async {});
+      when(() => mockUsp.add(any(), any())).thenAnswer((_) async => '');
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => {});
+
+      final original = [
+        Ipv6PortServiceRuleUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          description: 'ToDelete',
+          ipv6Address: '::1',
+          protocol: 'TCP',
+          startPort: 80,
+          endPort: 80,
+        ),
+        Ipv6PortServiceRuleUIModel(
+          instancePath: 'path.2.',
+          enabled: true,
+          description: 'ToUpdate',
+          ipv6Address: '2001:db8::2',
+          protocol: 'UDP',
+          startPort: 53,
+          endPort: 53,
+        ),
+      ];
+      final current = [
+        Ipv6PortServiceRuleUIModel(
+          instancePath: 'path.2.',
+          enabled: false, // changed
+          description: 'ToUpdate',
+          ipv6Address: '2001:db8::2',
+          protocol: 'UDP',
+          startPort: 53,
+          endPort: 53,
+        ),
+        Ipv6PortServiceRuleUIModel(
+          description: 'NewRule',
+          enabled: true,
+          ipv6Address: '2001:db8::3',
+          protocol: 'Both',
+          startPort: 1000,
+          endPort: 2000,
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: original,
+        current: current,
+      );
+
+      expect(result.deleted, 1);
+      expect(result.added, 1);
+      expect(result.updated, 1);
+    });
+  });
+}

--- a/test/page/port_forwarding/services/usp_port_forwarding_service_test.dart
+++ b/test/page/port_forwarding/services/usp_port_forwarding_service_test.dart
@@ -1,0 +1,387 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/services/usp_service.dart';
+import 'package:privacy_gui/page/_shared/models/port_forwarding_rule_ui_model.dart';
+import 'package:privacy_gui/page/_shared/services/usp_device_service.dart';
+import 'package:privacy_gui/page/port_forwarding/models/port_triggering_rule_ui_model.dart';
+import 'package:privacy_gui/page/port_forwarding/services/usp_port_forwarding_service.dart';
+
+class MockUspService extends Mock implements UspService {}
+
+class MockUspDeviceService extends Mock implements UspDeviceService {}
+
+void main() {
+  late MockUspService mockUsp;
+  late MockUspDeviceService mockDeviceSvc;
+  late UspPortForwardingService service;
+
+  setUp(() {
+    mockUsp = MockUspService();
+    mockDeviceSvc = MockUspDeviceService();
+    service = UspPortForwardingService(mockUsp, mockDeviceSvc);
+  });
+
+  // ---------------------------------------------------------------------------
+  // saveForwardingBatch
+  // ---------------------------------------------------------------------------
+
+  group('UspPortForwardingService — saveForwardingBatch', () {
+    test('no-op when lists identical', () async {
+      final rules = [
+        PortForwardingRuleUIModel(
+          instancePath: 'path.1.',
+          description: 'HTTP',
+          externalPort: 80,
+          internalPort: 80,
+          internalClient: '192.168.1.100',
+          protocol: 'TCP',
+          enabled: true,
+        ),
+      ];
+
+      final result = await service.saveForwardingBatch(
+        original: rules,
+        current: List.of(rules),
+      );
+
+      expect(result.added, 0);
+      expect(result.updated, 0);
+      expect(result.deleted, 0);
+    });
+
+    test('delete removes items missing from current', () async {
+      when(() => mockUsp.delete(any())).thenAnswer((_) async {});
+
+      final original = [
+        PortForwardingRuleUIModel(
+          instancePath: 'path.1.',
+          description: 'HTTP',
+          externalPort: 80,
+          internalPort: 80,
+          internalClient: '192.168.1.100',
+          protocol: 'TCP',
+          enabled: true,
+        ),
+      ];
+
+      final result = await service.saveForwardingBatch(
+        original: original,
+        current: [],
+      );
+
+      expect(result.deleted, 1);
+      verify(() => mockUsp.delete('path.1.')).called(1);
+    });
+
+    test('add creates items with null instancePath', () async {
+      when(() => mockUsp.add(any(), any())).thenAnswer((_) async => '');
+
+      final current = [
+        PortForwardingRuleUIModel(
+          description: 'SSH',
+          externalPort: 22,
+          internalPort: 22,
+          internalClient: '192.168.1.50',
+          protocol: 'Both',
+          enabled: true,
+        ),
+      ];
+
+      final result = await service.saveForwardingBatch(
+        original: [],
+        current: current,
+      );
+
+      expect(result.added, 1);
+      final captured =
+          verify(() => mockUsp.add(captureAny(), captureAny())).captured;
+      final params = captured[1] as Map<String, dynamic>;
+      expect(params['ExternalPort'], 22);
+      expect(params['InternalClient'], '192.168.1.50');
+      expect(params['Protocol'], 'Both');
+    });
+
+    test('update detects changed content', () async {
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => {});
+
+      final original = [
+        PortForwardingRuleUIModel(
+          instancePath: 'path.1.',
+          description: 'HTTP',
+          externalPort: 80,
+          internalPort: 80,
+          internalClient: '192.168.1.100',
+          protocol: 'TCP',
+          enabled: true,
+        ),
+      ];
+      final current = [
+        PortForwardingRuleUIModel(
+          instancePath: 'path.1.',
+          description: 'HTTP',
+          externalPort: 8080, // changed
+          internalPort: 80,
+          internalClient: '192.168.1.100',
+          protocol: 'TCP',
+          enabled: true,
+        ),
+      ];
+
+      final result = await service.saveForwardingBatch(
+        original: original,
+        current: current,
+      );
+
+      expect(result.updated, 1);
+    });
+
+    test('mixed batch: delete + add + update', () async {
+      when(() => mockUsp.delete(any())).thenAnswer((_) async {});
+      when(() => mockUsp.add(any(), any())).thenAnswer((_) async => '');
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => {});
+
+      final original = [
+        PortForwardingRuleUIModel(
+          instancePath: 'path.1.',
+          description: 'ToDelete',
+          externalPort: 80,
+          internalPort: 80,
+          internalClient: '192.168.1.100',
+          protocol: 'TCP',
+          enabled: true,
+        ),
+        PortForwardingRuleUIModel(
+          instancePath: 'path.2.',
+          description: 'ToUpdate',
+          externalPort: 443,
+          internalPort: 443,
+          internalClient: '192.168.1.100',
+          protocol: 'TCP',
+          enabled: true,
+        ),
+      ];
+      final current = [
+        PortForwardingRuleUIModel(
+          instancePath: 'path.2.',
+          description: 'ToUpdate',
+          externalPort: 443,
+          internalPort: 443,
+          internalClient: '192.168.1.100',
+          protocol: 'TCP',
+          enabled: false, // changed
+        ),
+        PortForwardingRuleUIModel(
+          description: 'NewRule',
+          externalPort: 22,
+          internalPort: 22,
+          internalClient: '192.168.1.50',
+          protocol: 'Both',
+          enabled: true,
+        ),
+      ];
+
+      final result = await service.saveForwardingBatch(
+        original: original,
+        current: current,
+      );
+
+      expect(result.deleted, 1);
+      expect(result.added, 1);
+      expect(result.updated, 1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // saveTriggeringBatch
+  // ---------------------------------------------------------------------------
+
+  group('UspPortForwardingService — saveTriggeringBatch', () {
+    test('no-op when lists identical', () async {
+      final rules = [
+        PortTriggeringRuleUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          description: 'FTP',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+          forwardRules: [
+            PortTriggerForwardRuleUIModel(
+              forwardPort: 1024,
+              forwardPortEndRange: 1030,
+              forwardProtocol: 'TCP',
+            ),
+          ],
+        ),
+      ];
+
+      final result = await service.saveTriggeringBatch(
+        original: rules,
+        current: List.of(rules),
+      );
+
+      expect(result.added, 0);
+      expect(result.updated, 0);
+      expect(result.deleted, 0);
+    });
+
+    test('delete removes items missing from current', () async {
+      when(() => mockUsp.delete(any())).thenAnswer((_) async {});
+
+      final original = [
+        PortTriggeringRuleUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          description: 'FTP',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+        ),
+      ];
+
+      final result = await service.saveTriggeringBatch(
+        original: original,
+        current: [],
+      );
+
+      expect(result.deleted, 1);
+      verify(() => mockUsp.delete('path.1.')).called(1);
+    });
+
+    test('add creates parent + forward rules', () async {
+      when(() => mockUsp.add(any(), any()))
+          .thenAnswer((_) async => 'Device.NAT.PortTrigger.5.');
+
+      final current = [
+        PortTriggeringRuleUIModel(
+          enabled: true,
+          description: 'FTP',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+          forwardRules: [
+            PortTriggerForwardRuleUIModel(
+              forwardPort: 1024,
+              forwardPortEndRange: 1030,
+              forwardProtocol: 'TCP',
+            ),
+            PortTriggerForwardRuleUIModel(
+              forwardPort: 2048,
+              forwardProtocol: 'UDP',
+            ),
+          ],
+        ),
+      ];
+
+      final result = await service.saveTriggeringBatch(
+        original: [],
+        current: current,
+      );
+
+      expect(result.added, 1);
+      // 1 parent add + 2 forward rule adds = 3 total add calls
+      verify(() => mockUsp.add(any(), any())).called(3);
+    });
+
+    test('add with no forward rules creates parent only', () async {
+      when(() => mockUsp.add(any(), any()))
+          .thenAnswer((_) async => 'Device.NAT.PortTrigger.5.');
+
+      final current = [
+        PortTriggeringRuleUIModel(
+          enabled: true,
+          description: 'Simple',
+          triggerPort: 5060,
+          triggerProtocol: 'UDP',
+        ),
+      ];
+
+      final result = await service.saveTriggeringBatch(
+        original: [],
+        current: current,
+      );
+
+      expect(result.added, 1);
+      verify(() => mockUsp.add(any(), any())).called(1);
+    });
+
+    test('update detects changed parent fields', () async {
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => {});
+
+      final original = [
+        PortTriggeringRuleUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          description: 'FTP',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+        ),
+      ];
+      final current = [
+        PortTriggeringRuleUIModel(
+          instancePath: 'path.1.',
+          enabled: false, // changed
+          description: 'FTP',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+        ),
+      ];
+
+      final result = await service.saveTriggeringBatch(
+        original: original,
+        current: current,
+      );
+
+      expect(result.updated, 1);
+    });
+
+    test('mixed batch: delete + add + update', () async {
+      when(() => mockUsp.delete(any())).thenAnswer((_) async {});
+      when(() => mockUsp.add(any(), any()))
+          .thenAnswer((_) async => 'Device.NAT.PortTrigger.9.');
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => {});
+
+      final original = [
+        PortTriggeringRuleUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          description: 'ToDelete',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+        ),
+        PortTriggeringRuleUIModel(
+          instancePath: 'path.2.',
+          enabled: true,
+          description: 'ToUpdate',
+          triggerPort: 5060,
+          triggerProtocol: 'UDP',
+        ),
+      ];
+      final current = [
+        PortTriggeringRuleUIModel(
+          instancePath: 'path.2.',
+          enabled: false, // changed
+          description: 'ToUpdate',
+          triggerPort: 5060,
+          triggerProtocol: 'UDP',
+        ),
+        PortTriggeringRuleUIModel(
+          enabled: true,
+          description: 'NewTrigger',
+          triggerPort: 80,
+          triggerProtocol: 'TCP',
+        ),
+      ];
+
+      final result = await service.saveTriggeringBatch(
+        original: original,
+        current: current,
+      );
+
+      expect(result.deleted, 1);
+      expect(result.added, 1);
+      expect(result.updated, 1);
+    });
+  });
+}

--- a/test/page/port_forwarding/services/usp_port_forwarding_service_test.dart
+++ b/test/page/port_forwarding/services/usp_port_forwarding_service_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
+import 'package:privacy_gui/generated/port_forwarding.g.dart';
+import 'package:privacy_gui/generated/port_triggering.g.dart';
 import 'package:privacy_gui/page/_shared/models/port_forwarding_rule_ui_model.dart';
 import 'package:privacy_gui/page/_shared/services/usp_device_service.dart';
 import 'package:privacy_gui/page/port_forwarding/models/port_triggering_rule_ui_model.dart';
@@ -15,10 +17,82 @@ void main() {
   late MockUspDeviceService mockDeviceSvc;
   late UspPortForwardingService service;
 
+  setUpAll(() {
+    registerFallbackValue(const PortForwarding(items: []));
+    registerFallbackValue(const PortTriggering(items: []));
+  });
+
   setUp(() {
     mockUsp = MockUspService();
     mockDeviceSvc = MockUspDeviceService();
     service = UspPortForwardingService(mockUsp, mockDeviceSvc);
+  });
+
+  // ---------------------------------------------------------------------------
+  // fetch
+  // ---------------------------------------------------------------------------
+
+  group('UspPortForwardingService — fetchForwardingRules', () {
+    test('fetches and transforms forwarding rules', () async {
+      when(() => mockUsp.get(any())).thenAnswer((_) async => <String, dynamic>{
+            'Device.NAT.PortMapping.1.Enable': true,
+            'Device.NAT.PortMapping.1.ExternalPort': 80,
+            'Device.NAT.PortMapping.1.ExternalPortEndRange': 80,
+            'Device.NAT.PortMapping.1.InternalPort': 8080,
+            'Device.NAT.PortMapping.1.InternalClient': '192.168.1.100',
+            'Device.NAT.PortMapping.1.Protocol': 'TCP',
+            'Device.NAT.PortMapping.1.Description': 'HTTP',
+          });
+      when(() => mockDeviceSvc.buildPortForwardingRuleUIModels(
+            any(),
+          )).thenReturn([
+        PortForwardingRuleUIModel(
+          instancePath: 'Device.NAT.PortMapping.1.',
+          description: 'HTTP',
+          externalPort: 80,
+          internalPort: 8080,
+          internalClient: '192.168.1.100',
+          protocol: 'TCP',
+          enabled: true,
+        ),
+      ]);
+
+      final result = await service.fetchForwardingRules();
+
+      expect(result, hasLength(1));
+      expect(result[0].description, 'HTTP');
+      verify(() => mockDeviceSvc.buildPortForwardingRuleUIModels(any()))
+          .called(1);
+    });
+  });
+
+  group('UspPortForwardingService — fetchTriggeringRules', () {
+    test('fetches and transforms triggering rules', () async {
+      when(() => mockUsp.get(any())).thenAnswer((_) async => <String, dynamic>{
+            'Device.NAT.PortTrigger.1.Enable': true,
+            'Device.NAT.PortTrigger.1.Description': 'FTP',
+            'Device.NAT.PortTrigger.1.TriggerPort': 21,
+            'Device.NAT.PortTrigger.1.TriggerProtocol': 'TCP',
+          });
+      when(() => mockDeviceSvc.buildPortTriggeringRuleUIModels(
+            any(),
+          )).thenReturn([
+        PortTriggeringRuleUIModel(
+          instancePath: 'Device.NAT.PortTrigger.1.',
+          enabled: true,
+          description: 'FTP',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+        ),
+      ]);
+
+      final result = await service.fetchTriggeringRules();
+
+      expect(result, hasLength(1));
+      expect(result[0].description, 'FTP');
+      verify(() => mockDeviceSvc.buildPortTriggeringRuleUIModels(any()))
+          .called(1);
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -190,6 +264,70 @@ void main() {
       expect(result.deleted, 1);
       expect(result.added, 1);
       expect(result.updated, 1);
+    });
+
+    test('multi-item delete uses sequential delay', () async {
+      when(() => mockUsp.delete(any())).thenAnswer((_) async {});
+
+      final original = [
+        PortForwardingRuleUIModel(
+          instancePath: 'path.1.',
+          description: 'Rule1',
+          externalPort: 80,
+          internalPort: 80,
+          internalClient: '192.168.1.100',
+          protocol: 'TCP',
+          enabled: true,
+        ),
+        PortForwardingRuleUIModel(
+          instancePath: 'path.2.',
+          description: 'Rule2',
+          externalPort: 443,
+          internalPort: 443,
+          internalClient: '192.168.1.100',
+          protocol: 'TCP',
+          enabled: true,
+        ),
+      ];
+
+      final result = await service.saveForwardingBatch(
+        original: original,
+        current: [],
+      );
+
+      expect(result.deleted, 2);
+      verify(() => mockUsp.delete(any())).called(2);
+    });
+
+    test('multi-item add uses sequential delay', () async {
+      when(() => mockUsp.add(any(), any())).thenAnswer((_) async => '');
+
+      final current = [
+        PortForwardingRuleUIModel(
+          description: 'Rule1',
+          externalPort: 80,
+          internalPort: 80,
+          internalClient: '192.168.1.100',
+          protocol: 'TCP',
+          enabled: true,
+        ),
+        PortForwardingRuleUIModel(
+          description: 'Rule2',
+          externalPort: 443,
+          internalPort: 443,
+          internalClient: '192.168.1.100',
+          protocol: 'TCP',
+          enabled: true,
+        ),
+      ];
+
+      final result = await service.saveForwardingBatch(
+        original: [],
+        current: current,
+      );
+
+      expect(result.added, 2);
+      verify(() => mockUsp.add(any(), any())).called(2);
     });
   });
 
@@ -382,6 +520,35 @@ void main() {
       expect(result.deleted, 1);
       expect(result.added, 1);
       expect(result.updated, 1);
+    });
+
+    test('multi-item delete uses sequential delay', () async {
+      when(() => mockUsp.delete(any())).thenAnswer((_) async {});
+
+      final original = [
+        PortTriggeringRuleUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          description: 'Trigger1',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+        ),
+        PortTriggeringRuleUIModel(
+          instancePath: 'path.2.',
+          enabled: true,
+          description: 'Trigger2',
+          triggerPort: 5060,
+          triggerProtocol: 'UDP',
+        ),
+      ];
+
+      final result = await service.saveTriggeringBatch(
+        original: original,
+        current: [],
+      );
+
+      expect(result.deleted, 2);
+      verify(() => mockUsp.delete(any())).called(2);
     });
   });
 }

--- a/test/page/static_routing/services/usp_static_routing_service_test.dart
+++ b/test/page/static_routing/services/usp_static_routing_service_test.dart
@@ -1,0 +1,430 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/services/usp_service.dart';
+import 'package:privacy_gui/generated/static_routing.g.dart';
+import 'package:privacy_gui/page/static_routing/models/static_routing_ui_model.dart';
+import 'package:privacy_gui/page/static_routing/services/usp_static_routing_service.dart';
+
+class MockUspService extends Mock implements UspService {}
+
+StaticRoute _route({
+  String instancePath = 'Device.Routing.Router.1.IPv4Forwarding.1.',
+  bool enable = true,
+  String destIpAddress = '10.0.0.0',
+  String destSubnetMask = '255.255.255.0',
+  String gatewayIpAddress = '192.168.1.1',
+  String interface_ = 'Device.IP.Interface.2',
+  String origin = 'Static',
+  String alias = 'TestRoute',
+}) =>
+    StaticRoute(
+      instancePath: instancePath,
+      enable: enable,
+      destIpAddress: destIpAddress,
+      destSubnetMask: destSubnetMask,
+      gatewayIpAddress: gatewayIpAddress,
+      interface_: interface_,
+      origin: origin,
+      alias: alias,
+    );
+
+void main() {
+  late MockUspService mockUsp;
+  late UspStaticRoutingService service;
+
+  setUp(() {
+    mockUsp = MockUspService();
+    service = UspStaticRoutingService(mockUsp);
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildRouteUIModels
+  // ---------------------------------------------------------------------------
+
+  group('UspStaticRoutingService — buildRouteUIModels', () {
+    test('filters to static routes only', () {
+      final data = StaticRouting(items: [
+        _route(origin: 'Static', alias: 'MyRoute'),
+        _route(origin: 'DHCPv4', alias: 'DhcpRoute'),
+      ]);
+
+      final result = service.buildRouteUIModels(data);
+
+      expect(result, hasLength(1));
+      expect(result[0].name, 'MyRoute');
+    });
+
+    test('maps interface path to display name', () {
+      final data = StaticRouting(items: [
+        _route(interface_: 'Device.IP.Interface.1', origin: 'Static'),
+        _route(
+          instancePath: 'p.2.',
+          interface_: 'Device.IP.Interface.2',
+          origin: 'Static',
+        ),
+      ]);
+
+      final result = service.buildRouteUIModels(data);
+
+      expect(result[0].interfaceName, 'LAN');
+      expect(result[1].interfaceName, 'Internet');
+    });
+
+    test('unknown interface falls through unchanged', () {
+      final data = StaticRouting(items: [
+        _route(interface_: 'Device.IP.Interface.99', origin: 'Static'),
+      ]);
+
+      final result = service.buildRouteUIModels(data);
+
+      expect(result[0].interfaceName, 'Device.IP.Interface.99');
+    });
+
+    test('preserves all fields correctly', () {
+      final data = StaticRouting(items: [
+        _route(
+          instancePath: 'path.1.',
+          enable: false,
+          destIpAddress: '10.0.0.0',
+          destSubnetMask: '255.0.0.0',
+          gatewayIpAddress: '192.168.1.254',
+          interface_: 'Device.IP.Interface.2',
+          origin: 'Static',
+          alias: 'VPN',
+        ),
+      ]);
+
+      final result = service.buildRouteUIModels(data);
+
+      expect(result[0].instancePath, 'path.1.');
+      expect(result[0].enabled, isFalse);
+      expect(result[0].destIpAddress, '10.0.0.0');
+      expect(result[0].destSubnetMask, '255.0.0.0');
+      expect(result[0].gatewayIpAddress, '192.168.1.254');
+      expect(result[0].interfacePath, 'Device.IP.Interface.2');
+    });
+
+    test('empty data returns empty list', () {
+      final result = service.buildRouteUIModels(StaticRouting(items: []));
+      expect(result, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // mapDisplayToInterface
+  // ---------------------------------------------------------------------------
+
+  group('UspStaticRoutingService — mapDisplayToInterface', () {
+    test('LAN maps to Device.IP.Interface.1', () {
+      expect(service.mapDisplayToInterface('LAN'), 'Device.IP.Interface.1');
+    });
+
+    test('Internet maps to Device.IP.Interface.2', () {
+      expect(
+          service.mapDisplayToInterface('Internet'), 'Device.IP.Interface.2');
+    });
+
+    test('unknown name passes through', () {
+      expect(service.mapDisplayToInterface('WAN2'), 'WAN2');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateRoute
+  // ---------------------------------------------------------------------------
+
+  group('UspStaticRoutingService — validateRoute', () {
+    test('valid route returns empty errors', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'MyRoute',
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: '192.168.1.1',
+      );
+      expect(errors, isEmpty);
+    });
+
+    test('empty name returns error', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: '',
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: '',
+      );
+      expect(errors['name'], 'Name is required');
+    });
+
+    test('name over 32 chars returns error', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'A' * 33,
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: '',
+      );
+      expect(errors['name'], 'Name must be 32 characters or less');
+    });
+
+    test('name exactly 32 chars is valid', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'A' * 32,
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: '',
+      );
+      expect(errors.containsKey('name'), isFalse);
+    });
+
+    test('empty destIp returns error', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'Route1',
+        destIp: '',
+        subnetMask: '255.255.255.0',
+        gateway: '',
+      );
+      expect(errors['destIp'], 'Destination IP is required');
+    });
+
+    test('invalid destIp returns error', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'Route1',
+        destIp: '999.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: '',
+      );
+      expect(errors['destIp'], 'Invalid IP address');
+    });
+
+    test('empty subnetMask returns error', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'Route1',
+        destIp: '10.0.0.0',
+        subnetMask: '',
+        gateway: '',
+      );
+      expect(errors['subnetMask'], 'Subnet mask is required');
+    });
+
+    test('invalid subnetMask returns error', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'Route1',
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.0.128',
+        gateway: '',
+      );
+      expect(errors['subnetMask'], 'Invalid subnet mask');
+    });
+
+    test('empty gateway is valid (optional)', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'Route1',
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: '',
+      );
+      expect(errors.containsKey('gateway'), isFalse);
+    });
+
+    test('invalid gateway returns error', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'Route1',
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: 'not-an-ip',
+      );
+      expect(errors['gateway'], 'Invalid IP address');
+    });
+
+    test('multiple errors returned simultaneously', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: '',
+        destIp: '',
+        subnetMask: '',
+        gateway: 'bad',
+      );
+      expect(errors, hasLength(4));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // saveBatch
+  // ---------------------------------------------------------------------------
+
+  group('UspStaticRoutingService — saveBatch', () {
+    test('no-op when lists are identical', () async {
+      final routes = [
+        StaticRouteUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          name: 'Route1',
+          destIpAddress: '10.0.0.0',
+          destSubnetMask: '255.255.255.0',
+          gatewayIpAddress: '192.168.1.1',
+          interfaceName: 'Internet',
+          interfacePath: 'Device.IP.Interface.2',
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: routes,
+        current: List.of(routes),
+      );
+
+      expect(result.added, 0);
+      expect(result.updated, 0);
+      expect(result.deleted, 0);
+    });
+
+    test('delete removes items missing from current', () async {
+      when(() => mockUsp.delete(any())).thenAnswer((_) async {});
+
+      final original = [
+        StaticRouteUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          name: 'Route1',
+          destIpAddress: '10.0.0.0',
+          destSubnetMask: '255.255.255.0',
+          gatewayIpAddress: '',
+          interfaceName: 'Internet',
+          interfacePath: 'Device.IP.Interface.2',
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: original,
+        current: [],
+      );
+
+      expect(result.deleted, 1);
+      verify(() => mockUsp.delete('path.1.')).called(1);
+    });
+
+    test('add creates items with null instancePath', () async {
+      when(() => mockUsp.add(any(), any())).thenAnswer((_) async => '');
+
+      final current = [
+        StaticRouteUIModel(
+          enabled: true,
+          name: 'NewRoute',
+          destIpAddress: '172.16.0.0',
+          destSubnetMask: '255.255.0.0',
+          gatewayIpAddress: '192.168.1.1',
+          interfaceName: 'LAN',
+          interfacePath: '',
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: [],
+        current: current,
+      );
+
+      expect(result.added, 1);
+      final captured =
+          verify(() => mockUsp.add(captureAny(), captureAny())).captured;
+      final params = captured[1] as Map<String, dynamic>;
+      expect(params['DestIPAddress'], '172.16.0.0');
+      // LAN should be mapped back to TR-181 path
+      expect(params['Interface'], 'Device.IP.Interface.1');
+    });
+
+    test('update detects changed content', () async {
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => {});
+
+      final original = [
+        StaticRouteUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          name: 'Route1',
+          destIpAddress: '10.0.0.0',
+          destSubnetMask: '255.255.255.0',
+          gatewayIpAddress: '192.168.1.1',
+          interfaceName: 'Internet',
+          interfacePath: 'Device.IP.Interface.2',
+        ),
+      ];
+      final current = [
+        StaticRouteUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          name: 'Route1',
+          destIpAddress: '10.0.0.0',
+          destSubnetMask: '255.255.0.0', // changed
+          gatewayIpAddress: '192.168.1.1',
+          interfaceName: 'Internet',
+          interfacePath: 'Device.IP.Interface.2',
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: original,
+        current: current,
+      );
+
+      expect(result.updated, 1);
+    });
+
+    test('mixed batch: delete + add + update', () async {
+      when(() => mockUsp.delete(any())).thenAnswer((_) async {});
+      when(() => mockUsp.add(any(), any())).thenAnswer((_) async => '');
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => {});
+
+      final original = [
+        StaticRouteUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          name: 'ToDelete',
+          destIpAddress: '10.0.0.0',
+          destSubnetMask: '255.255.255.0',
+          gatewayIpAddress: '',
+          interfaceName: 'Internet',
+          interfacePath: 'Device.IP.Interface.2',
+        ),
+        StaticRouteUIModel(
+          instancePath: 'path.2.',
+          enabled: true,
+          name: 'ToUpdate',
+          destIpAddress: '172.16.0.0',
+          destSubnetMask: '255.255.0.0',
+          gatewayIpAddress: '',
+          interfaceName: 'LAN',
+          interfacePath: 'Device.IP.Interface.1',
+        ),
+      ];
+      final current = [
+        // path.1. removed (delete)
+        StaticRouteUIModel(
+          instancePath: 'path.2.',
+          enabled: false, // changed (update)
+          name: 'ToUpdate',
+          destIpAddress: '172.16.0.0',
+          destSubnetMask: '255.255.0.0',
+          gatewayIpAddress: '',
+          interfaceName: 'LAN',
+          interfacePath: 'Device.IP.Interface.1',
+        ),
+        StaticRouteUIModel(
+          // new entry (add)
+          enabled: true,
+          name: 'NewRoute',
+          destIpAddress: '192.168.2.0',
+          destSubnetMask: '255.255.255.0',
+          gatewayIpAddress: '',
+          interfaceName: 'Internet',
+          interfacePath: '',
+        ),
+      ];
+
+      final result = await service.saveBatch(
+        original: original,
+        current: current,
+      );
+
+      expect(result.deleted, 1);
+      expect(result.added, 1);
+      expect(result.updated, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add **109 unit tests** across 5 medium-complexity USP page services (Phase 3 of #704)
- **Firewall service** (17 tests, 96.8%): parseFirewallRules, buildUIModel accept/drop inversion, buildSetPayload paired rules, save
- **Static routing service** (24 tests, 91.4%): buildRouteUIModels origin filter + interface mapping, validateRoute (7+ rules), saveBatch
- **IPv6 port service** (23 tests, 91.4%): protocol mapping IANA↔display, buildRuleUIModels filter + mapping, validateRule, saveBatch
- **Port forwarding service** (12 tests, 87.3%): saveForwardingBatch, saveTriggeringBatch parent + nested forward rule add
- **Instant privacy service** (34 tests, 83.7%): validateMac, normalizeMac, activeDevices, isEnabled, allowedDevices, build*Updates, fetchAll
- Overall coverage: **381/425 lines = 89.6%**

## Test plan

- [x] All 109 tests pass (`flutter test test/page/{firewall,static_routing,ipv6_port_service,port_forwarding,instant_privacy}/services/`)
- [x] `dart format .` executed (607 files, 1 changed)
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)