### PR TITLE
test: Preservable notifier tests (Phase 7)

### DIFF
--- a/test/page/dhcp/providers/usp_dhcp_reservations_notifier_test.dart
+++ b/test/page/dhcp/providers/usp_dhcp_reservations_notifier_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
+import 'package:privacy_gui/page/_shared/models/dhcp_reservation_ui_model.dart';
+import 'package:privacy_gui/page/dhcp/providers/usp_dhcp_reservations_notifier.dart';
+import 'package:privacy_gui/page/dhcp/services/usp_dhcp_service.dart';
+
+class MockUspDhcpService extends Mock implements UspDhcpService {}
+
+void main() {
+  late MockUspDhcpService mockService;
+
+  final r1 = DhcpReservationUIModel(
+    instancePath: 'Device.DHCPv4.Server.Pool.1.StaticAddress.1.',
+    mac: 'AA:BB:CC:DD:EE:01',
+    ip: '192.168.1.100',
+    enable: true,
+  );
+  final r2 = DhcpReservationUIModel(
+    instancePath: 'Device.DHCPv4.Server.Pool.1.StaticAddress.2.',
+    mac: 'AA:BB:CC:DD:EE:02',
+    ip: '192.168.1.101',
+    enable: false,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(<DhcpReservationUIModel>[]);
+  });
+
+  setUp(() {
+    mockService = MockUspDhcpService();
+  });
+
+  ProviderContainer createContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        uspDhcpServiceProvider.overrideWithValue(mockService),
+        uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+      ],
+    );
+    container.listen(uspDhcpReservationsProvider, (_, __) {});
+    return container;
+  }
+
+  group('UspDhcpReservationsNotifier', () {
+    test('build returns initial loading state', () {
+      when(() => mockService.fetchReservations())
+          .thenAnswer((_) async => [r1, r2]);
+      final container = createContainer();
+
+      final state = container.read(uspDhcpReservationsProvider);
+      expect(state.status.isLoading, isTrue);
+      expect(state.settings.current.reservations, isEmpty);
+      container.dispose();
+    });
+
+    test('fetch success populates reservations', () async {
+      when(() => mockService.fetchReservations())
+          .thenAnswer((_) async => [r1, r2]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspDhcpReservationsProvider);
+      expect(state.settings.current.reservations, hasLength(2));
+      expect(state.settings.current.reservations[0].mac, 'AA:BB:CC:DD:EE:01');
+      expect(state.settings.current.reservations[1].enable, isFalse);
+      container.dispose();
+    });
+
+    test('fetch error sets error status', () async {
+      when(() => mockService.fetchReservations())
+          .thenThrow(Exception('timeout'));
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspDhcpReservationsProvider);
+      expect(state.status.errorMessage, contains('timeout'));
+      expect(state.settings.current.reservations, isEmpty);
+      container.dispose();
+    });
+
+    test('performSave calls saveBatch with original and current', () async {
+      when(() => mockService.fetchReservations()).thenAnswer((_) async => [r1]);
+      when(() => mockService.saveBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).thenAnswer((_) async => (added: 1, updated: 0, deleted: 0));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspDhcpReservationsProvider.notifier);
+      // Add a reservation so state is dirty.
+      notifier.addReservation(r2);
+      await notifier.save();
+
+      verify(() => mockService.saveBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).called(1);
+      container.dispose();
+    });
+
+    test('addReservation appends to list', () async {
+      when(() => mockService.fetchReservations()).thenAnswer((_) async => [r1]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspDhcpReservationsProvider.notifier);
+      notifier.addReservation(r2);
+
+      final state = container.read(uspDhcpReservationsProvider);
+      expect(state.settings.current.reservations, hasLength(2));
+      expect(state.settings.current.reservations[1].mac, r2.mac);
+      container.dispose();
+    });
+
+    test('editReservation replaces by value match', () async {
+      when(() => mockService.fetchReservations())
+          .thenAnswer((_) async => [r1, r2]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspDhcpReservationsProvider.notifier);
+      final updated = r1.copyWith(ip: '192.168.1.200');
+      notifier.editReservation(r1, updated);
+
+      final state = container.read(uspDhcpReservationsProvider);
+      expect(state.settings.current.reservations[0].ip, '192.168.1.200');
+      expect(state.settings.current.reservations, hasLength(2));
+      container.dispose();
+    });
+
+    test('toggleReservation flips enable flag', () async {
+      when(() => mockService.fetchReservations()).thenAnswer((_) async => [r1]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspDhcpReservationsProvider.notifier);
+      notifier.toggleReservation(r1, false);
+
+      final state = container.read(uspDhcpReservationsProvider);
+      expect(state.settings.current.reservations[0].enable, isFalse);
+      container.dispose();
+    });
+
+    test('deleteReservation removes from list', () async {
+      when(() => mockService.fetchReservations())
+          .thenAnswer((_) async => [r1, r2]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspDhcpReservationsProvider.notifier);
+      notifier.deleteReservation(r1);
+
+      final state = container.read(uspDhcpReservationsProvider);
+      expect(state.settings.current.reservations, hasLength(1));
+      expect(state.settings.current.reservations[0].mac, r2.mac);
+      container.dispose();
+    });
+
+    test('isDirty after add, clean after revert', () async {
+      when(() => mockService.fetchReservations()).thenAnswer((_) async => [r1]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspDhcpReservationsProvider.notifier);
+      expect(notifier.isDirty(), isFalse);
+
+      notifier.addReservation(r2);
+      expect(notifier.isDirty(), isTrue);
+
+      notifier.revert();
+      expect(notifier.isDirty(), isFalse);
+      expect(
+          container
+              .read(uspDhcpReservationsProvider)
+              .settings
+              .current
+              .reservations,
+          hasLength(1));
+      container.dispose();
+    });
+  });
+}

--- a/test/page/dmz/providers/usp_dmz_notifier_test.dart
+++ b/test/page/dmz/providers/usp_dmz_notifier_test.dart
@@ -238,8 +238,7 @@ void main() {
       final notifier = container.read(uspDmzProvider.notifier);
       notifier.updateSetting((m) => m.copyWith(destIp: '10.0.0.1'));
 
-      expect(() => notifier.save(), throwsA(isA<Exception>()));
-      await Future.delayed(Duration.zero);
+      await expectLater(notifier.save(), throwsA(isA<Exception>()));
 
       expect(container.read(uspDmzProvider).status.isSaving, isFalse);
       container.dispose();
@@ -260,14 +259,15 @@ void main() {
       container.listen(uspDmzProvider, (_, __) {});
       await Future.delayed(Duration.zero);
 
-      // Initial fetch happened once.
+      // Initial fetch happened once — clear for clean counting.
       verify(() => mockService.fetch()).called(1);
+      clearInteractions(mockService);
 
       // Push a DMZ invalidation event.
       sseController.add(InvalidationDomain.dmz);
       await Future.delayed(Duration.zero);
 
-      // Should have re-fetched.
+      // Should have re-fetched exactly once after SSE.
       verify(() => mockService.fetch()).called(1);
 
       await sseController.close();

--- a/test/page/dmz/providers/usp_dmz_notifier_test.dart
+++ b/test/page/dmz/providers/usp_dmz_notifier_test.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/page/dmz/models/dmz_settings.dart';
 import 'package:privacy_gui/page/dmz/models/dmz_status.dart';
@@ -175,6 +178,32 @@ void main() {
       container.dispose();
     });
 
+    test('performSave skips when new entry and disabled', () async {
+      final disabledNew = DmzSettings(
+        model: DmzUIModel(
+          isEnabled: false,
+          destIp: '',
+          sourceType: DmzSourceType.any,
+          sourcePrefix: '',
+        ),
+        // No instancePath → isNewEntry = true.
+      );
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => (disabledNew, testStatus));
+      when(() => mockService.validateForm(any())).thenReturn({});
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      await container.read(uspDmzProvider.notifier).save();
+
+      verifyNever(() => mockService.add(model: any(named: 'model')));
+      verifyNever(() => mockService.update(
+          instancePath: any(named: 'instancePath'),
+          model: any(named: 'model')));
+      container.dispose();
+    });
+
     test('isDirty true after mutation, false after fetch', () async {
       when(() => mockService.fetch())
           .thenAnswer((_) async => (testSettings, testStatus));
@@ -191,6 +220,57 @@ void main() {
 
       await notifier.fetch();
       expect(notifier.isDirty(), isFalse);
+      container.dispose();
+    });
+
+    test('performSave rethrows on error and clears isSaving', () async {
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => (testSettings, testStatus));
+      when(() => mockService.update(
+            instancePath: any(named: 'instancePath'),
+            model: any(named: 'model'),
+          )).thenThrow(Exception('save failed'));
+      when(() => mockService.validateForm(any())).thenReturn({});
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspDmzProvider.notifier);
+      notifier.updateSetting((m) => m.copyWith(destIp: '10.0.0.1'));
+
+      expect(() => notifier.save(), throwsA(isA<Exception>()));
+      await Future.delayed(Duration.zero);
+
+      expect(container.read(uspDmzProvider).status.isSaving, isFalse);
+      container.dispose();
+    });
+
+    test('SSE invalidation triggers re-fetch when clean', () async {
+      final sseController = StreamController<InvalidationDomain>();
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => (testSettings, testStatus));
+
+      final container = ProviderContainer(
+        overrides: [
+          uspDmzServiceProvider.overrideWithValue(mockService),
+          uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+          sseInvalidationProvider.overrideWith((_) => sseController.stream),
+        ],
+      );
+      container.listen(uspDmzProvider, (_, __) {});
+      await Future.delayed(Duration.zero);
+
+      // Initial fetch happened once.
+      verify(() => mockService.fetch()).called(1);
+
+      // Push a DMZ invalidation event.
+      sseController.add(InvalidationDomain.dmz);
+      await Future.delayed(Duration.zero);
+
+      // Should have re-fetched.
+      verify(() => mockService.fetch()).called(1);
+
+      await sseController.close();
       container.dispose();
     });
 

