### PR TITLE
feat: implement USP error handling for DMZ and WiFi Settings

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -1063,30 +1063,31 @@ final class UnexpectedError extends ServiceError {
 
 **Responsibility**: The Service layer is the **only** place allowed to directly catch underlying exceptions (USP/WASM), and is responsible for converting them to `ServiceError`.
 
-**Correct Example**:
+> **Important — USP errors are raw `String`, not `Exception`:**
+> The WASM client throws plain `String` values across the JS→Dart interop boundary, not `Exception` or `Error` objects. Therefore, Service methods MUST use `catch (e)` (catch-all), **not** `on Exception catch (e)` — the latter silently misses all USP errors.
+
+**Standard Pattern — use `mapUspErrorToServiceError()`**
+
+All USP Service methods MUST use the centralized `mapUspErrorToServiceError()` utility. This function parses the structured USP error string, extracts fault codes and HTTP status, and maps to the appropriate `ServiceError` subtype. Do NOT manually parse USP error strings.
+
 ```dart
-// lib/page/wifi/services/wifi_service.dart
-Future<WifiState> fetchSettings() async {
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
+
+// ✅ Correct: USP Service uses mapUspErrorToServiceError()
+Future<DmzSettings> fetchSettings() async {
   try {
-    final ssids = await WifiSsids.fetch(_usp);  // codegen call, may throw underlying exception
-    return WifiState(ssidModels: ssids.items.map(_toUIModel).toList());
+    final dmz = await Dmz.fetch(_usp);
+    return _toUIModel(dmz);
   } catch (e) {
-    // ✅ Convert all underlying exceptions to ServiceError in Service layer
-    throw UnexpectedError(originalError: e);
+    throw mapUspErrorToServiceError(e);
   }
 }
-```
 
-For known business rule violations, convert to a specific `ServiceError` subtype:
-```dart
-Future<void> updatePassword(String newPassword) async {
+Future<void> update({required String instancePath, required DmzUIModel model}) async {
   try {
-    await AdminSettings.update(_usp, AdminSettingsUpdate(password: newPassword));
+    await Dmz.update(_usp, DmzEntryUpdate(...));
   } catch (e) {
-    if (e.toString().contains('ErrorInvalidPassword')) {
-      throw const InvalidAdminPasswordError();
-    }
-    throw UnexpectedError(originalError: e);
+    throw mapUspErrorToServiceError(e);
   }
 }
 ```
@@ -1104,9 +1105,12 @@ Future<WifiState> fetchSettings() async {
 
 **Section 13.4: Provider Layer Error Handling**
 
-**Responsibility**: The Provider layer only handles `ServiceError` types. `build()` exceptions are automatically wrapped as `AsyncError` state by `AsyncNotifier`; mutation methods require explicit error handling.
+**Responsibility**: The Provider layer only handles `ServiceError` types. MUST NOT catch generic exceptions or underlying error types.
 
-**Correct Example**:
+**13.4.1: AsyncNotifier Pattern (Type C pages)**
+
+`build()` exceptions are automatically wrapped as `AsyncError` state by `AsyncNotifier`; mutation methods require explicit error handling.
+
 ```dart
 // lib/page/wifi/providers/wifi_notifier.dart
 import 'package:privacy_gui/core/errors/service_error.dart';
@@ -1134,17 +1138,88 @@ Future<void> updatePassword(String newPassword) async {
 }
 ```
 
+**13.4.2: Preservable Pattern (Type A / Type B pages)**
+
+Pages using `PreservableAutoDisposeNotifierMixin` handle errors in `performFetch()` and `performSave()`:
+
+```dart
+import 'package:privacy_gui/core/errors/service_error.dart';
+
+// performFetch: catch ServiceError → return (null, errorStatus)
+// Do NOT rethrow — the mixin's fetch() handles null settings gracefully.
+@override
+Future<(DmzSettings?, DmzStatus?)> performFetch({
+  bool forceRemote = false,
+  bool updateStatusOnly = false,
+}) async {
+  try {
+    final (settings, status) = await _svc.fetch();
+    return (settings, status);
+  } on ServiceError catch (e) {
+    logger.e('[USP][DMZ] Fetch failed', error: e);
+    return (null, DmzStatus(isLoading: false, errorMessage: '$e'));
+  }
+}
+
+// performSave: catch ServiceError → log + rethrow
+// The mixin's save() will catch the rethrown error and handle UI state.
+@override
+Future<void> performSave() async {
+  try {
+    await ref.read(uspMutationLockProvider).withLock(() async {
+      await _svc.update(instancePath: path, model: pending);
+    });
+  } on ServiceError catch (e) {
+    logger.e('[USP][DMZ] Save failed', error: e);
+    rethrow;
+  }
+}
+```
+
 **Wrong Example**:
 ```dart
 // ❌ Wrong: Provider swallows generic exceptions without converting
-Future<void> updatePassword(String newPassword) async {
+Future<void> performSave() async {
   try {
-    await svc.updatePassword(newPassword);
-  } catch (e) {  // ❌ Absorbs all exceptions — UI won't know the operation failed
+    await _svc.update(...);
+  } catch (e) {  // ❌ Catches everything — bypasses ServiceError contract
     logger.e(e);
   }
 }
 ```
+
+---
+
+**Section 13.5: USP Error Handling Infrastructure**
+
+All USP error parsing and `ServiceError` mapping is centralized in a single utility file. Individual USP Services MUST NOT implement their own parsing logic.
+
+**File Location**: `lib/core/usp/errors/usp_error.dart`
+
+**Key utilities**:
+
+| Function | Purpose |
+|----------|---------|
+| `parseUspError(Object error)` | Parses raw USP error string into structured `UspError` (operation, category, fault code, HTTP status) |
+| `mapUspErrorToServiceError(Object error)` | Parses + maps to `ServiceError` subtype — **the only function USP Services need to call** |
+
+**Mapping summary**:
+
+| USP Error Category | Mapped ServiceError |
+|--------------------|---------------------|
+| Authentication (Invalid credentials) | `InvalidCredentialsError` |
+| Authentication (Session expired) | `SessionTokenExpiredError` |
+| Authentication (Permission denied) | `UnauthorizedError` |
+| Transport (HTTP 401) | `NotAuthenticatedError` |
+| Transport (HTTP 5xx, timeout) | `NetworkError` |
+| Transport (Connection refused) | `ConnectivityError` |
+| Protocol (fault 7026, 9005) | `ResourceNotFoundError` |
+| Protocol (fault 7004, 9008) | `InvalidInputError` |
+| Protocol (fault 9001) | `UnauthorizedError` |
+| Validation | `InvalidInputError` |
+| Unrecognized | `UnexpectedError` |
+
+**Reference implementation**: `lib/page/dmz/services/usp_dmz_service.dart`
 
 ---
 

--- a/lib/core/errors/service_error.dart
+++ b/lib/core/errors/service_error.dart
@@ -29,6 +29,32 @@
 /// ```
 sealed class ServiceError implements Exception {
   const ServiceError();
+
+  /// Human-readable label derived from the class name.
+  ///
+  /// `NetworkError` → `Network error`, `VPNNotConnectedError` → `VPN not connected`.
+  /// Subtypes with a `message` field override this to append details.
+  @override
+  String toString() {
+    final name = runtimeType.toString();
+    final base =
+        name.endsWith('Error') ? name.substring(0, name.length - 5) : name;
+    // Split into words: before uppercase after lowercase/digit, and before
+    // an uppercase letter followed by lowercase after an uppercase run.
+    final spaced = base
+        .replaceAllMapped(RegExp(r'(?<=[a-z\d])(?=[A-Z])'), (_) => ' ')
+        .replaceAllMapped(RegExp(r'(?<=[A-Z])(?=[A-Z][a-z])'), (_) => ' ');
+    if (spaced.isEmpty) return 'Unknown error';
+    // Lowercase each word unless it's all-uppercase (acronym like VPN, DNS, IP).
+    final words = spaced.split(' ');
+    final result = words.asMap().entries.map((e) {
+      final word = e.value;
+      if (word == word.toUpperCase() && word.length > 1) return word;
+      if (e.key == 0) return word;
+      return word.toLowerCase();
+    }).join(' ');
+    return result;
+  }
 }
 
 // ============================================================================
@@ -270,6 +296,15 @@ final class InvalidInputError extends ServiceError {
   final String? field;
   final String? message;
   const InvalidInputError({this.field, this.message});
+
+  @override
+  String toString() {
+    final detail = [
+      if (field != null) field,
+      if (message != null) message,
+    ].join(': ');
+    return detail.isNotEmpty ? 'Invalid input: $detail' : super.toString();
+  }
 }
 
 /// Unexpected error (fallback for unmapped errors)
@@ -277,12 +312,20 @@ final class UnexpectedError extends ServiceError {
   final Object? originalError;
   final String? message;
   const UnexpectedError({this.originalError, this.message});
+
+  @override
+  String toString() =>
+      message != null ? 'Unexpected error: $message' : super.toString();
 }
 
 /// Network communication error
 final class NetworkError extends ServiceError {
   final String? message;
   const NetworkError({this.message});
+
+  @override
+  String toString() =>
+      message != null ? 'Network error: $message' : super.toString();
 }
 
 /// Storage operation error
@@ -307,6 +350,10 @@ final class SerialNumberMismatchError extends ServiceError {
 final class ConnectivityError extends ServiceError {
   final String? message;
   const ConnectivityError({this.message});
+
+  @override
+  String toString() =>
+      message != null ? 'Connectivity error: $message' : super.toString();
 }
 
 // ============================================================================

--- a/lib/core/usp/errors/usp_error.dart
+++ b/lib/core/usp/errors/usp_error.dart
@@ -141,8 +141,9 @@ ServiceError mapUspErrorToServiceError(Object error) {
 
 ServiceError _mapAuthError(UspError e) {
   final msg = e.message;
-  if (msg.contains('Invalid credentials'))
+  if (msg.contains('Invalid credentials')) {
     return const InvalidCredentialsError();
+  }
   if (msg.contains('Session expired')) return const SessionTokenExpiredError();
   if (msg.contains('Invalid token')) return const InvalidSessionTokenError();
   if (msg.contains('Permission denied')) return const UnauthorizedError();

--- a/lib/core/usp/errors/usp_error.dart
+++ b/lib/core/usp/errors/usp_error.dart
@@ -141,7 +141,8 @@ ServiceError mapUspErrorToServiceError(Object error) {
 
 ServiceError _mapAuthError(UspError e) {
   final msg = e.message;
-  if (msg.contains('Invalid credentials')) return const InvalidCredentialsError();
+  if (msg.contains('Invalid credentials'))
+    return const InvalidCredentialsError();
   if (msg.contains('Session expired')) return const SessionTokenExpiredError();
   if (msg.contains('Invalid token')) return const InvalidSessionTokenError();
   if (msg.contains('Permission denied')) return const UnauthorizedError();
@@ -198,4 +199,3 @@ ServiceError _mapOperationError(UspError e) {
   }
   return UnexpectedError(originalError: e.rawError, message: msg);
 }
-

--- a/lib/core/usp/errors/usp_error.dart
+++ b/lib/core/usp/errors/usp_error.dart
@@ -1,0 +1,201 @@
+import 'package:privacy_gui/core/errors/service_error.dart';
+
+/// Error categories from the Rust WASM client's UspError hierarchy.
+enum UspErrorCategory {
+  transport,
+  protocol,
+  auth,
+  operation,
+  validation,
+}
+
+/// Parsed representation of a USP error string thrown by the WASM client.
+///
+/// The WASM client throws plain Dart [String] values (not [Exception]) with
+/// a consistent format: `"{Op} failed: {category}: {detail}"`.
+///
+/// This class extracts structured fields from that string so the Service layer
+/// can map it to the appropriate [ServiceError] subtype.
+class UspError {
+  /// The USP operation that failed (e.g., "Get", "Set", "Add", "Delete",
+  /// "Operate", "Login").
+  final String operation;
+
+  /// High-level error category.
+  final UspErrorCategory category;
+
+  /// Human-readable detail message (everything after the category prefix).
+  final String message;
+
+  /// USP fault code from the router, if present (e.g., 7004, 7026).
+  /// Extracted from `(code: XXXX)` suffix in Protocol errors.
+  final int? faultCode;
+
+  /// HTTP status code, if this is a Transport/HTTP error (e.g., 401, 504).
+  final int? httpStatus;
+
+  /// The original raw error string from WASM.
+  final String rawError;
+
+  const UspError({
+    required this.operation,
+    required this.category,
+    required this.message,
+    required this.rawError,
+    this.faultCode,
+    this.httpStatus,
+  });
+
+  @override
+  String toString() => rawError;
+}
+
+// =============================================================================
+// Parser
+// =============================================================================
+
+final _opPrefix = RegExp(r'^(\w+) failed: (.+)$', dotAll: true);
+final _faultCode = RegExp(r'\(code:\s*(\d+)\)');
+final _httpStatus = RegExp(r'HTTP error: HTTP (\d+)');
+
+/// Attempts to parse a raw USP error string into a structured [UspError].
+///
+/// Returns `null` if the string does not match the expected USP error format.
+UspError? parseUspError(Object error) {
+  final raw = error.toString();
+  final opMatch = _opPrefix.firstMatch(raw);
+  if (opMatch == null) return null;
+
+  final operation = opMatch.group(1)!;
+  final rest = opMatch.group(2)!;
+
+  final (category, message) = _parseCategoryAndMessage(rest);
+
+  final faultCodeMatch = _faultCode.firstMatch(raw);
+  final httpStatusMatch = _httpStatus.firstMatch(raw);
+
+  return UspError(
+    operation: operation,
+    category: category,
+    message: message,
+    rawError: raw,
+    faultCode:
+        faultCodeMatch != null ? int.parse(faultCodeMatch.group(1)!) : null,
+    httpStatus:
+        httpStatusMatch != null ? int.parse(httpStatusMatch.group(1)!) : null,
+  );
+}
+
+(UspErrorCategory, String) _parseCategoryAndMessage(String rest) {
+  if (rest.startsWith('Transport error: ')) {
+    return (UspErrorCategory.transport, rest.substring(17));
+  }
+  if (rest.startsWith('Protocol error: ')) {
+    return (UspErrorCategory.protocol, rest.substring(16));
+  }
+  if (rest.startsWith('Authentication error: ')) {
+    return (UspErrorCategory.auth, rest.substring(22));
+  }
+  if (rest.startsWith('Operation error: ')) {
+    return (UspErrorCategory.operation, rest.substring(17));
+  }
+  if (rest.startsWith('Validation error: ')) {
+    return (UspErrorCategory.validation, rest.substring(18));
+  }
+  // Fallback — treat entire rest as message under protocol (most common
+  // for error strings that don't perfectly match a known prefix).
+  return (UspErrorCategory.protocol, rest);
+}
+
+// =============================================================================
+// ServiceError mapping
+// =============================================================================
+
+/// Converts any caught error from a USP codegen call into a [ServiceError].
+///
+/// Usage in the Service layer:
+/// ```dart
+/// Future<DmzState> fetchSettings() async {
+///   try {
+///     final dmz = await Dmz.fetch(_usp);
+///     return DmzState(entries: dmz.items);
+///   } catch (e) {
+///     throw mapUspErrorToServiceError(e);
+///   }
+/// }
+/// ```
+ServiceError mapUspErrorToServiceError(Object error) {
+  final parsed = parseUspError(error);
+  if (parsed == null) {
+    return UnexpectedError(originalError: error);
+  }
+
+  return switch (parsed.category) {
+    UspErrorCategory.auth => _mapAuthError(parsed),
+    UspErrorCategory.transport => _mapTransportError(parsed),
+    UspErrorCategory.protocol => _mapProtocolError(parsed),
+    UspErrorCategory.operation => _mapOperationError(parsed),
+    UspErrorCategory.validation => InvalidInputError(message: parsed.message),
+  };
+}
+
+ServiceError _mapAuthError(UspError e) {
+  final msg = e.message;
+  if (msg.contains('Invalid credentials')) return const InvalidCredentialsError();
+  if (msg.contains('Session expired')) return const SessionTokenExpiredError();
+  if (msg.contains('Invalid token')) return const InvalidSessionTokenError();
+  if (msg.contains('Permission denied')) return const UnauthorizedError();
+  if (msg.contains('Authentication required')) {
+    return const NotAuthenticatedError();
+  }
+  return UnexpectedError(originalError: e.rawError, message: msg);
+}
+
+ServiceError _mapTransportError(UspError e) {
+  final status = e.httpStatus;
+  if (status != null) {
+    return switch (status) {
+      401 => const NotAuthenticatedError(),
+      504 => NetworkError(message: e.message),
+      _ => NetworkError(message: e.message),
+    };
+  }
+  final msg = e.message;
+  if (msg.contains('Request timeout')) {
+    return NetworkError(message: msg);
+  }
+  if (msg.contains('Connection refused')) {
+    return const ConnectivityError(message: 'Connection refused');
+  }
+  return NetworkError(message: msg);
+}
+
+ServiceError _mapProtocolError(UspError e) {
+  // Protocol errors with fault codes from the router
+  final code = e.faultCode;
+  if (code != null) {
+    return switch (code) {
+      7004 => InvalidInputError(message: e.message),
+      7026 => ResourceNotFoundError(),
+      9001 => UnauthorizedError(),
+      9005 => ResourceNotFoundError(),
+      9007 => ResourceNotFoundError(),
+      9008 => InvalidInputError(message: e.message),
+      _ => UnexpectedError(originalError: e.rawError, message: e.message),
+    };
+  }
+  return UnexpectedError(originalError: e.rawError, message: e.message);
+}
+
+ServiceError _mapOperationError(UspError e) {
+  final msg = e.message;
+  if (msg.contains('Path not found')) return const ResourceNotFoundError();
+  if (msg.contains('read-only')) {
+    return InvalidInputError(message: msg);
+  }
+  if (msg.contains('Invalid value')) {
+    return InvalidInputError(message: msg);
+  }
+  return UnexpectedError(originalError: e.rawError, message: msg);
+}
+

--- a/lib/page/dmz/providers/usp_dmz_notifier.dart
+++ b/lib/page/dmz/providers/usp_dmz_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
@@ -68,7 +69,7 @@ class UspDmzNotifier extends AutoDisposeNotifier<DmzFeatureState>
           'instancePath: ${settings.instancePath}');
 
       return (settings, status);
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][Firewall][DMZ] Fetch failed', error: e);
       return (
         null,
@@ -105,7 +106,7 @@ class UspDmzNotifier extends AutoDisposeNotifier<DmzFeatureState>
               'enabled: ${pending.isEnabled}, destIp: ${pending.destIp}');
         }
       });
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][Firewall][DMZ] Save failed', error: e);
       rethrow;
     } finally {

--- a/lib/page/dmz/services/usp_dmz_service.dart
+++ b/lib/page/dmz/services/usp_dmz_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/dmz.g.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
@@ -26,28 +27,36 @@ class UspDmzService {
 
   /// Fetch DMZ data from the router and transform into UI types.
   Future<(DmzSettings, DmzStatus)> fetch() async {
-    final dmzData = await Dmz.fetch(_usp);
-    final uiModel = buildUIModel(dmzData);
-    final instancePath =
-        dmzData.items.isNotEmpty ? dmzData.items.first.instancePath : null;
-    return (
-      DmzSettings(model: uiModel, instancePath: instancePath),
-      const DmzStatus(isLoading: false),
-    );
+    try {
+      final dmzData = await Dmz.fetch(_usp);
+      final uiModel = buildUIModel(dmzData);
+      final instancePath =
+          dmzData.items.isNotEmpty ? dmzData.items.first.instancePath : null;
+      return (
+        DmzSettings(model: uiModel, instancePath: instancePath),
+        const DmzStatus(isLoading: false),
+      );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   /// Add a new DMZ entry.
   Future<void> add({required DmzUIModel model}) async {
-    final sourcePrefix = model.sourceType == DmzSourceType.any
-        ? '0.0.0.0/0'
-        : model.sourcePrefix;
-    await Dmz.add(
-      _usp,
-      enable: true,
-      destIp: model.destIp,
-      sourcePrefix: sourcePrefix,
-      description: 'DMZ',
-    );
+    try {
+      final sourcePrefix = model.sourceType == DmzSourceType.any
+          ? '0.0.0.0/0'
+          : model.sourcePrefix;
+      await Dmz.add(
+        _usp,
+        enable: true,
+        destIp: model.destIp,
+        sourcePrefix: sourcePrefix,
+        description: 'DMZ',
+      );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   /// Update an existing DMZ entry.
@@ -55,18 +64,22 @@ class UspDmzService {
     required String instancePath,
     required DmzUIModel model,
   }) async {
-    final sourcePrefix = model.sourceType == DmzSourceType.any
-        ? '0.0.0.0/0'
-        : model.sourcePrefix;
-    await Dmz.update(
-      _usp,
-      DmzEntryUpdate(
-        instancePath: instancePath,
-        enable: model.isEnabled,
-        destIp: model.destIp,
-        sourcePrefix: sourcePrefix,
-      ),
-    );
+    try {
+      final sourcePrefix = model.sourceType == DmzSourceType.any
+          ? '0.0.0.0/0'
+          : model.sourcePrefix;
+      await Dmz.update(
+        _usp,
+        DmzEntryUpdate(
+          instancePath: instancePath,
+          enable: model.isEnabled,
+          destIp: model.destIp,
+          sourcePrefix: sourcePrefix,
+        ),
+      );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/page/test_console/views/usp_test_console_view.dart
+++ b/lib/page/test_console/views/usp_test_console_view.dart
@@ -455,6 +455,137 @@ class _UspTestConsoleViewState extends ConsumerState<UspTestConsoleView> {
   }
 
   // ════════════════════════════════════════════════════════════════════════════
+  // Error Probe — systematically trigger USP errors to capture error formats
+  // ════════════════════════════════════════════════════════════════════════════
+
+  bool _probeRunning = false;
+
+  Future<void> _runErrorProbe() async {
+    if (_service == null) {
+      _log('ERROR: Not connected — cannot run probe');
+      return;
+    }
+    if (_probeRunning) return;
+    setState(() => _probeRunning = true);
+
+    _log('');
+    _log('═══════════════════════════════════════════');
+    _log('  ERROR PROBE — Capturing USP error formats');
+    _log('═══════════════════════════════════════════');
+
+    final probes = <(String label, Future<void> Function() action)>[
+      // --- GET errors ---
+      (
+        'GET non-existent path (expect fault 9005)',
+        () => _service!.get(['Device.Bogus.NonExistent.Path']),
+      ),
+      (
+        'GET unimplemented module: DynamicDNS (expect fault 9005)',
+        () => _service!.get(['Device.DynamicDNS.']),
+      ),
+      (
+        'GET unimplemented module: UPnP (expect fault 9005)',
+        () => _service!.get(['Device.UPnP.']),
+      ),
+      (
+        'GET invalid path format (no Device. prefix)',
+        () => _service!.get(['InvalidPath']),
+      ),
+      (
+        'GET empty path',
+        () => _service!.get(['']),
+      ),
+
+      // --- SET errors ---
+      (
+        'SET read-only param: DeviceInfo.Manufacturer (expect fault 9008)',
+        () => _service!.set({'Device.DeviceInfo.Manufacturer': 'TestValue'}),
+      ),
+      (
+        'SET read-only param: Ethernet.Link.1.MACAddress (expect fault 9008)',
+        () => _service!
+            .set({'Device.Ethernet.Link.1.MACAddress': 'AA:BB:CC:DD:EE:FF'}),
+      ),
+      (
+        'SET non-existent path (expect fault 9005)',
+        () => _service!.set({'Device.Bogus.Param': 'value'}),
+      ),
+      (
+        'SET empty value to valid writable param',
+        () => _service!.set({'Device.Time.NTPServer5': ''}),
+      ),
+
+      // --- ADD errors ---
+      (
+        'ADD to non-addable object: Device.DeviceInfo.',
+        () => _service!.add('Device.DeviceInfo.', {}),
+      ),
+      (
+        'ADD to non-existent object path',
+        () => _service!.add('Device.Bogus.Object.', {}),
+      ),
+
+      // --- DELETE errors ---
+      (
+        'DELETE non-existent instance: Device.NAT.PortMapping.99999.',
+        () => _service!.delete('Device.NAT.PortMapping.99999.'),
+      ),
+      (
+        'DELETE non-deletable path: Device.DeviceInfo.',
+        () => _service!.delete('Device.DeviceInfo.'),
+      ),
+
+      // --- OPERATE errors ---
+      (
+        'OPERATE non-existent command: Device.BogusCommand()',
+        () => _service!.operate('Device.BogusCommand()'),
+      ),
+      (
+        'OPERATE valid command with bad args: Ping with empty host',
+        () => _service!.operate('Device.IP.Diagnostics.IPPing()',
+            args: {'Host': '', 'NumberOfRepetitions': '1'}),
+      ),
+    ];
+
+    for (final (label, action) in probes) {
+      _log('');
+      _log('--- PROBE: $label');
+      try {
+        await action();
+        _log('  RESULT: No error thrown (success or silent failure)');
+      } catch (e) {
+        _log('  runtimeType: ${e.runtimeType}');
+        _log('  toString(): $e');
+        // Try to extract more info if available
+        if (e is Error) {
+          _log('  stackTrace available: ${e.stackTrace != null}');
+        }
+      }
+    }
+
+    // --- Auth error (separate — uses a throwaway service) ---
+    _log('');
+    _log('--- PROBE: LOGIN with wrong password');
+    try {
+      final throwaway = UspService(_service!.baseUrl);
+      await throwaway.login('definitely_wrong_password_12345');
+      _log('  RESULT: No error thrown');
+      throwaway.dispose();
+    } catch (e) {
+      _log('  runtimeType: ${e.runtimeType}');
+      _log('  toString(): $e');
+    }
+
+    _log('');
+    _log('═══════════════════════════════════════════');
+    _log('  ERROR PROBE COMPLETE');
+    _log('═══════════════════════════════════════════');
+    _log('');
+
+    setState(() => _probeRunning = false);
+  }
+
+  // ════════════════════════════════════════════════════════════════════════════
   // Bridge: Turbo Channel
   // ════════════════════════════════════════════════════════════════════════════
 
@@ -547,6 +678,8 @@ class _UspTestConsoleViewState extends ConsumerState<UspTestConsoleView> {
                           _buildOperateSection(),
                           const Divider(height: 32),
                           _buildHealthSection(),
+                          const Divider(height: 32),
+                          _buildErrorProbeSection(),
                           const Divider(height: 32),
                           _buildSseSection(),
                           const Divider(height: 32),
@@ -876,6 +1009,25 @@ class _UspTestConsoleViewState extends ConsumerState<UspTestConsoleView> {
       children: [
         _buildSectionTitle('Bridge Health'),
         AppButton.primary(label: 'Health Check', onTap: _doHealth),
+      ],
+    );
+  }
+
+  Widget _buildErrorProbeSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _buildSectionTitle('Error Probe'),
+        AppText.bodySmall(
+          'Systematically triggers USP errors to capture error string formats. '
+          'Results appear in the log panel.',
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+        const SizedBox(height: 8),
+        AppButton.primary(
+          label: _probeRunning ? 'Running...' : 'Run Error Probe',
+          onTap: _probeRunning ? null : _runErrorProbe,
+        ),
       ],
     );
   }

--- a/lib/page/wifi_settings/providers/usp_wifi_advanced_provider.dart
+++ b/lib/page/wifi_settings/providers/usp_wifi_advanced_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/page/wifi_settings/providers/usp_wifi_advanced_state.dart';
@@ -17,11 +18,14 @@ class UspWifiAdvancedNotifier
   Future<UspWifiAdvancedState> build() async {
     logger.d('[USP][WiFi][Advanced]Fetching advanced settings...');
 
-    final ieee80211h = await _svc.fetchIeee80211h();
-
-    logger.d('[USP][WiFi][Advanced]radios=${ieee80211h.length}');
-
-    return UspWifiAdvancedState(ieee80211hByRadio: ieee80211h);
+    try {
+      final ieee80211h = await _svc.fetchIeee80211h();
+      logger.d('[USP][WiFi][Advanced]radios=${ieee80211h.length}');
+      return UspWifiAdvancedState(ieee80211hByRadio: ieee80211h);
+    } on ServiceError catch (e) {
+      logger.e('[USP][WiFi][Advanced] Fetch failed', error: e);
+      rethrow;
+    }
   }
 
   /// Toggles IEEE 802.11h (DFS + TPC) on ALL known radios simultaneously.
@@ -29,12 +33,17 @@ class UspWifiAdvancedNotifier
     final paths = state.requireValue.ieee80211hByRadio.keys.toList();
     if (paths.isEmpty) return;
 
-    await ref.read(uspMutationLockProvider).withLock(() async {
-      await _svc.setIeee80211hEnabled(radioPaths: paths, enabled: enabled);
-    });
+    try {
+      await ref.read(uspMutationLockProvider).withLock(() async {
+        await _svc.setIeee80211hEnabled(radioPaths: paths, enabled: enabled);
+      });
 
-    state = AsyncData(state.requireValue.copyWith(
-      ieee80211hByRadio: {for (final path in paths) path: enabled},
-    ));
+      state = AsyncData(state.requireValue.copyWith(
+        ieee80211hByRadio: {for (final path in paths) path: enabled},
+      ));
+    } on ServiceError catch (e) {
+      logger.e('[USP][WiFi][Advanced] Set IEEE80211h failed', error: e);
+      rethrow;
+    }
   }
 }

--- a/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
+++ b/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/framework/preservable.dart';
 import 'package:privacy_gui/framework/preservable_contract.dart';
@@ -87,11 +88,11 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
     final WifiData wifiData;
     try {
       wifiData = await ref.read(wifiDataProvider.future);
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.w('[USP][WiFi] WiFi data fetch failed: $e');
       return (
         null,
-        WifiSettingsStatus(errorMessage: 'WiFi data unavailable'),
+        WifiSettingsStatus(errorMessage: '$e'),
       );
     }
     final (:radios, :ssids, :accessPoints) = wifiData.codegenContext.raw;
@@ -154,7 +155,7 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
       return await super.save();
       // super.save() calls performSave() → markAsSaved() → fetch().
       // fetch() rebuilds status with a fresh WifiSettingsStatus (isSaving = false).
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][WiFi] Save failed', error: e);
       rethrow;
     } finally {

--- a/lib/page/wifi_settings/providers/wifi_data_provider.dart
+++ b/lib/page/wifi_settings/providers/wifi_data_provider.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/wi_fi_access_points.g.dart';
 import 'package:privacy_gui/generated/wi_fi_radios.g.dart';
 import 'package:privacy_gui/generated/wi_fi_ssids.g.dart';
@@ -117,7 +119,9 @@ class WifiDataNotifier extends AsyncNotifier<WifiData> {
 
   Future<WifiData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
+    if (usp == null) {
+      throw const ConnectivityError(message: 'USP service not available');
+    }
 
     // Parallel fetch all WiFi data. No overall timeout here — the throttler's
     // per-request timeout (15s) protects each individual request. An overall
@@ -125,12 +129,17 @@ class WifiDataNotifier extends AsyncNotifier<WifiData> {
     // queue wait time in the throttler. With ~14 normal-priority requests
     // ahead and fetchWifiClients at low priority, queue time alone can exceed
     // 12s, leaving insufficient time for the actual request.
-    final results = await Future.wait([
-      WiFiRadios.fetch(usp),
-      WiFiSsids.fetch(usp),
-      WiFiAccessPoints.fetch(usp),
-      fetchWifiClients(usp),
-    ]);
+    final List<Object> results;
+    try {
+      results = await Future.wait([
+        WiFiRadios.fetch(usp),
+        WiFiSsids.fetch(usp),
+        WiFiAccessPoints.fetch(usp),
+        fetchWifiClients(usp),
+      ]);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
 
     final radios = results[0] as WiFiRadios;
     final ssids = results[1] as WiFiSsids;
@@ -184,26 +193,34 @@ class WifiDataNotifier extends AsyncNotifier<WifiData> {
 
   Future<void> toggleWifiRadio(String instancePath, bool enable) async {
     final usp = ref.read(uspServiceProvider)!;
-    await ref.read(uspMutationLockProvider).withLock(() async {
-      await WiFiRadios.update(
-          usp, WiFiRadioUpdate(instancePath: instancePath, enable: enable));
-    });
+    try {
+      await ref.read(uspMutationLockProvider).withLock(() async {
+        await WiFiRadios.update(
+            usp, WiFiRadioUpdate(instancePath: instancePath, enable: enable));
+      });
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
     ref.invalidateSelf();
   }
 
   Future<void> updateWifiRadioChannel(
       String instancePath, int channel, bool autoChannel) async {
     final usp = ref.read(uspServiceProvider)!;
-    await ref.read(uspMutationLockProvider).withLock(() async {
-      await WiFiRadios.update(
-        usp,
-        WiFiRadioUpdate(
-          instancePath: instancePath,
-          channel: channel,
-          autoChannelEnable: autoChannel,
-        ),
-      );
-    });
+    try {
+      await ref.read(uspMutationLockProvider).withLock(() async {
+        await WiFiRadios.update(
+          usp,
+          WiFiRadioUpdate(
+            instancePath: instancePath,
+            channel: channel,
+            autoChannelEnable: autoChannel,
+          ),
+        );
+      });
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
     ref.invalidateSelf();
   }
 }

--- a/lib/page/wifi_settings/services/usp_wifi_advanced_service.dart
+++ b/lib/page/wifi_settings/services/usp_wifi_advanced_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
 
@@ -22,19 +23,23 @@ class UspWifiAdvancedService {
   /// Returns a map of radio instance path → enabled flag.
   /// e.g. `{"Device.WiFi.Radio.1." : true, "Device.WiFi.Radio.2." : false}`
   Future<Map<String, bool>> fetchIeee80211h() async {
-    final response = await _usp.get([_ieee80211hPath]);
+    try {
+      final response = await _usp.get([_ieee80211hPath]);
 
-    final result = <String, bool>{};
-    for (final key in response.keys) {
-      if (key.startsWith('Device.WiFi.Radio.') &&
-          key.endsWith('.IEEE80211hEnabled')) {
-        final radioPath =
-            key.substring(0, key.length - 'IEEE80211hEnabled'.length);
-        final val = response[key];
-        result[radioPath] = val == true || val == 'true' || val == '1';
+      final result = <String, bool>{};
+      for (final key in response.keys) {
+        if (key.startsWith('Device.WiFi.Radio.') &&
+            key.endsWith('.IEEE80211hEnabled')) {
+          final radioPath =
+              key.substring(0, key.length - 'IEEE80211hEnabled'.length);
+          final val = response[key];
+          result[radioPath] = val == true || val == 'true' || val == '1';
+        }
       }
+      return result;
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
     }
-    return result;
   }
 
   /// Sets IEEE 802.11h on all given radio paths.
@@ -43,9 +48,13 @@ class UspWifiAdvancedService {
     required bool enabled,
   }) async {
     if (radioPaths.isEmpty) return;
-    final params = <String, dynamic>{
-      for (final path in radioPaths) '${path}IEEE80211hEnabled': enabled,
-    };
-    await _usp.set(params);
+    try {
+      final params = <String, dynamic>{
+        for (final path in radioPaths) '${path}IEEE80211hEnabled': enabled,
+      };
+      await _usp.set(params);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 }

--- a/lib/page/wifi_settings/services/usp_wifi_settings_service.dart
+++ b/lib/page/wifi_settings/services/usp_wifi_settings_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/wi_fi_access_points.g.dart';
 import 'package:privacy_gui/generated/wi_fi_radios.g.dart';
 import 'package:privacy_gui/generated/wi_fi_ssids.g.dart';
@@ -192,52 +193,56 @@ class UspWifiSettingsService {
     required WifiSettingsSettings current,
     required WifiSettingsStatus status,
   }) async {
-    for (final pending in [current.quickSetupMain, current.quickSetupGuest]) {
-      if (pending == null || !pending.isValid) continue;
+    try {
+      for (final pending in [current.quickSetupMain, current.quickSetupGuest]) {
+        if (pending == null || !pending.isValid) continue;
 
-      final aggregate = pending.isGuest
-          ? status.quickSetupGuestAggregate
-          : status.quickSetupMainAggregate;
-      if (aggregate == null) continue;
+        final aggregate = pending.isGuest
+            ? status.quickSetupGuestAggregate
+            : status.quickSetupMainAggregate;
+        if (aggregate == null) continue;
 
-      if (aggregate.ssidInstancePaths.isNotEmpty) {
-        await WiFiSsids.updateMany(
-          _usp,
-          aggregate.ssidInstancePaths
-              .map((p) => WiFiSsidUpdate(
-                    instancePath: p,
-                    ssid: pending.ssid,
-                    enable: pending.enabled,
-                  ))
-              .toList(),
-        );
-      }
-      if (aggregate.apInstancePaths.isNotEmpty) {
-        // Build a band lookup: AP instance path → band string.
-        // Used to apply the 6 GHz security override (Wi-Fi 6E mandates WPA3).
-        final bandByApPath = <String, String>{};
-        for (final n in current.networks) {
-          if (n.accessPointInstancePath != null) {
-            bandByApPath[n.accessPointInstancePath!] = n.band;
-          }
+        if (aggregate.ssidInstancePaths.isNotEmpty) {
+          await WiFiSsids.updateMany(
+            _usp,
+            aggregate.ssidInstancePaths
+                .map((p) => WiFiSsidUpdate(
+                      instancePath: p,
+                      ssid: pending.ssid,
+                      enable: pending.enabled,
+                    ))
+                .toList(),
+          );
         }
+        if (aggregate.apInstancePaths.isNotEmpty) {
+          // Build a band lookup: AP instance path → band string.
+          // Used to apply the 6 GHz security override (Wi-Fi 6E mandates WPA3).
+          final bandByApPath = <String, String>{};
+          for (final n in current.networks) {
+            if (n.accessPointInstancePath != null) {
+              bandByApPath[n.accessPointInstancePath!] = n.band;
+            }
+          }
 
-        await WiFiAccessPoints.updateMany(
-          _usp,
-          aggregate.apInstancePaths.map((p) {
-            final band = bandByApPath[p] ?? '';
-            final securityMode = _securityModeFor6GHz(
-              band: band,
-              selectedMode: pending.securityMode,
-            );
-            return WiFiAccessPointUpdate(
-              instancePath: p,
-              keyPassphrase: pending.password,
-              securityModeEnabled: securityMode,
-            );
-          }).toList(),
-        );
+          await WiFiAccessPoints.updateMany(
+            _usp,
+            aggregate.apInstancePaths.map((p) {
+              final band = bandByApPath[p] ?? '';
+              final securityMode = _securityModeFor6GHz(
+                band: band,
+                selectedMode: pending.securityMode,
+              );
+              return WiFiAccessPointUpdate(
+                instancePath: p,
+                keyPassphrase: pending.password,
+                securityModeEnabled: securityMode,
+              );
+            }).toList(),
+          );
+        }
       }
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
     }
   }
 
@@ -250,69 +255,75 @@ class UspWifiSettingsService {
     required List<WifiNetworkUIModel> original,
     required List<WifiNetworkUIModel> current,
   }) async {
-    for (var i = 0; i < current.length; i++) {
-      final curr = current[i];
-      final orig = original.length > i ? original[i] : null;
+    try {
+      for (var i = 0; i < current.length; i++) {
+        final curr = current[i];
+        final orig = original.length > i ? original[i] : null;
 
-      // Skip unchanged networks.
-      if (orig != null && orig == curr) continue;
+        // Skip unchanged networks.
+        if (orig != null && orig == curr) continue;
 
-      // ── SSID layer ─────────────────────────────────────────────────────
-      if (orig == null ||
-          orig.enabled != curr.enabled ||
-          orig.ssid != curr.ssid) {
-        await WiFiSsids.update(
-          _usp,
-          WiFiSsidUpdate(
-            instancePath: curr.ssidInstancePath,
-            enable: curr.enabled,
-            ssid: curr.ssid,
-          ),
-        );
+        // ── SSID layer ─────────────────────────────────────────────────────
+        if (orig == null ||
+            orig.enabled != curr.enabled ||
+            orig.ssid != curr.ssid) {
+          await WiFiSsids.update(
+            _usp,
+            WiFiSsidUpdate(
+              instancePath: curr.ssidInstancePath,
+              enable: curr.enabled,
+              ssid: curr.ssid,
+            ),
+          );
+        }
+
+        // ── AccessPoint layer ───────────────────────────────────────────────
+        final ap = curr.accessPointInstancePath;
+        if (ap != null &&
+            (orig == null ||
+                orig.keyPassphrase != curr.keyPassphrase ||
+                orig.securityMode != curr.securityMode ||
+                orig.ssidAdvertisementEnabled !=
+                    curr.ssidAdvertisementEnabled)) {
+          await WiFiAccessPoints.update(
+            _usp,
+            WiFiAccessPointUpdate(
+              instancePath: ap,
+              keyPassphrase:
+                  curr.keyPassphrase.isNotEmpty ? curr.keyPassphrase : null,
+              securityModeEnabled:
+                  curr.securityMode.isNotEmpty ? curr.securityMode : null,
+              ssidAdvertisementEnabled: curr.ssidAdvertisementEnabled,
+            ),
+          );
+        }
+
+        // ── Radio layer ─────────────────────────────────────────────────────
+        final radio = curr.radioInstancePath;
+        if (radio != null &&
+            (orig == null ||
+                orig.operatingStandards != curr.operatingStandards ||
+                orig.channelBandwidth != curr.channelBandwidth ||
+                orig.channel != curr.channel ||
+                orig.autoChannelEnable != curr.autoChannelEnable)) {
+          await WiFiRadios.update(
+            _usp,
+            WiFiRadioUpdate(
+              instancePath: radio,
+              operatingStandards: curr.operatingStandards.isNotEmpty
+                  ? curr.operatingStandards
+                  : null,
+              operatingChannelBandwidth: curr.channelBandwidth.isNotEmpty
+                  ? curr.channelBandwidth
+                  : null,
+              autoChannelEnable: curr.autoChannelEnable,
+              channel: curr.autoChannelEnable ? null : curr.channel,
+            ),
+          );
+        }
       }
-
-      // ── AccessPoint layer ───────────────────────────────────────────────
-      final ap = curr.accessPointInstancePath;
-      if (ap != null &&
-          (orig == null ||
-              orig.keyPassphrase != curr.keyPassphrase ||
-              orig.securityMode != curr.securityMode ||
-              orig.ssidAdvertisementEnabled != curr.ssidAdvertisementEnabled)) {
-        await WiFiAccessPoints.update(
-          _usp,
-          WiFiAccessPointUpdate(
-            instancePath: ap,
-            keyPassphrase:
-                curr.keyPassphrase.isNotEmpty ? curr.keyPassphrase : null,
-            securityModeEnabled:
-                curr.securityMode.isNotEmpty ? curr.securityMode : null,
-            ssidAdvertisementEnabled: curr.ssidAdvertisementEnabled,
-          ),
-        );
-      }
-
-      // ── Radio layer ─────────────────────────────────────────────────────
-      final radio = curr.radioInstancePath;
-      if (radio != null &&
-          (orig == null ||
-              orig.operatingStandards != curr.operatingStandards ||
-              orig.channelBandwidth != curr.channelBandwidth ||
-              orig.channel != curr.channel ||
-              orig.autoChannelEnable != curr.autoChannelEnable)) {
-        await WiFiRadios.update(
-          _usp,
-          WiFiRadioUpdate(
-            instancePath: radio,
-            operatingStandards: curr.operatingStandards.isNotEmpty
-                ? curr.operatingStandards
-                : null,
-            operatingChannelBandwidth:
-                curr.channelBandwidth.isNotEmpty ? curr.channelBandwidth : null,
-            autoChannelEnable: curr.autoChannelEnable,
-            channel: curr.autoChannelEnable ? null : curr.channel,
-          ),
-        );
-      }
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
     }
   }
 

--- a/lib/page/wifi_settings/views/tabs/wifi_advanced_tab.dart
+++ b/lib/page/wifi_settings/views/tabs/wifi_advanced_tab.dart
@@ -79,7 +79,17 @@ class UspWifiAdvancedTab extends ConsumerWidget {
                   'will automatically switch to an unoccupied channel, which '
                   'may cause a brief interruption in connectivity.',
               value: state.isDfsEnabled,
-              onChanged: (v) => notifier.setIeee80211hEnabled(v),
+              onChanged: (v) async {
+                try {
+                  await notifier.setIeee80211hEnabled(v);
+                } catch (e) {
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Failed to save: $e')),
+                    );
+                  }
+                }
+              },
             ),
             AppGap.lg(),
           ],

--- a/lib/page/wifi_settings/views/tabs/wifi_list_tab.dart
+++ b/lib/page/wifi_settings/views/tabs/wifi_list_tab.dart
@@ -282,11 +282,11 @@ class UspWifiListTab extends ConsumerWidget {
                         ),
                       );
                     }
-                  } catch (_) {
+                  } catch (e) {
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content: Text('Failed to save settings'),
+                        SnackBar(
+                          content: Text('Failed to save: $e'),
                         ),
                       );
                     }

--- a/test/core/errors/service_error_test.dart
+++ b/test/core/errors/service_error_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+
+void main() {
+  group('ServiceError toString', () {
+    test('base class converts class name to human-readable format', () {
+      expect('${const InvalidCredentialsError()}', 'Invalid credentials');
+      expect('${const SessionTokenExpiredError()}', 'Session token expired');
+      expect('${const NotAuthenticatedError()}', 'Not authenticated');
+      expect('${const ResourceNotFoundError()}', 'Resource not found');
+      expect('${const AdminAccountLockedError()}', 'Admin account locked');
+    });
+
+    test('preserves acronyms (VPN, IP, DNS, SSID, MAC, OTP)', () {
+      expect('${const VPNNotConnectedError()}', 'VPN not connected');
+      expect('${const InvalidIPAddressError()}', 'Invalid IP address');
+      expect('${const InvalidPrimaryDNSServerError()}',
+          'Invalid primary DNS server');
+      expect('${const GuestSSIDConflictError()}', 'Guest SSID conflict');
+      expect('${const InvalidMACAddressError()}', 'Invalid MAC address');
+      expect('${const InvalidOtpError()}', 'Invalid otp');
+    });
+
+    test('NetworkError appends message when present', () {
+      expect('${const NetworkError(message: 'Request timeout')}',
+          'Network error: Request timeout');
+      expect('${const NetworkError()}', 'Network');
+    });
+
+    test('ConnectivityError appends message when present', () {
+      expect('${const ConnectivityError(message: 'Connection refused')}',
+          'Connectivity error: Connection refused');
+      expect('${const ConnectivityError()}', 'Connectivity');
+    });
+
+    test('InvalidInputError shows field and message', () {
+      expect(
+          '${const InvalidInputError(field: 'destIp', message: 'Invalid IP')}',
+          'Invalid input: destIp: Invalid IP');
+      expect('${const InvalidInputError(message: 'bad value')}',
+          'Invalid input: bad value');
+      expect('${const InvalidInputError()}', 'Invalid input');
+    });
+
+    test('UnexpectedError appends message when present', () {
+      expect('${const UnexpectedError(message: 'bad data')}',
+          'Unexpected error: bad data');
+      expect('${const UnexpectedError()}', 'Unexpected');
+    });
+  });
+}

--- a/test/core/usp/errors/usp_error_test.dart
+++ b/test/core/usp/errors/usp_error_test.dart
@@ -246,5 +246,4 @@ void main() {
       expect(mapUspErrorToServiceError(raw), isA<UnexpectedError>());
     });
   });
-
 }

--- a/test/core/usp/errors/usp_error_test.dart
+++ b/test/core/usp/errors/usp_error_test.dart
@@ -1,0 +1,250 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
+
+void main() {
+  group('parseUspError', () {
+    test('parses Protocol error with fault code 7026', () {
+      const raw =
+          'Set failed: Protocol error: Decoding error: Received error response: '
+          'CheckPathProperties: Path (Device.Bogus) does not exist in the schema (code: 7026)';
+
+      final result = parseUspError(raw);
+
+      expect(result, isNotNull);
+      expect(result!.operation, 'Set');
+      expect(result.category, UspErrorCategory.protocol);
+      expect(result.faultCode, 7026);
+      expect(result.httpStatus, isNull);
+      expect(result.message, contains('Decoding error'));
+    });
+
+    test('parses Protocol error with fault code 7004', () {
+      const raw =
+          'Add failed: Protocol error: Decoding error: Received error response: '
+          'CheckPathProperties: Path (Device.DeviceInfo) is not a multi-instance object (code: 7004)';
+
+      final result = parseUspError(raw);
+
+      expect(result, isNotNull);
+      expect(result!.operation, 'Add');
+      expect(result.category, UspErrorCategory.protocol);
+      expect(result.faultCode, 7004);
+    });
+
+    test('parses Transport error with HTTP status', () {
+      const raw = 'Delete failed: Transport error: HTTP error: HTTP 504';
+
+      final result = parseUspError(raw);
+
+      expect(result, isNotNull);
+      expect(result!.operation, 'Delete');
+      expect(result.category, UspErrorCategory.transport);
+      expect(result.httpStatus, 504);
+      expect(result.faultCode, isNull);
+    });
+
+    test('parses Authentication error', () {
+      const raw = 'Login failed: Authentication error: Invalid credentials';
+
+      final result = parseUspError(raw);
+
+      expect(result, isNotNull);
+      expect(result!.operation, 'Login');
+      expect(result.category, UspErrorCategory.auth);
+      expect(result.message, 'Invalid credentials');
+    });
+
+    test('parses Validation error', () {
+      const raw =
+          "Get failed: Validation error: Path must start with 'Device.'";
+
+      final result = parseUspError(raw);
+
+      expect(result, isNotNull);
+      expect(result!.operation, 'Get');
+      expect(result.category, UspErrorCategory.validation);
+      expect(result.message, "Path must start with 'Device.'");
+    });
+
+    test('parses Transport error with Connection refused', () {
+      const raw = 'Get failed: Transport error: Connection refused';
+
+      final result = parseUspError(raw);
+
+      expect(result, isNotNull);
+      expect(result!.category, UspErrorCategory.transport);
+      expect(result.message, 'Connection refused');
+      expect(result.httpStatus, isNull);
+    });
+
+    test('parses Transport error with Request timeout', () {
+      const raw = 'Set failed: Transport error: Request timeout';
+
+      final result = parseUspError(raw);
+
+      expect(result, isNotNull);
+      expect(result!.category, UspErrorCategory.transport);
+      expect(result.message, 'Request timeout');
+    });
+
+    test('parses Authentication error with Session expired', () {
+      const raw = 'Get failed: Authentication error: Session expired';
+
+      final result = parseUspError(raw);
+
+      expect(result, isNotNull);
+      expect(result!.category, UspErrorCategory.auth);
+      expect(result.message, 'Session expired');
+    });
+
+    test('parses Operation error with Path not found', () {
+      const raw =
+          'Get failed: Operation error: Path not found: Device.Bogus.Path';
+
+      final result = parseUspError(raw);
+
+      expect(result, isNotNull);
+      expect(result!.category, UspErrorCategory.operation);
+      expect(result.message, contains('Path not found'));
+    });
+
+    test('parses Operation error with read-only', () {
+      const raw =
+          'Set failed: Operation error: Parameter is read-only: Device.DeviceInfo.Manufacturer';
+
+      final result = parseUspError(raw);
+
+      expect(result, isNotNull);
+      expect(result!.category, UspErrorCategory.operation);
+      expect(result.message, contains('read-only'));
+    });
+
+    test('returns null for non-USP error string', () {
+      expect(parseUspError('some random error'), isNull);
+      expect(parseUspError(''), isNull);
+      expect(parseUspError(42), isNull);
+    });
+
+    test('preserves rawError', () {
+      const raw = 'Get failed: Validation error: Path cannot be empty';
+      final result = parseUspError(raw);
+      expect(result!.rawError, raw);
+      expect(result.toString(), raw);
+    });
+  });
+
+  group('mapUspErrorToServiceError', () {
+    test('maps auth Invalid credentials to InvalidCredentialsError', () {
+      const raw = 'Login failed: Authentication error: Invalid credentials';
+      expect(mapUspErrorToServiceError(raw), isA<InvalidCredentialsError>());
+    });
+
+    test('maps auth Session expired to SessionTokenExpiredError', () {
+      const raw = 'Get failed: Authentication error: Session expired';
+      expect(mapUspErrorToServiceError(raw), isA<SessionTokenExpiredError>());
+    });
+
+    test('maps auth Invalid token to InvalidSessionTokenError', () {
+      const raw = 'Get failed: Authentication error: Invalid token: bad_token';
+      expect(mapUspErrorToServiceError(raw), isA<InvalidSessionTokenError>());
+    });
+
+    test('maps auth Permission denied to UnauthorizedError', () {
+      const raw = 'Set failed: Authentication error: Permission denied';
+      expect(mapUspErrorToServiceError(raw), isA<UnauthorizedError>());
+    });
+
+    test('maps auth Authentication required to NotAuthenticatedError', () {
+      const raw = 'Get failed: Authentication error: Authentication required';
+      expect(mapUspErrorToServiceError(raw), isA<NotAuthenticatedError>());
+    });
+
+    test('maps Transport HTTP 401 to NotAuthenticatedError', () {
+      const raw = 'Get failed: Transport error: HTTP error: HTTP 401';
+      expect(mapUspErrorToServiceError(raw), isA<NotAuthenticatedError>());
+    });
+
+    test('maps Transport HTTP 504 to NetworkError', () {
+      const raw = 'Delete failed: Transport error: HTTP error: HTTP 504';
+      expect(mapUspErrorToServiceError(raw), isA<NetworkError>());
+    });
+
+    test('maps Transport Connection refused to ConnectivityError', () {
+      const raw = 'Get failed: Transport error: Connection refused';
+      expect(mapUspErrorToServiceError(raw), isA<ConnectivityError>());
+    });
+
+    test('maps Transport Request timeout to NetworkError', () {
+      const raw = 'Set failed: Transport error: Request timeout';
+      expect(mapUspErrorToServiceError(raw), isA<NetworkError>());
+    });
+
+    test('maps Protocol fault 7026 to ResourceNotFoundError', () {
+      const raw =
+          'Set failed: Protocol error: Decoding error: Received error response: '
+          'CheckPathProperties: Path (Device.Bogus) does not exist in the schema (code: 7026)';
+      expect(mapUspErrorToServiceError(raw), isA<ResourceNotFoundError>());
+    });
+
+    test('maps Protocol fault 7004 to InvalidInputError', () {
+      const raw =
+          'Add failed: Protocol error: Decoding error: Received error response: '
+          'CheckPathProperties: Path (Device.DeviceInfo) is not a multi-instance object (code: 7004)';
+      expect(mapUspErrorToServiceError(raw), isA<InvalidInputError>());
+    });
+
+    test('maps Protocol fault 9001 to UnauthorizedError', () {
+      const raw =
+          'Set failed: Protocol error: Decoding error: Received error response: '
+          'SetFailed: Request denied (code: 9001)';
+      expect(mapUspErrorToServiceError(raw), isA<UnauthorizedError>());
+    });
+
+    test('maps Protocol fault 9005 to ResourceNotFoundError', () {
+      const raw =
+          'Get failed: Protocol error: Decoding error: Received error response: '
+          'InvalidParam: Invalid parameter name (code: 9005)';
+      expect(mapUspErrorToServiceError(raw), isA<ResourceNotFoundError>());
+    });
+
+    test('maps Protocol fault 9008 to InvalidInputError', () {
+      const raw =
+          'Set failed: Protocol error: Decoding error: Received error response: '
+          'SetFailed: Non-writable parameter (code: 9008)';
+      expect(mapUspErrorToServiceError(raw), isA<InvalidInputError>());
+    });
+
+    test('maps Operation Path not found to ResourceNotFoundError', () {
+      const raw =
+          'Get failed: Operation error: Path not found: Device.Bogus.Path';
+      expect(mapUspErrorToServiceError(raw), isA<ResourceNotFoundError>());
+    });
+
+    test('maps Operation read-only to InvalidInputError', () {
+      const raw =
+          'Set failed: Operation error: Parameter is read-only: Device.DeviceInfo.Manufacturer';
+      expect(mapUspErrorToServiceError(raw), isA<InvalidInputError>());
+    });
+
+    test('maps Validation error to InvalidInputError', () {
+      const raw =
+          "Get failed: Validation error: Path must start with 'Device.'";
+      expect(mapUspErrorToServiceError(raw), isA<InvalidInputError>());
+    });
+
+    test('maps non-USP error to UnexpectedError', () {
+      expect(mapUspErrorToServiceError('random error'), isA<UnexpectedError>());
+    });
+
+    test('maps non-string error to UnexpectedError', () {
+      expect(mapUspErrorToServiceError(42), isA<UnexpectedError>());
+    });
+
+    test('maps Protocol error without fault code to UnexpectedError', () {
+      const raw = 'Get failed: Protocol error: Malformed message: bad data';
+      expect(mapUspErrorToServiceError(raw), isA<UnexpectedError>());
+    });
+  });
+
+}

--- a/test/page/dmz/providers/usp_dmz_notifier_test.dart
+++ b/test/page/dmz/providers/usp_dmz_notifier_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/page/dmz/models/dmz_settings.dart';
@@ -48,7 +49,7 @@ void main() {
   }
 
   group('UspDmzNotifier', () {
-    test('build returns initial loading state', () {
+    test('build returns initial loading state', () async {
       when(() => mockService.fetch())
           .thenAnswer((_) async => (testSettings, testStatus));
       final container = createContainer();
@@ -56,6 +57,9 @@ void main() {
       final state = container.read(uspDmzProvider);
       expect(state.status.isLoading, isTrue);
       expect(state.settings.current, const DmzSettings.empty());
+
+      // Let microtask (Future.microtask in build) complete before disposing.
+      await Future.delayed(Duration.zero);
       container.dispose();
     });
 
@@ -76,13 +80,14 @@ void main() {
     });
 
     test('fetch error sets error status, no settings change', () async {
-      when(() => mockService.fetch()).thenThrow(Exception('network error'));
+      when(() => mockService.fetch())
+          .thenThrow(const NetworkError(message: 'network error'));
       final container = createContainer();
 
       await Future.delayed(Duration.zero);
 
       final state = container.read(uspDmzProvider);
-      expect(state.status.errorMessage, contains('network error'));
+      expect(state.status.errorMessage, contains('Network error'));
       // Settings remain empty (initial) since performFetch returned null.
       expect(state.settings.current, const DmzSettings.empty());
       container.dispose();
@@ -229,7 +234,7 @@ void main() {
       when(() => mockService.update(
             instancePath: any(named: 'instancePath'),
             model: any(named: 'model'),
-          )).thenThrow(Exception('save failed'));
+          )).thenThrow(const NetworkError(message: 'save failed'));
       when(() => mockService.validateForm(any())).thenReturn({});
 
       final container = createContainer();
@@ -238,7 +243,7 @@ void main() {
       final notifier = container.read(uspDmzProvider.notifier);
       notifier.updateSetting((m) => m.copyWith(destIp: '10.0.0.1'));
 
-      await expectLater(notifier.save(), throwsA(isA<Exception>()));
+      await expectLater(notifier.save(), throwsA(isA<ServiceError>()));
 
       expect(container.read(uspDmzProvider).status.isSaving, isFalse);
       container.dispose();

--- a/test/page/wifi_settings/providers/usp_wifi_advanced_notifier_test.dart
+++ b/test/page/wifi_settings/providers/usp_wifi_advanced_notifier_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/page/wifi_settings/providers/usp_wifi_advanced_provider.dart';
 import 'package:privacy_gui/page/wifi_settings/services/usp_wifi_advanced_service.dart';
@@ -152,6 +153,71 @@ void main() {
             radioPaths: any(named: 'radioPaths'),
             enabled: any(named: 'enabled'),
           ));
+      container.dispose();
+    });
+
+    // -----------------------------------------------------------------------
+    // Error handling
+    // -----------------------------------------------------------------------
+
+    test('build sets AsyncError when service throws ServiceError', () async {
+      when(() => mockService.fetchIeee80211h())
+          .thenThrow(const NetworkError(message: 'timeout'));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspWifiAdvancedProvider);
+      expect(state.hasError, isTrue);
+      expect(state.error, isA<NetworkError>());
+      container.dispose();
+    });
+
+    test('setIeee80211hEnabled rethrows ServiceError from service', () async {
+      when(() => mockService.fetchIeee80211h()).thenAnswer((_) async => {
+            'Device.WiFi.Radio.1.': false,
+          });
+      when(() => mockService.setIeee80211hEnabled(
+            radioPaths: any(named: 'radioPaths'),
+            enabled: any(named: 'enabled'),
+          )).thenThrow(const InvalidInputError(message: 'read-only'));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspWifiAdvancedProvider.notifier);
+
+      expect(
+        () => notifier.setIeee80211hEnabled(true),
+        throwsA(isA<InvalidInputError>()),
+      );
+      container.dispose();
+    });
+
+    test('setIeee80211hEnabled does not update state when service throws',
+        () async {
+      when(() => mockService.fetchIeee80211h()).thenAnswer((_) async => {
+            'Device.WiFi.Radio.1.': false,
+          });
+      when(() => mockService.setIeee80211hEnabled(
+            radioPaths: any(named: 'radioPaths'),
+            enabled: any(named: 'enabled'),
+          )).thenThrow(const NetworkError(message: 'connection refused'));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspWifiAdvancedProvider.notifier);
+
+      try {
+        await notifier.setIeee80211hEnabled(true);
+      } on ServiceError catch (_) {
+        // expected
+      }
+
+      // State should remain unchanged (still false)
+      final state = container.read(uspWifiAdvancedProvider).requireValue;
+      expect(state.ieee80211hByRadio['Device.WiFi.Radio.1.'], isFalse);
       container.dispose();
     });
   });

