### PR TITLE
test: Phase 4 — complex service layer tests (116 tests, 90.2%)

### DIFF
--- a/lib/page/_shared/services/usp_device_service.dart
+++ b/lib/page/_shared/services/usp_device_service.dart
@@ -273,11 +273,13 @@ class UspDeviceService {
     List<String> ipv6Addresses = const [],
   }) {
     return LanInfoUIModel(
+      hostName: info.hostName,
       ipAddress: info.ipAddress,
       subnetMask: info.subnetMask,
       dhcpEnabled: info.dhcpEnabled,
       minAddress: info.minAddress,
       maxAddress: info.maxAddress,
+      leaseTimeMinutes: (info.leaseTime / 60).round(),
       dnsServers: info.dnsServers,
       ipv6Enabled: ipv6Enabled,
       ipv6Addresses: ipv6Addresses,

--- a/test/page/_shared/services/usp_device_service_test.dart
+++ b/test/page/_shared/services/usp_device_service_test.dart
@@ -503,8 +503,10 @@ void main() {
         ipv6Addresses: ['2001:db8::1'],
       );
 
+      expect(result.hostName, 'Router');
       expect(result.ipAddress, '192.168.1.1');
       expect(result.dhcpEnabled, isTrue);
+      expect(result.leaseTimeMinutes, 1440); // 86400s / 60
       expect(result.ipv6Enabled, isTrue);
       expect(result.ipv6Addresses, ['2001:db8::1']);
     });