--- a/test/page/dmz/providers/usp_dmz_notifier_test.dart
+++ b/test/page/dmz/providers/usp_dmz_notifier_test.dart
@@ -1,0 +1,216 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
+import 'package:privacy_gui/page/dmz/models/dmz_settings.dart';
+import 'package:privacy_gui/page/dmz/models/dmz_status.dart';
+import 'package:privacy_gui/page/dmz/models/dmz_ui_model.dart';
+import 'package:privacy_gui/page/dmz/providers/usp_dmz_notifier.dart';
+import 'package:privacy_gui/page/dmz/services/usp_dmz_service.dart';
+
+class MockUspDmzService extends Mock implements UspDmzService {}
+
+void main() {
+  late MockUspDmzService mockService;
+
+  final testSettings = DmzSettings(
+    model: DmzUIModel(
+      isEnabled: true,
+      destIp: '192.168.1.100',
+      sourceType: DmzSourceType.any,
+      sourcePrefix: '',
+    ),
+    instancePath: 'Device.Firewall.DMZ.1.',
+  );
+  const testStatus = DmzStatus(isLoading: false);
+
+  setUpAll(() {
+    registerFallbackValue(const DmzUIModel.disabled());
+  });
+
+  setUp(() {
+    mockService = MockUspDmzService();
+  });
+
+  ProviderContainer createContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        uspDmzServiceProvider.overrideWithValue(mockService),
+        uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+      ],
+    );
+    // Prevent auto-dispose.
+    container.listen(uspDmzProvider, (_, __) {});
+    return container;
+  }
+
+  group('UspDmzNotifier', () {
+    test('build returns initial loading state', () {
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => (testSettings, testStatus));
+      final container = createContainer();
+
+      final state = container.read(uspDmzProvider);
+      expect(state.status.isLoading, isTrue);
+      expect(state.settings.current, const DmzSettings.empty());
+      container.dispose();
+    });
+
+    test('fetch success populates settings and status', () async {
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => (testSettings, testStatus));
+      final container = createContainer();
+
+      // Let microtask (Future.microtask in build) complete.
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspDmzProvider);
+      expect(state.settings.current.model.isEnabled, isTrue);
+      expect(state.settings.current.model.destIp, '192.168.1.100');
+      expect(state.settings.current.instancePath, 'Device.Firewall.DMZ.1.');
+      expect(state.status.isLoading, isFalse);
+      container.dispose();
+    });
+
+    test('fetch error sets error status, no settings change', () async {
+      when(() => mockService.fetch()).thenThrow(Exception('network error'));
+      final container = createContainer();
+
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspDmzProvider);
+      expect(state.status.errorMessage, contains('network error'));
+      // Settings remain empty (initial) since performFetch returned null.
+      expect(state.settings.current, const DmzSettings.empty());
+      container.dispose();
+    });
+
+    test('performSave calls add for new entry', () async {
+      // Existing entry returned from fetch.
+      final newSettings = DmzSettings(
+        model: DmzUIModel(
+          isEnabled: true,
+          destIp: '192.168.1.50',
+          sourceType: DmzSourceType.any,
+          sourcePrefix: '',
+        ),
+        // No instancePath → isNewEntry = true.
+      );
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => (newSettings, testStatus));
+      when(() => mockService.add(model: any(named: 'model')))
+          .thenAnswer((_) async {});
+      when(() => mockService.validateForm(any())).thenReturn({});
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspDmzProvider.notifier);
+      // Trigger save — the current settings have isNewEntry = true.
+      await notifier.save();
+
+      verify(() => mockService.add(model: any(named: 'model'))).called(1);
+      verifyNever(() => mockService.update(
+          instancePath: any(named: 'instancePath'),
+          model: any(named: 'model')));
+      container.dispose();
+    });
+
+    test('performSave calls update for existing entry', () async {
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => (testSettings, testStatus));
+      when(() => mockService.update(
+            instancePath: any(named: 'instancePath'),
+            model: any(named: 'model'),
+          )).thenAnswer((_) async {});
+      when(() => mockService.validateForm(any())).thenReturn({});
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspDmzProvider.notifier);
+      // Mutate to make dirty — then save.
+      notifier.updateSetting((m) => m.copyWith(destIp: '192.168.1.200'));
+      await notifier.save();
+
+      verify(() => mockService.update(
+            instancePath: 'Device.Firewall.DMZ.1.',
+            model: any(named: 'model'),
+          )).called(1);
+      verifyNever(() => mockService.add(model: any(named: 'model')));
+      container.dispose();
+    });
+
+    test('updateSetting mutates current model and validates', () async {
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => (testSettings, testStatus));
+      when(() => mockService.validateForm(any())).thenReturn({});
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspDmzProvider.notifier);
+      notifier.updateSetting((m) => m.copyWith(destIp: '10.0.0.1'));
+
+      final state = container.read(uspDmzProvider);
+      expect(state.settings.current.model.destIp, '10.0.0.1');
+      verify(() => mockService.validateForm(any())).called(1);
+      container.dispose();
+    });
+
+    test('updateSetting propagates validation errors to status', () async {
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => (testSettings, testStatus));
+      when(() => mockService.validateForm(any()))
+          .thenReturn({'destIp': 'Invalid IP'});
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspDmzProvider.notifier);
+      notifier.updateSetting((m) => m.copyWith(destIp: 'bad'));
+
+      final state = container.read(uspDmzProvider);
+      expect(state.status.fieldErrors['destIp'], 'Invalid IP');
+      container.dispose();
+    });
+
+    test('isDirty true after mutation, false after fetch', () async {
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => (testSettings, testStatus));
+      when(() => mockService.validateForm(any())).thenReturn({});
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspDmzProvider.notifier);
+      expect(notifier.isDirty(), isFalse);
+
+      notifier.updateSetting((m) => m.copyWith(destIp: '10.0.0.1'));
+      expect(notifier.isDirty(), isTrue);
+
+      await notifier.fetch();
+      expect(notifier.isDirty(), isFalse);
+      container.dispose();
+    });
+
+    test('revert restores original settings', () async {
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => (testSettings, testStatus));
+      when(() => mockService.validateForm(any())).thenReturn({});
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspDmzProvider.notifier);
+      notifier.updateSetting((m) => m.copyWith(destIp: '10.0.0.1'));
+      expect(container.read(uspDmzProvider).settings.current.model.destIp,
+          '10.0.0.1');
+
+      notifier.revert();
+      expect(container.read(uspDmzProvider).settings.current.model.destIp,
+          '192.168.1.100');
+      container.dispose();
+    });
+  });
+}

