### PR TITLE
chore: add shared Claude Code hooks and skills for team workflow

### DIFF
--- a/.claude/hooks/pr_gate.py
+++ b/.claude/hooks/pr_gate.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Pre-tool hook: block `gh pr create` unless review-pr-readiness was run recently."""
+import json, os, sys, time
+
+STAMP = "/tmp/.pr-review-passed"
+MAX_AGE = 600  # 10 minutes
+
+data = json.load(sys.stdin)
+cmd = data.get("tool_input", {}).get("command", "")
+
+if "gh pr create" not in cmd:
+    print(json.dumps({"continue": True}))
+    sys.exit(0)
+
+if os.path.exists(STAMP) and (time.time() - os.path.getmtime(STAMP)) < MAX_AGE:
+    os.remove(STAMP)
+    print(json.dumps({"continue": True}))
+else:
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                "STOP: Before creating a PR, you MUST first execute the "
+                "review-pr-readiness skill. Run the full skill workflow, "
+                "present the report, and only proceed after user confirms."
+            ),
+        }
+    }))

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/pr_gate.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: prepare-release
+description: Verify project readiness before a release. Runs full test suite, static analysis, formatting check, screenshot test validation, and version verification. Use before tagging or publishing a release build. Trigger keywords (English) - prepare release, release check, pre-release, release ready, verify release. Trigger keywords (Chinese) - 準備發版, 發版檢查, 發版前檢查, 檢查發版, 發版準備, release 檢查.
+---
+
+# Pre-Release Verification
+
+## Purpose
+
+Perform a full verification of the project before creating a release build. This ensures all tests pass, code quality is clean, and the version is properly set. Modeled after a release preparation workflow adapted for PrivacyGUI.
+
+## When to Use This Skill
+
+- Before creating a release build (`build_web.sh`)
+- Before tagging a release version
+- When the user says: "prepare release", "release check", "準備發版", "發版檢查"
+
+## When NOT to Use This Skill
+
+- During normal development (use `review-pr-readiness` instead)
+- For hotfix branches where only a targeted check is needed
+
+## Execution Workflow
+
+### Phase 1: Pre-Release Checks
+
+**Step 1.1: Verify Version**
+
+Read `pubspec.yaml` and report the current version:
+
+```bash
+grep '^version:' pubspec.yaml
+```
+
+- Display the current version to the user
+- Ask the user to confirm this is the intended release version
+- If the user wants to update the version, assist with the change
+
+**Step 1.2: Run Static Analysis**
+
+```bash
+flutter analyze
+```
+
+- If errors or warnings are found:
+  - List each issue with file path, line number, and description
+  - Severity: **ERROR** — must fix before release
+- If clean: report PASS
+
+**Step 1.3: Check Formatting**
+
+```bash
+dart format --set-exit-if-changed --output=none lib/ test/
+```
+
+- If unformatted files found:
+  - List them
+  - Severity: **ERROR** — must fix before release
+  - Suggestion: "Run `dart format lib/ test/` to fix all"
+- If clean: report PASS
+
+### Phase 2: Test Suite
+
+**Step 2.1: Run Unit Tests**
+
+```bash
+./run_tests.sh
+```
+
+- Report total passed, failed, skipped counts
+- If any test fails:
+  - List each failure: test file, test name, failure reason
+  - Severity: **ERROR** — must fix before release
+- If all pass: report PASS
+
+**Step 2.2: Verify Screenshot Tests (If UI Changes Exist)**
+
+Check if any View files changed since the last release tag:
+
+```bash
+git diff --name-only <last_release_tag>...HEAD -- 'lib/page/*/views/*.dart'
+```
+
+If View files changed:
+- Remind the user to run screenshot tests:
+  ```bash
+  ./run_generate_loc_snapshots.sh
+  ```
+- Severity: **WARNING** — recommend running before release
+- Note: Do NOT auto-run this — it can be time-consuming. Just remind the user.
+
+If no View files changed: report SKIP (no UI changes)
+
+### Phase 3: Build Verification
+
+**Step 3.1: Verify Dependencies**
+
+```bash
+flutter pub get
+```
+
+- If dependency resolution fails: **ERROR**
+- If clean: report PASS
+
+**Step 3.2: Dry Run Build Check (Optional)**
+
+Ask the user if they want to run a test build:
+
+```bash
+flutter build web --target=lib/main.dart --build-number=0 --dart-define=force=false --dart-define=cloud_env=prod --dart-define=enable_env_picker=false --dart-define=ca=true
+```
+
+- This is optional — the user decides whether to run it
+- If build fails: **ERROR** — report the build output
+- If build succeeds: report PASS
+
+### Phase 4: Report
+
+```
+## Pre-Release Verification Report
+
+Version: <version from pubspec.yaml>
+Date: <current date>
+
+### Results
+
+#### Code Quality
+- [PASS/ERROR] Static Analysis: <summary>
+- [PASS/ERROR] Formatting: <summary>
+
+#### Tests
+- [PASS/ERROR] Unit Tests: <passed>/<total> passed
+- [PASS/WARN/SKIP] Screenshot Tests: <summary>
+
+#### Build
+- [PASS/ERROR] Dependencies: <summary>
+- [PASS/ERROR/SKIP] Build Check: <summary>
+
+### Overall: [READY / NOT READY]
+
+<if NOT READY: list all blocking issues>
+<if READY: "All checks passed. Ready to proceed with release.">
+
+### Recommended Next Steps
+1. <action items based on results>
+```
+
+## Decision Criteria
+
+The release is considered **READY** when ALL of the following are true:
+- Static analysis: 0 errors
+- Formatting: all files formatted
+- Unit tests: all passing
+- Dependencies: resolved successfully
+
+The release is considered **NOT READY** if any of the above fail.
+
+**WARNING-level items** (screenshot tests) do not block the release but are flagged as recommendations.
+
+## Important Notes
+
+- This skill is primarily **read-only** — it only modifies files if the user explicitly requests a version bump
+- Communicate with the user in Traditional Chinese (Taiwan)
+- Always ask for user confirmation before any version changes
+- The build verification step is optional and should be offered, not auto-run
+- If `./run_tests.sh` takes a long time, inform the user and let them decide to continue or skip

--- a/.claude/skills/review-pr-readiness/SKILL.md
+++ b/.claude/skills/review-pr-readiness/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: review-pr-readiness
+description: Review current branch changes for PR readiness. Checks code quality (dart format, flutter analyze), UI Kit library usage in Views, and test file coverage. Use before creating a Pull Request. Trigger keywords (English) - review pr, check pr, pr ready, pre-pr check, review before pr. Trigger keywords (Chinese) - 檢查 PR, PR 檢查, 準備 PR, PR 審查, 發 PR 前檢查.
+---
+
+# Pre-PR Readiness Review
+
+## Purpose
+
+Perform a comprehensive review of all branch changes before creating a Pull Request. This skill checks code quality, UI Kit library compliance, and test coverage to catch issues before they reach code review.
+
+## When to Use This Skill
+
+- Before creating a Pull Request
+- When the user says: "review pr", "check pr", "pr ready", "準備 PR", "檢查 PR", "發 PR 前檢查"
+- When the user is about to run `gh pr create`
+
+## When NOT to Use This Skill
+
+- Documentation-only branches (only `.md` files changed)
+- Branches with no `.dart` file changes
+
+## Execution Workflow
+
+### Phase 0: Determine Scope
+
+**Step 0.1: Identify Base Branch and Changed Files**
+
+```bash
+# Detect base branch (main or dev-*)
+git merge-base --fork-point main HEAD 2>/dev/null || git merge-base main HEAD
+
+# Get all changed Dart files compared to base branch
+git diff --name-only <base>...HEAD -- '*.dart'
+```
+
+**Step 0.2: Filter and Categorize Files**
+
+- If NO `.dart` files changed, report "No Dart files changed — skipping review" and **STOP**
+- Categorize changed files:
+  - `lib/page/*/views/*.dart` → View files
+  - `lib/page/*/providers/*.dart` → Provider files
+  - `lib/page/*/services/*.dart` → Service files
+  - `lib/page/*/models/*.dart` → Model files
+  - `test/**/*.dart` → Test files
+  - Other `lib/**/*.dart` → Other source files
+
+### Phase 1: Code Quality
+
+**Step 1.1: Check Formatting**
+
+Run `dart format` in dry-run mode on ALL changed `.dart` files:
+
+```bash
+dart format --set-exit-if-changed --output=none <changed_dart_files>
+```
+
+- If exit code is non-zero, list the unformatted files
+- Severity: **ERROR**
+- Suggestion: "Run `dart format <file>` to fix"
+
+**Step 1.2: Run Static Analysis**
+
+```bash
+flutter analyze
+```
+
+- Filter results to only show issues in the changed files
+- Severity: **ERROR** for errors, **WARNING** for warnings, **INFO** for info
+- Suggestion: Quote the specific lint rule and how to fix
+
+**Step 1.3: Check Imports**
+
+From `flutter analyze` output, specifically highlight:
+- `unused_import` warnings
+- Unsorted imports (if detected)
+
+Severity: **WARNING**
+
+### Phase 2: UI Kit Usage (Only If View Files Changed)
+
+**Step 2.1: Scan for Non-UI-Kit Widget Usage**
+
+For each changed View file, check for direct usage of Flutter Material/Cupertino widgets that have UI Kit equivalents:
+
+```
+# Pattern → UI Kit Equivalent
+ElevatedButton / TextButton / OutlinedButton  → AppButton
+Text(                                          → AppText
+TextField / TextFormField                      → AppTextFormField
+Checkbox(                                      → AppCheckbox
+Switch(                                        → AppSwitch
+AlertDialog / SimpleDialog                     → showSimpleAppDialog
+CircularProgressIndicator                      → AppSpinnerDialog
+Card(                                          → AppCard
+SizedBox(height: / SizedBox(width:            → AppGap / AppSpacing
+```
+
+For each detection:
+- Severity: **WARNING**
+- Suggestion: "Consider using `<UIKit equivalent>` from ui_kit_library instead of `<Material widget>`"
+
+**Step 2.2: Verify UI Kit Import**
+
+For each changed View file that renders UI, verify it imports:
+```dart
+import 'package:ui_kit_library/ui_kit.dart';
+```
+
+If not found:
+- Severity: **INFO**
+- Suggestion: "Add `import 'package:ui_kit_library/ui_kit.dart';`"
+
+### Phase 3: Test Coverage
+
+**Step 3.1: Check Test File Existence**
+
+For each changed source file in `lib/`, check if a corresponding test file exists:
+
+| Source File Pattern | Expected Test File Pattern |
+|---|---|
+| `lib/page/[feature]/providers/[name].dart` | `test/page/[feature]/providers/[name]_test.dart` |
+| `lib/page/[feature]/services/[name].dart` | `test/page/[feature]/services/[name]_test.dart` |
+| `lib/page/[feature]/models/[name].dart` | `test/page/[feature]/models/[name]_test.dart` |
+
+Note: View files (`views/*.dart`) are excluded — they are covered by widget/golden tests.
+
+For each missing test file:
+- Severity: **WARNING**
+- Suggestion: "No test file found at `<expected_path>`. Consider adding unit tests."
+
+**Step 3.2: Check Test Files Were Updated**
+
+If a source file was changed but its existing test file was NOT changed in this branch:
+- Severity: **INFO**
+- Suggestion: "Source `<name>.dart` was modified but its test was not updated. Verify tests still cover the changes."
+
+### Phase 4: Report
+
+```
+## Pre-PR Readiness Report
+
+Branch: <branch_name>
+Base: <base_branch>
+Changed Dart files: <count>
+
+### Code Quality
+- [PASS/WARN/ERROR] Formatting: <summary>
+- [PASS/WARN/ERROR] Static Analysis: <summary>
+- [PASS/WARN] Imports: <summary>
+
+### UI Kit Usage
+- [PASS/WARN/SKIP] Compliance: <summary>
+
+### Test Coverage
+- [PASS/WARN] Test files: <summary>
+- [PASS/INFO] Test freshness: <summary>
+
+### Issues Found: <total_count>
+- ERROR: <count>
+- WARNING: <count>
+- INFO: <count>
+
+<detailed issue list grouped by category>
+
+### Recommended Actions Before PR
+<numbered list ordered by severity>
+```
+
+## Severity Levels
+
+| Level | Meaning | Recommendation |
+|---|---|---|
+| **ERROR** | Static analysis errors, build failures | Fix before creating PR |
+| **WARNING** | Missing tests, non-UI-Kit widgets | Strongly recommend fixing |
+| **INFO** | Test freshness, minor suggestions | Optional, nice to have |
+
+### Phase 5: Gate Stamp
+
+After presenting the report to the user, if there are **no ERROR-level issues** and the user confirms they want to proceed:
+
+```bash
+touch /tmp/.pr-review-passed
+```
+
+This stamp file is consumed by the `pr_gate.py` hook to allow `gh pr create` through. It is:
+- **One-shot**: deleted after a single successful `gh pr create`
+- **Time-limited**: expires after 10 minutes
+
+Do NOT create the stamp if there are unresolved ERROR-level issues.
+
+## Important Notes
+
+- This skill is **read-only** — it does NOT modify any files (except the gate stamp)
+- All findings are recommendations, not enforced blocks
+- Communicate with the user in Traditional Chinese (Taiwan)
+- If a command fails to execute, report the failure and continue with remaining checks
+- Group similar issues together for readability
+- If the branch is clean, report a brief success message


### PR DESCRIPTION
## Summary
- Add `pr_gate.py` PreToolUse hook to enforce `review-pr-readiness` skill before PR creation
- Add shared `.claude/settings.json` with team hook configuration
- Add `review-pr-readiness` skill for pre-PR quality checks (formatting, analysis, UI Kit compliance, test coverage)
- Add `prepare-release` skill for release verification workflow

## Notes
- `.claude/settings.json` is the **team-shared** config (hooks only)
- `.claude/settings.local.json` remains personal (permissions) and should NOT be committed
- No Dart code changes — config only

## Test plan
- [ ] Verify `gh pr create` is blocked without running `review-pr-readiness` first
- [ ] Verify `review-pr-readiness` skill executes correctly and creates gate stamp
- [ ] Verify `prepare-release` skill runs all verification steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)