--- a/test/page/wifi_settings/providers/usp_wifi_settings_notifier_test.dart
+++ b/test/page/wifi_settings/providers/usp_wifi_settings_notifier_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_auth_coordinator.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
@@ -533,8 +534,110 @@ void main() {
       expect(notifier.effectiveNetwork('Device.WiFi.SSID.99.'), isNull);
       container.dispose();
     });
+
+    // -----------------------------------------------------------------------
+    // Error handling — performFetch
+    // -----------------------------------------------------------------------
+
+    test(
+        'performFetch returns error status when wifiDataProvider throws ServiceError',
+        () async {
+      final container = ProviderContainer(
+        overrides: [
+          uspWifiSettingsServiceProvider.overrideWithValue(mockService),
+          uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+          uspServiceProvider.overrideWithValue(mockUsp),
+          uspAuthCoordinatorProvider.overrideWithValue(mockAuthCoordinator),
+          wifiDataProvider.overrideWith(() =>
+              _ErrorWifiDataNotifier(const NetworkError(message: 'timeout'))),
+        ],
+      );
+      container.listen(uspWifiSettingsProvider, (_, __) {});
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspWifiSettingsProvider);
+      expect(state.status.errorMessage, isNotNull);
+      expect(state.status.errorMessage, contains('Network error'));
+      expect(state.settings.current.networks, isEmpty);
+      container.dispose();
+    });
+
+    // -----------------------------------------------------------------------
+    // Error handling — save
+    // -----------------------------------------------------------------------
+
+    test('save rethrows ServiceError from service', () async {
+      final networks = WifiSettingsTestData.createNetworks();
+      when(() => mockService.buildWifiNetworks(
+            ssids: any(named: 'ssids'),
+            accessPoints: any(named: 'accessPoints'),
+            radios: any(named: 'radios'),
+          )).thenReturn(networks);
+      when(() => mockService.buildQuickSetupNetworks(any())).thenReturn((
+        main: null,
+        guest: null,
+        isQuickSetup: false,
+      ));
+      when(() => mockService.saveAdvanced(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).thenThrow(const NetworkError(message: 'HTTP 504'));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspWifiSettingsProvider.notifier);
+      notifier.updateNetworkField('Device.WiFi.SSID.1.', ssid: 'Changed');
+
+      expect(
+        () => notifier.save(),
+        throwsA(isA<NetworkError>()),
+      );
+      container.dispose();
+    });
+
+    test('save resets isSaving flag after ServiceError', () async {
+      final networks = WifiSettingsTestData.createNetworks();
+      when(() => mockService.buildWifiNetworks(
+            ssids: any(named: 'ssids'),
+            accessPoints: any(named: 'accessPoints'),
+            radios: any(named: 'radios'),
+          )).thenReturn(networks);
+      when(() => mockService.buildQuickSetupNetworks(any())).thenReturn((
+        main: null,
+        guest: null,
+        isQuickSetup: false,
+      ));
+      when(() => mockService.saveAdvanced(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).thenThrow(const NetworkError(message: 'HTTP 504'));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspWifiSettingsProvider.notifier);
+      notifier.updateNetworkField('Device.WiFi.SSID.1.', ssid: 'Changed');
+
+      try {
+        await notifier.save();
+      } on ServiceError catch (_) {
+        // expected
+      }
+
+      final state = container.read(uspWifiSettingsProvider);
+      expect(state.status.isSaving, isFalse);
+      container.dispose();
+    });
   });
 }