--- a/test/page/firewall/providers/usp_firewall_notifier_test.dart
+++ b/test/page/firewall/providers/usp_firewall_notifier_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
+import 'package:privacy_gui/page/firewall/models/firewall_ui_model.dart';
+import 'package:privacy_gui/page/firewall/providers/firewall_data_provider.dart';
+import 'package:privacy_gui/page/firewall/providers/usp_firewall_notifier.dart';
+import 'package:privacy_gui/page/dmz/models/dmz_ui_model.dart';
+import 'package:privacy_gui/page/firewall/services/usp_firewall_service.dart';
+
+class MockUspFirewallService extends Mock implements UspFirewallService {}
+
+/// Test-only notifier that returns canned data instead of real fetch.
+class _TestFirewallDataNotifier extends FirewallDataNotifier {
+  final FirewallData _testData;
+  _TestFirewallDataNotifier(this._testData);
+
+  @override
+  Future<FirewallData> build() async => _testData;
+}
+
+void main() {
+  late MockUspFirewallService mockService;
+
+  final testData = FirewallData(
+    firewallModel: FirewallUIModel(
+      isIPv4FirewallEnabled: true,
+      isIPv6FirewallEnabled: false,
+      blockIPSec: true,
+    ),
+    ruleContext: FirewallRuleContext.empty,
+    ruleSummaries: const [],
+    dmzModel: const DmzUIModel.disabled(),
+    dmzSummaries: const [],
+  );
+
+  setUpAll(() {
+    registerFallbackValue(const FirewallUIModel());
+    registerFallbackValue(FirewallRuleContext.empty);
+  });
+
+  setUp(() {
+    mockService = MockUspFirewallService();
+  });
+
+  ProviderContainer createContainer({FirewallData? data}) {
+    final container = ProviderContainer(
+      overrides: [
+        uspFirewallServiceProvider.overrideWithValue(mockService),
+        uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+        firewallDataProvider
+            .overrideWith(() => _TestFirewallDataNotifier(data ?? testData)),
+      ],
+    );
+    container.listen(uspFirewallProvider, (_, __) {});
+    return container;
+  }
+
+  group('UspFirewallNotifier', () {
+    test('build returns initial loading state', () {
+      final container = createContainer();
+
+      final state = container.read(uspFirewallProvider);
+      expect(state.status.isLoading, isTrue);
+      container.dispose();
+    });
+
+    test('fetch success populates settings from data provider', () async {
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspFirewallProvider);
+      expect(state.settings.current.model.isIPv4FirewallEnabled, isTrue);
+      expect(state.settings.current.model.isIPv6FirewallEnabled, isFalse);
+      expect(state.settings.current.model.blockIPSec, isTrue);
+      expect(state.status.isLoading, isFalse);
+      container.dispose();
+    });
+
+    test('performSave calls service.save with original and pending', () async {
+      when(() => mockService.save(
+            original: any(named: 'original'),
+            pending: any(named: 'pending'),
+            context: any(named: 'context'),
+          )).thenAnswer((_) async => 2);
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspFirewallProvider.notifier);
+      // Mutate to make dirty.
+      notifier.updateSetting((m) => m.copyWith(isIPv6FirewallEnabled: true));
+      await notifier.save();
+
+      verify(() => mockService.save(
+            original: any(named: 'original'),
+            pending: any(named: 'pending'),
+            context: any(named: 'context'),
+          )).called(1);
+      container.dispose();
+    });
+
+    test('updateSetting mutates current model', () async {
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspFirewallProvider.notifier);
+      notifier.updateSetting((m) => m.copyWith(isIPv6FirewallEnabled: true));
+
+      final state = container.read(uspFirewallProvider);
+      expect(state.settings.current.model.isIPv6FirewallEnabled, isTrue);
+      container.dispose();
+    });
+
+    test('isDirty after mutation, clean after revert', () async {
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspFirewallProvider.notifier);
+      expect(notifier.isDirty(), isFalse);
+
+      notifier.updateSetting((m) => m.copyWith(blockMulticast: true));
+      expect(notifier.isDirty(), isTrue);
+
+      notifier.revert();
+      expect(notifier.isDirty(), isFalse);
+      container.dispose();
+    });
+
+    test('revert restores original settings', () async {
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspFirewallProvider.notifier);
+      notifier.updateSetting((m) => m.copyWith(blockIPSec: false));
+      expect(
+          container.read(uspFirewallProvider).settings.current.model.blockIPSec,
+          isFalse);
+
+      notifier.revert();
+      expect(
+          container.read(uspFirewallProvider).settings.current.model.blockIPSec,
+          isTrue);
+      container.dispose();
+    });
+  });
+}

--- a/test/page/firewall/providers/usp_firewall_notifier_test.dart
+++ b/test/page/firewall/providers/usp_firewall_notifier_test.dart
@@ -13,10 +13,14 @@ class MockUspFirewallService extends Mock implements UspFirewallService {}
 /// Test-only notifier that returns canned data instead of real fetch.
 class _TestFirewallDataNotifier extends FirewallDataNotifier {
   final FirewallData _testData;
-  _TestFirewallDataNotifier(this._testData);
+  final bool shouldThrow;
+  _TestFirewallDataNotifier(this._testData, {this.shouldThrow = false});
 
   @override
-  Future<FirewallData> build() async => _testData;
+  Future<FirewallData> build() async {
+    if (shouldThrow) throw Exception('data provider error');
+    return _testData;
+  }
 }
 
 void main() {
@@ -141,6 +145,32 @@ void main() {
       expect(
           container.read(uspFirewallProvider).settings.current.model.blockIPSec,
           isTrue);
+      container.dispose();
+    });
+
+    test('fetch error sets error status', () async {
+      final errorData = FirewallData(
+        firewallModel: const FirewallUIModel(),
+        ruleContext: FirewallRuleContext.empty,
+        ruleSummaries: const [],
+        dmzModel: const DmzUIModel.disabled(),
+        dmzSummaries: const [],
+      );
+      // Override firewallDataProvider to throw on read.
+      final container = ProviderContainer(
+        overrides: [
+          uspFirewallServiceProvider.overrideWithValue(mockService),
+          uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+          firewallDataProvider.overrideWith(() {
+            return _TestFirewallDataNotifier(errorData, shouldThrow: true);
+          }),
+        ],
+      );
+      container.listen(uspFirewallProvider, (_, __) {});
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspFirewallProvider);
+      expect(state.status.errorMessage, isNotNull);
       container.dispose();
     });
   });

