### PR TITLE
fix: WiFi Settings Quick Setup and dirty guard issues

### DIFF
--- a/lib/page/devices/views/usp_device_list_view.dart
+++ b/lib/page/devices/views/usp_device_list_view.dart
@@ -41,7 +41,7 @@ class _UspDeviceListViewState extends ConsumerState<UspDeviceListView> {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      backFallback: RouteNamed.uspDashboard,
+      backFallback: RouteNamed.uspMenu,
       onRefresh: () => ref.refresh(devicesDataProvider.future),
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: (childContext, constraints) {

--- a/lib/page/topology/views/usp_topology_view.dart
+++ b/lib/page/topology/views/usp_topology_view.dart
@@ -28,7 +28,7 @@ class UspTopologyView extends ConsumerWidget {
         preferredSize: Size.fromHeight(64),
         child: UspTopBar(),
       ),
-      backFallback: RouteNamed.uspDashboard,
+      backFallback: RouteNamed.uspMenu,
       onRefresh: () => ref.refresh(devicesDataProvider.future),
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: (childContext, constraints) {

--- a/lib/page/wifi_settings/models/wifi_settings_settings.dart
+++ b/lib/page/wifi_settings/models/wifi_settings_settings.dart
@@ -40,9 +40,7 @@ class WifiQuickSetupSettings extends Equatable {
   /// True when all required fields are filled and valid.
   bool get isValid {
     if (ssid.trim().isEmpty) return false;
-    final isOpen = securityMode == 'None' ||
-        securityMode == 'Enhanced-Open' ||
-        securityMode.isEmpty;
+    final isOpen = securityMode == 'None' || securityMode == 'Enhanced-Open';
     if (isOpen) return true;
     return password.isNotEmpty &&
         LengthRule(min: 8, max: 63).validate(password) &&

--- a/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
+++ b/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/framework/preservable.dart';
 import 'package:privacy_gui/framework/preservable_contract.dart';
 import 'package:privacy_gui/framework/preservable_notifier_mixin.dart';
 import 'package:privacy_gui/core/usp/providers/usp_auth_coordinator.dart';
@@ -116,10 +117,12 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
 
     if (effectiveQsEnabled) {
       qsMain = quickSetup.main != null
-          ? _buildQsSettings(quickSetup.main!, isGuest: false)
+          ? _buildQsSettings(quickSetup.main!,
+              isGuest: false, networks: networks)
           : null;
       qsGuest = quickSetup.guest != null
-          ? _buildQsSettings(quickSetup.guest!, isGuest: true)
+          ? _buildQsSettings(quickSetup.guest!,
+              isGuest: true, networks: networks)
           : null;
     }
 
@@ -244,28 +247,24 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
     if (enabled) {
       final mainAgg = state.status.quickSetupMainAggregate;
       final guestAgg = state.status.quickSetupGuestAggregate;
+      final newSettings = current.copyWith(
+        quickSetupEnabled: true,
+        quickSetupMain:
+            mainAgg != null ? _buildQsSettings(mainAgg, isGuest: false) : null,
+        quickSetupGuest:
+            guestAgg != null ? _buildQsSettings(guestAgg, isGuest: true) : null,
+      );
       state = state.copyWith(
-        settings: state.settings.update(
-          current.copyWith(
-            quickSetupEnabled: true,
-            quickSetupMain: mainAgg != null
-                ? _buildQsSettings(mainAgg, isGuest: false)
-                : null,
-            quickSetupGuest: guestAgg != null
-                ? _buildQsSettings(guestAgg, isGuest: true)
-                : null,
-          ),
-        ),
+        settings: Preservable(original: newSettings, current: newSettings),
       );
     } else {
+      final newSettings = current.copyWith(
+        quickSetupEnabled: false,
+        clearQuickSetupMain: true,
+        clearQuickSetupGuest: true,
+      );
       state = state.copyWith(
-        settings: state.settings.update(
-          current.copyWith(
-            quickSetupEnabled: false,
-            clearQuickSetupMain: true,
-            clearQuickSetupGuest: true,
-          ),
-        ),
+        settings: Preservable(original: newSettings, current: newSettings),
       );
     }
   }
@@ -315,9 +314,13 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
   WifiQuickSetupSettings _buildQsSettings(
     WifiQuickSetupNetwork aggregate, {
     required bool isGuest,
+    List<WifiNetworkUIModel>? networks,
   }) {
     // enabled = true only when ALL networks in the group are currently enabled.
-    final allEnabled = state.settings.current.networks
+    // Use the explicit [networks] list when called from performFetch (the new
+    // networks haven't been written to state yet at that point).
+    final effectiveNetworks = networks ?? state.settings.current.networks;
+    final allEnabled = effectiveNetworks
         .where((n) => n.isGuest == isGuest)
         .every((n) => n.enabled);
 
@@ -326,9 +329,7 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
       enabled: allEnabled,
       ssid: aggregate.ssid,
       password: '',
-      securityMode: aggregate.supportedSecurityModes.isNotEmpty
-          ? aggregate.supportedSecurityModes.first
-          : aggregate.securityMode,
+      securityMode: aggregate.securityMode,
       supportedSecurityModes: aggregate.supportedSecurityModes,
     );
   }

--- a/lib/page/wifi_settings/providers/usp_wifi_settings_state.dart
+++ b/lib/page/wifi_settings/providers/usp_wifi_settings_state.dart
@@ -31,19 +31,16 @@ class UspWifiSettingsState
 
   /// True when the user has unsaved changes.
   ///
-  /// Compares [networks] and Quick Setup settings between `original` and
-  /// `current`. The [quickSetupEnabled] flag is intentionally excluded —
-  /// toggling the mode switch is not itself a "data change", but initialising
-  /// the Quick Setup settings objects (via [setQuickSetupEnabled]) will set
-  /// [quickSetupMain] / [quickSetupGuest] to non-null, which does trigger dirty.
+  /// Normalises [quickSetupEnabled] before comparing so that toggling the
+  /// mode switch alone is not treated as a data change.  Uses Equatable's
+  /// `==` (which applies [DeepCollectionEquality] on [List] props) instead
+  /// of comparing extracted fields directly — Dart's [List.==] is reference
+  /// equality and would produce false positives after any `copyWith` call.
   @override
   bool get isDirty {
-    final orig = settings.original;
-    final curr = settings.current;
-    if (orig.networks != curr.networks) return true;
-    if (orig.quickSetupMain != curr.quickSetupMain) return true;
-    if (orig.quickSetupGuest != curr.quickSetupGuest) return true;
-    return false;
+    final orig = settings.original.copyWith(quickSetupEnabled: false);
+    final curr = settings.current.copyWith(quickSetupEnabled: false);
+    return orig != curr;
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/page/wifi_settings/views/tabs/wifi_list_tab.dart
+++ b/lib/page/wifi_settings/views/tabs/wifi_list_tab.dart
@@ -71,7 +71,7 @@ class UspWifiListTab extends ConsumerWidget {
 
     return Column(
       children: [
-        Expanded(
+        Flexible(
           child: SingleChildScrollView(
             padding: const EdgeInsets.symmetric(vertical: AppSpacing.lg),
             child: Column(
@@ -113,8 +113,12 @@ class UspWifiListTab extends ConsumerWidget {
                 ),
                 AppGap.lg(),
                 // ── Quick Setup mode: Main + Guest cards ─────────────────
-                if (quickSetupEnabled)
-                  _buildQuickSetupGrid(context, columnCount, fixedWidth, gutter)
+                if (quickSetupEnabled) ...[
+                  _buildQuickSetupNotice(context),
+                  AppGap.md(),
+                  _buildQuickSetupGrid(
+                      context, columnCount, fixedWidth, gutter),
+                ]
                 // ── Normal mode: per-band grid ───────────────────────────
                 else
                   _buildAdvancedGrid(
@@ -124,7 +128,7 @@ class UspWifiListTab extends ConsumerWidget {
           ),
         ),
         // ── Page-level Save button ───────────────────────────────────────
-        if (quickSetupEnabled || state.isDirty || isSaving)
+        if (state.isDirty || isSaving)
           _buildSaveBar(context, ref, canSave, isSaving),
       ],
     );
@@ -159,6 +163,34 @@ class UspWifiListTab extends ConsumerWidget {
       defaultVerticalAlignment: TableCellVerticalAlignment.intrinsicHeight,
       columnWidths: _columnWidths(columnCount, fixedWidth, gutter),
       children: rows,
+    );
+  }
+
+  Widget _buildQuickSetupNotice(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return AppSurface(
+      variant: SurfaceVariant.tonal,
+      borderRadius: AppRadius.md,
+      showBorder: false,
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          AppIcon.font(
+            AppFontIcons.infoCircle,
+            color: colorScheme.onSurfaceVariant,
+            size: 18,
+          ),
+          AppGap.sm(),
+          Expanded(
+            child: AppText.bodySmall(
+              'Quick Setup applies the same name, password, and security '
+              'mode to all bands. A password is required to save.',
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/page/wifi_settings/views/usp_wifi_settings_view.dart
+++ b/lib/page/wifi_settings/views/usp_wifi_settings_view.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:privacy_gui/route/navigation_extensions.dart';
 import 'package:privacy_gui/components/shortcuts/dialogs.dart';
+import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/shell/usp_top_bar.dart';
 import 'package:privacy_gui/page/wifi_settings/providers/usp_wifi_settings_provider.dart';
 import 'package:privacy_gui/page/wifi_settings/views/tabs/wifi_advanced_tab.dart';
 import 'package:privacy_gui/page/wifi_settings/views/tabs/wifi_list_tab.dart';
-import 'package:ui_kit_library/ui_kit.dart';
 
 class UspWifiSettingsView extends ConsumerStatefulWidget {
   const UspWifiSettingsView({super.key});
@@ -22,12 +21,12 @@ class _UspWifiSettingsViewState extends ConsumerState<UspWifiSettingsView>
   late TabController _tabController;
   late int _previousTabIndex;
 
-  static const _tabs = ['WiFi', 'Advanced'];
+  static const _tabLabels = ['WiFi', 'Advanced'];
 
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: _tabs.length, vsync: this);
+    _tabController = TabController(length: _tabLabels.length, vsync: this);
     _previousTabIndex = _tabController.index;
     _tabController.addListener(_handleTabChange);
   }
@@ -65,63 +64,23 @@ class _UspWifiSettingsViewState extends ConsumerState<UspWifiSettingsView>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // ── Navigation bar (full width, no margin) ────────────────────
-          const UspTopBar(),
-          // ── Everything below uses the standard layout margin ──────────
-          Expanded(
-            child: Padding(
-              padding: EdgeInsets.symmetric(horizontal: context.layoutMargin),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // ── Page header: back arrow + title ──────────────────
-                  Padding(
-                    padding:
-                        const EdgeInsets.symmetric(vertical: AppSpacing.md),
-                    child: _buildPageHeader(context),
-                  ),
-                  // ── Tab bar ───────────────────────────────────────────
-                  TabBar(
-                    controller: _tabController,
-                    tabs: _tabs
-                        .map((label) => Tab(child: AppText.titleSmall(label)))
-                        .toList(),
-                  ),
-                  // ── Tab content ───────────────────────────────────────
-                  Expanded(
-                    child: TabBarView(
-                      controller: _tabController,
-                      physics: const NeverScrollableScrollPhysics(),
-                      children: const [
-                        UspWifiListTab(),
-                        UspWifiAdvancedTab(),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ],
+    return UiKitPageView.withSliver(
+      title: 'WiFi Settings',
+      topbar: const PreferredSize(
+        preferredSize: Size.fromHeight(64),
+        child: UspTopBar(),
       ),
-    );
-  }
-
-  Widget _buildPageHeader(BuildContext context) {
-    return Row(
-      children: [
-        AppIconButton(
-          icon: const AppIcon.font(Icons.arrow_back),
-          onTap: () => context.navigateBack(fallback: RouteNamed.uspMenu),
-        ),
-        AppGap.md(),
-        Expanded(
-          child: AppText.headlineSmall('WiFi Settings'),
-        ),
+      showAppBarBorder: false,
+      showTabBorder: false,
+      backFallback: RouteNamed.uspMenu,
+      tabController: _tabController,
+      tabs: const [
+        Tab(text: 'WiFi'),
+        Tab(text: 'Advanced'),
+      ],
+      tabContentViews: const [
+        UspWifiListTab(),
+        UspWifiAdvancedTab(),
       ],
     );
   }

--- a/test/page/internet_settings/providers/wan_data_provider_test.dart
+++ b/test/page/internet_settings/providers/wan_data_provider_test.dart
@@ -13,12 +13,14 @@ void main() {
   late MockUspService mockUsp;
 
   /// Simulated WAN status response (Device.IP.Interface.2.*).
+  /// Includes IPv6Enable since WanStatus codegen v1.1.0 fetches it.
   final wanStatusResponse = <String, dynamic>{
     'Device.IP.Interface.2.Status': 'Up',
     'Device.IP.Interface.2.IPv4Address.1.IPAddress': '100.64.0.10',
     'Device.IP.Interface.2.IPv4Address.1.SubnetMask': '255.255.255.0',
     'Device.IP.Interface.2.IPv4Address.1.AddressingType': 'DHCP',
     'Device.IP.Interface.2.MaxMTUSize': '1500',
+    'Device.IP.Interface.2.IPv6Enable': true,
   };
 
   /// Simulated routing table response for gateway lookup.
@@ -44,15 +46,21 @@ void main() {
     mockUsp = MockUspService();
 
     // Route usp.get() calls by path content.
+    //
+    // _fetch() issues two concurrent requests:
+    //   1. WanStatus.fetch  → paths include IPv6Enable (codegen v1.1.0)
+    //   2. _fetchGatewayAndIpv6Addresses → paths include IPv4Forwarding + IPv6Address
+    //
+    // Distinguish by the presence of 'IPv4Forwarding' (only in request #2).
     when(() => mockUsp.get(any())).thenAnswer((invocation) async {
       final paths = invocation.positionalArguments[0] as List;
       final joined = paths.join(',');
 
-      if (joined.contains('IPv4Forwarding')) return routingResponse;
-      if (joined.contains('IPv6Enable') || joined.contains('IPv6Address')) {
-        return ipv6Response;
+      if (joined.contains('IPv4Forwarding')) {
+        // Combined gateway + IPv6 addresses request
+        return {...routingResponse, ...ipv6Response};
       }
-      // WAN status (Device.IP.Interface.2.*)
+      // WanStatus.fetch (includes IPv6Enable in its paths)
       return wanStatusResponse;
     });
   });
@@ -142,9 +150,9 @@ void main() {
                 '0.0.0.0',
             'Device.Routing.Router.1.IPv4Forwarding.1.Interface':
                 'Device.IP.Interface.1.',
+            ...ipv6Response,
           };
         }
-        if (joined.contains('IPv6')) return ipv6Response;
         return wanStatusResponse;
       });
 
@@ -164,7 +172,6 @@ void main() {
         if (joined.contains('IPv4Forwarding')) {
           throw Exception('timeout');
         }
-        if (joined.contains('IPv6')) return ipv6Response;
         return wanStatusResponse;
       });
 
@@ -187,8 +194,11 @@ void main() {
         final paths = invocation.positionalArguments[0] as List;
         final joined = paths.join(',');
 
-        if (joined.contains('IPv6')) throw Exception('not supported');
-        if (joined.contains('IPv4Forwarding')) return routingResponse;
+        // The combined gateway+IPv6 call fails entirely — both gateway and
+        // IPv6 fall back to empty.
+        if (joined.contains('IPv4Forwarding')) {
+          throw Exception('not supported');
+        }
         return wanStatusResponse;
       });
 
@@ -196,7 +206,9 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final data = container.read(wanDataProvider).requireValue;
-      expect(data.model.ipv6Enabled, isFalse);
+      // ipv6Enabled comes from WanStatus.fetch (succeeds), addresses from
+      // the combined call (fails) — graceful degradation.
+      expect(data.model.ipv6Enabled, isTrue);
       expect(data.model.ipv6Addresses, isEmpty);
       // Core WAN data still loads
       expect(data.model.ipAddress, '100.64.0.10');

--- a/test/page/wifi_settings/providers/usp_wifi_settings_notifier_test.dart
+++ b/test/page/wifi_settings/providers/usp_wifi_settings_notifier_test.dart
@@ -245,6 +245,67 @@ void main() {
       container.dispose();
     });
 
+    test('setQuickSetupEnabled does not make state dirty', () async {
+      final networks = WifiSettingsTestData.createNetworks();
+      final mainAggregate = WifiSettingsTestData.createQuickSetupAggregate();
+      when(() => mockService.buildWifiNetworks(
+            ssids: any(named: 'ssids'),
+            accessPoints: any(named: 'accessPoints'),
+            radios: any(named: 'radios'),
+          )).thenReturn(networks);
+      when(() => mockService.buildQuickSetupNetworks(any())).thenReturn((
+        main: mainAggregate,
+        guest: null,
+        isQuickSetup: false,
+      ));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspWifiSettingsProvider.notifier);
+      notifier.setQuickSetupEnabled(true);
+
+      expect(notifier.isDirty(), isFalse);
+
+      final state = container.read(uspWifiSettingsProvider);
+      expect(state.settings.original.quickSetupMain, isNotNull);
+      expect(state.settings.original.quickSetupMain,
+          state.settings.current.quickSetupMain);
+      container.dispose();
+    });
+
+    test('updateQuickSetupField makes state dirty after setQuickSetupEnabled',
+        () async {
+      final networks = WifiSettingsTestData.createNetworks();
+      final mainAggregate = WifiSettingsTestData.createQuickSetupAggregate();
+      when(() => mockService.buildWifiNetworks(
+            ssids: any(named: 'ssids'),
+            accessPoints: any(named: 'accessPoints'),
+            radios: any(named: 'radios'),
+          )).thenReturn(networks);
+      when(() => mockService.buildQuickSetupNetworks(any())).thenReturn((
+        main: mainAggregate,
+        guest: null,
+        isQuickSetup: false,
+      ));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspWifiSettingsProvider.notifier);
+      notifier.setQuickSetupEnabled(true);
+      expect(notifier.isDirty(), isFalse);
+
+      notifier.updateQuickSetupField(
+        isGuest: false,
+        securityMode: 'WPA3-Personal',
+      );
+      expect(notifier.isDirty(), isTrue);
+      container.dispose();
+    });
+
     test('setQuickSetupEnabled(false) clears quick setup settings', () async {
       final networks = WifiSettingsTestData.createNetworks();
       final mainAggregate = WifiSettingsTestData.createQuickSetupAggregate();

--- a/test/page/wifi_settings/providers/usp_wifi_settings_state_test.dart
+++ b/test/page/wifi_settings/providers/usp_wifi_settings_state_test.dart
@@ -104,6 +104,32 @@ void main() {
         expect(state.isDirty, isTrue);
       });
 
+      test(
+          'false when quick setup is initialized with same values on both original and current',
+          () {
+        final networks = WifiSettingsTestData.createNetworks();
+        const qsMain = WifiQuickSetupSettings(
+          isGuest: false,
+          enabled: true,
+          ssid: 'Home',
+          password: '',
+          securityMode: 'WPA2-Personal',
+          supportedSecurityModes: ['WPA2-Personal', 'WPA3-Personal'],
+        );
+        final settings = WifiSettingsSettings(
+          networks: networks,
+          quickSetupEnabled: true,
+          quickSetupMain: qsMain,
+        );
+
+        final state = UspWifiSettingsState(
+          settings: Preservable(original: settings, current: settings),
+          status: const WifiSettingsStatus(),
+        );
+
+        expect(state.isDirty, isFalse);
+      });
+
       test('true when quickSetupGuest password changes', () {
         const qsGuest = WifiQuickSetupSettings(
           isGuest: true,
@@ -245,6 +271,67 @@ void main() {
         );
 
         // isDirty is false because original == current, so canSave is false
+        expect(state.canSave, isFalse);
+      });
+
+      test('true in quick setup mode when only security mode changes to open',
+          () {
+        final networks = WifiSettingsTestData.createNetworks();
+        const qsMain = WifiQuickSetupSettings(
+          isGuest: false,
+          enabled: true,
+          ssid: 'Home',
+          password: '',
+          securityMode: 'WPA2-Personal',
+          supportedSecurityModes: ['None', 'WPA2-Personal', 'WPA3-Personal'],
+        );
+        final settings = WifiSettingsSettings(
+          networks: networks,
+          quickSetupEnabled: true,
+          quickSetupMain: qsMain,
+        );
+        final current = settings.copyWith(
+          quickSetupMain: qsMain.copyWith(securityMode: 'None'),
+        );
+
+        final state = UspWifiSettingsState(
+          settings: Preservable(original: settings, current: current),
+          status: const WifiSettingsStatus(),
+        );
+
+        expect(state.isDirty, isTrue);
+        expect(state.canSave, isTrue);
+      });
+
+      test(
+          'false in quick setup mode when security mode changes but password still empty',
+          () {
+        final networks = WifiSettingsTestData.createNetworks();
+        const qsMain = WifiQuickSetupSettings(
+          isGuest: false,
+          enabled: true,
+          ssid: 'Home',
+          password: '',
+          securityMode: 'WPA2-Personal',
+          supportedSecurityModes: ['WPA2-Personal', 'WPA3-Personal'],
+        );
+        final settings = WifiSettingsSettings(
+          networks: networks,
+          quickSetupEnabled: true,
+          quickSetupMain: qsMain,
+        );
+        final current = settings.copyWith(
+          quickSetupMain: qsMain.copyWith(securityMode: 'WPA3-Personal'),
+        );
+
+        final state = UspWifiSettingsState(
+          settings: Preservable(original: settings, current: current),
+          status: const WifiSettingsStatus(),
+        );
+
+        // isDirty because securityMode changed, but canSave false because
+        // password is still empty and the new mode requires one.
+        expect(state.isDirty, isTrue);
         expect(state.canSave, isFalse);
       });
 


### PR DESCRIPTION
## Summary
- Save button appeared immediately (disabled) when Quick Setup was enabled
- Save button stayed disabled after changing Security Mode in Quick Setup
- Security Mode showed incorrect initial value in Quick Setup (e.g. "None" instead of "WPA2-Personal")
- Large blank scrollable area at the bottom of the page in Quick Setup mode
- Save button persisted after reverting a field to its original value in Advanced mode
- Guest could be saved without a password when Security Mode was unknown
- Guest enabled state in Quick Setup did not match the actual device state
- Added info notice above Quick Setup cards explaining password requirement