### PR TITLE
fix: make topology scrollbar thumb draggable on desktop/web

### DIFF
--- a/lib/page/instant_topology/views/instant_topology_view.dart
+++ b/lib/page/instant_topology/views/instant_topology_view.dart
@@ -51,6 +51,8 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
   bool _isLoading = false;
   bool _isWidget = false;
   late final TreeController<RouterTreeNode> treeController;
+  final ScrollController _desktopScrollController = ScrollController();
+  final ScrollController _mobileScrollController = ScrollController();
 
   @override
   void initState() {
@@ -70,8 +72,10 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
 
   @override
   void dispose() {
-    super.dispose();
+    _mobileScrollController.dispose();
+    _desktopScrollController.dispose();
     treeController.dispose();
+    super.dispose();
   }
 
   @override
@@ -142,8 +146,10 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
       BuildContext context, WidgetRef ref, double largeDesiredTreeWidth) {
     return ResponsiveLayout.isMobileLayout(context)
         ? Scrollbar(
+            controller: _mobileScrollController,
             thumbVisibility: true,
             child: TreeView<RouterTreeNode>(
+              controller: _mobileScrollController,
               treeController: treeController,
               physics: const BouncingScrollPhysics(
                   parent: AlwaysScrollableScrollPhysics()),
@@ -182,12 +188,14 @@ class _InstantTopologyViewState extends ConsumerState<InstantTopologyView> {
             ),
           )
         : Scrollbar(
+            controller: _desktopScrollController,
             thumbVisibility: true,
             child: RefreshIndicator(
               onRefresh: () {
                 return ref.read(pollingProvider.notifier).forcePolling();
               },
               child: SingleChildScrollView(
+                controller: _desktopScrollController,
                 physics: const BouncingScrollPhysics(
                     parent: AlwaysScrollableScrollPhysics()),
                 child: SingleChildScrollView(


### PR DESCRIPTION
## Summary
- Add explicit shared `ScrollController` for both mobile and desktop topology layouts
- Without it, `Scrollbar` falls back to `PrimaryScrollController` which is not inherited on desktop platforms (`shouldInherit` returns false for non-mobile `TargetPlatform`), causing the thumb to be visible but not interactive

Closes #712

## Root Cause

On desktop/web platforms, `Scrollbar` without an explicit `controller` resolves to `PrimaryScrollController` via:

```dart
ScrollController? get _effectiveScrollController =>
    widget.controller ?? PrimaryScrollController.maybeOf(context);
```

However, `SingleChildScrollView` (desktop) and `TreeView` (mobile) determine whether to use `PrimaryScrollController` through `PrimaryScrollController.shouldInherit()`:

```dart
// Flutter 3.27 — primary_scroll_controller.dart
static bool shouldInherit(BuildContext context, Axis scrollDirection) {
  final result = context.findAncestorWidgetOfExactType<PrimaryScrollController>();
  final platform = ScrollConfiguration.of(context).getPlatform(context);
  if (result.automaticallyInheritForPlatforms.contains(platform)) {
    return result.scrollDirection == scrollDirection;
  }
  return false;  // ← desktop platforms (macOS/Windows/Linux) hit this path
}
```

`automaticallyInheritForPlatforms` defaults to `{android, iOS, fuchsia}` only, so on desktop/web the scroll views create their **own internal controllers** instead. This results in:

- `Scrollbar` → attached to `PrimaryScrollController` (0 positions)
- `SingleChildScrollView` / `TreeView` → attached to a private controller

Since `Scrollbar._canHandleScrollGestures()` requires `positions.length == 1`, the thumb is rendered (via `ScrollNotification`) but **all interactive gestures are disabled** — thumb drag, track tap, and track scroll all fail silently.

## Resolution

Provide an explicit `ScrollController` shared between `Scrollbar` and the corresponding scroll view in both layouts:

```dart
// Desktop
Scrollbar(controller: _desktopScrollController, ...)
  └─ SingleChildScrollView(controller: _desktopScrollController, ...)

// Mobile
Scrollbar(controller: _mobileScrollController, ...)
  └─ TreeView(controller: _mobileScrollController, ...)
```

## Test plan
- [ ] On desktop browser: verify scrollbar thumb can be dragged to scroll the topology view
- [ ] On desktop browser: verify mouse wheel scrolling still works
- [ ] On mobile browser: verify scrollbar thumb can be dragged
- [ ] Verify topology view with 3+ nodes to ensure overflow scrolling works

🤖 Generated with [Claude Code](https://claude.com/claude-code)