--- a/test/page/internet_settings/providers/usp_internet_settings_notifier_test.dart
+++ b/test/page/internet_settings/providers/usp_internet_settings_notifier_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
+import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
+import 'package:privacy_gui/core/usp/services/usp_service.dart';
+import 'package:privacy_gui/page/internet_settings/models/internet_settings_read_only_info.dart';
+import 'package:privacy_gui/page/internet_settings/models/usp_internet_settings_form.dart';
+import 'package:privacy_gui/page/internet_settings/models/usp_wan_connection_type.dart';
+import 'package:privacy_gui/page/internet_settings/providers/usp_internet_settings_notifier.dart';
+import 'package:privacy_gui/page/internet_settings/services/usp_internet_settings_service.dart';
+
+class MockUspService extends Mock implements UspService {}
+
+class MockUspInternetSettingsService extends Mock
+    implements UspInternetSettingsService {}
+
+void main() {
+  late MockUspService mockUsp;
+  late MockUspInternetSettingsService mockService;
+
+  final testForm = UspInternetSettingsForm(
+    connectionType: UspWanConnectionType.dhcp,
+    mtu: 1500,
+    ipv6Enabled: true,
+  );
+  final testFetchResult = InternetSettingsFetchResult(
+    form: testForm,
+    readOnlyInfo: const InternetSettingsReadOnlyInfo(),
+  );
+
+  setUpAll(() {
+    registerFallbackValue(const UspInternetSettingsForm(
+        connectionType: UspWanConnectionType.dhcp));
+  });
+
+  setUp(() {
+    mockUsp = MockUspService();
+    mockService = MockUspInternetSettingsService();
+    when(() => mockUsp.isAuthenticated).thenReturn(true);
+  });
+
+  ProviderContainer createContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        uspServiceProvider.overrideWithValue(mockUsp),
+        uspInternetSettingsServiceProvider.overrideWithValue(mockService),
+        uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+      ],
+    );
+    container.listen(uspInternetSettingsProvider, (_, __) {});
+    return container;
+  }
+
+  group('UspInternetSettingsNotifier', () {
+    test('build returns initial loading state', () {
+      when(() => mockService.fetchSettings())
+          .thenAnswer((_) async => testFetchResult);
+      final container = createContainer();
+
+      final state = container.read(uspInternetSettingsProvider);
+      expect(state.status.isLoading, isTrue);
+      container.dispose();
+    });
+
+    test('fetch success populates form and read-only info', () async {
+      when(() => mockService.fetchSettings())
+          .thenAnswer((_) async => testFetchResult);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspInternetSettingsProvider);
+      expect(state.settings.current.form.connectionType,
+          UspWanConnectionType.dhcp);
+      expect(state.settings.current.form.mtu, 1500);
+      expect(state.settings.current.form.ipv6Enabled, isTrue);
+      expect(state.status.isLoading, isFalse);
+      container.dispose();
+    });
+
+    test('fetch error sets error status', () async {
+      when(() => mockService.fetchSettings())
+          .thenThrow(Exception('bridge unreachable'));
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspInternetSettingsProvider);
+      expect(state.status.errorMessage, contains('bridge unreachable'));
+      container.dispose();
+    });
+
+    test('enterEditMode and exitEditMode toggle isEditing', () async {
+      when(() => mockService.fetchSettings())
+          .thenAnswer((_) async => testFetchResult);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspInternetSettingsProvider.notifier);
+
+      notifier.enterEditMode();
+      expect(
+          container.read(uspInternetSettingsProvider).status.isEditing, isTrue);
+
+      notifier.exitEditMode();
+      expect(container.read(uspInternetSettingsProvider).status.isEditing,
+          isFalse);
+      container.dispose();
+    });
+
+    test('exitEditMode reverts form to original', () async {
+      when(() => mockService.fetchSettings())
+          .thenAnswer((_) async => testFetchResult);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspInternetSettingsProvider.notifier);
+      notifier.enterEditMode();
+      notifier.updateField((f) => f.copyWith(mtu: 9000));
+      expect(
+          container.read(uspInternetSettingsProvider).settings.current.form.mtu,
+          9000);
+
+      notifier.exitEditMode();
+      expect(
+          container.read(uspInternetSettingsProvider).settings.current.form.mtu,
+          1500);
+      container.dispose();
+    });
+
+    test('updateField modifies form in current settings', () async {
+      when(() => mockService.fetchSettings())
+          .thenAnswer((_) async => testFetchResult);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      container
+          .read(uspInternetSettingsProvider.notifier)
+          .updateField((f) => f.copyWith(dnsServer1: '1.1.1.1'));
+
+      expect(
+          container
+              .read(uspInternetSettingsProvider)
+              .settings
+              .current
+              .form
+              .dnsServer1,
+          '1.1.1.1');
+      container.dispose();
+    });
+
+    test('updateConnectionType to bridge resets MTU to 0', () async {
+      when(() => mockService.fetchSettings())
+          .thenAnswer((_) async => testFetchResult);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      container
+          .read(uspInternetSettingsProvider.notifier)
+          .updateConnectionType(UspWanConnectionType.bridge);
+
+      final form =
+          container.read(uspInternetSettingsProvider).settings.current.form;
+      expect(form.connectionType, UspWanConnectionType.bridge);
+      expect(form.mtu, 0);
+      container.dispose();
+    });
+
+    test('isDirty after field update, clean after revert', () async {
+      when(() => mockService.fetchSettings())
+          .thenAnswer((_) async => testFetchResult);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspInternetSettingsProvider.notifier);
+      expect(notifier.isDirty(), isFalse);
+
+      notifier.updateField((f) => f.copyWith(mtu: 9000));
+      expect(notifier.isDirty(), isTrue);
+
+      notifier.revert(); // revert calls exitEditMode
+      expect(notifier.isDirty(), isFalse);
+      container.dispose();
+    });
+
+    test('revert exits edit mode', () async {
+      when(() => mockService.fetchSettings())
+          .thenAnswer((_) async => testFetchResult);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspInternetSettingsProvider.notifier);
+      notifier.enterEditMode();
+      expect(
+          container.read(uspInternetSettingsProvider).status.isEditing, isTrue);
+
+      notifier.revert();
+      expect(container.read(uspInternetSettingsProvider).status.isEditing,
+          isFalse);
+      container.dispose();
+    });
+  });
+}

--- a/test/page/internet_settings/providers/usp_internet_settings_notifier_test.dart
+++ b/test/page/internet_settings/providers/usp_internet_settings_notifier_test.dart
@@ -285,8 +285,7 @@ void main() {
       final notifier = container.read(uspInternetSettingsProvider.notifier);
       notifier.updateField((f) => f.copyWith(mtu: 9000));
 
-      expect(() => notifier.save(), throwsA(isA<Exception>()));
-      await Future.delayed(Duration.zero);
+      await expectLater(notifier.save(), throwsA(isA<Exception>()));
 
       expect(
           container.read(uspInternetSettingsProvider).status.isSaving, isFalse);

--- a/test/page/internet_settings/providers/usp_internet_settings_notifier_test.dart
+++ b/test/page/internet_settings/providers/usp_internet_settings_notifier_test.dart
@@ -198,5 +198,113 @@ void main() {
           isFalse);
       container.dispose();
     });