--- a/test/page/_shared/services/usp_device_service_test.dart
+++ b/test/page/_shared/services/usp_device_service_test.dart
@@ -1,0 +1,983 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/generated/connected_devices.g.dart';
+import 'package:privacy_gui/generated/dhcp_clients.g.dart';
+import 'package:privacy_gui/generated/dhcp_reservations.g.dart';
+import 'package:privacy_gui/generated/ethernet_interfaces.g.dart';
+import 'package:privacy_gui/generated/firmware_images.g.dart';
+import 'package:privacy_gui/generated/lan_network_info.g.dart';
+import 'package:privacy_gui/generated/port_forwarding.g.dart';
+import 'package:privacy_gui/generated/port_triggering.g.dart';
+import 'package:privacy_gui/generated/system_info.g.dart';
+import 'package:privacy_gui/generated/time_settings.g.dart';
+import 'package:privacy_gui/generated/wan_status.g.dart';
+import 'package:privacy_gui/generated/wi_fi_access_points.g.dart';
+import 'package:privacy_gui/generated/wi_fi_radios.g.dart';
+import 'package:privacy_gui/generated/wi_fi_ssids.g.dart';
+import 'package:privacy_gui/page/_shared/models/device_ui_model.dart';
+import 'package:privacy_gui/page/_shared/models/system_info_ui_model.dart';
+import 'package:privacy_gui/page/_shared/models/wifi_client_ui_model.dart';
+import 'package:privacy_gui/page/_shared/providers/mesh_node_enricher.dart';
+import 'package:privacy_gui/page/_shared/services/usp_device_service.dart';
+
+SystemInfo _sysInfo({
+  String manufacturer = 'Linksys',
+  String modelName = 'M60TB',
+  String serialNumber = 'SN123',
+  String hardwareVersion = '1.0',
+  String softwareVersion = '2.0.0',
+  int uptime = 3600,
+  int totalMemory = 512000,
+  int freeMemory = 256000,
+  int cpuUsage = 25,
+}) =>
+    SystemInfo(
+      manufacturer: manufacturer,
+      modelName: modelName,
+      serialNumber: serialNumber,
+      hardwareVersion: hardwareVersion,
+      softwareVersion: softwareVersion,
+      uptime: uptime,
+      totalMemory: totalMemory,
+      freeMemory: freeMemory,
+      cpuUsage: cpuUsage,
+    );
+
+ConnectedDevice _device({
+  String instancePath = 'Device.Hosts.Host.1.',
+  String macAddress = 'AA:BB:CC:DD:EE:FF',
+  String ipAddress = '192.168.1.100',
+  String hostName = 'TestDevice',
+  bool isActive = true,
+  String interface_ = 'Device.WiFi.SSID.1',
+  String addressSource = 'DHCP',
+  List<ConnectedDeviceIpv6> ipv6Addresses = const [],
+}) =>
+    ConnectedDevice(
+      instancePath: instancePath,
+      macAddress: macAddress,
+      ipAddress: ipAddress,
+      hostName: hostName,
+      isActive: isActive,
+      interface_: interface_,
+      addressSource: addressSource,
+      ipv6Addresses: ipv6Addresses,
+    );
+
+void main() {
+  late UspDeviceService service;
+
+  setUp(() {
+    service = UspDeviceService();
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildSystemInfoUIModel
+  // ---------------------------------------------------------------------------
+
+  group('UspDeviceService — buildSystemInfoUIModel', () {
+    test('maps all fields correctly', () {
+      final info = _sysInfo();
+      final result = service.buildSystemInfoUIModel(info);
+
+      expect(result.manufacturer, 'Linksys');
+      expect(result.modelName, 'M60TB');
+      expect(result.serialNumber, 'SN123');
+      expect(result.hardwareVersion, '1.0');
+      expect(result.softwareVersion, '2.0.0');
+      expect(result.uptime, 3600);
+      expect(result.totalMemory, 512000);
+      expect(result.freeMemory, 256000);
+      expect(result.cpuUsage, 25);
+      expect(result.firmwareImages, isEmpty);
+    });
+
+    test('includes firmware images when provided', () {
+      final images = [
+        FirmwareImageUIModel(
+          instancePath: 'p.1.',
+          name: 'fw1',
+          version: '1.0',
+          status: 'active',
+          available: true,
+        ),
+      ];
+      final result =
+          service.buildSystemInfoUIModel(_sysInfo(), firmwareImages: images);
+      expect(result.firmwareImages, hasLength(1));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildFirmwareImageUIModels
+  // ---------------------------------------------------------------------------
+
+  group('UspDeviceService — buildFirmwareImageUIModels', () {
+    test('identifies active and boot target images', () {
+      final data = FirmwareImages(items: [
+        FirmwareImage(
+          instancePath: 'Device.FW.1.',
+          name: 'fw1',
+          version: '1.0',
+          status: 'active',
+          available: true,
+        ),
+        FirmwareImage(
+          instancePath: 'Device.FW.2.',
+          name: 'fw2',
+          version: '2.0',
+          status: 'inactive',
+          available: true,
+        ),
+      ]);
+
+      final result = service.buildFirmwareImageUIModels(
+        data: data,
+        activeRef: 'Device.FW.1.',
+        bootRef: 'Device.FW.2.',
+      );
+
+      expect(result[0].isActive, isTrue);
+      expect(result[0].isBootTarget, isFalse);
+      expect(result[1].isActive, isFalse);
+      expect(result[1].isBootTarget, isTrue);
+    });
+
+    test('strips trailing dot for comparison', () {
+      final data = FirmwareImages(items: [
+        FirmwareImage(
+          instancePath: 'Device.FW.1.',
+          name: 'fw1',
+          version: '1.0',
+          status: 'active',
+          available: true,
+        ),
+      ]);
+
+      // activeRef without trailing dot should still match
+      final result = service.buildFirmwareImageUIModels(
+        data: data,
+        activeRef: 'Device.FW.1',
+        bootRef: '',
+      );
+
+      expect(result[0].isActive, isTrue);
+      expect(result[0].isBootTarget, isFalse);
+    });
+
+    test('empty refs mark nothing as active/boot', () {
+      final data = FirmwareImages(items: [
+        FirmwareImage(
+          instancePath: 'Device.FW.1.',
+          name: 'fw1',
+          version: '1.0',
+          status: 'inactive',
+          available: true,
+        ),
+      ]);
+
+      final result = service.buildFirmwareImageUIModels(
+        data: data,
+        activeRef: '',
+        bootRef: '',
+      );
+
+      expect(result[0].isActive, isFalse);
+      expect(result[0].isBootTarget, isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildDeviceUIModels
+  // ---------------------------------------------------------------------------
+
+  group('UspDeviceService — buildDeviceUIModels', () {
+    final emptyMesh = MeshTopologyInfo(nodes: [], clientToNodeMap: {});
+
+    test('filters out devices with empty interface', () {
+      final devices = ConnectedDevices(items: [
+        _device(interface_: 'Device.WiFi.SSID.1'),
+        _device(
+          instancePath: 'p.2.',
+          macAddress: 'BB:CC:DD:EE:FF:00',
+          interface_: '',
+        ),
+      ]);
+
+      final result = service.buildDeviceUIModels(
+        connectedDevices: devices,
+        wifiClientMap: {},
+        connectionDetailMap: {},
+        meshTopology: emptyMesh,
+        gatewayName: 'Router',
+      );
+
+      expect(result, hasLength(1));
+    });
+
+    test('detects WiFi devices by interface containing wifi', () {
+      final devices = ConnectedDevices(items: [
+        _device(interface_: 'Device.WiFi.SSID.1'),
+        _device(
+          instancePath: 'p.2.',
+          macAddress: 'BB:CC:DD:EE:FF:00',
+          interface_: 'Device.Ethernet.Interface.1',
+        ),
+      ]);
+
+      final result = service.buildDeviceUIModels(
+        connectedDevices: devices,
+        wifiClientMap: {},
+        connectionDetailMap: {},
+        meshTopology: emptyMesh,
+        gatewayName: 'Router',
+      );
+
+      expect(result[0].isWifi, isTrue);
+      expect(result[1].isWifi, isFalse);
+    });
+
+    test('enriches WiFi devices with signal data', () {
+      final devices = ConnectedDevices(items: [
+        _device(macAddress: 'aa:bb:cc:dd:ee:ff'),
+      ]);
+      final wifiMap = {
+        'AA:BB:CC:DD:EE:FF': WifiClientUIModel(
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          signalStrength: -50,
+          noise: -90,
+          lastDataDownlinkRate: 100,
+          lastDataUplinkRate: 50,
+          active: true,
+        ),
+      };
+
+      final result = service.buildDeviceUIModels(
+        connectedDevices: devices,
+        wifiClientMap: wifiMap,
+        connectionDetailMap: {},
+        meshTopology: emptyMesh,
+        gatewayName: 'Router',
+      );
+
+      expect(result[0].signalStrength, -50);
+      expect(result[0].downlinkRate, 100);
+    });
+
+    test('non-mesh active device gets gateway name as parent', () {
+      final devices = ConnectedDevices(items: [_device()]);
+
+      final result = service.buildDeviceUIModels(
+        connectedDevices: devices,
+        wifiClientMap: {},
+        connectionDetailMap: {},
+        meshTopology: emptyMesh,
+        gatewayName: 'MyRouter',
+      );
+
+      expect(result[0].parentNodeName, 'MyRouter');
+      expect(result[0].parentNodeId, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildTimeSettingsUIModel
+  // ---------------------------------------------------------------------------
+
+  group('UspDeviceService — buildTimeSettingsUIModel', () {
+    test('maps all fields', () {
+      final settings = TimeSettings(
+        enable: true,
+        status: 'Synchronized',
+        currentLocalTime: '2026-03-23T12:00:00',
+        localTimeZone: 'Asia/Taipei',
+        ntpServer1: 'pool.ntp.org',
+        ntpServer2: 'time.google.com',
+      );
+
+      final result = service.buildTimeSettingsUIModel(settings);
+
+      expect(result.enable, isTrue);
+      expect(result.status, 'Synchronized');
+      expect(result.localTimeZone, 'Asia/Taipei');
+      expect(result.ntpServer1, 'pool.ntp.org');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildDhcpClientUIModels
+  // ---------------------------------------------------------------------------
+
+  group('UspDeviceService — buildDhcpClientUIModels', () {
+    test('enriches with hostname from connected devices', () {
+      final clients = DhcpClients(items: [
+        DhcpClient(
+          instancePath: 'p.1.',
+          chaddr: 'AA:BB:CC:DD:EE:FF',
+          active: true,
+          ipAddress: '192.168.1.100',
+          leaseTimeRemaining: DateTime(2026, 1, 1, 1, 0, 0),
+        ),
+      ]);
+      final devices = ConnectedDevices(items: [
+        _device(
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          hostName: 'Laptop',
+        ),
+      ]);
+
+      final result = service.buildDhcpClientUIModels(
+        clients: clients,
+        connectedDevices: devices,
+      );
+
+      expect(result[0].hostName, 'Laptop');
+      expect(result[0].mac, 'AA:BB:CC:DD:EE:FF');
+    });
+
+    test('missing hostname defaults to empty string', () {
+      final clients = DhcpClients(items: [
+        DhcpClient(
+          instancePath: 'p.1.',
+          chaddr: 'AA:BB:CC:DD:EE:FF',
+          active: true,
+          ipAddress: '192.168.1.100',
+          leaseTimeRemaining: DateTime(2026, 1, 1, 1, 0, 0),
+        ),
+      ]);
+
+      final result = service.buildDhcpClientUIModels(
+        clients: clients,
+        connectedDevices: ConnectedDevices(items: []),
+      );
+
+      expect(result[0].hostName, '');
+    });
+
+    test('MAC case normalized for lookup', () {
+      final clients = DhcpClients(items: [
+        DhcpClient(
+          instancePath: 'p.1.',
+          chaddr: 'aa:bb:cc:dd:ee:ff',
+          active: true,
+          ipAddress: '192.168.1.100',
+          leaseTimeRemaining: DateTime(2026, 1, 1, 1, 0, 0),
+        ),
+      ]);
+      final devices = ConnectedDevices(items: [
+        _device(macAddress: 'AA:BB:CC:DD:EE:FF', hostName: 'Match'),
+      ]);
+
+      final result = service.buildDhcpClientUIModels(
+        clients: clients,
+        connectedDevices: devices,
+      );
+
+      expect(result[0].hostName, 'Match');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildDhcpReservationUIModels
+  // ---------------------------------------------------------------------------
+
+  group('UspDeviceService — buildDhcpReservationUIModels', () {
+    test('maps all fields', () {
+      final data = DhcpReservations(items: [
+        DhcpReservation(
+          instancePath: 'path.1.',
+          enable: true,
+          chaddr: 'AA:BB:CC:DD:EE:FF',
+          yiaddr: '192.168.1.50',
+        ),
+      ]);
+
+      final result = service.buildDhcpReservationUIModels(data);
+
+      expect(result, hasLength(1));
+      expect(result[0].instancePath, 'path.1.');
+      expect(result[0].mac, 'AA:BB:CC:DD:EE:FF');
+      expect(result[0].ip, '192.168.1.50');
+      expect(result[0].enable, isTrue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildPortForwardingRuleUIModels
+  // ---------------------------------------------------------------------------
+
+  group('UspDeviceService — buildPortForwardingRuleUIModels', () {
+    test('maps all fields including nested data', () {
+      final data = PortForwarding(items: [
+        PortForwardingRule(
+          instancePath: 'path.1.',
+          description: 'HTTP',
+          externalPort: 80,
+          externalPortEndRange: 80,
+          internalPort: 80,
+          internalClient: '192.168.1.100',
+          protocol: 'TCP',
+          enabled: true,
+        ),
+      ]);
+
+      final result = service.buildPortForwardingRuleUIModels(data);
+
+      expect(result, hasLength(1));
+      expect(result[0].description, 'HTTP');
+      expect(result[0].protocol, 'TCP');
+      expect(result[0].enabled, isTrue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildPortTriggeringRuleUIModels
+  // ---------------------------------------------------------------------------
+
+  group('UspDeviceService — buildPortTriggeringRuleUIModels', () {
+    test('maps parent + nested forward rules', () {
+      final data = PortTriggering(items: [
+        PortTrigger(
+          instancePath: 'path.1.',
+          enabled: true,
+          description: 'FTP',
+          triggerPort: 21,
+          triggerPortEndRange: 21,
+          triggerProtocol: 'TCP',
+          rules: [
+            PortTriggerForwardRule(
+              instancePath: 'path.1.Rule.1.',
+              forwardPort: 1024,
+              forwardPortEndRange: 1030,
+              forwardProtocol: 'TCP',
+            ),
+          ],
+        ),
+      ]);
+
+      final result = service.buildPortTriggeringRuleUIModels(data);
+
+      expect(result, hasLength(1));
+      expect(result[0].description, 'FTP');
+      expect(result[0].forwardRules, hasLength(1));
+      expect(result[0].forwardRules[0].forwardPort, 1024);
+    });
+
+    test('empty forward rules list', () {
+      final data = PortTriggering(items: [
+        PortTrigger(
+          instancePath: 'path.1.',
+          enabled: true,
+          description: 'Simple',
+          triggerPort: 5060,
+          triggerPortEndRange: 5060,
+          triggerProtocol: 'UDP',
+          rules: [],
+        ),
+      ]);
+
+      final result = service.buildPortTriggeringRuleUIModels(data);
+      expect(result[0].forwardRules, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildLanInfoUIModel
+  // ---------------------------------------------------------------------------
+
+  group('UspDeviceService — buildLanInfoUIModel', () {
+    test('maps all fields with optional IPv6', () {
+      final info = LanNetworkInfo(
+        ipAddress: '192.168.1.1',
+        subnetMask: '255.255.255.0',
+        dhcpEnabled: true,
+        minAddress: '192.168.1.100',
+        maxAddress: '192.168.1.200',
+        leaseTime: 86400,
+        dnsServers: '8.8.8.8',
+        hostName: 'Router',
+      );
+
+      final result = service.buildLanInfoUIModel(
+        info,
+        ipv6Enabled: true,
+        ipv6Addresses: ['2001:db8::1'],
+      );
+
+      expect(result.ipAddress, '192.168.1.1');
+      expect(result.dhcpEnabled, isTrue);
+      expect(result.ipv6Enabled, isTrue);
+      expect(result.ipv6Addresses, ['2001:db8::1']);
+    });
+
+    test('IPv6 defaults to false/empty', () {
+      final info = LanNetworkInfo(
+        ipAddress: '192.168.1.1',
+        subnetMask: '255.255.255.0',
+        dhcpEnabled: false,
+        minAddress: '',
+        maxAddress: '',
+        leaseTime: 0,
+        dnsServers: '',
+        hostName: '',
+      );
+
+      final result = service.buildLanInfoUIModel(info);
+
+      expect(result.ipv6Enabled, isFalse);
+      expect(result.ipv6Addresses, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildWanStatusUIModel
+  // ---------------------------------------------------------------------------
+
+  group('UspDeviceService — buildWanStatusUIModel', () {
+    test('maps fields and derives isUp from status', () {
+      final status = WanStatus(
+        status: 'Up',
+        ipAddress: '203.0.113.1',
+        subnetMask: '255.255.255.0',
+        addressingType: 'DHCP',
+        maxMtuSize: 1500,
+      );
+
+      final result = service.buildWanStatusUIModel(
+        wanStatus: status,
+        gateway: '203.0.113.254',
+      );
+
+      expect(result.isUp, isTrue);
+      expect(result.ipAddress, '203.0.113.1');
+      expect(result.mtu, 1500);
+      expect(result.gateway, '203.0.113.254');
+    });
+
+    test('status "down" → isUp false (case insensitive)', () {
+      final status = WanStatus(
+        status: 'Down',
+        ipAddress: '',
+        subnetMask: '',
+        addressingType: '',
+        maxMtuSize: 0,
+      );
+
+      final result = service.buildWanStatusUIModel(
+        wanStatus: status,
+        gateway: '',
+      );
+
+      expect(result.isUp, isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildEthernetPortUIModels
+  // ---------------------------------------------------------------------------
+
+  group('UspDeviceService — buildEthernetPortUIModels', () {
+    test('classifies by bridge membership not upstream flag', () {
+      final interfaces = EthernetInterfaces(items: [
+        EthernetInterface(
+          instancePath: 'Device.Ethernet.Interface.1.',
+          name: 'eth1',
+          status: 'Up',
+          upstream: true, // misleading — actually LAN
+          currentBitRate: 1000,
+        ),
+        EthernetInterface(
+          instancePath: 'Device.Ethernet.Interface.2.',
+          name: 'eth0',
+          status: 'Up',
+          upstream: false, // misleading — actually WAN
+          currentBitRate: 1000,
+        ),
+      ]);
+
+      // Bridge port map: eth1 is a bridge member → LAN
+      final bridgePortMap = {
+        'Device.Bridging.Bridge.1.Port.1.': 'Device.Ethernet.Interface.1',
+      };
+
+      final result = service.buildEthernetPortUIModels(
+        ethernetInterfaces: interfaces,
+        deviceModels: [],
+        bridgePortMap: bridgePortMap,
+      );
+
+      // eth1 is bridge member → LAN (no wired devices, so no LAN ports)
+      // eth0 is NOT bridge member → WAN port
+      expect(result, hasLength(1));
+      expect(result[0].isWan, isTrue);
+      expect(result[0].label, 'WAN');
+    });
+
+    test('creates LAN port per active wired device', () {
+      final interfaces = EthernetInterfaces(items: [
+        EthernetInterface(
+          instancePath: 'Device.Ethernet.Interface.1.',
+          name: 'eth1',
+          status: 'Up',
+          upstream: false,
+          currentBitRate: 1000,
+        ),
+      ]);
+      final bridgePortMap = {
+        'port.1.': 'Device.Ethernet.Interface.1',
+      };
+      final devices = [
+        DeviceUIModel(
+          mac: 'AA:BB:CC:DD:EE:01',
+          ip: '192.168.1.10',
+          hostName: 'PC1',
+          isActive: true,
+          isWifi: false,
+        ),
+        DeviceUIModel(
+          mac: 'AA:BB:CC:DD:EE:02',
+          ip: '192.168.1.11',
+          hostName: 'PC2',
+          isActive: true,
+          isWifi: false,
+        ),
+      ];
+
+      final result = service.buildEthernetPortUIModels(
+        ethernetInterfaces: interfaces,
+        deviceModels: devices,
+        bridgePortMap: bridgePortMap,
+      );
+
+      expect(result, hasLength(2));
+      expect(result[0].label, 'LAN 1');
+      expect(result[1].label, 'LAN 2');
+      expect(result[0].connectedDevices[0].hostName, 'PC1');
+    });
+
+    test('WiFi and inactive devices excluded from wired count', () {
+      final interfaces = EthernetInterfaces(items: [
+        EthernetInterface(
+          instancePath: 'Device.Ethernet.Interface.1.',
+          name: 'eth1',
+          status: 'Up',
+          upstream: false,
+          currentBitRate: 1000,
+        ),
+      ]);
+      final bridgePortMap = {'port.1.': 'Device.Ethernet.Interface.1'};
+      final devices = [
+        DeviceUIModel(
+          mac: 'AA:BB:CC:DD:EE:01',
+          ip: '192.168.1.10',
+          hostName: 'WiFi',
+          isActive: true,
+          isWifi: true, // excluded — WiFi
+        ),
+        DeviceUIModel(
+          mac: 'AA:BB:CC:DD:EE:02',
+          ip: '192.168.1.11',
+          hostName: 'Inactive',
+          isActive: false, // excluded — inactive
+          isWifi: false,
+        ),
+      ];
+
+      final result = service.buildEthernetPortUIModels(
+        ethernetInterfaces: interfaces,
+        deviceModels: devices,
+        bridgePortMap: bridgePortMap,
+      );
+
+      // No LAN ports because no active wired devices
+      expect(result, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildNodeUIModels
+  // ---------------------------------------------------------------------------
+
+  group('UspDeviceService — buildNodeUIModels', () {
+    test('empty mesh creates synthetic gateway node', () {
+      final emptyMesh = MeshTopologyInfo(nodes: [], clientToNodeMap: {});
+      final sysInfo = SystemInfoUIModel(
+        manufacturer: 'Linksys',
+        modelName: 'M60TB',
+        serialNumber: 'SN123',
+        hardwareVersion: '1.0',
+        softwareVersion: '2.0.0',
+        uptime: 3600,
+        totalMemory: 512000,
+        freeMemory: 256000,
+        cpuUsage: 25,
+      );
+
+      final result = service.buildNodeUIModels(
+        meshTopology: emptyMesh,
+        deviceModels: [
+          DeviceUIModel(
+            mac: 'AA:BB:CC:DD:EE:01',
+            ip: '192.168.1.10',
+            hostName: 'PC',
+            isActive: true,
+            isWifi: false,
+          ),
+        ],
+        systemInfo: sysInfo,
+      );
+
+      expect(result, hasLength(1));
+      expect(result[0].deviceId, 'gateway');
+      expect(result[0].isMaster, isTrue);
+      expect(result[0].model, 'M60TB');
+      expect(result[0].connectedDeviceCount, 1);
+    });
+
+    test('mesh network: first node is master', () {
+      final mesh = MeshTopologyInfo(
+        nodes: [
+          MeshNodeInfo(
+            instancePath: 'p.1.',
+            deviceId: 'node-1',
+            model: 'M60',
+          ),
+          MeshNodeInfo(
+            instancePath: 'p.2.',
+            deviceId: 'node-2',
+            model: 'M60',
+          ),
+        ],
+        clientToNodeMap: {},
+      );
+
+      final result = service.buildNodeUIModels(
+        meshTopology: mesh,
+        deviceModels: [],
+        systemInfo: SystemInfoUIModel(
+          manufacturer: '',
+          modelName: '',
+          serialNumber: '',
+          hardwareVersion: '',
+          softwareVersion: '',
+          uptime: 0,
+          totalMemory: 0,
+          freeMemory: 0,
+          cpuUsage: 0,
+        ),
+      );
+
+      expect(result[0].isMaster, isTrue);
+      expect(result[1].isMaster, isFalse);
+    });
+
+    test('counts connected devices per node (case insensitive)', () {
+      final mesh = MeshTopologyInfo(
+        nodes: [
+          MeshNodeInfo(
+            instancePath: 'p.1.',
+            deviceId: 'NODE-A',
+            model: 'M60',
+          ),
+        ],
+        clientToNodeMap: {},
+      );
+
+      final devices = [
+        DeviceUIModel(
+          mac: 'AA:BB:CC:DD:EE:01',
+          ip: '192.168.1.10',
+          hostName: 'PC1',
+          isActive: true,
+          isWifi: false,
+          parentNodeId: 'node-a', // lowercase
+        ),
+        DeviceUIModel(
+          mac: 'AA:BB:CC:DD:EE:02',
+          ip: '192.168.1.11',
+          hostName: 'PC2',
+          isActive: false, // inactive — not counted
+          isWifi: false,
+          parentNodeId: 'node-a',
+        ),
+      ];
+
+      final result = service.buildNodeUIModels(
+        meshTopology: mesh,
+        deviceModels: devices,
+        systemInfo: SystemInfoUIModel(
+          manufacturer: '',
+          modelName: '',
+          serialNumber: '',
+          hardwareVersion: '',
+          softwareVersion: '',
+          uptime: 0,
+          totalMemory: 0,
+          freeMemory: 0,
+          cpuUsage: 0,
+        ),
+      );
+
+      expect(result[0].connectedDeviceCount, 1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildWifiRadioUIModels
+  // ---------------------------------------------------------------------------
+
+  group('UspDeviceService — buildWifiRadioUIModels', () {
+    test('groups APs by radio via SSID lowerLayers reference', () {
+      final radios = WiFiRadios(items: [
+        WiFiRadio(
+          instancePath: 'Device.WiFi.Radio.1.',
+          enable: true,
+          status: 'Up',
+          channel: 6,
+          operatingFrequencyBand: '2.4GHz',
+          operatingChannelBandwidth: '20MHz',
+          possibleChannels: '1,6,11',
+          operatingStandards: 'n',
+          supportedStandards: 'b,g,n',
+          transmitPower: 100,
+          maxBitRate: 300,
+          autoChannelEnable: true,
+          ieee80211hEnabled: false,
+          supportedOperatingChannelBandwidths: '20MHz,40MHz',
+        ),
+      ]);
+      final ssids = WiFiSsids(items: [
+        WiFiSsid(
+          instancePath: 'Device.WiFi.SSID.1.',
+          ssid: 'MyNetwork',
+          enable: true,
+          status: 'Up',
+          bssid: 'AA:BB:CC:DD:EE:FF',
+          lowerLayers: 'Device.WiFi.Radio.1.',
+        ),
+      ]);
+      final aps = WiFiAccessPoints(items: [
+        WiFiAccessPoint(
+          instancePath: 'Device.WiFi.AccessPoint.1.',
+          enable: true,
+          status: 'Up',
+          modesSupported: 'WPA2-Personal',
+          securityModeEnabled: 'WPA2-Personal',
+          encryptionMode: 'AES',
+          keyPassphrase: 'password',
+          ssidAdvertisementEnabled: true,
+          ssidReference: 'Device.WiFi.SSID.1.',
+        ),
+      ]);
+
+      final result = service.buildWifiRadioUIModels(
+        radios: radios,
+        ssids: ssids,
+        accessPoints: aps,
+      );
+
+      expect(result, hasLength(1));
+      expect(result[0].band, '2.4GHz');
+      expect(result[0].accessPoints, hasLength(1));
+      expect(result[0].accessPoints[0].ssidName, 'MyNetwork');
+      expect(result[0].accessPoints[0].securityMode, 'WPA2-Personal');
+    });
+
+    test('AP with missing SSID reference is skipped', () {
+      final radios = WiFiRadios(items: [
+        WiFiRadio(
+          instancePath: 'Device.WiFi.Radio.1.',
+          enable: true,
+          status: 'Up',
+          channel: 36,
+          operatingFrequencyBand: '5GHz',
+          operatingChannelBandwidth: '80MHz',
+          possibleChannels: '36,40,44,48',
+          operatingStandards: 'ac',
+          supportedStandards: 'a,n,ac',
+          transmitPower: 100,
+          maxBitRate: 1300,
+          autoChannelEnable: true,
+          ieee80211hEnabled: false,
+          supportedOperatingChannelBandwidths: '20MHz,40MHz,80MHz',
+        ),
+      ]);
+      final ssids = WiFiSsids(items: []); // No SSIDs
+      final aps = WiFiAccessPoints(items: [
+        WiFiAccessPoint(
+          instancePath: 'Device.WiFi.AccessPoint.1.',
+          enable: true,
+          status: 'Up',
+          modesSupported: 'WPA2-Personal',
+          securityModeEnabled: 'WPA2-Personal',
+          encryptionMode: 'AES',
+          keyPassphrase: 'password',
+          ssidAdvertisementEnabled: true,
+          ssidReference: 'Device.WiFi.SSID.1.', // Not in SSIDs
+        ),
+      ]);
+
+      final result = service.buildWifiRadioUIModels(
+        radios: radios,
+        ssids: ssids,
+        accessPoints: aps,
+      );
+
+      // Radio should exist but with no access points
+      expect(result, hasLength(1));
+      expect(result[0].accessPoints, isEmpty);
+    });
+
+    test('empty SSID name falls back to AP ssidReference', () {
+      final radios = WiFiRadios(items: [
+        WiFiRadio(
+          instancePath: 'Device.WiFi.Radio.1.',
+          enable: true,
+          status: 'Up',
+          channel: 6,
+          operatingFrequencyBand: '2.4GHz',
+          operatingChannelBandwidth: '20MHz',
+          possibleChannels: '1,6,11',
+          operatingStandards: 'n',
+          supportedStandards: 'n',
+          transmitPower: 100,
+          maxBitRate: 300,
+          autoChannelEnable: true,
+          ieee80211hEnabled: false,
+          supportedOperatingChannelBandwidths: '20MHz',
+        ),
+      ]);
+      final ssids = WiFiSsids(items: [
+        WiFiSsid(
+          instancePath: 'Device.WiFi.SSID.1.',
+          ssid: '', // empty
+          enable: true,
+          status: 'Up',
+          bssid: '',
+          lowerLayers: 'Device.WiFi.Radio.1.',
+        ),
+      ]);
+      final aps = WiFiAccessPoints(items: [
+        WiFiAccessPoint(
+          instancePath: 'Device.WiFi.AccessPoint.1.',
+          enable: true,
+          status: 'Up',
+          modesSupported: '',
+          securityModeEnabled: '',
+          encryptionMode: '',
+          keyPassphrase: '',
+          ssidAdvertisementEnabled: true,
+          ssidReference: 'Device.WiFi.SSID.1.',
+        ),
+      ]);
+
+      final result = service.buildWifiRadioUIModels(
+        radios: radios,
+        ssids: ssids,
+        accessPoints: aps,
+      );
+
+      // Fallback to ssidReference since SSID.ssid is empty
+      expect(result[0].accessPoints[0].ssidName, 'Device.WiFi.SSID.1.');
+    });
+  });
+}

--- a/test/page/local_network/services/usp_local_network_service_test.dart
+++ b/test/page/local_network/services/usp_local_network_service_test.dart
@@ -1,0 +1,418 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/services/usp_service.dart';
+import 'package:privacy_gui/generated/lan_network_info.g.dart';
+import 'package:privacy_gui/page/local_network/models/local_network_ui_model.dart';
+import 'package:privacy_gui/page/local_network/services/usp_local_network_service.dart';
+
+class MockUspService extends Mock implements UspService {}
+
+LanNetworkInfo _lanInfo({
+  String ipAddress = '192.168.1.1',
+  String subnetMask = '255.255.255.0',
+  bool dhcpEnabled = true,
+  String minAddress = '192.168.1.100',
+  String maxAddress = '192.168.1.200',
+  int leaseTime = 86400,
+  String dnsServers = '8.8.8.8,8.8.4.4',
+  String hostName = 'MyRouter',
+}) =>
+    LanNetworkInfo(
+      ipAddress: ipAddress,
+      subnetMask: subnetMask,
+      dhcpEnabled: dhcpEnabled,
+      minAddress: minAddress,
+      maxAddress: maxAddress,
+      leaseTime: leaseTime,
+      dnsServers: dnsServers,
+      hostName: hostName,
+    );
+
+LocalNetworkUIModel _model({
+  String hostName = 'MyRouter',
+  String ipAddress = '192.168.1.1',
+  String subnetMask = '255.255.255.0',
+  bool dhcpEnabled = true,
+  String minAddress = '192.168.1.100',
+  String maxAddress = '192.168.1.200',
+  int leaseTimeMinutes = 1440,
+  String dnsServer1 = '8.8.8.8',
+  String dnsServer2 = '8.8.4.4',
+  String dnsServer3 = '',
+}) =>
+    LocalNetworkUIModel(
+      hostName: hostName,
+      ipAddress: ipAddress,
+      subnetMask: subnetMask,
+      dhcpEnabled: dhcpEnabled,
+      minAddress: minAddress,
+      maxAddress: maxAddress,
+      leaseTimeMinutes: leaseTimeMinutes,
+      dnsServer1: dnsServer1,
+      dnsServer2: dnsServer2,
+      dnsServer3: dnsServer3,
+    );
+
+void main() {
+  late MockUspService mockUsp;
+  late UspLocalNetworkService service;
+
+  setUp(() {
+    mockUsp = MockUspService();
+    service = UspLocalNetworkService(mockUsp);
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildUIModel
+  // ---------------------------------------------------------------------------
+
+  group('UspLocalNetworkService — buildUIModel', () {
+    test('maps all fields correctly', () {
+      final data = _lanInfo(
+        ipAddress: '192.168.1.1',
+        subnetMask: '255.255.255.0',
+        dhcpEnabled: true,
+        minAddress: '192.168.1.100',
+        maxAddress: '192.168.1.200',
+        leaseTime: 7200,
+        dnsServers: '1.1.1.1,8.8.8.8,9.9.9.9',
+        hostName: 'Router',
+      );
+
+      final result = service.buildUIModel(data);
+
+      expect(result.hostName, 'Router');
+      expect(result.ipAddress, '192.168.1.1');
+      expect(result.subnetMask, '255.255.255.0');
+      expect(result.dhcpEnabled, isTrue);
+      expect(result.minAddress, '192.168.1.100');
+      expect(result.maxAddress, '192.168.1.200');
+      expect(result.leaseTimeMinutes, 120); // 7200s / 60
+      expect(result.dnsServer1, '1.1.1.1');
+      expect(result.dnsServer2, '8.8.8.8');
+      expect(result.dnsServer3, '9.9.9.9');
+    });
+
+    test('splits DNS: single server', () {
+      final data = _lanInfo(dnsServers: '1.1.1.1');
+      final result = service.buildUIModel(data);
+      expect(result.dnsServer1, '1.1.1.1');
+      expect(result.dnsServer2, '');
+      expect(result.dnsServer3, '');
+    });
+
+    test('splits DNS: empty string yields one empty field', () {
+      final data = _lanInfo(dnsServers: '');
+      final result = service.buildUIModel(data);
+      expect(result.dnsServer1, '');
+    });
+
+    test('lease time rounds correctly', () {
+      // 90 seconds → 2 minutes (rounds 1.5)
+      final data = _lanInfo(leaseTime: 90);
+      expect(service.buildUIModel(data).leaseTimeMinutes, 2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // joinDnsServers
+  // ---------------------------------------------------------------------------
+
+  group('UspLocalNetworkService — joinDnsServers', () {
+    test('joins non-empty servers', () {
+      expect(service.joinDnsServers('1.1.1.1', '8.8.8.8', '9.9.9.9'),
+          '1.1.1.1,8.8.8.8,9.9.9.9');
+    });
+
+    test('skips empty servers', () {
+      expect(
+          service.joinDnsServers('1.1.1.1', '', '9.9.9.9'), '1.1.1.1,9.9.9.9');
+    });
+
+    test('all empty returns empty string', () {
+      expect(service.joinDnsServers('', '', ''), '');
+    });
+
+    test('whitespace-only servers are excluded', () {
+      expect(service.joinDnsServers(' 1.1.1.1 ', '  ', ' 9.9.9.9'),
+          ' 1.1.1.1 , 9.9.9.9');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateHostName
+  // ---------------------------------------------------------------------------
+
+  group('UspLocalNetworkService — validateHostName', () {
+    test('valid hostname returns null', () {
+      expect(service.validateHostName('MyRouter'), isNull);
+    });
+
+    test('empty hostname returns error', () {
+      expect(service.validateHostName(''), isNotNull);
+    });
+
+    test('over 15 chars returns error', () {
+      expect(service.validateHostName('A' * 16), isNotNull);
+    });
+
+    test('exactly 15 chars is valid', () {
+      expect(service.validateHostName('A' * 15), isNull);
+    });
+
+    test('leading hyphen rejected', () {
+      expect(service.validateHostName('-router'), isNotNull);
+    });
+
+    test('trailing hyphen rejected', () {
+      expect(service.validateHostName('router-'), isNotNull);
+    });
+
+    test('hyphens in middle allowed', () {
+      expect(service.validateHostName('my-router'), isNull);
+    });
+
+    test('single character valid', () {
+      expect(service.validateHostName('R'), isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateIpAddress
+  // ---------------------------------------------------------------------------
+
+  group('UspLocalNetworkService — validateIpAddress', () {
+    test('valid IP returns null', () {
+      expect(service.validateIpAddress('192.168.1.1'), isNull);
+    });
+
+    test('empty IP returns error', () {
+      expect(service.validateIpAddress(''), isNotNull);
+    });
+
+    test('invalid format returns error', () {
+      expect(service.validateIpAddress('not.an.ip'), isNotNull);
+    });
+
+    test('0.0.0.0 returns reserved error', () {
+      expect(service.validateIpAddress('0.0.0.0'), contains('Reserved'));
+    });
+
+    test('255.255.255.255 returns reserved error', () {
+      expect(
+          service.validateIpAddress('255.255.255.255'), contains('Reserved'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateSubnetMask
+  // ---------------------------------------------------------------------------
+
+  group('UspLocalNetworkService — validateSubnetMask', () {
+    test('valid mask returns null', () {
+      expect(service.validateSubnetMask('255.255.255.0'), isNull);
+    });
+
+    test('empty mask returns error', () {
+      expect(service.validateSubnetMask(''), isNotNull);
+    });
+
+    test('invalid mask returns error', () {
+      expect(service.validateSubnetMask('255.0.255.0'), isNotNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateLeaseTime
+  // ---------------------------------------------------------------------------
+
+  group('UspLocalNetworkService — validateLeaseTime', () {
+    test('1 minute is valid', () {
+      expect(service.validateLeaseTime(1), isNull);
+    });
+
+    test('525600 minutes is valid', () {
+      expect(service.validateLeaseTime(525600), isNull);
+    });
+
+    test('0 minutes returns error', () {
+      expect(service.validateLeaseTime(0), isNotNull);
+    });
+
+    test('525601 minutes returns error', () {
+      expect(service.validateLeaseTime(525601), isNotNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateDns
+  // ---------------------------------------------------------------------------
+
+  group('UspLocalNetworkService — validateDns', () {
+    test('empty string is valid (optional)', () {
+      expect(service.validateDns(''), isNull);
+    });
+
+    test('whitespace-only is valid (optional)', () {
+      expect(service.validateDns('   '), isNull);
+    });
+
+    test('valid IP is valid', () {
+      expect(service.validateDns('8.8.8.8'), isNull);
+    });
+
+    test('invalid IP returns error', () {
+      expect(service.validateDns('not-ip'), isNotNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // lockedOctetCount
+  // ---------------------------------------------------------------------------
+
+  group('UspLocalNetworkService — lockedOctetCount', () {
+    test('/24 → 3', () {
+      expect(service.lockedOctetCount('255.255.255.0'), 3);
+    });
+
+    test('/16 → 2', () {
+      expect(service.lockedOctetCount('255.255.0.0'), 2);
+    });
+
+    test('/8 → 1', () {
+      expect(service.lockedOctetCount('255.0.0.0'), 1);
+    });
+
+    test('invalid mask → 0', () {
+      expect(service.lockedOctetCount('invalid'), 0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ipPrefix
+  // ---------------------------------------------------------------------------
+
+  group('UspLocalNetworkService — ipPrefix', () {
+    test('3 locked octets', () {
+      expect(service.ipPrefix('192.168.1.100', 3), '192.168.1');
+    });
+
+    test('2 locked octets', () {
+      expect(service.ipPrefix('10.0.0.1', 2), '10.0');
+    });
+
+    test('0 locked octets returns empty', () {
+      expect(service.ipPrefix('192.168.1.1', 0), '');
+    });
+
+    test('invalid IP returns empty', () {
+      expect(service.ipPrefix('invalid', 3), '');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // syncPrefix
+  // ---------------------------------------------------------------------------
+
+  group('UspLocalNetworkService — syncPrefix', () {
+    test('replaces locked octets from router IP', () {
+      expect(
+          service.syncPrefix('10.0.0.100', '192.168.1.1', 3), '192.168.1.100');
+    });
+
+    test('2 locked octets', () {
+      expect(service.syncPrefix('10.0.0.100', '172.16.0.1', 2), '172.16.0.100');
+    });
+
+    test('0 locked octets returns original', () {
+      expect(service.syncPrefix('10.0.0.100', '192.168.1.1', 0), '10.0.0.100');
+    });
+
+    test('empty ip returns empty', () {
+      expect(service.syncPrefix('', '192.168.1.1', 3), '');
+    });
+
+    test('invalid IP parts returns original', () {
+      expect(service.syncPrefix('invalid', '192.168.1.1', 3), 'invalid');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateAll
+  // ---------------------------------------------------------------------------
+
+  group('UspLocalNetworkService — validateAll', () {
+    test('valid model with DHCP enabled returns no errors', () {
+      final errors = service.validateAll(_model());
+      // All values should be null (no errors)
+      expect(errors.values.where((v) => v != null), isEmpty);
+    });
+
+    test('DHCP disabled skips pool/DNS validation', () {
+      final errors = service.validateAll(_model(
+        dhcpEnabled: false,
+        minAddress: '', // would fail if validated
+        maxAddress: '',
+        dnsServer1: 'not-an-ip', // would fail if validated
+      ));
+      expect(errors['minAddress'], isNull);
+      expect(errors['maxAddress'], isNull);
+      expect(errors['dnsServer1'], isNull);
+    });
+
+    test('validates hostName, ipAddress, subnetMask independently', () {
+      final errors = service.validateAll(_model(
+        hostName: '',
+        ipAddress: '',
+        subnetMask: '',
+      ));
+      expect(errors['hostName'], isNotNull);
+      expect(errors['ipAddress'], isNotNull);
+      expect(errors['subnetMask'], isNotNull);
+    });
+
+    test('pool validation cascades after IP/subnet are valid', () {
+      final errors = service.validateAll(_model(
+        ipAddress: '192.168.1.1',
+        subnetMask: '255.255.255.0',
+        minAddress: '10.0.0.1', // wrong subnet
+        maxAddress: '192.168.1.200',
+      ));
+      expect(errors['minAddress'], isNotNull);
+    });
+
+    test('pool validation skipped when IP is invalid', () {
+      final errors = service.validateAll(_model(
+        ipAddress: 'invalid',
+        minAddress: '10.0.0.1', // would fail subnet check
+      ));
+      // Pool validation not run because IP itself is invalid
+      expect(errors['minAddress'], isNull);
+    });
+
+    test('min >= max returns error', () {
+      final errors = service.validateAll(_model(
+        minAddress: '192.168.1.200',
+        maxAddress: '192.168.1.100',
+      ));
+      expect(errors['maxAddress'], isNotNull);
+    });
+
+    test('pool containing router IP returns error', () {
+      final errors = service.validateAll(_model(
+        ipAddress: '192.168.1.150',
+        minAddress: '192.168.1.100',
+        maxAddress: '192.168.1.200',
+      ));
+      expect(errors['minAddress'], contains('router IP'));
+    });
+
+    test('pool address equal to router IP returns error', () {
+      final errors = service.validateAll(_model(
+        ipAddress: '192.168.1.1',
+        minAddress: '192.168.1.1',
+      ));
+      expect(errors['minAddress'], contains('router IP'));
+    });
+  });
+}

--- a/test/page/wifi_settings/services/wifi_channel_bonding_test.dart
+++ b/test/page/wifi_settings/services/wifi_channel_bonding_test.dart
@@ -1,0 +1,240 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/wifi_settings/services/wifi_channel_bonding.dart';
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // bandwidthIndex
+  // ---------------------------------------------------------------------------
+
+  group('bandwidthIndex', () {
+    test('returns ordered indices for known bandwidths', () {
+      expect(bandwidthIndex('20MHz'), 0);
+      expect(bandwidthIndex('40MHz'), 1);
+      expect(bandwidthIndex('80MHz'), 2);
+      expect(bandwidthIndex('160MHz'), 3);
+      expect(bandwidthIndex('320MHz'), 4);
+    });
+
+    test('Auto returns highest index (no constraint)', () {
+      expect(bandwidthIndex('Auto'), 5);
+    });
+
+    test('unknown bandwidth returns -1', () {
+      expect(bandwidthIndex('10MHz'), -1);
+      expect(bandwidthIndex(''), -1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // maxBandwidthForStandards
+  // ---------------------------------------------------------------------------
+
+  group('maxBandwidthForStandards', () {
+    test('empty string returns 320MHz (mixed/no limit)', () {
+      expect(maxBandwidthForStandards(''), '320MHz');
+    });
+
+    test('802.11b → 20MHz', () {
+      expect(maxBandwidthForStandards('b'), '20MHz');
+    });
+
+    test('802.11n → 40MHz', () {
+      expect(maxBandwidthForStandards('n'), '40MHz');
+    });
+
+    test('802.11ac → 160MHz', () {
+      expect(maxBandwidthForStandards('ac'), '160MHz');
+    });
+
+    test('802.11ax → 160MHz', () {
+      expect(maxBandwidthForStandards('ax'), '160MHz');
+    });
+
+    test('802.11be → 320MHz', () {
+      expect(maxBandwidthForStandards('be'), '320MHz');
+    });
+
+    test('comma-separated takes maximum', () {
+      expect(maxBandwidthForStandards('a,n,ac'), '160MHz');
+    });
+
+    test('concatenated format parsed correctly', () {
+      expect(maxBandwidthForStandards('anacax'), '160MHz');
+    });
+
+    test('mixed keyword returns all standards (320MHz)', () {
+      expect(maxBandwidthForStandards('mixed'), '320MHz');
+    });
+
+    test('unknown standard alone defaults to 20MHz', () {
+      expect(maxBandwidthForStandards('xyz'), '20MHz');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // minStandardForBandwidth
+  // ---------------------------------------------------------------------------
+
+  group('minStandardForBandwidth', () {
+    test('Auto returns null', () {
+      expect(minStandardForBandwidth('Auto'), isNull);
+    });
+
+    test('empty returns null', () {
+      expect(minStandardForBandwidth(''), isNull);
+    });
+
+    test('20MHz returns null (any standard)', () {
+      expect(minStandardForBandwidth('20MHz'), isNull);
+    });
+
+    test('40MHz requires n', () {
+      expect(minStandardForBandwidth('40MHz'), 'n');
+    });
+
+    test('80MHz requires ac', () {
+      expect(minStandardForBandwidth('80MHz'), 'ac');
+    });
+
+    test('160MHz requires ac', () {
+      expect(minStandardForBandwidth('160MHz'), 'ac');
+    });
+
+    test('320MHz requires be', () {
+      expect(minStandardForBandwidth('320MHz'), 'be');
+    });
+
+    test('unknown bandwidth returns null', () {
+      expect(minStandardForBandwidth('10MHz'), isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // computeChannelsPerBandwidth
+  // ---------------------------------------------------------------------------
+
+  group('computeChannelsPerBandwidth', () {
+    test('empty possibleChannels returns empty map', () {
+      final result = computeChannelsPerBandwidth(
+        band: '2.4GHz',
+        possibleChannels: [],
+        supportedBandwidths: ['20MHz'],
+      );
+      expect(result, isEmpty);
+    });
+
+    test('Auto key always includes all possible channels', () {
+      final result = computeChannelsPerBandwidth(
+        band: '2.4GHz',
+        possibleChannels: [1, 6, 11],
+        supportedBandwidths: ['20MHz'],
+      );
+      expect(result['Auto'], [1, 6, 11]);
+    });
+
+    test('2.4GHz 20MHz returns all possible channels sorted', () {
+      final result = computeChannelsPerBandwidth(
+        band: '2.4GHz',
+        possibleChannels: [11, 1, 6],
+        supportedBandwidths: ['20MHz'],
+      );
+      expect(result['20MHz'], [1, 6, 11]);
+    });
+
+    test('2.4GHz 40MHz filters by HT40+ bonding pairs', () {
+      // Channels 1,5,6,11 — only pair [1,5] is complete
+      final result = computeChannelsPerBandwidth(
+        band: '2.4GHz',
+        possibleChannels: [1, 5, 6, 11],
+        supportedBandwidths: ['40MHz'],
+      );
+      // Pair [1,5] is complete → channels 1,5 valid
+      // Pair [2,6] needs 2 → incomplete; pair [6,10] needs 10 → incomplete
+      // Pair [7,11] needs 7 → incomplete
+      expect(result['40MHz'], [1, 5]);
+    });
+
+    test('5GHz 40MHz filters by bonding pairs', () {
+      final result = computeChannelsPerBandwidth(
+        band: '5GHz',
+        possibleChannels: [36, 40, 44, 48, 149, 153],
+        supportedBandwidths: ['40MHz'],
+      );
+      // Pairs: [36,40], [44,48], [149,153] — all complete
+      expect(result['40MHz'], [36, 40, 44, 48, 149, 153]);
+    });
+
+    test('5GHz 80MHz requires all 4 group members', () {
+      final result = computeChannelsPerBandwidth(
+        band: '5GHz',
+        possibleChannels: [36, 40, 44, 48, 52, 56],
+        supportedBandwidths: ['80MHz'],
+      );
+      // Group [36,40,44,48] complete → all valid
+      // Group [52,56,60,64] incomplete (missing 60,64)
+      expect(result['80MHz'], [36, 40, 44, 48]);
+    });
+
+    test('5GHz 160MHz requires all 8 group members', () {
+      final result = computeChannelsPerBandwidth(
+        band: '5GHz',
+        possibleChannels: [36, 40, 44, 48, 52, 56, 60, 64],
+        supportedBandwidths: ['160MHz'],
+      );
+      // Group [36..64] complete
+      expect(result['160MHz'], [36, 40, 44, 48, 52, 56, 60, 64]);
+    });
+
+    test('6GHz 40MHz uses dynamically built groups', () {
+      final result = computeChannelsPerBandwidth(
+        band: '6GHz',
+        possibleChannels: [1, 5, 9, 13],
+        supportedBandwidths: ['40MHz'],
+      );
+      // Groups of 2: [1,5], [9,13] — both complete
+      expect(result['40MHz'], [1, 5, 9, 13]);
+    });
+
+    test('6GHz 320MHz requires 16 consecutive channels', () {
+      // First 16 channels: 1,5,9,...,61
+      final channels = List.generate(16, (i) => 1 + i * 4);
+      final result = computeChannelsPerBandwidth(
+        band: '6GHz',
+        possibleChannels: channels,
+        supportedBandwidths: ['320MHz'],
+      );
+      expect(result['320MHz'], channels);
+    });
+
+    test('uses default widths when supportedBandwidths empty', () {
+      final result = computeChannelsPerBandwidth(
+        band: '2.4GHz',
+        possibleChannels: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        supportedBandwidths: [],
+      );
+      // Default 2.4GHz widths: 20MHz, 40MHz
+      expect(result.containsKey('20MHz'), isTrue);
+      expect(result.containsKey('40MHz'), isTrue);
+      expect(result.containsKey('80MHz'), isFalse);
+    });
+
+    test('unknown band returns all channels for all widths', () {
+      final result = computeChannelsPerBandwidth(
+        band: 'unknown',
+        possibleChannels: [1, 2, 3],
+        supportedBandwidths: ['20MHz'],
+      );
+      expect(result['20MHz'], [1, 2, 3]);
+    });
+
+    test('incomplete groups are excluded from results', () {
+      // Only channel 36 available — no complete pair
+      final result = computeChannelsPerBandwidth(
+        band: '5GHz',
+        possibleChannels: [36],
+        supportedBandwidths: ['40MHz'],
+      );
+      expect(result.containsKey('40MHz'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add **116 unit tests** covering 3 complex service files in Phase 4 of issue #704
- **UspDeviceService** (30 tests, 94.5%): 13 build methods — systemInfo, firmwareImages, devices, wifiRadios, dhcpClients, dhcpReservations, portForwarding, portTriggering, lanInfo, wanStatus, ethernetPorts, nodes
- **UspLocalNetworkService** (53 tests, 79.4%): buildUIModel, joinDnsServers, 8 validation methods, lockedOctetCount, ipPrefix, syncPrefix, validateAll cascade
- **WiFiChannelBonding** (33 tests, 92.9%): bandwidthIndex, maxBandwidthForStandards, minStandardForBandwidth, computeChannelsPerBandwidth across 2.4/5/6 GHz

## Coverage
| File | Lines | Coverage |
|------|:-----:|:--------:|
| usp_device_service.dart | 205/217 | 94.5% |
| usp_local_network_service.dart | 85/107 | 79.4% |
| wifi_channel_bonding.dart | 78/84 | 92.9% |
| **Total** | **368/408** | **90.2%** |

## Test plan
- [x] All 116 Phase 4 tests pass
- [x] Full regression (491 tests, 100% pass)
- [x] `dart format .` applied

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Qodo Review Fix (2026-03-24)
- **fix**: `buildLanInfoUIModel()` missing `hostName` and `leaseTimeMinutes` mapping from `LanNetworkInfo` → production code bug causing UI to show empty/zero values
- Added test assertions for both fields