+
+// ---------------------------------------------------------------------------
+// Fake WifiDataNotifier that returns pre-built data without real USP calls
+// ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
 // Fake WifiDataNotifier that returns pre-built data without real USP calls
@@ -547,6 +650,26 @@ class _FakeWifiDataNotifier extends AsyncNotifier<WifiData>
 
   @override
   Future<WifiData> build() async => _data;
+
+  @override
+  Future<void> toggleWifiRadio(String instancePath, bool enable) async {}
+
+  @override
+  Future<void> updateWifiRadioChannel(
+      String instancePath, int channel, bool autoChannel) async {}
+}
+
+// ---------------------------------------------------------------------------
+// Fake WifiDataNotifier that throws ServiceError on build
+// ---------------------------------------------------------------------------
+
+class _ErrorWifiDataNotifier extends AsyncNotifier<WifiData>
+    implements WifiDataNotifier {
+  final ServiceError _error;
+  _ErrorWifiDataNotifier(this._error);
+
+  @override
+  Future<WifiData> build() async => throw _error;
 
   @override
   Future<void> toggleWifiRadio(String instancePath, bool enable) async {}

--- a/test/page/wifi_settings/services/usp_wifi_advanced_service_test.dart
+++ b/test/page/wifi_settings/services/usp_wifi_advanced_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
 import 'package:privacy_gui/page/wifi_settings/services/usp_wifi_advanced_service.dart';
 
@@ -99,6 +100,69 @@ void main() {
       verify(() => mockUsp.set({
             'Device.WiFi.Radio.1.IEEE80211hEnabled': false,
           })).called(1);
+    });
+
+    test('throws NetworkError when USP set throws transport error', () async {
+      when(() => mockUsp.set(any()))
+          .thenThrow('Set failed: Transport error: Request timeout');
+
+      expect(
+        () => svc.setIeee80211hEnabled(
+          radioPaths: ['Device.WiFi.Radio.1.'],
+          enabled: true,
+        ),
+        throwsA(isA<NetworkError>()),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling
+  // -------------------------------------------------------------------------
+
+  group('UspWifiAdvancedService - error handling', () {
+    test('fetchIeee80211h maps USP protocol error to ServiceError', () {
+      when(() => mockUsp.get(any())).thenThrow(
+        'Get failed: Protocol error: Decoding error: '
+        'Path (Device.WiFi.Radio) does not exist (code: 7026)',
+      );
+
+      expect(
+        () => svc.fetchIeee80211h(),
+        throwsA(isA<ResourceNotFoundError>()),
+      );
+    });
+
+    test('fetchIeee80211h maps USP auth error to ServiceError', () {
+      when(() => mockUsp.get(any()))
+          .thenThrow('Get failed: Authentication error: Session expired');
+
+      expect(
+        () => svc.fetchIeee80211h(),
+        throwsA(isA<SessionTokenExpiredError>()),
+      );
+    });
+
+    test('fetchIeee80211h maps non-USP error to UnexpectedError', () {
+      when(() => mockUsp.get(any())).thenThrow('some random error');
+
+      expect(
+        () => svc.fetchIeee80211h(),
+        throwsA(isA<UnexpectedError>()),
+      );
+    });
+
+    test('setIeee80211hEnabled maps USP transport error to ServiceError', () {
+      when(() => mockUsp.set(any()))
+          .thenThrow('Set failed: Transport error: Connection refused');
+
+      expect(
+        () => svc.setIeee80211hEnabled(
+          radioPaths: ['Device.WiFi.Radio.1.'],
+          enabled: true,
+        ),
+        throwsA(isA<ConnectivityError>()),
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- Add centralized USP error parser and `mapUspErrorToServiceError()` utility for structured error mapping
- Integrate error handling into DMZ service and provider layers
- Integrate error handling into WiFi Settings service, provider, data provider, and view layers
- Add human-readable `toString()` to all `ServiceError` subtypes (e.g. "Network error: Request timeout")
- Add try/catch with snackbar error feedback in WiFi views (DFS toggle + save)
- Update constitution Section 13 with USP error handling patterns and infrastructure documentation
- Add comprehensive tests: USP error parser, ServiceError toString, WiFi service/provider error paths