+
+    test('performSave calls service.saveAll and exits edit mode', () async {
+      when(() => mockService.fetchSettings())
+          .thenAnswer((_) async => testFetchResult);
+      when(() => mockService.saveAll(any(), any())).thenAnswer((_) async {});
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspInternetSettingsProvider.notifier);
+      notifier.enterEditMode();
+      notifier.updateField((f) => f.copyWith(mtu: 9000));
+      await notifier.save();
+
+      verify(() => mockService.saveAll(any(), any())).called(1);
+      expect(container.read(uspInternetSettingsProvider).status.isEditing,
+          isFalse);
+      container.dispose();
+    });
+
+    test('performSave sets isSaving flag during save', () async {
+      when(() => mockService.fetchSettings())
+          .thenAnswer((_) async => testFetchResult);
+      when(() => mockService.saveAll(any(), any())).thenAnswer((_) async {});
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspInternetSettingsProvider.notifier);
+      notifier.updateField((f) => f.copyWith(mtu: 9000));
+
+      // After save completes, isSaving should be false.
+      await notifier.save();
+      expect(
+          container.read(uspInternetSettingsProvider).status.isSaving, isFalse);
+      container.dispose();
+    });
+
+    test('renewDhcpLease calls service and tracks activeMutation', () async {
+      when(() => mockService.fetchSettings())
+          .thenAnswer((_) async => testFetchResult);
+      when(() => mockService.renewDhcpLease()).thenAnswer((_) async {});
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      await container
+          .read(uspInternetSettingsProvider.notifier)
+          .renewDhcpLease();
+
+      verify(() => mockService.renewDhcpLease()).called(1);
+      // After completion, activeMutation should be cleared.
+      expect(container.read(uspInternetSettingsProvider).status.activeMutation,
+          isNull);
+      container.dispose();
+    });
+
+    test('renewDhcpv6Lease calls service and tracks activeMutation', () async {
+      when(() => mockService.fetchSettings())
+          .thenAnswer((_) async => testFetchResult);
+      when(() => mockService.renewDhcpv6Lease()).thenAnswer((_) async {});
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      await container
+          .read(uspInternetSettingsProvider.notifier)
+          .renewDhcpv6Lease();
+
+      verify(() => mockService.renewDhcpv6Lease()).called(1);
+      expect(container.read(uspInternetSettingsProvider).status.activeMutation,
+          isNull);
+      container.dispose();
+    });
+
+    test('performSave rethrows on error and clears isSaving', () async {
+      when(() => mockService.fetchSettings())
+          .thenAnswer((_) async => testFetchResult);
+      when(() => mockService.saveAll(any(), any()))
+          .thenThrow(Exception('save failed'));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspInternetSettingsProvider.notifier);
+      notifier.updateField((f) => f.copyWith(mtu: 9000));
+
+      expect(() => notifier.save(), throwsA(isA<Exception>()));
+      await Future.delayed(Duration.zero);
+
+      expect(
+          container.read(uspInternetSettingsProvider).status.isSaving, isFalse);
+      container.dispose();
+    });
+
+    test('fetch with unauthenticated service sets error status', () async {
+      when(() => mockUsp.isAuthenticated).thenReturn(false);
+      when(() => mockService.fetchSettings())
+          .thenAnswer((_) async => testFetchResult);
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspInternetSettingsProvider);
+      // Should hit the restore path which won't succeed with our mock.
+      expect(state.status.errorMessage, isNotNull);
+      container.dispose();
+    });
   });
 }

--- a/test/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier_test.dart
+++ b/test/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
+import 'package:privacy_gui/page/ipv6_port_service/models/ipv6_port_service_ui_model.dart';
+import 'package:privacy_gui/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier.dart';
+import 'package:privacy_gui/page/ipv6_port_service/services/usp_ipv6_port_service_service.dart';
+
+class MockUspIpv6PortServiceService extends Mock
+    implements UspIpv6PortServiceService {}
+
+void main() {
+  late MockUspIpv6PortServiceService mockService;
+
+  final rule1 = Ipv6PortServiceRuleUIModel(
+    instancePath: 'Device.Firewall.Chain.1.Rule.1.',
+    enabled: true,
+    description: 'Web Server',
+    ipv6Address: '2001:db8::1',
+    protocol: 'TCP',
+    startPort: 80,
+    endPort: 80,
+  );
+  final rule2 = Ipv6PortServiceRuleUIModel(
+    instancePath: 'Device.Firewall.Chain.1.Rule.2.',
+    enabled: false,
+    description: 'DNS',
+    ipv6Address: '2001:db8::2',
+    protocol: 'UDP',
+    startPort: 53,
+    endPort: 53,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(<Ipv6PortServiceRuleUIModel>[]);
+  });
+
+  setUp(() {
+    mockService = MockUspIpv6PortServiceService();
+  });
+
+  ProviderContainer createContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        uspIpv6PortServiceServiceProvider.overrideWithValue(mockService),
+        uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+      ],
+    );
+    container.listen(uspIpv6PortServiceProvider, (_, __) {});
+    return container;
+  }
+
+  group('UspIpv6PortServiceNotifier', () {
+    test('build returns initial loading state', () {
+      when(() => mockService.fetch()).thenAnswer((_) async => [rule1]);
+      final container = createContainer();
+
+      final state = container.read(uspIpv6PortServiceProvider);
+      expect(state.status.isLoading, isTrue);
+      expect(state.settings.current.rules, isEmpty);
+      container.dispose();
+    });
+
+    test('fetch success populates rules', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [rule1, rule2]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspIpv6PortServiceProvider);
+      expect(state.settings.current.rules, hasLength(2));
+      expect(state.settings.current.rules[0].description, 'Web Server');
+      expect(state.settings.current.rules[1].protocol, 'UDP');
+      container.dispose();
+    });
+
+    test('fetch error sets error status', () async {
+      when(() => mockService.fetch()).thenThrow(Exception('fetch failed'));
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspIpv6PortServiceProvider);
+      expect(state.status.errorMessage, contains('fetch failed'));
+      expect(state.settings.current.rules, isEmpty);
+      container.dispose();
+    });
+
+    test('performSave calls saveBatch', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [rule1]);
+      when(() => mockService.saveBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).thenAnswer((_) async => (added: 1, updated: 0, deleted: 0));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspIpv6PortServiceProvider.notifier);
+      notifier.addRule(rule2);
+      await notifier.save();
+
+      verify(() => mockService.saveBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).called(1);
+      container.dispose();
+    });
+
+    test('addRule appends to list', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [rule1]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      container.read(uspIpv6PortServiceProvider.notifier).addRule(rule2);
+
+      final rules =
+          container.read(uspIpv6PortServiceProvider).settings.current.rules;
+      expect(rules, hasLength(2));
+      expect(rules[1].description, 'DNS');
+      container.dispose();
+    });
+
+    test('editRule replaces by index', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [rule1, rule2]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final updated = rule1.copyWith(description: 'HTTPS');
+      container.read(uspIpv6PortServiceProvider.notifier).editRule(0, updated);
+
+      final rules =
+          container.read(uspIpv6PortServiceProvider).settings.current.rules;
+      expect(rules[0].description, 'HTTPS');
+      expect(rules, hasLength(2));
+      container.dispose();
+    });
+
+    test('toggleRule flips enabled flag', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [rule1]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      container.read(uspIpv6PortServiceProvider.notifier).toggleRule(0, false);
+
+      final rules =
+          container.read(uspIpv6PortServiceProvider).settings.current.rules;
+      expect(rules[0].enabled, isFalse);
+      container.dispose();
+    });
+
+    test('deleteRule removes by index', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [rule1, rule2]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      container.read(uspIpv6PortServiceProvider.notifier).deleteRule(0);
+
+      final rules =
+          container.read(uspIpv6PortServiceProvider).settings.current.rules;
+      expect(rules, hasLength(1));
+      expect(rules[0].description, 'DNS');
+      container.dispose();
+    });
+
+    test('isDirty after mutation, clean after revert', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [rule1]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspIpv6PortServiceProvider.notifier);
+      expect(notifier.isDirty(), isFalse);
+
+      notifier.addRule(rule2);
+      expect(notifier.isDirty(), isTrue);
+
+      notifier.revert();
+      expect(notifier.isDirty(), isFalse);
+      expect(container.read(uspIpv6PortServiceProvider).settings.current.rules,
+          hasLength(1));
+      container.dispose();
+    });
+  });
+}

--- a/test/page/local_network/providers/usp_local_network_notifier_test.dart
+++ b/test/page/local_network/providers/usp_local_network_notifier_test.dart
@@ -14,10 +14,14 @@ class MockUspLocalNetworkService extends Mock
 /// Test-only notifier that returns canned data.
 class _TestLanDataNotifier extends LanDataNotifier {
   final LanData _testData;
-  _TestLanDataNotifier(this._testData);
+  final bool shouldThrow;
+  _TestLanDataNotifier(this._testData, {this.shouldThrow = false});
 
   @override
-  Future<LanData> build() async => _testData;
+  Future<LanData> build() async {
+    if (shouldThrow) throw Exception('lan data error');
+    return _testData;
+  }
 }
 
 void main() {
@@ -163,6 +167,23 @@ void main() {
 
       notifier.revert();
       expect(notifier.isDirty(), isFalse);
+      container.dispose();
+    });
+
+    test('fetch error sets error status', () async {
+      final container = ProviderContainer(
+        overrides: [
+          uspLocalNetworkServiceProvider.overrideWithValue(mockService),
+          uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+          lanDataProvider.overrideWith(
+              () => _TestLanDataNotifier(testLanData, shouldThrow: true)),
+        ],
+      );
+      container.listen(uspLocalNetworkProvider, (_, __) {});
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspLocalNetworkProvider);
+      expect(state.status.errorMessage, contains('lan data error'));
       container.dispose();
     });
 

--- a/test/page/local_network/providers/usp_local_network_notifier_test.dart
+++ b/test/page/local_network/providers/usp_local_network_notifier_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
+import 'package:privacy_gui/page/_shared/models/lan_info_ui_model.dart';
+import 'package:privacy_gui/page/local_network/models/local_network_ui_model.dart';
+import 'package:privacy_gui/page/local_network/providers/lan_data_provider.dart';
+import 'package:privacy_gui/page/local_network/providers/usp_local_network_notifier.dart';
+import 'package:privacy_gui/page/local_network/services/usp_local_network_service.dart';
+
+class MockUspLocalNetworkService extends Mock
+    implements UspLocalNetworkService {}
+
+/// Test-only notifier that returns canned data.
+class _TestLanDataNotifier extends LanDataNotifier {
+  final LanData _testData;
+  _TestLanDataNotifier(this._testData);
+
+  @override
+  Future<LanData> build() async => _testData;
+}
+
+void main() {
+  late MockUspLocalNetworkService mockService;
+
+  final testLanData = LanData(
+    model: LanInfoUIModel(
+      hostName: 'MyRouter',
+      ipAddress: '192.168.1.1',
+      subnetMask: '255.255.255.0',
+      dhcpEnabled: true,
+      minAddress: '192.168.1.100',
+      maxAddress: '192.168.1.200',
+      leaseTimeMinutes: 1440,
+      dnsServers: '1.1.1.1,8.8.8.8',
+    ),
+  );
+
+  setUpAll(() {
+    registerFallbackValue(const LocalNetworkUIModel.initial());
+  });
+
+  setUp(() {
+    mockService = MockUspLocalNetworkService();
+    when(() => mockService.validateAll(any())).thenReturn({});
+    when(() => mockService.lockedOctetCount(any())).thenReturn(3);
+    when(() => mockService.syncPrefix(any(), any(), any()))
+        .thenAnswer((inv) => inv.positionalArguments[0] as String);
+  });
+
+  ProviderContainer createContainer({LanData? data}) {
+    final container = ProviderContainer(
+      overrides: [
+        uspLocalNetworkServiceProvider.overrideWithValue(mockService),
+        uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+        lanDataProvider
+            .overrideWith(() => _TestLanDataNotifier(data ?? testLanData)),
+      ],
+    );
+    container.listen(uspLocalNetworkProvider, (_, __) {});
+    return container;
+  }
+
+  group('UspLocalNetworkNotifier', () {
+    test('build returns initial loading state', () {
+      final container = createContainer();
+
+      final state = container.read(uspLocalNetworkProvider);
+      expect(state.status.isLoading, isTrue);
+      container.dispose();
+    });
+
+    test('fetch success parses DNS and populates model', () async {
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspLocalNetworkProvider);
+      final model = state.settings.current.model;
+      expect(model.hostName, 'MyRouter');
+      expect(model.ipAddress, '192.168.1.1');
+      expect(model.dhcpEnabled, isTrue);
+      expect(model.dnsServer1, '1.1.1.1');
+      expect(model.dnsServer2, '8.8.8.8');
+      expect(model.dnsServer3, '');
+      expect(state.status.isLoading, isFalse);
+      container.dispose();
+    });
+
+    test('updateSetting triggers validation', () async {
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspLocalNetworkProvider.notifier);
+      notifier.updateSetting((m) => m.copyWith(hostName: 'NewName'));
+
+      verify(() => mockService.validateAll(any())).called(1);
+      final state = container.read(uspLocalNetworkProvider);
+      expect(state.settings.current.model.hostName, 'NewName');
+      container.dispose();
+    });
+
+    test('updateSetting syncs prefix when IP changes', () async {
+      when(() => mockService.syncPrefix(any(), any(), any()))
+          .thenReturn('192.168.2.100');
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspLocalNetworkProvider.notifier);
+      notifier.updateSetting((m) => m.copyWith(ipAddress: '192.168.2.1'));
+
+      verify(() => mockService.lockedOctetCount('255.255.255.0')).called(1);
+      // syncPrefix called for both min and max addresses.
+      verify(() => mockService.syncPrefix(any(), '192.168.2.1', 3)).called(2);
+      container.dispose();
+    });
+
+    test('updateSetting propagates validation errors to status', () async {
+      when(() => mockService.validateAll(any()))
+          .thenReturn({'hostName': 'Too long'});
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspLocalNetworkProvider.notifier);
+      notifier.updateSetting((m) => m.copyWith(hostName: 'VeryLongHostNameX'));
+
+      final state = container.read(uspLocalNetworkProvider);
+      expect(state.status.validationErrors['hostName'], 'Too long');
+      container.dispose();
+    });
+
+    test('revert clears validation errors and restores settings', () async {
+      when(() => mockService.validateAll(any()))
+          .thenReturn({'hostName': 'error'});
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspLocalNetworkProvider.notifier);
+      notifier.updateSetting((m) => m.copyWith(hostName: 'X'));
+      expect(
+          container
+              .read(uspLocalNetworkProvider)
+              .status
+              .validationErrors['hostName'],
+          'error');
+
+      notifier.revert();
+
+      final state = container.read(uspLocalNetworkProvider);
+      expect(state.settings.current.model.hostName, 'MyRouter');
+      expect(state.status.validationErrors, isEmpty);
+      container.dispose();
+    });
+
+    test('isDirty after mutation, clean after revert', () async {
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspLocalNetworkProvider.notifier);
+      expect(notifier.isDirty(), isFalse);
+
+      notifier.updateSetting((m) => m.copyWith(hostName: 'Changed'));
+      expect(notifier.isDirty(), isTrue);
+
+      notifier.revert();
+      expect(notifier.isDirty(), isFalse);
+      container.dispose();
+    });
+
+    test('performSave calls service.save with original and pending', () async {
+      when(() => mockService.save(
+            original: any(named: 'original'),
+            pending: any(named: 'pending'),
+          )).thenAnswer((_) async {});
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspLocalNetworkProvider.notifier);
+      notifier.updateSetting((m) => m.copyWith(hostName: 'NewRouter'));
+      await notifier.save();
+
+      verify(() => mockService.save(
+            original: any(named: 'original'),
+            pending: any(named: 'pending'),
+          )).called(1);
+      container.dispose();
+    });
+  });
+}

--- a/test/page/port_forwarding/providers/usp_port_forwarding_page_notifier_test.dart
+++ b/test/page/port_forwarding/providers/usp_port_forwarding_page_notifier_test.dart
@@ -1,0 +1,261 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
+import 'package:privacy_gui/page/_shared/models/port_forwarding_rule_ui_model.dart';
+import 'package:privacy_gui/page/port_forwarding/models/port_triggering_rule_ui_model.dart';
+import 'package:privacy_gui/page/port_forwarding/providers/usp_port_forwarding_page_notifier.dart';
+import 'package:privacy_gui/page/port_forwarding/services/usp_port_forwarding_service.dart';
+
+class MockUspPortForwardingService extends Mock
+    implements UspPortForwardingService {}
+
+void main() {
+  late MockUspPortForwardingService mockService;
+
+  final pf1 = PortForwardingRuleUIModel(
+    instancePath: 'Device.NAT.PortMapping.1.',
+    description: 'HTTP',
+    externalPort: 80,
+    internalPort: 80,
+    internalClient: '192.168.1.100',
+    protocol: 'TCP',
+    enabled: true,
+  );
+  final pf2 = PortForwardingRuleUIModel(
+    instancePath: 'Device.NAT.PortMapping.2.',
+    description: 'HTTPS',
+    externalPort: 443,
+    internalPort: 443,
+    internalClient: '192.168.1.100',
+    protocol: 'TCP',
+    enabled: true,
+  );
+  final pt1 = PortTriggeringRuleUIModel(
+    instancePath: 'Device.NAT.PortTrigger.1.',
+    enabled: true,
+    description: 'Game',
+    triggerPort: 3000,
+    triggerProtocol: 'TCP',
+  );
+
+  setUpAll(() {
+    registerFallbackValue(<PortForwardingRuleUIModel>[]);
+    registerFallbackValue(<PortTriggeringRuleUIModel>[]);
+  });
+
+  setUp(() {
+    mockService = MockUspPortForwardingService();
+  });
+
+  ProviderContainer createContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        uspPortForwardingServiceProvider.overrideWithValue(mockService),
+        uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+      ],
+    );
+    container.listen(uspPortForwardingPageProvider, (_, __) {});
+    return container;
+  }
+
+  void stubFetch({
+    List<PortForwardingRuleUIModel>? forwarding,
+    List<PortTriggeringRuleUIModel>? triggering,
+  }) {
+    when(() => mockService.fetchForwardingRules())
+        .thenAnswer((_) async => forwarding ?? [pf1]);
+    when(() => mockService.fetchTriggeringRules())
+        .thenAnswer((_) async => triggering ?? [pt1]);
+  }
+
+  group('UspPortForwardingPageNotifier', () {
+    test('build returns initial loading state', () {
+      stubFetch();
+      final container = createContainer();
+
+      final state = container.read(uspPortForwardingPageProvider);
+      expect(state.status.isLoading, isTrue);
+      expect(state.settings.current.forwardingRules, isEmpty);
+      expect(state.settings.current.triggeringRules, isEmpty);
+      container.dispose();
+    });
+
+    test('fetch success populates both rule types', () async {
+      stubFetch(forwarding: [pf1, pf2], triggering: [pt1]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspPortForwardingPageProvider);
+      expect(state.settings.current.forwardingRules, hasLength(2));
+      expect(state.settings.current.triggeringRules, hasLength(1));
+      expect(state.settings.current.forwardingRules[0].description, 'HTTP');
+      expect(state.settings.current.triggeringRules[0].description, 'Game');
+      container.dispose();
+    });
+
+    test('fetch error sets error status', () async {
+      when(() => mockService.fetchForwardingRules())
+          .thenThrow(Exception('timeout'));
+      when(() => mockService.fetchTriggeringRules())
+          .thenAnswer((_) async => [pt1]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspPortForwardingPageProvider);
+      expect(state.status.errorMessage, contains('timeout'));
+      container.dispose();
+    });
+
+    test('performSave calls both batch saves', () async {
+      stubFetch();
+      when(() => mockService.saveForwardingBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).thenAnswer((_) async => (added: 1, updated: 0, deleted: 0));
+      when(() => mockService.saveTriggeringBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).thenAnswer((_) async => (added: 0, updated: 0, deleted: 0));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspPortForwardingPageProvider.notifier);
+      notifier.addForwardingRule(pf2);
+      await notifier.save();
+
+      verify(() => mockService.saveForwardingBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).called(1);
+      verify(() => mockService.saveTriggeringBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).called(1);
+      container.dispose();
+    });
+
+    // --- Port Forwarding Mutations ---
+
+    test('addForwardingRule appends, preserves triggering', () async {
+      stubFetch();
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      container
+          .read(uspPortForwardingPageProvider.notifier)
+          .addForwardingRule(pf2);
+
+      final state = container.read(uspPortForwardingPageProvider);
+      expect(state.settings.current.forwardingRules, hasLength(2));
+      expect(state.settings.current.triggeringRules, hasLength(1));
+      container.dispose();
+    });
+
+    test('editForwardingRule replaces by value match', () async {
+      stubFetch(forwarding: [pf1, pf2]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final updated = pf1.copyWith(description: 'HTTP-Updated');
+      container
+          .read(uspPortForwardingPageProvider.notifier)
+          .editForwardingRule(pf1, updated);
+
+      final rules = container
+          .read(uspPortForwardingPageProvider)
+          .settings
+          .current
+          .forwardingRules;
+      expect(rules[0].description, 'HTTP-Updated');
+      expect(rules, hasLength(2));
+      container.dispose();
+    });
+
+    test('toggleForwardingRule flips enabled flag', () async {
+      stubFetch();
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      container
+          .read(uspPortForwardingPageProvider.notifier)
+          .toggleForwardingRule(pf1, false);
+
+      final rules = container
+          .read(uspPortForwardingPageProvider)
+          .settings
+          .current
+          .forwardingRules;
+      expect(rules[0].enabled, isFalse);
+      container.dispose();
+    });
+
+    test('deleteForwardingRule removes from list', () async {
+      stubFetch(forwarding: [pf1, pf2]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      container
+          .read(uspPortForwardingPageProvider.notifier)
+          .deleteForwardingRule(pf1);
+
+      final rules = container
+          .read(uspPortForwardingPageProvider)
+          .settings
+          .current
+          .forwardingRules;
+      expect(rules, hasLength(1));
+      expect(rules[0].description, 'HTTPS');
+      container.dispose();
+    });
+
+    // --- Port Triggering Mutations ---
+
+    test('addTriggeringRule appends, preserves forwarding', () async {
+      stubFetch(triggering: []);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      container
+          .read(uspPortForwardingPageProvider.notifier)
+          .addTriggeringRule(pt1);
+
+      final state = container.read(uspPortForwardingPageProvider);
+      expect(state.settings.current.triggeringRules, hasLength(1));
+      expect(state.settings.current.forwardingRules, hasLength(1));
+      container.dispose();
+    });
+
+    test('deleteTriggeringRule removes from list', () async {
+      stubFetch();
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      container
+          .read(uspPortForwardingPageProvider.notifier)
+          .deleteTriggeringRule(pt1);
+
+      final state = container.read(uspPortForwardingPageProvider);
+      expect(state.settings.current.triggeringRules, isEmpty);
+      expect(state.settings.current.forwardingRules, hasLength(1));
+      container.dispose();
+    });
+
+    test('isDirty after adding, clean after revert', () async {
+      stubFetch();
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspPortForwardingPageProvider.notifier);
+      expect(notifier.isDirty(), isFalse);
+
+      notifier.addForwardingRule(pf2);
+      expect(notifier.isDirty(), isTrue);
+
+      notifier.revert();
+      expect(notifier.isDirty(), isFalse);
+      container.dispose();
+    });
+  });
+}

--- a/test/page/port_forwarding/providers/usp_port_forwarding_page_notifier_test.dart
+++ b/test/page/port_forwarding/providers/usp_port_forwarding_page_notifier_test.dart
@@ -242,6 +242,44 @@ void main() {
       container.dispose();
     });
 
+    test('editTriggeringRule replaces by value match', () async {
+      stubFetch();
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final updated = pt1.copyWith(description: 'Game-Updated');
+      container
+          .read(uspPortForwardingPageProvider.notifier)
+          .editTriggeringRule(pt1, updated);
+
+      final rules = container
+          .read(uspPortForwardingPageProvider)
+          .settings
+          .current
+          .triggeringRules;
+      expect(rules[0].description, 'Game-Updated');
+      expect(rules, hasLength(1));
+      container.dispose();
+    });
+
+    test('toggleTriggeringRule flips enabled flag', () async {
+      stubFetch();
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      container
+          .read(uspPortForwardingPageProvider.notifier)
+          .toggleTriggeringRule(pt1, false);
+
+      final rules = container
+          .read(uspPortForwardingPageProvider)
+          .settings
+          .current
+          .triggeringRules;
+      expect(rules[0].enabled, isFalse);
+      container.dispose();
+    });
+
     test('isDirty after adding, clean after revert', () async {
       stubFetch();
       final container = createContainer();

--- a/test/page/static_routing/providers/usp_static_routing_notifier_test.dart
+++ b/test/page/static_routing/providers/usp_static_routing_notifier_test.dart
@@ -176,8 +176,7 @@ void main() {
       final notifier = container.read(uspStaticRoutingProvider.notifier);
       notifier.addRoute(route2);
 
-      expect(() => notifier.save(), throwsA(isA<Exception>()));
-      await Future.delayed(Duration.zero);
+      await expectLater(notifier.save(), throwsA(isA<Exception>()));
 
       expect(container.read(uspStaticRoutingProvider).status.isSaving, isFalse);
       container.dispose();

--- a/test/page/static_routing/providers/usp_static_routing_notifier_test.dart
+++ b/test/page/static_routing/providers/usp_static_routing_notifier_test.dart
@@ -1,0 +1,184 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
+import 'package:privacy_gui/page/static_routing/models/static_routing_ui_model.dart';
+import 'package:privacy_gui/page/static_routing/providers/usp_static_routing_notifier.dart';
+import 'package:privacy_gui/page/static_routing/services/usp_static_routing_service.dart';
+
+class MockUspStaticRoutingService extends Mock
+    implements UspStaticRoutingService {}
+
+void main() {
+  late MockUspStaticRoutingService mockService;
+
+  final route1 = StaticRouteUIModel(
+    instancePath: 'Device.Routing.Router.1.IPv4Forwarding.1.',
+    enabled: true,
+    name: 'Office',
+    destIpAddress: '10.0.0.0',
+    destSubnetMask: '255.255.255.0',
+    gatewayIpAddress: '192.168.1.1',
+    interfaceName: 'eth0',
+    interfacePath: 'Device.Ethernet.Interface.2.',
+  );
+  final route2 = StaticRouteUIModel(
+    instancePath: 'Device.Routing.Router.1.IPv4Forwarding.2.',
+    enabled: false,
+    name: 'VPN',
+    destIpAddress: '172.16.0.0',
+    destSubnetMask: '255.255.0.0',
+    gatewayIpAddress: '192.168.1.254',
+    interfaceName: 'eth0',
+    interfacePath: 'Device.Ethernet.Interface.2.',
+  );
+
+  setUpAll(() {
+    registerFallbackValue(<StaticRouteUIModel>[]);
+  });
+
+  setUp(() {
+    mockService = MockUspStaticRoutingService();
+  });
+
+  ProviderContainer createContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        uspStaticRoutingServiceProvider.overrideWithValue(mockService),
+        uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+      ],
+    );
+    container.listen(uspStaticRoutingProvider, (_, __) {});
+    return container;
+  }
+
+  group('UspStaticRoutingNotifier', () {
+    test('build returns initial loading state', () {
+      when(() => mockService.fetch()).thenAnswer((_) async => [route1]);
+      final container = createContainer();
+
+      final state = container.read(uspStaticRoutingProvider);
+      expect(state.status.isLoading, isTrue);
+      expect(state.settings.current.routes, isEmpty);
+      container.dispose();
+    });
+
+    test('fetch success populates routes', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [route1, route2]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspStaticRoutingProvider);
+      expect(state.settings.current.routes, hasLength(2));
+      expect(state.settings.current.routes[0].name, 'Office');
+      expect(state.settings.current.routes[1].enabled, isFalse);
+      container.dispose();
+    });
+
+    test('fetch error sets error status', () async {
+      when(() => mockService.fetch()).thenThrow(Exception('connection lost'));
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspStaticRoutingProvider);
+      expect(state.status.errorMessage, contains('connection lost'));
+      expect(state.settings.current.routes, isEmpty);
+      container.dispose();
+    });
+
+    test('performSave calls saveBatch', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [route1]);
+      when(() => mockService.saveBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).thenAnswer((_) async => (added: 1, updated: 0, deleted: 0));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspStaticRoutingProvider.notifier);
+      notifier.addRoute(route2);
+      await notifier.save();
+
+      verify(() => mockService.saveBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).called(1);
+      container.dispose();
+    });
+
+    test('addRoute appends to list', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [route1]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      container.read(uspStaticRoutingProvider.notifier).addRoute(route2);
+
+      final routes =
+          container.read(uspStaticRoutingProvider).settings.current.routes;
+      expect(routes, hasLength(2));
+      expect(routes[1].name, 'VPN');
+      container.dispose();
+    });
+
+    test('editRoute replaces by index', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [route1, route2]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final updated = route1.copyWith(name: 'Updated');
+      container.read(uspStaticRoutingProvider.notifier).editRoute(0, updated);
+
+      final routes =
+          container.read(uspStaticRoutingProvider).settings.current.routes;
+      expect(routes[0].name, 'Updated');
+      expect(routes, hasLength(2));
+      container.dispose();
+    });
+
+    test('toggleRoute flips enabled flag', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [route1]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      container.read(uspStaticRoutingProvider.notifier).toggleRoute(0, false);
+
+      final routes =
+          container.read(uspStaticRoutingProvider).settings.current.routes;
+      expect(routes[0].enabled, isFalse);
+      container.dispose();
+    });
+
+    test('deleteRoute removes by index', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [route1, route2]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      container.read(uspStaticRoutingProvider.notifier).deleteRoute(0);
+
+      final routes =
+          container.read(uspStaticRoutingProvider).settings.current.routes;
+      expect(routes, hasLength(1));
+      expect(routes[0].name, 'VPN');
+      container.dispose();
+    });
+
+    test('isDirty after mutation, clean after revert', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [route1]);
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspStaticRoutingProvider.notifier);
+      expect(notifier.isDirty(), isFalse);
+
+      notifier.addRoute(route2);
+      expect(notifier.isDirty(), isTrue);
+
+      notifier.revert();
+      expect(notifier.isDirty(), isFalse);
+      expect(container.read(uspStaticRoutingProvider).settings.current.routes,
+          hasLength(1));
+      container.dispose();
+    });
+  });
+}

--- a/test/page/static_routing/providers/usp_static_routing_notifier_test.dart
+++ b/test/page/static_routing/providers/usp_static_routing_notifier_test.dart
@@ -163,6 +163,26 @@ void main() {
       container.dispose();
     });
 
+    test('performSave rethrows on error and clears isSaving', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [route1]);
+      when(() => mockService.saveBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).thenThrow(Exception('save failed'));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspStaticRoutingProvider.notifier);
+      notifier.addRoute(route2);
+
+      expect(() => notifier.save(), throwsA(isA<Exception>()));
+      await Future.delayed(Duration.zero);
+
+      expect(container.read(uspStaticRoutingProvider).status.isSaving, isFalse);
+      container.dispose();
+    });
+
     test('isDirty after mutation, clean after revert', () async {
       when(() => mockService.fetch()).thenAnswer((_) async => [route1]);
       final container = createContainer();


### PR DESCRIPTION
## Summary
- Add unit tests for all 8 Preservable Pattern A notifiers (DMZ, Firewall, DHCP Reservations, Static Routing, IPv6 Port Service, Local Network, Port Forwarding, Internet Settings)
- **84 tests** across 8 test files, **92.5%** overall coverage (every file ≥ 90%)
- Tests cover: build/loading state, fetch success/error, performSave (add/update/delete paths), save error rethrow + isSaving cleanup, local mutations (add/edit/toggle/delete), isDirty/revert, SSE invalidation wiring, validation propagation, session restore error path

## Per-File Coverage
| File | Coverage |
|------|:--------:|
| usp_dmz_notifier.dart | 93.3% |
| usp_firewall_notifier.dart | 90.0% |
| usp_dhcp_reservations_notifier.dart | 90.2% |
| usp_static_routing_notifier.dart | 91.7% |
| usp_ipv6_port_service_notifier.dart | 93.3% |
| usp_local_network_notifier.dart | 95.0% |
| usp_port_forwarding_page_notifier.dart | 94.6% |
| usp_internet_settings_notifier.dart | 90.2% |

## Test plan
- [x] All 84 notifier tests pass
- [x] Full regression: 459 tests, 0 failures
- [x] `dart format .` applied

Closes #734
Part of #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Qodo Review Fixes (2026-03-24)
- **fix**: `expect(() => notifier.save(), throwsA(...))` → `await expectLater()` in DMZ, StaticRouting, InternetSettings (async Future error assertion)
- **fix**: DMZ SSE test added `clearInteractions()` for unambiguous verify count