### PR TITLE
feat: implement USP error handling across all remaining feature pages (#794)

### DIFF
--- a/lib/core/errors/service_error.dart
+++ b/lib/core/errors/service_error.dart
@@ -291,6 +291,20 @@ final class VPNUserNotFoundError extends ServiceError {
 // General Errors
 // ============================================================================
 
+/// USP service not initialized or not registered.
+///
+/// Thrown when `uspServiceProvider` returns null — the app was not properly
+/// initialized (e.g. non-Web platform or WASM not loaded). This is a setup
+/// error, not a network connectivity issue.
+final class ServiceNotInitializedError extends ServiceError {
+  final String? message;
+  const ServiceNotInitializedError({this.message});
+
+  @override
+  String toString() =>
+      message != null ? 'Service not initialized: $message' : super.toString();
+}
+
 /// Invalid input data
 final class InvalidInputError extends ServiceError {
   final String? field;

--- a/lib/core/session/services/session_service.dart
+++ b/lib/core/session/services/session_service.dart
@@ -62,7 +62,8 @@ class SessionService {
   Future<NodeDeviceInfo> _fetchUspDeviceInfo() async {
     if (_usp == null) {
       logger.e('[SessionService] USP not available');
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
     if (!_usp.isAuthenticated) {
       logger.d('[SessionService] USP not authenticated');

--- a/lib/page/admin/providers/system_info_data_provider.dart
+++ b/lib/page/admin/providers/system_info_data_provider.dart
@@ -1,6 +1,8 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/firmware_images.g.dart';
 import 'package:privacy_gui/generated/system_info.g.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
@@ -39,14 +41,22 @@ class SystemInfoDataNotifier extends AsyncNotifier<SystemInfoData> {
 
   Future<SystemInfoData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
+    if (usp == null) {
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
+    }
 
     // SystemInfo.fetch now includes ActiveFirmwareImage + BootFirmwareImage
     // (merged in YAML v1.1.0), reducing from 3 → 2 USP requests.
-    final results = await Future.wait([
-      SystemInfo.fetch(usp),
-      _fetchFirmwareImages(usp),
-    ]);
+    final List<Object> results;
+    try {
+      results = await Future.wait([
+        SystemInfo.fetch(usp),
+        _fetchFirmwareImages(usp),
+      ]);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
 
     final systemInfo = results[0] as SystemInfo;
     final fwImages = results[1] as FirmwareImages;

--- a/lib/page/admin/providers/time_data_provider.dart
+++ b/lib/page/admin/providers/time_data_provider.dart
@@ -1,6 +1,8 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/time_settings.g.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
@@ -40,23 +42,29 @@ class TimeDataNotifier extends AsyncNotifier<TimeData> {
 
   Future<TimeData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
+    if (usp == null) {
+      throw const ConnectivityError(message: 'USP service not available');
+    }
 
-    final ts = await TimeSettings.fetch(usp);
+    try {
+      final ts = await TimeSettings.fetch(usp);
 
-    logger.d('[USP][TimeData] Fetched — '
-        'enable: ${ts.enable}, status: ${ts.status}');
+      logger.d('[USP][TimeData] Fetched — '
+          'enable: ${ts.enable}, status: ${ts.status}');
 
-    return TimeData(
-      model: TimeSettingsUIModel(
-        enable: ts.enable,
-        status: ts.status,
-        currentLocalTime: ts.currentLocalTime,
-        localTimeZone: ts.localTimeZone,
-        ntpServer1: ts.ntpServer1,
-        ntpServer2: ts.ntpServer2,
-      ),
-    );
+      return TimeData(
+        model: TimeSettingsUIModel(
+          enable: ts.enable,
+          status: ts.status,
+          currentLocalTime: ts.currentLocalTime,
+          localTimeZone: ts.localTimeZone,
+          ntpServer1: ts.ntpServer1,
+          ntpServer2: ts.ntpServer2,
+        ),
+      );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -71,16 +79,22 @@ class TimeDataNotifier extends AsyncNotifier<TimeData> {
     String? ntpServer2,
   }) async {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
+    if (usp == null) {
+      throw const ConnectivityError(message: 'USP service not available');
+    }
 
-    await ref.read(uspMutationLockProvider).withLock(() async {
-      await TimeSettings.save(
-        usp,
-        enable: enable,
-        ntpServer1: ntpServer1,
-        ntpServer2: ntpServer2,
-      );
-    });
+    try {
+      await ref.read(uspMutationLockProvider).withLock(() async {
+        await TimeSettings.save(
+          usp,
+          enable: enable,
+          ntpServer1: ntpServer1,
+          ntpServer2: ntpServer2,
+        );
+      });
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
 
     ref.invalidateSelf();
   }
@@ -93,17 +107,23 @@ class TimeDataNotifier extends AsyncNotifier<TimeData> {
     bool? enable,
   }) async {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
+    if (usp == null) {
+      throw const ConnectivityError(message: 'USP service not available');
+    }
 
-    await ref.read(uspMutationLockProvider).withLock(() async {
-      await TimeSettings.save(
-        usp,
-        localTimeZone: localTimeZone,
-        ntpServer1: ntpServer1,
-        ntpServer2: ntpServer2,
-        enable: enable,
-      );
-    });
+    try {
+      await ref.read(uspMutationLockProvider).withLock(() async {
+        await TimeSettings.save(
+          usp,
+          localTimeZone: localTimeZone,
+          ntpServer1: ntpServer1,
+          ntpServer2: ntpServer2,
+          enable: enable,
+        );
+      });
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
 
     ref.invalidateSelf();
   }

--- a/lib/page/admin/providers/time_data_provider.dart
+++ b/lib/page/admin/providers/time_data_provider.dart
@@ -43,7 +43,8 @@ class TimeDataNotifier extends AsyncNotifier<TimeData> {
   Future<TimeData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) {
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
 
     try {
@@ -80,7 +81,8 @@ class TimeDataNotifier extends AsyncNotifier<TimeData> {
   }) async {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) {
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
 
     try {
@@ -108,7 +110,8 @@ class TimeDataNotifier extends AsyncNotifier<TimeData> {
   }) async {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) {
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
 
     try {

--- a/lib/page/admin/providers/usp_admin_notifier.dart
+++ b/lib/page/admin/providers/usp_admin_notifier.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
-import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
-import 'package:privacy_gui/core/usp/services/usp_service.dart';
 import 'package:privacy_gui/page/admin/providers/time_data_provider.dart';
 import 'package:privacy_gui/page/admin/providers/usp_admin_state.dart';
 import 'package:privacy_gui/page/admin/services/usp_admin_service.dart';
@@ -12,25 +12,23 @@ final uspAdminProvider =
 );
 
 class UspAdminNotifier extends AutoDisposeAsyncNotifier<UspAdminState> {
-  UspService get _usp {
-    final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
-    return usp;
-  }
-
   UspAdminService get _svc => ref.read(uspAdminServiceProvider);
 
   @override
   Future<UspAdminState> build() async {
-    // Time settings from shared data provider.
-    final timeData = await ref.watch(timeDataProvider.future);
+    try {
+      // Time settings from shared data provider.
+      final timeData = await ref.watch(timeDataProvider.future);
+      final adminUser = await _svc.fetchAdmin();
 
-    final adminUser = await _svc.fetchAdmin();
-
-    return UspAdminState(
-      adminUser: adminUser,
-      timeSettings: timeData.model,
-    );
+      return UspAdminState(
+        adminUser: adminUser,
+        timeSettings: timeData.model,
+      );
+    } on ServiceError catch (e) {
+      logger.e('[USP][Admin] Fetch failed', error: e);
+      rethrow;
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -38,12 +36,17 @@ class UspAdminNotifier extends AutoDisposeAsyncNotifier<UspAdminState> {
   // ---------------------------------------------------------------------------
 
   Future<void> setAdminPassword(String newPassword) async {
-    await ref.read(uspMutationLockProvider).withLock(() async {
-      await _svc.updatePassword(
-        instancePath: state.requireValue.adminUser.instancePath,
-        newPassword: newPassword,
-      );
-    });
+    try {
+      await ref.read(uspMutationLockProvider).withLock(() async {
+        await _svc.updatePassword(
+          instancePath: state.requireValue.adminUser.instancePath,
+          newPassword: newPassword,
+        );
+      });
+    } on ServiceError catch (e) {
+      logger.e('[USP][Admin] Password update failed', error: e);
+      rethrow;
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -65,18 +68,28 @@ class UspAdminNotifier extends AutoDisposeAsyncNotifier<UspAdminState> {
   }
 
   // ---------------------------------------------------------------------------
-  // Reboot / Factory Reset (direct USP operate — not codegen)
+  // Reboot / Factory Reset — delegates to service
   // ---------------------------------------------------------------------------
 
   Future<void> reboot() async {
-    await ref.read(uspMutationLockProvider).withLock(() async {
-      await _usp.operate('Device.Reboot()');
-    });
+    try {
+      await ref.read(uspMutationLockProvider).withLock(() async {
+        await _svc.reboot();
+      });
+    } on ServiceError catch (e) {
+      logger.e('[USP][Admin] Reboot failed', error: e);
+      rethrow;
+    }
   }
 
   Future<void> factoryReset() async {
-    await ref.read(uspMutationLockProvider).withLock(() async {
-      await _usp.operate('Device.FactoryReset()');
-    });
+    try {
+      await ref.read(uspMutationLockProvider).withLock(() async {
+        await _svc.factoryReset();
+      });
+    } on ServiceError catch (e) {
+      logger.e('[USP][Admin] Factory reset failed', error: e);
+      rethrow;
+    }
   }
 }

--- a/lib/page/admin/services/usp_admin_service.dart
+++ b/lib/page/admin/services/usp_admin_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/admin_users.g.dart';
 import 'package:privacy_gui/generated/time_settings.g.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
@@ -22,8 +23,12 @@ class UspAdminService {
 
   /// Fetch admin users and return the admin user UI model.
   Future<AdminUserUIModel> fetchAdmin() async {
-    final adminUsers = await AdminUsers.fetch(_usp);
-    return _buildAdminUserUIModel(adminUsers);
+    try {
+      final adminUsers = await AdminUsers.fetch(_usp);
+      return _buildAdminUserUIModel(adminUsers);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   /// Update the admin user password.
@@ -31,10 +36,36 @@ class UspAdminService {
     required String instancePath,
     required String newPassword,
   }) async {
-    await AdminUsers.update(
-      _usp,
-      AdminUserUpdate(instancePath: instancePath, password: newPassword),
-    );
+    try {
+      await AdminUsers.update(
+        _usp,
+        AdminUserUpdate(instancePath: instancePath, password: newPassword),
+      );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // System Operations
+  // ---------------------------------------------------------------------------
+
+  /// Reboot the router.
+  Future<void> reboot() async {
+    try {
+      await _usp.operate('Device.Reboot()');
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
+  }
+
+  /// Factory reset the router.
+  Future<void> factoryReset() async {
+    try {
+      await _usp.operate('Device.FactoryReset()');
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/page/admin/views/usp_admin_view.dart
+++ b/lib/page/admin/views/usp_admin_view.dart
@@ -165,20 +165,28 @@ class UspAdminView extends ConsumerWidget {
       if (context.mounted) showSuccessSnackBar(context, 'Timezone updated');
     } catch (e) {
       if (context.mounted) {
-        showFailedSnackBar(context, 'Failed to update timezone');
+        showFailedSnackBar(context, 'Failed to update timezone: $e');
       }
     }
   }
 
   Future<void> _changePassword(BuildContext context, WidgetRef ref) async {
-    final result = await showChangePasswordDialog(
-      context,
-      onSave: (newPassword) async {
-        await ref.read(uspAdminProvider.notifier).setAdminPassword(newPassword);
-      },
-    );
-    if (result == true && context.mounted) {
-      showSuccessSnackBar(context, 'Password updated');
+    try {
+      final result = await showChangePasswordDialog(
+        context,
+        onSave: (newPassword) async {
+          await ref
+              .read(uspAdminProvider.notifier)
+              .setAdminPassword(newPassword);
+        },
+      );
+      if (result == true && context.mounted) {
+        showSuccessSnackBar(context, 'Password updated');
+      }
+    } catch (e) {
+      if (context.mounted) {
+        showFailedSnackBar(context, 'Failed to update password: $e');
+      }
     }
   }
 
@@ -195,7 +203,7 @@ class UspAdminView extends ConsumerWidget {
       await ref.read(uspAdminProvider.notifier).reboot();
       if (context.mounted) showSuccessSnackBar(context, 'Reboot command sent');
     } catch (e) {
-      if (context.mounted) showFailedSnackBar(context, 'Reboot failed');
+      if (context.mounted) showFailedSnackBar(context, 'Reboot failed: $e');
     }
   }
 
@@ -214,7 +222,9 @@ class UspAdminView extends ConsumerWidget {
         showSuccessSnackBar(context, 'Factory reset command sent');
       }
     } catch (e) {
-      if (context.mounted) showFailedSnackBar(context, 'Factory reset failed');
+      if (context.mounted) {
+        showFailedSnackBar(context, 'Factory reset failed: $e');
+      }
     }
   }
 }

--- a/lib/page/dashboard/orchestrator/dashboard_orchestrator.dart
+++ b/lib/page/dashboard/orchestrator/dashboard_orchestrator.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/page/_shared/utils/usp_subscriptions.dart';
 import 'package:privacy_gui/page/admin/providers/system_info_data_provider.dart';
@@ -112,13 +113,14 @@ class DashboardOrchestrator extends AsyncNotifier<DashboardOrchestratorState> {
   Future<DashboardOrchestratorState> _buildImpl() async {
     final usp = ref.watch(uspServiceProvider);
     if (usp == null) {
-      throw StateError('USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
     // On page reload WASM state is lost — attempt session restore
     if (!usp.isAuthenticated) {
       await ref.read(uspAuthCoordinatorProvider).restoreSession();
       if (!usp.isAuthenticated) {
-        throw StateError('USP not authenticated after restore attempt');
+        throw const NotAuthenticatedError();
       }
     }
 

--- a/lib/page/devices/providers/devices_data_provider.dart
+++ b/lib/page/devices/providers/devices_data_provider.dart
@@ -118,7 +118,8 @@ class DevicesDataNotifier extends AsyncNotifier<DevicesData> {
   Future<DevicesData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) {
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
 
     // Fetch ConnectedDevices immediately; mesh topology in background.

--- a/lib/page/devices/providers/devices_data_provider.dart
+++ b/lib/page/devices/providers/devices_data_provider.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/connected_devices.g.dart';
 import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
@@ -115,13 +117,20 @@ class DevicesDataNotifier extends AsyncNotifier<DevicesData> {
 
   Future<DevicesData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
+    if (usp == null) {
+      throw const ConnectivityError(message: 'USP service not available');
+    }
 
     // Fetch ConnectedDevices immediately; mesh topology in background.
     // DataElements (mesh) uses 9 deep-wildcard paths that often timeout
     // (15s) on single-router setups where it always returns empty.
     // Don't block devices on it — show devices first, update mesh later.
-    final connectedDevices = await ConnectedDevices.fetch(usp);
+    final ConnectedDevices connectedDevices;
+    try {
+      connectedDevices = await ConnectedDevices.fetch(usp);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
 
     // Cache raw for WiFi listener rebuild.
     _rawConnectedDevices = connectedDevices;

--- a/lib/page/dhcp/providers/usp_dhcp_reservations_notifier.dart
+++ b/lib/page/dhcp/providers/usp_dhcp_reservations_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
@@ -70,7 +71,7 @@ class UspDhcpReservationsNotifier
         DhcpReservationList(reservations: reservations),
         const DhcpReservationsStatus(),
       );
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][DHCP][Reservations] Fetch failed', error: e);
       return (
         null,
@@ -106,7 +107,7 @@ class UspDhcpReservationsNotifier
 
       // Invalidate Layer 1 provider to refresh dashboard card
       ref.invalidate(dhcpDataProvider);
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][DHCP][Reservations] Save failed', error: e);
       rethrow;
     } finally {

--- a/lib/page/dhcp/services/usp_dhcp_service.dart
+++ b/lib/page/dhcp/services/usp_dhcp_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/dhcp_reservations.g.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
@@ -20,15 +21,19 @@ class UspDhcpService {
 
   /// Fetch DHCP reservations and transform to UI models.
   Future<List<DhcpReservationUIModel>> fetchReservations() async {
-    final raw = await DhcpReservations.fetch(_usp);
-    return raw.items
-        .map((r) => DhcpReservationUIModel(
-              instancePath: r.instancePath,
-              mac: r.chaddr,
-              ip: r.yiaddr,
-              enable: r.enable,
-            ))
-        .toList();
+    try {
+      final raw = await DhcpReservations.fetch(_usp);
+      return raw.items
+          .map((r) => DhcpReservationUIModel(
+                instancePath: r.instancePath,
+                mac: r.chaddr,
+                ip: r.yiaddr,
+                enable: r.enable,
+              ))
+          .toList();
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   /// Batch save: diff original vs current, execute delete/add/update.
@@ -36,68 +41,72 @@ class UspDhcpService {
     required List<DhcpReservationUIModel> original,
     required List<DhcpReservationUIModel> current,
   }) async {
-    // 1. Delete (in original, not in current)
-    final currentPaths = <String>{
-      for (final r in current)
-        if (r.instancePath != null) r.instancePath!,
-    };
-    final toDelete = original
-        .where((r) =>
-            r.instancePath != null && !currentPaths.contains(r.instancePath))
-        .toList();
+    try {
+      // 1. Delete (in original, not in current)
+      final currentPaths = <String>{
+        for (final r in current)
+          if (r.instancePath != null) r.instancePath!,
+      };
+      final toDelete = original
+          .where((r) =>
+              r.instancePath != null && !currentPaths.contains(r.instancePath))
+          .toList();
 
-    for (var i = 0; i < toDelete.length; i++) {
-      if (i > 0) {
-        await Future.delayed(const Duration(milliseconds: 300));
+      for (var i = 0; i < toDelete.length; i++) {
+        if (i > 0) {
+          await Future.delayed(const Duration(milliseconds: 300));
+        }
+        await DhcpReservations.delete(_usp, toDelete[i].instancePath!);
       }
-      await DhcpReservations.delete(_usp, toDelete[i].instancePath!);
-    }
 
-    // 2. Add (sequential with delay to avoid bridge 504)
-    final toAdd = current.where((r) => r.instancePath == null).toList();
+      // 2. Add (sequential with delay to avoid bridge 504)
+      final toAdd = current.where((r) => r.instancePath == null).toList();
 
-    for (var i = 0; i < toAdd.length; i++) {
-      if (i > 0) {
-        await Future.delayed(const Duration(milliseconds: 300));
+      for (var i = 0; i < toAdd.length; i++) {
+        if (i > 0) {
+          await Future.delayed(const Duration(milliseconds: 300));
+        }
+        final r = toAdd[i];
+        await DhcpReservations.add(
+          _usp,
+          enable: r.enable,
+          chaddr: r.mac,
+          yiaddr: r.ip,
+        );
       }
-      final r = toAdd[i];
-      await DhcpReservations.add(
-        _usp,
-        enable: r.enable,
-        chaddr: r.mac,
-        yiaddr: r.ip,
+
+      // 3. Update (same path, different content)
+      final originalByPath = <String, DhcpReservationUIModel>{
+        for (final r in original)
+          if (r.instancePath != null) r.instancePath!: r,
+      };
+
+      final toUpdate = <DhcpReservationUpdate>[];
+      for (final cur in current) {
+        if (cur.instancePath == null) continue;
+        final orig = originalByPath[cur.instancePath!];
+        if (orig == null) continue;
+        if (cur != orig) {
+          toUpdate.add(DhcpReservationUpdate(
+            instancePath: cur.instancePath!,
+            enable: cur.enable,
+            chaddr: cur.mac,
+            yiaddr: cur.ip,
+          ));
+        }
+      }
+
+      if (toUpdate.isNotEmpty) {
+        await DhcpReservations.updateMany(_usp, toUpdate);
+      }
+
+      return (
+        added: toAdd.length,
+        updated: toUpdate.length,
+        deleted: toDelete.length,
       );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
     }
-
-    // 3. Update (same path, different content)
-    final originalByPath = <String, DhcpReservationUIModel>{
-      for (final r in original)
-        if (r.instancePath != null) r.instancePath!: r,
-    };
-
-    final toUpdate = <DhcpReservationUpdate>[];
-    for (final cur in current) {
-      if (cur.instancePath == null) continue;
-      final orig = originalByPath[cur.instancePath!];
-      if (orig == null) continue;
-      if (cur != orig) {
-        toUpdate.add(DhcpReservationUpdate(
-          instancePath: cur.instancePath!,
-          enable: cur.enable,
-          chaddr: cur.mac,
-          yiaddr: cur.ip,
-        ));
-      }
-    }
-
-    if (toUpdate.isNotEmpty) {
-      await DhcpReservations.updateMany(_usp, toUpdate);
-    }
-
-    return (
-      added: toAdd.length,
-      updated: toUpdate.length,
-      deleted: toDelete.length,
-    );
   }
 }

--- a/lib/page/firewall/providers/firewall_data_provider.dart
+++ b/lib/page/firewall/providers/firewall_data_provider.dart
@@ -114,7 +114,8 @@ class FirewallDataNotifier extends AsyncNotifier<FirewallData> {
   Future<FirewallData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) {
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
 
     final List<Object> results;

--- a/lib/page/firewall/providers/firewall_data_provider.dart
+++ b/lib/page/firewall/providers/firewall_data_provider.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/dmz.g.dart';
 import 'package:privacy_gui/generated/firewall_chain_rules.g.dart';
 import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
@@ -111,12 +113,19 @@ class FirewallDataNotifier extends AsyncNotifier<FirewallData> {
 
   Future<FirewallData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
+    if (usp == null) {
+      throw const ConnectivityError(message: 'USP service not available');
+    }
 
-    final results = await Future.wait([
-      FirewallChainRules.fetch(usp),
-      Dmz.fetch(usp),
-    ]);
+    final List<Object> results;
+    try {
+      results = await Future.wait([
+        FirewallChainRules.fetch(usp),
+        Dmz.fetch(usp),
+      ]);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
 
     final chainRules = results[0] as FirewallChainRules;
     final dmzRaw = results[1] as Dmz;

--- a/lib/page/firewall/providers/usp_firewall_notifier.dart
+++ b/lib/page/firewall/providers/usp_firewall_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/framework/preservable_contract.dart';
@@ -73,7 +74,7 @@ class UspFirewallNotifier extends AutoDisposeNotifier<FirewallFeatureState>
         FirewallSettings(model: uiModel, ruleContext: ruleContext),
         const FirewallStatus(isLoading: false),
       );
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][Firewall] Fetch failed', error: e);
       return (
         null,
@@ -107,7 +108,7 @@ class UspFirewallNotifier extends AutoDisposeNotifier<FirewallFeatureState>
 
       // Force data provider to re-fetch so dashboard card updates too.
       ref.invalidate(firewallDataProvider);
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][Firewall] Save failed', error: e);
       rethrow;
     } finally {

--- a/lib/page/firewall/services/usp_firewall_service.dart
+++ b/lib/page/firewall/services/usp_firewall_service.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/firewall_chain_rules.g.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
@@ -57,15 +58,19 @@ class UspFirewallService {
     required FirewallUIModel pending,
     required FirewallRuleContext context,
   }) async {
-    final updates = buildSetPayload(
-      original: original,
-      pending: pending,
-      rules: context._ruleMap,
-    );
-    if (updates.isNotEmpty) {
-      await FirewallChainRules.updateMany(_usp, updates);
+    try {
+      final updates = buildSetPayload(
+        original: original,
+        pending: pending,
+        rules: context._ruleMap,
+      );
+      if (updates.isNotEmpty) {
+        await FirewallChainRules.updateMany(_usp, updates);
+      }
+      return updates.length;
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
     }
-    return updates.length;
   }
 
   // -------------------------------------------------------------------------

--- a/lib/page/instant_privacy/providers/instant_privacy_notifier.dart
+++ b/lib/page/instant_privacy/providers/instant_privacy_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/page/instant_privacy/providers/instant_privacy_state.dart';
@@ -15,18 +16,23 @@ class UspInstantPrivacyNotifier extends AsyncNotifier<UspInstantPrivacyState> {
 
   @override
   Future<UspInstantPrivacyState> build() async {
-    final result = await _svc.fetchAll();
+    try {
+      final result = await _svc.fetchAll();
 
-    logger.d('[USP] Instant Privacy fetched — '
-        'activeDevices: ${result.connectedDevices.length}, '
-        'isEnabled: ${result.isEnabled}');
+      logger.d('[USP][Privacy] Fetched — '
+          'activeDevices: ${result.connectedDevices.length}, '
+          'isEnabled: ${result.isEnabled}');
 
-    return UspInstantPrivacyState(
-      isEnabled: result.isEnabled,
-      connectedDevices: result.connectedDevices,
-      allowedDevices: result.allowedDevices,
-      macFilterContext: result.macFilterContext,
-    );
+      return UspInstantPrivacyState(
+        isEnabled: result.isEnabled,
+        connectedDevices: result.connectedDevices,
+        allowedDevices: result.allowedDevices,
+        macFilterContext: result.macFilterContext,
+      );
+    } on ServiceError catch (e) {
+      logger.e('[USP][Privacy] Fetch failed', error: e);
+      rethrow;
+    }
   }
 
   /// Enables Instant Privacy by snapshotting currently connected devices
@@ -41,9 +47,10 @@ class UspInstantPrivacyNotifier extends AsyncNotifier<UspInstantPrivacyState> {
       await ref.read(uspMutationLockProvider).withLock(() async {
         await _svc.enable(macs, s.macFilterContext);
       });
-      logger.d('[USP] Instant Privacy enabled — ${macs.length} MACs');
+      logger.d('[USP][Privacy] Enabled — ${macs.length} MACs');
       ref.invalidateSelf();
-    } catch (e) {
+    } on ServiceError catch (e) {
+      logger.e('[USP][Privacy] Enable failed', error: e);
       state = AsyncData(s.copyWith(isToggleLocked: false));
       rethrow;
     }
@@ -59,9 +66,10 @@ class UspInstantPrivacyNotifier extends AsyncNotifier<UspInstantPrivacyState> {
       await ref.read(uspMutationLockProvider).withLock(() async {
         await _svc.disable(s.macFilterContext);
       });
-      logger.d('[USP] Instant Privacy disabled');
+      logger.d('[USP][Privacy] Disabled');
       ref.invalidateSelf();
-    } catch (e) {
+    } on ServiceError catch (e) {
+      logger.e('[USP][Privacy] Disable failed', error: e);
       state = AsyncData(s.copyWith(isToggleLocked: false));
       rethrow;
     }
@@ -81,9 +89,10 @@ class UspInstantPrivacyNotifier extends AsyncNotifier<UspInstantPrivacyState> {
         state = AsyncData(s.copyWith(isToggleLocked: false));
         return;
       }
-      logger.d('[USP] Instant Privacy addMac — $mac');
+      logger.d('[USP][Privacy] addMac — $mac');
       ref.invalidateSelf();
-    } catch (e) {
+    } on ServiceError catch (e) {
+      logger.e('[USP][Privacy] addMac failed', error: e);
       state = AsyncData(s.copyWith(isToggleLocked: false));
       rethrow;
     }

--- a/lib/page/instant_privacy/services/instant_privacy_service.dart
+++ b/lib/page/instant_privacy/services/instant_privacy_service.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/connected_devices.g.dart';
 import 'package:privacy_gui/generated/mac_filter_access_points.g.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
@@ -162,10 +163,15 @@ class UspInstantPrivacyService {
 
   /// Fetch all data needed for Instant Privacy and return UI-safe result.
   Future<InstantPrivacyFetchResult> fetchAll() async {
-    final results = await Future.wait([
-      ConnectedDevices.fetch(_usp),
-      MacFilterAccessPoints.fetch(_usp),
-    ]);
+    final List<Object> results;
+    try {
+      results = await Future.wait([
+        ConnectedDevices.fetch(_usp),
+        MacFilterAccessPoints.fetch(_usp),
+      ]);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
 
     final devices = results[0] as ConnectedDevices;
     final macAps = results[1] as MacFilterAccessPoints;
@@ -197,23 +203,35 @@ class UspInstantPrivacyService {
 
   /// Enable MAC filtering on all APs with the given MAC whitelist.
   Future<void> enable(List<String> macs, MacFilterContext ctx) async {
-    final updates = buildEnableUpdates(macs, ctx._data);
-    await MacFilterAccessPoints.updateMany(_usp, updates);
+    try {
+      final updates = buildEnableUpdates(macs, ctx._data);
+      await MacFilterAccessPoints.updateMany(_usp, updates);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   /// Disable MAC filtering on all APs.
   Future<void> disable(MacFilterContext ctx) async {
-    final updates = buildDisableUpdates(ctx._data);
-    await MacFilterAccessPoints.updateMany(_usp, updates);
+    try {
+      final updates = buildDisableUpdates(ctx._data);
+      await MacFilterAccessPoints.updateMany(_usp, updates);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   /// Add a MAC address to the allowed list across all APs.
   /// Returns true if the MAC was added, false if already present.
   Future<bool> addMac(String mac, MacFilterContext ctx) async {
-    final updates = buildAddMacUpdates(mac, ctx._data);
-    if (updates.isEmpty) return false;
-    await MacFilterAccessPoints.updateMany(_usp, updates);
-    return true;
+    try {
+      final updates = buildAddMacUpdates(mac, ctx._data);
+      if (updates.isEmpty) return false;
+      await MacFilterAccessPoints.updateMany(_usp, updates);
+      return true;
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/page/instant_privacy/views/instant_privacy_view.dart
+++ b/lib/page/instant_privacy/views/instant_privacy_view.dart
@@ -32,21 +32,26 @@ class InstantPrivacyView extends ConsumerWidget {
       child: (childContext, constraints) {
         return asyncState.when(
           loading: () => const Center(child: CircularProgressIndicator()),
-          error: (error, _) => _buildError(context, ref),
+          error: (error, _) => _buildError(context, ref, error),
           data: (state) => _buildContent(context, ref, state),
         );
       },
     );
   }
 
-  Widget _buildError(BuildContext context, WidgetRef ref) {
+  Widget _buildError(BuildContext context, WidgetRef ref, Object error) {
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
+          AppIcon.font(Icons.error_outline,
+              size: 48, color: Theme.of(context).colorScheme.error),
+          AppGap.xl(),
           AppText.titleMedium('Unable to load Instant Privacy settings'),
           AppGap.md(),
-          AppButton.text(
+          AppText.bodyMedium(error.toString()),
+          AppGap.xxl(),
+          AppButton(
             label: 'Retry',
             onTap: () => ref.invalidate(uspInstantPrivacyProvider),
           ),

--- a/lib/page/instant_safety/providers/instant_safety_provider.dart
+++ b/lib/page/instant_safety/providers/instant_safety_provider.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/page/instant_safety/models/safe_browsing_ui_model.dart';
@@ -60,15 +61,20 @@ final uspInstantSafetyProvider =
 class UspInstantSafetyNotifier extends AsyncNotifier<UspInstantSafetyState> {
   @override
   Future<UspInstantSafetyState> build() async {
-    final svc = ref.read(uspInstantSafetyServiceProvider);
-    final uiModel = await svc.fetch();
+    try {
+      final svc = ref.read(uspInstantSafetyServiceProvider);
+      final uiModel = await svc.fetch();
 
-    logger.d('[USP][Safety]Instant Safety fetched — type: ${uiModel.type}');
+      logger.d('[USP][Safety]Instant Safety fetched — type: ${uiModel.type}');
 
-    return UspInstantSafetyState(
-      uiModel: uiModel,
-      pendingType: uiModel.type,
-    );
+      return UspInstantSafetyState(
+        uiModel: uiModel,
+        pendingType: uiModel.type,
+      );
+    } on ServiceError catch (e) {
+      logger.e('[USP][Safety] Fetch failed', error: e);
+      rethrow;
+    }
   }
 
   /// Toggle safe browsing on/off.
@@ -94,7 +100,8 @@ class UspInstantSafetyNotifier extends AsyncNotifier<UspInstantSafetyState> {
 
       // Re-fetch to confirm the change took effect.
       ref.invalidateSelf();
-    } catch (e) {
+    } on ServiceError catch (e) {
+      logger.e('[USP][Safety] Save failed', error: e);
       state = AsyncData(s.copyWith(isSaving: false));
       rethrow;
     }

--- a/lib/page/instant_safety/services/instant_safety_service.dart
+++ b/lib/page/instant_safety/services/instant_safety_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/lan_network_info.g.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
@@ -26,14 +27,22 @@ class UspInstantSafetyService {
 
   /// Fetch LAN network info and transform to safe browsing UI model.
   Future<SafeBrowsingUIModel> fetch() async {
-    final data = await LanNetworkInfo.fetch(_usp);
-    return buildUIModel(data);
+    try {
+      final data = await LanNetworkInfo.fetch(_usp);
+      return buildUIModel(data);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   /// Save safe browsing DNS setting.
   Future<void> save(SafeBrowsingType type) async {
-    final dnsValue = dnsValueForType(type);
-    await LanNetworkInfo.save(_usp, dnsServers: dnsValue);
+    try {
+      final dnsValue = dnsValueForType(type);
+      await LanNetworkInfo.save(_usp, dnsServers: dnsValue);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   // ─── Transform ─────────────────────────────────────────────

--- a/lib/page/instant_safety/views/instant_safety_view.dart
+++ b/lib/page/instant_safety/views/instant_safety_view.dart
@@ -26,21 +26,26 @@ class UspInstantSafetyView extends ConsumerWidget {
       child: (childContext, constraints) {
         return asyncState.when(
           loading: () => const Center(child: CircularProgressIndicator()),
-          error: (error, _) => _buildError(context, ref),
+          error: (error, _) => _buildError(context, ref, error),
           data: (state) => _buildContent(context, ref, state),
         );
       },
     );
   }
 
-  Widget _buildError(BuildContext context, WidgetRef ref) {
+  Widget _buildError(BuildContext context, WidgetRef ref, Object error) {
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
+          AppIcon.font(Icons.error_outline,
+              size: 48, color: Theme.of(context).colorScheme.error),
+          AppGap.xl(),
           AppText.titleMedium('Unable to load safe browsing settings'),
           AppGap.md(),
-          AppButton.text(
+          AppText.bodyMedium(error.toString()),
+          AppGap.xxl(),
+          AppButton(
             label: 'Retry',
             onTap: () => ref.invalidate(uspInstantSafetyProvider),
           ),

--- a/lib/page/internet_settings/providers/usp_internet_settings_notifier.dart
+++ b/lib/page/internet_settings/providers/usp_internet_settings_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/providers/usp_auth_coordinator.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
@@ -33,7 +34,9 @@ final preservableUspInternetSettingsProvider = AutoDisposeProvider<
 final uspInternetSettingsServiceProvider =
     Provider.autoDispose<UspInternetSettingsService>((ref) {
   final usp = ref.watch(uspServiceProvider);
-  if (usp == null) throw StateError('USP service not available');
+  if (usp == null) {
+    throw const ConnectivityError(message: 'USP service not available');
+  }
   return UspInternetSettingsService(usp);
 });
 
@@ -75,13 +78,16 @@ class UspInternetSettingsNotifier
   }) async {
     try {
       final usp = ref.read(uspServiceProvider);
-      if (usp == null) throw StateError('USP service not available');
+      if (usp == null) {
+        throw const ConnectivityError(message: 'USP service not available');
+      }
 
       // Session restore on page reload (WASM state may be lost)
       if (!usp.isAuthenticated) {
         await ref.read(uspAuthCoordinatorProvider).restoreSession();
         if (!usp.isAuthenticated) {
-          throw StateError('USP not authenticated after restore attempt');
+          throw const ConnectivityError(
+              message: 'USP not authenticated after restore attempt');
         }
       }
 
@@ -116,7 +122,7 @@ class UspInternetSettingsNotifier
           vlanInstancePath: result.vlanInstancePath,
         ),
       );
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][Network][WAN] Fetch failed', error: e);
       return (
         null,
@@ -162,7 +168,7 @@ class UspInternetSettingsNotifier
           clearActiveMutation: true,
         ),
       );
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][Network][WAN] Save failed', error: e);
       rethrow;
     } finally {

--- a/lib/page/internet_settings/providers/usp_internet_settings_notifier.dart
+++ b/lib/page/internet_settings/providers/usp_internet_settings_notifier.dart
@@ -35,7 +35,8 @@ final uspInternetSettingsServiceProvider =
     Provider.autoDispose<UspInternetSettingsService>((ref) {
   final usp = ref.watch(uspServiceProvider);
   if (usp == null) {
-    throw const ConnectivityError(message: 'USP service not available');
+    throw const ServiceNotInitializedError(
+        message: 'USP service not available');
   }
   return UspInternetSettingsService(usp);
 });
@@ -79,7 +80,8 @@ class UspInternetSettingsNotifier
     try {
       final usp = ref.read(uspServiceProvider);
       if (usp == null) {
-        throw const ConnectivityError(message: 'USP service not available');
+        throw const ServiceNotInitializedError(
+            message: 'USP service not available');
       }
 
       // Session restore on page reload (WASM state may be lost)

--- a/lib/page/internet_settings/providers/wan_data_provider.dart
+++ b/lib/page/internet_settings/providers/wan_data_provider.dart
@@ -42,7 +42,8 @@ class WanDataNotifier extends AsyncNotifier<WanData> {
   Future<WanData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) {
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
 
     try {
@@ -83,7 +84,8 @@ class WanDataNotifier extends AsyncNotifier<WanData> {
   Future<void> renewLease() async {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) {
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
 
     await ref.read(uspMutationLockProvider).withLock(() async {

--- a/lib/page/internet_settings/providers/wan_data_provider.dart
+++ b/lib/page/internet_settings/providers/wan_data_provider.dart
@@ -1,5 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/generated/wan_operations.g.dart';
 import 'package:privacy_gui/generated/wan_status.g.dart';
@@ -39,30 +41,37 @@ class WanDataNotifier extends AsyncNotifier<WanData> {
 
   Future<WanData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
+    if (usp == null) {
+      throw const ConnectivityError(message: 'USP service not available');
+    }
 
-    // WanStatus.fetch includes IPv6Enable (merged in YAML v1.1.0).
-    // Gateway + IPv6 addresses are combined into one manual request
-    // to reduce throttler pressure (was 3 → now 2 USP requests).
-    final results = await Future.wait([
-      WanStatus.fetch(usp),
-      _fetchGatewayAndIpv6Addresses(usp),
-    ]);
+    try {
+      // WanStatus.fetch includes IPv6Enable (merged in YAML v1.1.0).
+      // Gateway + IPv6 addresses are combined into one manual request
+      // to reduce throttler pressure (was 3 → now 2 USP requests).
+      final results = await Future.wait([
+        WanStatus.fetch(usp),
+        _fetchGatewayAndIpv6Addresses(usp),
+      ]);
 
-    final wanStatus = results[0] as WanStatus;
-    final extra = results[1] as ({String gateway, List<String> ipv6Addresses});
+      final wanStatus = results[0] as WanStatus;
+      final extra =
+          results[1] as ({String gateway, List<String> ipv6Addresses});
 
-    final svc = UspDeviceService();
-    final model = svc.buildWanStatusUIModel(
-      wanStatus: wanStatus,
-      gateway: extra.gateway,
-      ipv6Addresses: extra.ipv6Addresses,
-    );
+      final svc = UspDeviceService();
+      final model = svc.buildWanStatusUIModel(
+        wanStatus: wanStatus,
+        gateway: extra.gateway,
+        ipv6Addresses: extra.ipv6Addresses,
+      );
 
-    logger.d('[USP][WanData] Fetched — ip=${wanStatus.ipAddress}, '
-        'status=${wanStatus.status}, gateway=${extra.gateway}, '
-        'ipv6=${wanStatus.ipv6Enabled}');
-    return WanData(model: model);
+      logger.d('[USP][WanData] Fetched — ip=${wanStatus.ipAddress}, '
+          'status=${wanStatus.status}, gateway=${extra.gateway}, '
+          'ipv6=${wanStatus.ipv6Enabled}');
+      return WanData(model: model);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   // ── Mutation ──
@@ -73,20 +82,26 @@ class WanDataNotifier extends AsyncNotifier<WanData> {
   /// Waits 2 seconds then re-fetches WAN status.
   Future<void> renewLease() async {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
+    if (usp == null) {
+      throw const ConnectivityError(message: 'USP service not available');
+    }
 
     await ref.read(uspMutationLockProvider).withLock(() async {
-      await WanOperations.renewDhcpLease(usp);
-      await Future.delayed(const Duration(seconds: 2));
-      final wan = await WanStatus.fetch(usp);
-      final prev = state.valueOrNull;
-      final svc = UspDeviceService();
-      state = AsyncData(WanData(
-        model: svc.buildWanStatusUIModel(
-          wanStatus: wan,
-          gateway: prev?.model.gateway ?? '',
-        ),
-      ));
+      try {
+        await WanOperations.renewDhcpLease(usp);
+        await Future.delayed(const Duration(seconds: 2));
+        final wan = await WanStatus.fetch(usp);
+        final prev = state.valueOrNull;
+        final svc = UspDeviceService();
+        state = AsyncData(WanData(
+          model: svc.buildWanStatusUIModel(
+            wanStatus: wan,
+            gateway: prev?.model.gateway ?? '',
+          ),
+        ));
+      } catch (e) {
+        throw mapUspErrorToServiceError(e);
+      }
     });
   }
 

--- a/lib/page/internet_settings/services/usp_internet_settings_service.dart
+++ b/lib/page/internet_settings/services/usp_internet_settings_service.dart
@@ -1,3 +1,4 @@
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/generated/ipv6settings.g.dart';
 import 'package:privacy_gui/generated/ppp_interface.g.dart';
@@ -25,30 +26,34 @@ class UspInternetSettingsService {
 
   /// Fetch WAN, IPv6, PPP, and VLAN settings in parallel.
   Future<InternetSettingsFetchResult> fetchSettings() async {
-    final results = await Future.wait([
-      WanSettings.fetch(_usp),
-      Ipv6Settings.fetch(_usp),
-      PppInterface.fetch(_usp),
-      VlanTermination.fetch(_usp),
-    ]);
-    final wan = results[0] as WanSettings;
-    final ipv6 = results[1] as Ipv6Settings;
-    final ppp = results[2] as PppInterface;
-    final vlan = results[3] as VlanTermination;
+    try {
+      final results = await Future.wait([
+        WanSettings.fetch(_usp),
+        Ipv6Settings.fetch(_usp),
+        PppInterface.fetch(_usp),
+        VlanTermination.fetch(_usp),
+      ]);
+      final wan = results[0] as WanSettings;
+      final ipv6 = results[1] as Ipv6Settings;
+      final ppp = results[2] as PppInterface;
+      final vlan = results[3] as VlanTermination;
 
-    final pppInstance = ppp.items.isNotEmpty ? ppp.items.first : null;
-    final vlanInstance = vlan.items.isNotEmpty ? vlan.items.first : null;
+      final pppInstance = ppp.items.isNotEmpty ? ppp.items.first : null;
+      final vlanInstance = vlan.items.isNotEmpty ? vlan.items.first : null;
 
-    return InternetSettingsFetchResult(
-      form: _buildForm(wan, ipv6, pppInstance, vlanInstance),
-      readOnlyInfo: _buildReadOnlyInfo(wan, pppInstance),
-      pppInstancePath: pppInstance?.instancePath,
-      vlanInstancePath: vlanInstance?.instancePath,
-      debugAddressingType: wan.addressingType,
-      debugBridgeEnabled: wan.bridgeEnabled,
-      debugMtu: wan.mtu,
-      debugIpv6Enabled: ipv6.ipv6Enabled,
-    );
+      return InternetSettingsFetchResult(
+        form: _buildForm(wan, ipv6, pppInstance, vlanInstance),
+        readOnlyInfo: _buildReadOnlyInfo(wan, pppInstance),
+        pppInstancePath: pppInstance?.instancePath,
+        vlanInstancePath: vlanInstance?.instancePath,
+        debugAddressingType: wan.addressingType,
+        debugBridgeEnabled: wan.bridgeEnabled,
+        debugMtu: wan.mtu,
+        debugIpv6Enabled: ipv6.ipv6Enabled,
+      );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -128,36 +133,40 @@ class UspInternetSettingsService {
     String? pppInstancePath,
     String? vlanInstancePath,
   }) async {
-    // Step 1: PPP lifecycle
-    final pppPath = await _handlePppLifecycle(
-      original,
-      edited,
-      currentInstancePath: pppInstancePath,
-    );
+    try {
+      // Step 1: PPP lifecycle
+      final pppPath = await _handlePppLifecycle(
+        original,
+        edited,
+        currentInstancePath: pppInstancePath,
+      );
 
-    // Step 2: VLAN lifecycle
-    final vlanPath = await _handleVlanLifecycle(
-      original,
-      edited,
-      currentInstancePath: vlanInstancePath,
-    );
+      // Step 2: VLAN lifecycle
+      final vlanPath = await _handleVlanLifecycle(
+        original,
+        edited,
+        currentInstancePath: vlanInstancePath,
+      );
 
-    // Step 3: Singleton WAN fields
-    await _saveWanSettings(original, edited);
+      // Step 3: Singleton WAN fields
+      await _saveWanSettings(original, edited);
 
-    // Step 4: PPP instance fields
-    if (pppPath != null &&
-        edited.connectionType == UspWanConnectionType.pppoe) {
-      await _savePppSettings(original, edited, pppPath);
+      // Step 4: PPP instance fields
+      if (pppPath != null &&
+          edited.connectionType == UspWanConnectionType.pppoe) {
+        await _savePppSettings(original, edited, pppPath);
+      }
+
+      // Step 5: VLAN instance fields
+      if (vlanPath != null && edited.vlanEnabled) {
+        await _saveVlanSettings(original, edited, vlanPath);
+      }
+
+      // Step 6: IPv6 fields
+      await _saveIpv6Settings(original, edited);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
     }
-
-    // Step 5: VLAN instance fields
-    if (vlanPath != null && edited.vlanEnabled) {
-      await _saveVlanSettings(original, edited, vlanPath);
-    }
-
-    // Step 6: IPv6 fields
-    await _saveIpv6Settings(original, edited);
   }
 
   // ---------------------------------------------------------------------------
@@ -330,8 +339,21 @@ class UspInternetSettingsService {
   // DHCP Renewal
   // ---------------------------------------------------------------------------
 
-  Future<void> renewDhcpLease() => WanOperations.renewDhcpLease(_usp);
-  Future<void> renewDhcpv6Lease() => WanOperations.renewDhcpv6Lease(_usp);
+  Future<void> renewDhcpLease() async {
+    try {
+      await WanOperations.renewDhcpLease(_usp);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
+  }
+
+  Future<void> renewDhcpv6Lease() async {
+    try {
+      await WanOperations.renewDhcpv6Lease(_usp);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
+  }
 
   // ---------------------------------------------------------------------------
   // Helpers

--- a/lib/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier.dart
+++ b/lib/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/framework/preservable_contract.dart';
@@ -63,7 +64,7 @@ class UspIpv6PortServiceNotifier
         Ipv6PortServiceRuleList(rules: rules),
         const Ipv6PortServiceStatus(),
       );
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][Firewall][IPv6Port] Fetch failed', error: e);
       return (
         null,
@@ -96,7 +97,7 @@ class UspIpv6PortServiceNotifier
             'added: ${result.added}, updated: ${result.updated}, '
             'deleted: ${result.deleted}');
       });
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][Firewall][IPv6Port] Save failed', error: e);
       rethrow;
     } finally {

--- a/lib/page/ipv6_port_service/services/usp_ipv6_port_service_service.dart
+++ b/lib/page/ipv6_port_service/services/usp_ipv6_port_service_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/ipv6port_service.g.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
@@ -20,8 +21,12 @@ class UspIpv6PortServiceService {
 
   /// Fetch IPv6 port service rules and transform to UI models.
   Future<List<Ipv6PortServiceRuleUIModel>> fetch() async {
-    final data = await Ipv6PortService.fetch(_usp);
-    return buildRuleUIModels(data);
+    try {
+      final data = await Ipv6PortService.fetch(_usp);
+      return buildRuleUIModels(data);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   /// Batch save: diff original vs current, execute delete/add/update.
@@ -29,78 +34,82 @@ class UspIpv6PortServiceService {
     required List<Ipv6PortServiceRuleUIModel> original,
     required List<Ipv6PortServiceRuleUIModel> current,
   }) async {
-    // 1. Delete (in original, not in current)
-    final currentPaths = <String>{
-      for (final r in current)
-        if (r.instancePath != null) r.instancePath!,
-    };
-    final toDelete = original
-        .where((r) =>
-            r.instancePath != null && !currentPaths.contains(r.instancePath))
-        .toList();
+    try {
+      // 1. Delete (in original, not in current)
+      final currentPaths = <String>{
+        for (final r in current)
+          if (r.instancePath != null) r.instancePath!,
+      };
+      final toDelete = original
+          .where((r) =>
+              r.instancePath != null && !currentPaths.contains(r.instancePath))
+          .toList();
 
-    for (var i = 0; i < toDelete.length; i++) {
-      if (i > 0) {
-        await Future.delayed(const Duration(milliseconds: 300));
+      for (var i = 0; i < toDelete.length; i++) {
+        if (i > 0) {
+          await Future.delayed(const Duration(milliseconds: 300));
+        }
+        await Ipv6PortService.delete(_usp, toDelete[i].instancePath!);
       }
-      await Ipv6PortService.delete(_usp, toDelete[i].instancePath!);
-    }
 
-    // 2. Add (instancePath == null → new)
-    final toAdd = current.where((r) => r.instancePath == null).toList();
+      // 2. Add (instancePath == null → new)
+      final toAdd = current.where((r) => r.instancePath == null).toList();
 
-    for (var i = 0; i < toAdd.length; i++) {
-      if (i > 0) {
-        await Future.delayed(const Duration(milliseconds: 300));
-      }
-      final r = toAdd[i];
-      await Ipv6PortService.add(
-        _usp,
-        enable: r.enabled,
-        description: r.description,
-        ipVersion: 6,
-        destIp: r.ipv6Address,
-        destPort: r.startPort,
-        destPortRangeMax: r.endPort,
-        protocol: mapDisplayToIana(r.protocol),
-        target: 'Accept',
-      );
-    }
-
-    // 3. Update (same path, different content)
-    final originalByPath = <String, Ipv6PortServiceRuleUIModel>{
-      for (final r in original)
-        if (r.instancePath != null) r.instancePath!: r,
-    };
-
-    final toUpdate = <Ipv6PortServiceRuleUpdate>[];
-    for (final cur in current) {
-      if (cur.instancePath == null) continue;
-      final orig = originalByPath[cur.instancePath!];
-      if (orig == null) continue;
-      if (cur != orig) {
-        toUpdate.add(Ipv6PortServiceRuleUpdate(
-          instancePath: cur.instancePath!,
-          enable: cur.enabled,
-          description: cur.description,
-          destIp: cur.ipv6Address,
-          destPort: cur.startPort,
-          destPortRangeMax: cur.endPort,
-          protocol: mapDisplayToIana(cur.protocol),
+      for (var i = 0; i < toAdd.length; i++) {
+        if (i > 0) {
+          await Future.delayed(const Duration(milliseconds: 300));
+        }
+        final r = toAdd[i];
+        await Ipv6PortService.add(
+          _usp,
+          enable: r.enabled,
+          description: r.description,
+          ipVersion: 6,
+          destIp: r.ipv6Address,
+          destPort: r.startPort,
+          destPortRangeMax: r.endPort,
+          protocol: mapDisplayToIana(r.protocol),
           target: 'Accept',
-        ));
+        );
       }
-    }
 
-    if (toUpdate.isNotEmpty) {
-      await Ipv6PortService.updateMany(_usp, toUpdate);
-    }
+      // 3. Update (same path, different content)
+      final originalByPath = <String, Ipv6PortServiceRuleUIModel>{
+        for (final r in original)
+          if (r.instancePath != null) r.instancePath!: r,
+      };
 
-    return (
-      added: toAdd.length,
-      updated: toUpdate.length,
-      deleted: toDelete.length,
-    );
+      final toUpdate = <Ipv6PortServiceRuleUpdate>[];
+      for (final cur in current) {
+        if (cur.instancePath == null) continue;
+        final orig = originalByPath[cur.instancePath!];
+        if (orig == null) continue;
+        if (cur != orig) {
+          toUpdate.add(Ipv6PortServiceRuleUpdate(
+            instancePath: cur.instancePath!,
+            enable: cur.enabled,
+            description: cur.description,
+            destIp: cur.ipv6Address,
+            destPort: cur.startPort,
+            destPortRangeMax: cur.endPort,
+            protocol: mapDisplayToIana(cur.protocol),
+            target: 'Accept',
+          ));
+        }
+      }
+
+      if (toUpdate.isNotEmpty) {
+        await Ipv6PortService.updateMany(_usp, toUpdate);
+      }
+
+      return (
+        added: toAdd.length,
+        updated: toUpdate.length,
+        deleted: toDelete.length,
+      );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/page/local_network/providers/dhcp_data_provider.dart
+++ b/lib/page/local_network/providers/dhcp_data_provider.dart
@@ -58,7 +58,8 @@ class DhcpDataNotifier extends AsyncNotifier<DhcpData> {
   Future<DhcpData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) {
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
 
     try {

--- a/lib/page/local_network/providers/dhcp_data_provider.dart
+++ b/lib/page/local_network/providers/dhcp_data_provider.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/generated/dhcp_clients.g.dart';
 import 'package:privacy_gui/generated/dhcp_reservations.g.dart';
@@ -55,47 +57,53 @@ class DhcpDataNotifier extends AsyncNotifier<DhcpData> {
 
   Future<DhcpData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
+    if (usp == null) {
+      throw const ConnectivityError(message: 'USP service not available');
+    }
 
-    final results = await Future.wait([
-      DhcpClients.fetch(usp),
-      DhcpReservations.fetch(usp),
-    ]);
+    try {
+      final results = await Future.wait([
+        DhcpClients.fetch(usp),
+        DhcpReservations.fetch(usp),
+      ]);
 
-    final clients = results[0] as DhcpClients;
-    final reservations = results[1] as DhcpReservations;
+      final clients = results[0] as DhcpClients;
+      final reservations = results[1] as DhcpReservations;
 
-    // Hostname enrichment: read pre-computed map from devices provider.
-    final devicesData = ref.read(devicesDataProvider).valueOrNull;
-    final hostNameByMac = devicesData?.hostNameByMac ?? const {};
+      // Hostname enrichment: read pre-computed map from devices provider.
+      final devicesData = ref.read(devicesDataProvider).valueOrNull;
+      final hostNameByMac = devicesData?.hostNameByMac ?? const {};
 
-    final clientModels = clients.items
-        .map((c) => DhcpClientUIModel(
-              mac: c.chaddr,
-              ip: c.ipAddress,
-              active: c.active,
-              hostName: hostNameByMac[c.chaddr.trim().toUpperCase()] ?? '',
-              leaseExpiry: c.leaseTimeRemaining,
-            ))
-        .toList();
+      final clientModels = clients.items
+          .map((c) => DhcpClientUIModel(
+                mac: c.chaddr,
+                ip: c.ipAddress,
+                active: c.active,
+                hostName: hostNameByMac[c.chaddr.trim().toUpperCase()] ?? '',
+                leaseExpiry: c.leaseTimeRemaining,
+              ))
+          .toList();
 
-    final reservationModels = reservations.items
-        .map((r) => DhcpReservationUIModel(
-              instancePath: r.instancePath,
-              mac: r.chaddr,
-              ip: r.yiaddr,
-              enable: r.enable,
-            ))
-        .toList();
+      final reservationModels = reservations.items
+          .map((r) => DhcpReservationUIModel(
+                instancePath: r.instancePath,
+                mac: r.chaddr,
+                ip: r.yiaddr,
+                enable: r.enable,
+              ))
+          .toList();
 
-    logger.d('[USP][DhcpData] Fetched — '
-        'clients: ${clients.items.length}, '
-        'reservations: ${reservations.items.length}');
+      logger.d('[USP][DhcpData] Fetched — '
+          'clients: ${clients.items.length}, '
+          'reservations: ${reservations.items.length}');
 
-    return DhcpData(
-      clientModels: clientModels,
-      reservationModels: reservationModels,
-    );
+      return DhcpData(
+        clientModels: clientModels,
+        reservationModels: reservationModels,
+      );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   void _debouncedInvalidate() {

--- a/lib/page/local_network/providers/ethernet_data_provider.dart
+++ b/lib/page/local_network/providers/ethernet_data_provider.dart
@@ -1,6 +1,8 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/ethernet_interfaces.g.dart';
 import 'package:privacy_gui/page/_shared/models/ethernet_port_ui_model.dart';
 import 'package:privacy_gui/page/_shared/services/usp_device_service.dart';
@@ -69,13 +71,21 @@ class EthernetDataNotifier extends AsyncNotifier<EthernetData> {
 
   Future<EthernetData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
+    if (usp == null) {
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
+    }
 
     // Parallel: fetch Ethernet interfaces + bridge port map
-    final results = await Future.wait([
-      EthernetInterfaces.fetch(usp),
-      _fetchBridgePortMap(usp),
-    ]);
+    final List<Object> results;
+    try {
+      results = await Future.wait([
+        EthernetInterfaces.fetch(usp),
+        _fetchBridgePortMap(usp),
+      ]);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
     final ethernetInterfaces = results[0] as EthernetInterfaces;
     final bridgePortMap = results[1] as Map<String, String>;
 

--- a/lib/page/local_network/providers/lan_data_provider.dart
+++ b/lib/page/local_network/providers/lan_data_provider.dart
@@ -45,7 +45,8 @@ class LanDataNotifier extends AsyncNotifier<LanData> {
   Future<LanData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) {
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
 
     // LanNetworkInfo.fetch includes IPv6Enable (merged in YAML v1.2.0).

--- a/lib/page/local_network/providers/lan_data_provider.dart
+++ b/lib/page/local_network/providers/lan_data_provider.dart
@@ -1,6 +1,8 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/lan_network_info.g.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
@@ -42,14 +44,21 @@ class LanDataNotifier extends AsyncNotifier<LanData> {
 
   Future<LanData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
+    if (usp == null) {
+      throw const ConnectivityError(message: 'USP service not available');
+    }
 
     // LanNetworkInfo.fetch includes IPv6Enable (merged in YAML v1.2.0).
     // IPv6 addresses still need a separate multi-instance query.
-    final results = await Future.wait([
-      LanNetworkInfo.fetch(usp),
-      _fetchLanIpv6Addresses(usp),
-    ]);
+    final List<Object> results;
+    try {
+      results = await Future.wait([
+        LanNetworkInfo.fetch(usp),
+        _fetchLanIpv6Addresses(usp),
+      ]);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
 
     final lanInfo = results[0] as LanNetworkInfo;
     final ipv6Addresses = results[1] as List<String>;

--- a/lib/page/local_network/providers/usp_local_network_notifier.dart
+++ b/lib/page/local_network/providers/usp_local_network_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/framework/preservable_contract.dart';
@@ -83,7 +84,7 @@ class UspLocalNetworkNotifier
         LocalNetworkSettings(model: uiModel),
         const LocalNetworkStatus(isLoading: false),
       );
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][Network][LAN] Fetch failed', error: e);
       return (
         null,
@@ -113,7 +114,7 @@ class UspLocalNetworkNotifier
 
       // Force data provider to re-fetch so dashboard card updates too.
       ref.invalidate(lanDataProvider);
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][Network][LAN] Save failed', error: e);
       rethrow;
     } finally {

--- a/lib/page/local_network/services/usp_local_network_service.dart
+++ b/lib/page/local_network/services/usp_local_network_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/lan_network_info.g.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
@@ -27,28 +28,36 @@ class UspLocalNetworkService {
     required LocalNetworkUIModel original,
     required LocalNetworkUIModel pending,
   }) async {
-    await LanNetworkInfo.save(
-      _usp,
-      ipAddress:
-          original.ipAddress != pending.ipAddress ? pending.ipAddress : null,
-      subnetMask:
-          original.subnetMask != pending.subnetMask ? pending.subnetMask : null,
-      hostName: original.hostName != pending.hostName ? pending.hostName : null,
-      dhcpEnabled: original.dhcpEnabled != pending.dhcpEnabled
-          ? pending.dhcpEnabled
-          : null,
-      minAddress:
-          original.minAddress != pending.minAddress ? pending.minAddress : null,
-      maxAddress:
-          original.maxAddress != pending.maxAddress ? pending.maxAddress : null,
-      leaseTime: original.leaseTimeMinutes != pending.leaseTimeMinutes
-          ? pending.leaseTimeMinutes * 60
-          : null,
-      dnsServers: _dnsChanged(original, pending)
-          ? joinDnsServers(
-              pending.dnsServer1, pending.dnsServer2, pending.dnsServer3)
-          : null,
-    );
+    try {
+      await LanNetworkInfo.save(
+        _usp,
+        ipAddress:
+            original.ipAddress != pending.ipAddress ? pending.ipAddress : null,
+        subnetMask: original.subnetMask != pending.subnetMask
+            ? pending.subnetMask
+            : null,
+        hostName:
+            original.hostName != pending.hostName ? pending.hostName : null,
+        dhcpEnabled: original.dhcpEnabled != pending.dhcpEnabled
+            ? pending.dhcpEnabled
+            : null,
+        minAddress: original.minAddress != pending.minAddress
+            ? pending.minAddress
+            : null,
+        maxAddress: original.maxAddress != pending.maxAddress
+            ? pending.maxAddress
+            : null,
+        leaseTime: original.leaseTimeMinutes != pending.leaseTimeMinutes
+            ? pending.leaseTimeMinutes * 60
+            : null,
+        dnsServers: _dnsChanged(original, pending)
+            ? joinDnsServers(
+                pending.dnsServer1, pending.dnsServer2, pending.dnsServer3)
+            : null,
+      );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   static bool _dnsChanged(LocalNetworkUIModel o, LocalNetworkUIModel p) {

--- a/lib/page/network_diagnostics/providers/usp_network_diagnostics_notifier.dart
+++ b/lib/page/network_diagnostics/providers/usp_network_diagnostics_notifier.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/providers/sse_providers.dart';
 import 'package:privacy_gui/core/usp/services/sse_operation_awaiter.dart';
@@ -30,7 +31,8 @@ class UspNetworkDiagnosticsNotifier
   SseOperationAwaiter get _awaiter {
     final awaiter = ref.read(sseOperationAwaiterProvider);
     if (awaiter == null) {
-      throw StateError('SseOperationAwaiter not available');
+      throw const ConnectivityError(
+          message: 'SseOperationAwaiter not available');
     }
     return awaiter;
   }

--- a/lib/page/network_diagnostics/views/usp_network_diagnostics_view.dart
+++ b/lib/page/network_diagnostics/views/usp_network_diagnostics_view.dart
@@ -42,14 +42,14 @@ class _UspNetworkDiagnosticsViewState
       child: (childContext, constraints) {
         return asyncState.when(
           loading: () => const Center(child: AppLoader()),
-          error: (error, _) => _buildPageError(context),
+          error: (error, _) => _buildPageError(context, error),
           data: (state) => _buildContent(context, state),
         );
       },
     );
   }
 
-  Widget _buildPageError(BuildContext context) {
+  Widget _buildPageError(BuildContext context, Object error) {
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -59,6 +59,8 @@ class _UspNetworkDiagnosticsViewState
           AppGap.xl(),
           AppText.titleMedium('Unable to load diagnostics'),
           AppGap.md(),
+          AppText.bodyMedium(error.toString()),
+          AppGap.xxl(),
           AppButton(
             label: 'Retry',
             onTap: () => ref.invalidate(uspNetworkDiagnosticsProvider),

--- a/lib/page/port_forwarding/providers/port_forwarding_data_provider.dart
+++ b/lib/page/port_forwarding/providers/port_forwarding_data_provider.dart
@@ -54,7 +54,8 @@ class PortForwardingDataNotifier extends AsyncNotifier<PortForwardingData> {
   Future<PortForwardingData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) {
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
     try {
       final codegen = await PortForwarding.fetch(usp);
@@ -147,7 +148,8 @@ class PortForwardingDataNotifier extends AsyncNotifier<PortForwardingData> {
   UspService get _usp {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) {
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
     return usp;
   }

--- a/lib/page/port_forwarding/providers/port_forwarding_data_provider.dart
+++ b/lib/page/port_forwarding/providers/port_forwarding_data_provider.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/port_forwarding.g.dart';
 import 'package:privacy_gui/page/_shared/models/port_forwarding_rule_ui_model.dart';
 import 'package:privacy_gui/page/_shared/services/usp_device_service.dart';
@@ -51,12 +53,18 @@ class PortForwardingDataNotifier extends AsyncNotifier<PortForwardingData> {
 
   Future<PortForwardingData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
-    final codegen = await PortForwarding.fetch(usp);
-    final svc = ref.read(uspDeviceServiceProvider);
-    return PortForwardingData(
-      ruleModels: svc.buildPortForwardingRuleUIModels(codegen),
-    );
+    if (usp == null) {
+      throw const ConnectivityError(message: 'USP service not available');
+    }
+    try {
+      final codegen = await PortForwarding.fetch(usp);
+      final svc = ref.read(uspDeviceServiceProvider);
+      return PortForwardingData(
+        ruleModels: svc.buildPortForwardingRuleUIModels(codegen),
+      );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -138,7 +146,9 @@ class PortForwardingDataNotifier extends AsyncNotifier<PortForwardingData> {
 
   UspService get _usp {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
+    if (usp == null) {
+      throw const ConnectivityError(message: 'USP service not available');
+    }
     return usp;
   }
 }

--- a/lib/page/port_forwarding/providers/port_triggering_data_provider.dart
+++ b/lib/page/port_forwarding/providers/port_triggering_data_provider.dart
@@ -1,5 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/port_triggering.g.dart';
 import 'package:privacy_gui/page/port_forwarding/models/port_triggering_rule_ui_model.dart';
 import 'package:privacy_gui/page/_shared/services/usp_device_service.dart';
@@ -35,12 +37,18 @@ class PortTriggeringDataNotifier extends AsyncNotifier<PortTriggeringData> {
 
   Future<PortTriggeringData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
-    final codegen = await PortTriggering.fetch(usp);
-    final svc = ref.read(uspDeviceServiceProvider);
-    return PortTriggeringData(
-      ruleModels: svc.buildPortTriggeringRuleUIModels(codegen),
-    );
+    if (usp == null) {
+      throw const ConnectivityError(message: 'USP service not available');
+    }
+    try {
+      final codegen = await PortTriggering.fetch(usp);
+      final svc = ref.read(uspDeviceServiceProvider);
+      return PortTriggeringData(
+        ruleModels: svc.buildPortTriggeringRuleUIModels(codegen),
+      );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -153,7 +161,9 @@ class PortTriggeringDataNotifier extends AsyncNotifier<PortTriggeringData> {
 
   UspService get _usp {
     final usp = ref.read(uspServiceProvider);
-    if (usp == null) throw StateError('USP service not available');
+    if (usp == null) {
+      throw const ConnectivityError(message: 'USP service not available');
+    }
     return usp;
   }
 }

--- a/lib/page/port_forwarding/providers/port_triggering_data_provider.dart
+++ b/lib/page/port_forwarding/providers/port_triggering_data_provider.dart
@@ -38,7 +38,8 @@ class PortTriggeringDataNotifier extends AsyncNotifier<PortTriggeringData> {
   Future<PortTriggeringData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) {
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
     try {
       final codegen = await PortTriggering.fetch(usp);
@@ -162,7 +163,8 @@ class PortTriggeringDataNotifier extends AsyncNotifier<PortTriggeringData> {
   UspService get _usp {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) {
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
     return usp;
   }

--- a/lib/page/port_forwarding/providers/usp_port_forwarding_page_notifier.dart
+++ b/lib/page/port_forwarding/providers/usp_port_forwarding_page_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
@@ -84,7 +85,7 @@ class UspPortForwardingPageNotifier
         ),
         const PortForwardingPageStatus(),
       );
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][Firewall][PortForwarding] Fetch failed', error: e);
       return (
         null,
@@ -130,7 +131,7 @@ class UspPortForwardingPageNotifier
       // Invalidate Layer 1 providers to refresh dashboard card
       ref.invalidate(portForwardingDataProvider);
       ref.invalidate(portTriggeringDataProvider);
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][Firewall][PortForwarding] Save failed', error: e);
       rethrow;
     } finally {

--- a/lib/page/port_forwarding/services/usp_port_forwarding_service.dart
+++ b/lib/page/port_forwarding/services/usp_port_forwarding_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/port_forwarding.g.dart';
 import 'package:privacy_gui/generated/port_triggering.g.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
@@ -27,14 +28,22 @@ class UspPortForwardingService {
 
   /// Fetch port forwarding rules and transform to UI models.
   Future<List<PortForwardingRuleUIModel>> fetchForwardingRules() async {
-    final raw = await PortForwarding.fetch(_usp);
-    return _deviceSvc.buildPortForwardingRuleUIModels(raw);
+    try {
+      final raw = await PortForwarding.fetch(_usp);
+      return _deviceSvc.buildPortForwardingRuleUIModels(raw);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   /// Fetch port triggering rules and transform to UI models.
   Future<List<PortTriggeringRuleUIModel>> fetchTriggeringRules() async {
-    final raw = await PortTriggering.fetch(_usp);
-    return _deviceSvc.buildPortTriggeringRuleUIModels(raw);
+    try {
+      final raw = await PortTriggering.fetch(_usp);
+      return _deviceSvc.buildPortTriggeringRuleUIModels(raw);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -46,73 +55,77 @@ class UspPortForwardingService {
     required List<PortForwardingRuleUIModel> original,
     required List<PortForwardingRuleUIModel> current,
   }) async {
-    // 1. Delete
-    final currentPaths = <String>{
-      for (final r in current)
-        if (r.instancePath != null) r.instancePath!,
-    };
-    final toDelete = original
-        .where((r) =>
-            r.instancePath != null && !currentPaths.contains(r.instancePath))
-        .toList();
-    for (var i = 0; i < toDelete.length; i++) {
-      if (i > 0) {
-        await Future.delayed(const Duration(milliseconds: 300));
+    try {
+      // 1. Delete
+      final currentPaths = <String>{
+        for (final r in current)
+          if (r.instancePath != null) r.instancePath!,
+      };
+      final toDelete = original
+          .where((r) =>
+              r.instancePath != null && !currentPaths.contains(r.instancePath))
+          .toList();
+      for (var i = 0; i < toDelete.length; i++) {
+        if (i > 0) {
+          await Future.delayed(const Duration(milliseconds: 300));
+        }
+        await PortForwarding.delete(_usp, toDelete[i].instancePath!);
       }
-      await PortForwarding.delete(_usp, toDelete[i].instancePath!);
-    }
 
-    // 2. Add
-    final toAdd = current.where((r) => r.instancePath == null).toList();
-    for (var i = 0; i < toAdd.length; i++) {
-      if (i > 0) {
-        await Future.delayed(const Duration(milliseconds: 300));
+      // 2. Add
+      final toAdd = current.where((r) => r.instancePath == null).toList();
+      for (var i = 0; i < toAdd.length; i++) {
+        if (i > 0) {
+          await Future.delayed(const Duration(milliseconds: 300));
+        }
+        final r = toAdd[i];
+        await PortForwarding.add(
+          _usp,
+          enabled: r.enabled,
+          externalPort: r.externalPort,
+          externalPortEndRange: r.externalPortEndRange,
+          internalPort: r.internalPort,
+          internalClient: r.internalClient,
+          protocol: r.protocol,
+          description: r.description,
+        );
       }
-      final r = toAdd[i];
-      await PortForwarding.add(
-        _usp,
-        enabled: r.enabled,
-        externalPort: r.externalPort,
-        externalPortEndRange: r.externalPortEndRange,
-        internalPort: r.internalPort,
-        internalClient: r.internalClient,
-        protocol: r.protocol,
-        description: r.description,
+
+      // 3. Update
+      final originalByPath = <String, PortForwardingRuleUIModel>{
+        for (final r in original)
+          if (r.instancePath != null) r.instancePath!: r,
+      };
+      final toUpdate = <PortForwardingRuleUpdate>[];
+      for (final cur in current) {
+        if (cur.instancePath == null) continue;
+        final orig = originalByPath[cur.instancePath!];
+        if (orig == null) continue;
+        if (cur != orig) {
+          toUpdate.add(PortForwardingRuleUpdate(
+            instancePath: cur.instancePath!,
+            enabled: cur.enabled,
+            externalPort: cur.externalPort,
+            externalPortEndRange: cur.externalPortEndRange,
+            internalPort: cur.internalPort,
+            internalClient: cur.internalClient,
+            protocol: cur.protocol,
+            description: cur.description,
+          ));
+        }
+      }
+      if (toUpdate.isNotEmpty) {
+        await PortForwarding.updateMany(_usp, toUpdate);
+      }
+
+      return (
+        added: toAdd.length,
+        updated: toUpdate.length,
+        deleted: toDelete.length,
       );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
     }
-
-    // 3. Update
-    final originalByPath = <String, PortForwardingRuleUIModel>{
-      for (final r in original)
-        if (r.instancePath != null) r.instancePath!: r,
-    };
-    final toUpdate = <PortForwardingRuleUpdate>[];
-    for (final cur in current) {
-      if (cur.instancePath == null) continue;
-      final orig = originalByPath[cur.instancePath!];
-      if (orig == null) continue;
-      if (cur != orig) {
-        toUpdate.add(PortForwardingRuleUpdate(
-          instancePath: cur.instancePath!,
-          enabled: cur.enabled,
-          externalPort: cur.externalPort,
-          externalPortEndRange: cur.externalPortEndRange,
-          internalPort: cur.internalPort,
-          internalClient: cur.internalClient,
-          protocol: cur.protocol,
-          description: cur.description,
-        ));
-      }
-    }
-    if (toUpdate.isNotEmpty) {
-      await PortForwarding.updateMany(_usp, toUpdate);
-    }
-
-    return (
-      added: toAdd.length,
-      updated: toUpdate.length,
-      deleted: toDelete.length,
-    );
   }
 
   // ---------------------------------------------------------------------------
@@ -124,73 +137,77 @@ class UspPortForwardingService {
     required List<PortTriggeringRuleUIModel> original,
     required List<PortTriggeringRuleUIModel> current,
   }) async {
-    // 1. Delete
-    final currentPaths = <String>{
-      for (final r in current)
-        if (r.instancePath != null) r.instancePath!,
-    };
-    final toDelete = original
-        .where((r) =>
-            r.instancePath != null && !currentPaths.contains(r.instancePath))
-        .toList();
-    for (var i = 0; i < toDelete.length; i++) {
-      if (i > 0) {
-        await Future.delayed(const Duration(milliseconds: 300));
+    try {
+      // 1. Delete
+      final currentPaths = <String>{
+        for (final r in current)
+          if (r.instancePath != null) r.instancePath!,
+      };
+      final toDelete = original
+          .where((r) =>
+              r.instancePath != null && !currentPaths.contains(r.instancePath))
+          .toList();
+      for (var i = 0; i < toDelete.length; i++) {
+        if (i > 0) {
+          await Future.delayed(const Duration(milliseconds: 300));
+        }
+        await PortTriggering.delete(_usp, toDelete[i].instancePath!);
       }
-      await PortTriggering.delete(_usp, toDelete[i].instancePath!);
-    }
 
-    // 2. Add (parent + forward rules)
-    final toAdd = current.where((r) => r.instancePath == null).toList();
-    for (final r in toAdd) {
-      final parentPath = await PortTriggering.add(
-        _usp,
-        enabled: r.enabled,
-        description: r.description,
-        triggerPort: r.triggerPort,
-        triggerPortEndRange: r.triggerPortEndRange,
-        triggerProtocol: r.triggerProtocol,
-      );
-      for (final fr in r.forwardRules) {
-        await PortTriggering.addPortTriggerForwardRule(
+      // 2. Add (parent + forward rules)
+      final toAdd = current.where((r) => r.instancePath == null).toList();
+      for (final r in toAdd) {
+        final parentPath = await PortTriggering.add(
           _usp,
-          parentPath,
-          forwardPort: fr.forwardPort,
-          forwardPortEndRange: fr.forwardPortEndRange,
-          forwardProtocol: fr.forwardProtocol,
+          enabled: r.enabled,
+          description: r.description,
+          triggerPort: r.triggerPort,
+          triggerPortEndRange: r.triggerPortEndRange,
+          triggerProtocol: r.triggerProtocol,
         );
+        for (final fr in r.forwardRules) {
+          await PortTriggering.addPortTriggerForwardRule(
+            _usp,
+            parentPath,
+            forwardPort: fr.forwardPort,
+            forwardPortEndRange: fr.forwardPortEndRange,
+            forwardProtocol: fr.forwardProtocol,
+          );
+        }
       }
-    }
 
-    // 3. Update (parent-level only)
-    final originalByPath = <String, PortTriggeringRuleUIModel>{
-      for (final r in original)
-        if (r.instancePath != null) r.instancePath!: r,
-    };
-    final toUpdate = <PortTriggerUpdate>[];
-    for (final cur in current) {
-      if (cur.instancePath == null) continue;
-      final orig = originalByPath[cur.instancePath!];
-      if (orig == null) continue;
-      if (cur != orig) {
-        toUpdate.add(PortTriggerUpdate(
-          instancePath: cur.instancePath!,
-          enabled: cur.enabled,
-          description: cur.description,
-          triggerPort: cur.triggerPort,
-          triggerPortEndRange: cur.triggerPortEndRange,
-          triggerProtocol: cur.triggerProtocol,
-        ));
+      // 3. Update (parent-level only)
+      final originalByPath = <String, PortTriggeringRuleUIModel>{
+        for (final r in original)
+          if (r.instancePath != null) r.instancePath!: r,
+      };
+      final toUpdate = <PortTriggerUpdate>[];
+      for (final cur in current) {
+        if (cur.instancePath == null) continue;
+        final orig = originalByPath[cur.instancePath!];
+        if (orig == null) continue;
+        if (cur != orig) {
+          toUpdate.add(PortTriggerUpdate(
+            instancePath: cur.instancePath!,
+            enabled: cur.enabled,
+            description: cur.description,
+            triggerPort: cur.triggerPort,
+            triggerPortEndRange: cur.triggerPortEndRange,
+            triggerProtocol: cur.triggerProtocol,
+          ));
+        }
       }
-    }
-    if (toUpdate.isNotEmpty) {
-      await PortTriggering.updateMany(_usp, toUpdate);
-    }
+      if (toUpdate.isNotEmpty) {
+        await PortTriggering.updateMany(_usp, toUpdate);
+      }
 
-    return (
-      added: toAdd.length,
-      updated: toUpdate.length,
-      deleted: toDelete.length,
-    );
+      return (
+        added: toAdd.length,
+        updated: toUpdate.length,
+        deleted: toDelete.length,
+      );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 }

--- a/lib/page/static_routing/providers/usp_static_routing_notifier.dart
+++ b/lib/page/static_routing/providers/usp_static_routing_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
@@ -71,7 +72,7 @@ class UspStaticRoutingNotifier
         StaticRouteList(routes: routes),
         const StaticRoutingStatus(),
       );
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][Network][Routing] Fetch failed', error: e);
       return (
         null,
@@ -104,7 +105,7 @@ class UspStaticRoutingNotifier
             'added: ${result.added}, updated: ${result.updated}, '
             'deleted: ${result.deleted}');
       });
-    } catch (e) {
+    } on ServiceError catch (e) {
       logger.e('[USP][Network][Routing] Save failed', error: e);
       rethrow;
     } finally {

--- a/lib/page/static_routing/services/usp_static_routing_service.dart
+++ b/lib/page/static_routing/services/usp_static_routing_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/static_routing.g.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
@@ -33,8 +34,12 @@ class UspStaticRoutingService {
 
   /// Fetch static routes and transform to UI models.
   Future<List<StaticRouteUIModel>> fetch() async {
-    final data = await StaticRouting.fetch(_usp);
-    return buildRouteUIModels(data);
+    try {
+      final data = await StaticRouting.fetch(_usp);
+      return buildRouteUIModels(data);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   /// Batch save: diff original vs current, execute delete/add/update.
@@ -42,75 +47,79 @@ class UspStaticRoutingService {
     required List<StaticRouteUIModel> original,
     required List<StaticRouteUIModel> current,
   }) async {
-    // 1. Delete (in original, not in current)
-    final currentPaths = <String>{
-      for (final r in current)
-        if (r.instancePath != null) r.instancePath!,
-    };
-    final toDelete = original
-        .where((r) =>
-            r.instancePath != null && !currentPaths.contains(r.instancePath))
-        .toList();
+    try {
+      // 1. Delete (in original, not in current)
+      final currentPaths = <String>{
+        for (final r in current)
+          if (r.instancePath != null) r.instancePath!,
+      };
+      final toDelete = original
+          .where((r) =>
+              r.instancePath != null && !currentPaths.contains(r.instancePath))
+          .toList();
 
-    for (var i = 0; i < toDelete.length; i++) {
-      if (i > 0) {
-        await Future.delayed(const Duration(milliseconds: 300));
+      for (var i = 0; i < toDelete.length; i++) {
+        if (i > 0) {
+          await Future.delayed(const Duration(milliseconds: 300));
+        }
+        await StaticRouting.delete(_usp, toDelete[i].instancePath!);
       }
-      await StaticRouting.delete(_usp, toDelete[i].instancePath!);
-    }
 
-    // 2. Add (instancePath == null → new)
-    final toAdd = current.where((r) => r.instancePath == null).toList();
+      // 2. Add (instancePath == null → new)
+      final toAdd = current.where((r) => r.instancePath == null).toList();
 
-    for (var i = 0; i < toAdd.length; i++) {
-      if (i > 0) {
-        await Future.delayed(const Duration(milliseconds: 300));
+      for (var i = 0; i < toAdd.length; i++) {
+        if (i > 0) {
+          await Future.delayed(const Duration(milliseconds: 300));
+        }
+        final r = toAdd[i];
+        await StaticRouting.add(
+          _usp,
+          enable: r.enabled,
+          destIpAddress: r.destIpAddress,
+          destSubnetMask: r.destSubnetMask,
+          gatewayIpAddress: r.gatewayIpAddress,
+          interface_: mapDisplayToInterface(r.interfaceName),
+          alias: r.name,
+        );
       }
-      final r = toAdd[i];
-      await StaticRouting.add(
-        _usp,
-        enable: r.enabled,
-        destIpAddress: r.destIpAddress,
-        destSubnetMask: r.destSubnetMask,
-        gatewayIpAddress: r.gatewayIpAddress,
-        interface_: mapDisplayToInterface(r.interfaceName),
-        alias: r.name,
+
+      // 3. Update (same path, different content)
+      final originalByPath = <String, StaticRouteUIModel>{
+        for (final r in original)
+          if (r.instancePath != null) r.instancePath!: r,
+      };
+
+      final toUpdate = <StaticRouteUpdate>[];
+      for (final cur in current) {
+        if (cur.instancePath == null) continue;
+        final orig = originalByPath[cur.instancePath!];
+        if (orig == null) continue;
+        if (cur != orig) {
+          toUpdate.add(StaticRouteUpdate(
+            instancePath: cur.instancePath!,
+            enable: cur.enabled,
+            destIpAddress: cur.destIpAddress,
+            destSubnetMask: cur.destSubnetMask,
+            gatewayIpAddress: cur.gatewayIpAddress,
+            interface_: mapDisplayToInterface(cur.interfaceName),
+            alias: cur.name,
+          ));
+        }
+      }
+
+      if (toUpdate.isNotEmpty) {
+        await StaticRouting.updateMany(_usp, toUpdate);
+      }
+
+      return (
+        added: toAdd.length,
+        updated: toUpdate.length,
+        deleted: toDelete.length,
       );
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
     }
-
-    // 3. Update (same path, different content)
-    final originalByPath = <String, StaticRouteUIModel>{
-      for (final r in original)
-        if (r.instancePath != null) r.instancePath!: r,
-    };
-
-    final toUpdate = <StaticRouteUpdate>[];
-    for (final cur in current) {
-      if (cur.instancePath == null) continue;
-      final orig = originalByPath[cur.instancePath!];
-      if (orig == null) continue;
-      if (cur != orig) {
-        toUpdate.add(StaticRouteUpdate(
-          instancePath: cur.instancePath!,
-          enable: cur.enabled,
-          destIpAddress: cur.destIpAddress,
-          destSubnetMask: cur.destSubnetMask,
-          gatewayIpAddress: cur.gatewayIpAddress,
-          interface_: mapDisplayToInterface(cur.interfaceName),
-          alias: cur.name,
-        ));
-      }
-    }
-
-    if (toUpdate.isNotEmpty) {
-      await StaticRouting.updateMany(_usp, toUpdate);
-    }
-
-    return (
-      added: toAdd.length,
-      updated: toUpdate.length,
-      deleted: toDelete.length,
-    );
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/page/system_log/providers/usp_system_log_notifier.dart
+++ b/lib/page/system_log/providers/usp_system_log_notifier.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/page/system_log/models/log_file_ui_model.dart';
 import 'package:privacy_gui/page/system_log/services/usp_system_log_service.dart';
 
@@ -11,7 +13,12 @@ class UspSystemLogNotifier
     extends AutoDisposeAsyncNotifier<List<LogFileUIModel>> {
   @override
   Future<List<LogFileUIModel>> build() async {
-    final svc = ref.read(uspSystemLogServiceProvider);
-    return svc.fetch();
+    try {
+      final svc = ref.read(uspSystemLogServiceProvider);
+      return await svc.fetch();
+    } on ServiceError catch (e) {
+      logger.e('[USP][SystemLog] Fetch failed', error: e);
+      rethrow;
+    }
   }
 }

--- a/lib/page/system_log/services/usp_system_log_service.dart
+++ b/lib/page/system_log/services/usp_system_log_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/generated/vendor_log_files.g.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
@@ -16,8 +17,12 @@ class UspSystemLogService {
 
   /// Fetch vendor log files and transform to UI models.
   Future<List<LogFileUIModel>> fetch() async {
-    final data = await VendorLogFiles.fetch(_usp);
-    return _buildLogFileUIModels(data);
+    try {
+      final data = await VendorLogFiles.fetch(_usp);
+      return _buildLogFileUIModels(data);
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
   }
 
   List<LogFileUIModel> _buildLogFileUIModels(VendorLogFiles data) {

--- a/lib/page/wifi_settings/providers/wifi_data_provider.dart
+++ b/lib/page/wifi_settings/providers/wifi_data_provider.dart
@@ -120,7 +120,8 @@ class WifiDataNotifier extends AsyncNotifier<WifiData> {
   Future<WifiData> _fetch() async {
     final usp = ref.read(uspServiceProvider);
     if (usp == null) {
-      throw const ConnectivityError(message: 'USP service not available');
+      throw const ServiceNotInitializedError(
+          message: 'USP service not available');
     }
 
     // Parallel fetch all WiFi data. No overall timeout here — the throttler's

--- a/test/core/errors/service_error_test.dart
+++ b/test/core/errors/service_error_test.dart
@@ -47,5 +47,13 @@ void main() {
           'Unexpected error: bad data');
       expect('${const UnexpectedError()}', 'Unexpected');
     });
+
+    test('ServiceNotInitializedError appends message when present', () {
+      expect(
+          '${const ServiceNotInitializedError(message: 'USP service not available')}',
+          'Service not initialized: USP service not available');
+      expect(
+          '${const ServiceNotInitializedError()}', 'Service not initialized');
+    });
   });
 }

--- a/test/page/admin/providers/system_info_data_provider_test.dart
+++ b/test/page/admin/providers/system_info_data_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
 import 'package:privacy_gui/page/admin/providers/system_info_data_provider.dart';
@@ -111,7 +112,7 @@ void main() {
 
       expect(
         container.read(systemInfoDataProvider.future),
-        throwsA(isA<StateError>()),
+        throwsA(isA<ServiceNotInitializedError>()),
       );
       container.dispose();
     });

--- a/test/page/admin/providers/time_data_provider_test.dart
+++ b/test/page/admin/providers/time_data_provider_test.dart
@@ -50,7 +50,7 @@ void main() {
       container.dispose();
     });
 
-    test('build throws ConnectivityError when usp is null', () async {
+    test('build throws ServiceNotInitializedError when usp is null', () async {
       final container = ProviderContainer(
         overrides: [
           uspServiceProvider.overrideWithValue(null),
@@ -59,7 +59,7 @@ void main() {
 
       expect(
         container.read(timeDataProvider.future),
-        throwsA(isA<ConnectivityError>()),
+        throwsA(isA<ServiceNotInitializedError>()),
       );
       container.dispose();
     });

--- a/test/page/admin/providers/time_data_provider_test.dart
+++ b/test/page/admin/providers/time_data_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
@@ -49,7 +50,7 @@ void main() {
       container.dispose();
     });
 
-    test('build throws when usp is null', () async {
+    test('build throws ConnectivityError when usp is null', () async {
       final container = ProviderContainer(
         overrides: [
           uspServiceProvider.overrideWithValue(null),
@@ -58,7 +59,7 @@ void main() {
 
       expect(
         container.read(timeDataProvider.future),
-        throwsA(isA<StateError>()),
+        throwsA(isA<ConnectivityError>()),
       );
       container.dispose();
     });
@@ -95,6 +96,55 @@ void main() {
       // Same model → equal
       expect(data1, equals(data2));
       expect(data1.props, isNotEmpty);
+      container.dispose();
+    });
+
+    // -----------------------------------------------------------------------
+    // Error handling
+    // -----------------------------------------------------------------------
+
+    test('fetch maps USP error to ServiceError', () async {
+      when(() => mockUsp.get(any()))
+          .thenThrow('Get failed: Transport error: Request timeout');
+
+      final container = createContainer();
+
+      expect(
+        container.read(timeDataProvider.future),
+        throwsA(isA<NetworkError>()),
+      );
+      container.dispose();
+    });
+
+    test('updateTimeSettings maps USP error to ServiceError', () async {
+      final container = createContainer();
+      await container.read(timeDataProvider.future);
+
+      when(() => mockUsp.set(any()))
+          .thenThrow('Set failed: Authentication error: Session expired');
+
+      expect(
+        () => container
+            .read(timeDataProvider.notifier)
+            .updateTimeSettings(enable: false),
+        throwsA(isA<SessionTokenExpiredError>()),
+      );
+      container.dispose();
+    });
+
+    test('updateTimezone maps USP error to ServiceError', () async {
+      final container = createContainer();
+      await container.read(timeDataProvider.future);
+
+      when(() => mockUsp.set(any()))
+          .thenThrow('Set failed: Transport error: Connection refused');
+
+      expect(
+        () => container
+            .read(timeDataProvider.notifier)
+            .updateTimezone(localTimeZone: 'US/Pacific'),
+        throwsA(isA<ConnectivityError>()),
+      );
       container.dispose();
     });
   });

--- a/test/page/admin/providers/usp_admin_notifier_test.dart
+++ b/test/page/admin/providers/usp_admin_notifier_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
@@ -92,7 +93,7 @@ void main() {
 
     test('build error sets AsyncError', () async {
       when(() => mockAdminService.fetchAdmin())
-          .thenThrow(Exception('admin fetch failed'));
+          .thenThrow(const NetworkError(message: 'admin fetch failed'));
       final container = createContainer();
 
       try {
@@ -101,7 +102,7 @@ void main() {
 
       final state = container.read(uspAdminProvider);
       expect(state.hasError, isTrue);
-      expect(state.error.toString(), contains('admin fetch failed'));
+      expect(state.error, isA<NetworkError>());
       container.dispose();
     });
 
@@ -141,31 +142,87 @@ void main() {
       container.dispose();
     });
 
-    test('reboot calls USP operate Device.Reboot()', () async {
+    test('reboot calls service reboot', () async {
       when(() => mockAdminService.fetchAdmin())
           .thenAnswer((_) async => testAdmin);
-      when(() => mockUsp.operate(any())).thenAnswer((_) async => {});
+      when(() => mockAdminService.reboot()).thenAnswer((_) async {});
 
       final container = createContainer();
       await container.read(uspAdminProvider.future);
 
       await container.read(uspAdminProvider.notifier).reboot();
 
-      verify(() => mockUsp.operate('Device.Reboot()')).called(1);
+      verify(() => mockAdminService.reboot()).called(1);
       container.dispose();
     });
 
-    test('factoryReset calls USP operate Device.FactoryReset()', () async {
+    test('factoryReset calls service factoryReset', () async {
       when(() => mockAdminService.fetchAdmin())
           .thenAnswer((_) async => testAdmin);
-      when(() => mockUsp.operate(any())).thenAnswer((_) async => {});
+      when(() => mockAdminService.factoryReset()).thenAnswer((_) async {});
 
       final container = createContainer();
       await container.read(uspAdminProvider.future);
 
       await container.read(uspAdminProvider.notifier).factoryReset();
 
-      verify(() => mockUsp.operate('Device.FactoryReset()')).called(1);
+      verify(() => mockAdminService.factoryReset()).called(1);
+      container.dispose();
+    });
+
+    // -----------------------------------------------------------------------
+    // Error handling
+    // -----------------------------------------------------------------------
+
+    test('setAdminPassword rethrows ServiceError', () async {
+      when(() => mockAdminService.fetchAdmin())
+          .thenAnswer((_) async => testAdmin);
+      when(() => mockAdminService.updatePassword(
+            instancePath: any(named: 'instancePath'),
+            newPassword: any(named: 'newPassword'),
+          )).thenThrow(const NetworkError(message: 'timeout'));
+
+      final container = createContainer();
+      await container.read(uspAdminProvider.future);
+
+      expect(
+        () => container
+            .read(uspAdminProvider.notifier)
+            .setAdminPassword('new123'),
+        throwsA(isA<NetworkError>()),
+      );
+      container.dispose();
+    });
+
+    test('reboot rethrows ServiceError', () async {
+      when(() => mockAdminService.fetchAdmin())
+          .thenAnswer((_) async => testAdmin);
+      when(() => mockAdminService.reboot())
+          .thenThrow(const ConnectivityError(message: 'connection refused'));
+
+      final container = createContainer();
+      await container.read(uspAdminProvider.future);
+
+      expect(
+        () => container.read(uspAdminProvider.notifier).reboot(),
+        throwsA(isA<ConnectivityError>()),
+      );
+      container.dispose();
+    });
+
+    test('factoryReset rethrows ServiceError', () async {
+      when(() => mockAdminService.fetchAdmin())
+          .thenAnswer((_) async => testAdmin);
+      when(() => mockAdminService.factoryReset())
+          .thenThrow(const SessionTokenExpiredError());
+
+      final container = createContainer();
+      await container.read(uspAdminProvider.future);
+
+      expect(
+        () => container.read(uspAdminProvider.notifier).factoryReset(),
+        throwsA(isA<SessionTokenExpiredError>()),
+      );
       container.dispose();
     });
   });

--- a/test/page/admin/services/usp_admin_service_test.dart
+++ b/test/page/admin/services/usp_admin_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
 import 'package:privacy_gui/generated/time_settings.g.dart';
 import 'package:privacy_gui/page/admin/services/usp_admin_service.dart';
@@ -98,6 +99,43 @@ void main() {
       final model = service.buildTimeSettingsUIModel(ts);
 
       expect(model.isSynchronized, isFalse);
+    });
+  });
+
+  group('UspAdminService — error handling', () {
+    test('fetchAdmin maps USP error to ServiceError', () {
+      when(() => mockUsp.get(any()))
+          .thenThrow('Get failed: Transport error: Request timeout');
+
+      expect(() => service.fetchAdmin(), throwsA(isA<NetworkError>()));
+    });
+
+    test('updatePassword maps USP error to ServiceError', () {
+      when(() => mockUsp.set(any()))
+          .thenThrow('Set failed: Authentication error: Permission denied');
+
+      expect(
+        () => service.updatePassword(
+          instancePath: 'Device.Users.User.1.',
+          newPassword: 'test',
+        ),
+        throwsA(isA<UnauthorizedError>()),
+      );
+    });
+
+    test('reboot maps USP error to ServiceError', () {
+      when(() => mockUsp.operate(any()))
+          .thenThrow('Operate failed: Transport error: Connection refused');
+
+      expect(() => service.reboot(), throwsA(isA<ConnectivityError>()));
+    });
+
+    test('factoryReset maps USP error to ServiceError', () {
+      when(() => mockUsp.operate(any()))
+          .thenThrow('Operate failed: Authentication error: Session expired');
+
+      expect(() => service.factoryReset(),
+          throwsA(isA<SessionTokenExpiredError>()));
     });
   });
 }

--- a/test/page/devices/providers/devices_data_provider_test.dart
+++ b/test/page/devices/providers/devices_data_provider_test.dart
@@ -182,7 +182,7 @@ void main() {
 
       expect(
         container.read(devicesDataProvider.future),
-        throwsA(isA<ConnectivityError>()),
+        throwsA(isA<ServiceNotInitializedError>()),
       );
       container.dispose();
     });

--- a/test/page/devices/providers/devices_data_provider_test.dart
+++ b/test/page/devices/providers/devices_data_provider_test.dart
@@ -4,6 +4,7 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
@@ -181,7 +182,7 @@ void main() {
 
       expect(
         container.read(devicesDataProvider.future),
-        throwsA(isA<StateError>()),
+        throwsA(isA<ConnectivityError>()),
       );
       container.dispose();
     });

--- a/test/page/dhcp/providers/usp_dhcp_reservations_notifier_test.dart
+++ b/test/page/dhcp/providers/usp_dhcp_reservations_notifier_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/page/_shared/models/dhcp_reservation_ui_model.dart';
 import 'package:privacy_gui/page/dhcp/providers/usp_dhcp_reservations_notifier.dart';
@@ -44,7 +45,7 @@ void main() {
   }
 
   group('UspDhcpReservationsNotifier', () {
-    test('build returns initial loading state', () {
+    test('build returns initial loading state', () async {
       when(() => mockService.fetchReservations())
           .thenAnswer((_) async => [r1, r2]);
       final container = createContainer();
@@ -52,6 +53,7 @@ void main() {
       final state = container.read(uspDhcpReservationsProvider);
       expect(state.status.isLoading, isTrue);
       expect(state.settings.current.reservations, isEmpty);
+      await Future.delayed(Duration.zero);
       container.dispose();
     });
 
@@ -70,7 +72,7 @@ void main() {
 
     test('fetch error sets error status', () async {
       when(() => mockService.fetchReservations())
-          .thenThrow(Exception('timeout'));
+          .thenThrow(const NetworkError(message: 'timeout'));
       final container = createContainer();
       await Future.delayed(Duration.zero);
 
@@ -157,6 +159,26 @@ void main() {
       final state = container.read(uspDhcpReservationsProvider);
       expect(state.settings.current.reservations, hasLength(1));
       expect(state.settings.current.reservations[0].mac, r2.mac);
+      container.dispose();
+    });
+
+    test('performSave rethrows ServiceError and clears isSaving', () async {
+      when(() => mockService.fetchReservations()).thenAnswer((_) async => [r1]);
+      when(() => mockService.saveBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).thenThrow(const NetworkError(message: 'save failed'));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspDhcpReservationsProvider.notifier);
+      notifier.addReservation(r2);
+
+      await expectLater(notifier.save(), throwsA(isA<ServiceError>()));
+
+      expect(
+          container.read(uspDhcpReservationsProvider).status.isSaving, isFalse);
       container.dispose();
     });
 

--- a/test/page/dhcp/services/usp_dhcp_service_test.dart
+++ b/test/page/dhcp/services/usp_dhcp_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
 import 'package:privacy_gui/page/_shared/models/dhcp_reservation_ui_model.dart';
 import 'package:privacy_gui/page/dhcp/services/usp_dhcp_service.dart';
@@ -269,6 +270,41 @@ void main() {
       // Second add should be at least 200ms after first (300ms delay, allow margin)
       final gap = addTimes[1].difference(addTimes[0]);
       expect(gap.inMilliseconds, greaterThanOrEqualTo(200));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error handling
+  // ---------------------------------------------------------------------------
+
+  group('UspDhcpService — error handling', () {
+    test('fetchReservations maps USP error to ServiceError', () async {
+      when(() => mockUsp.get(any()))
+          .thenThrow('Get failed: Transport error: HTTP error: HTTP 504');
+
+      expect(
+        () => service.fetchReservations(),
+        throwsA(isA<ServiceError>()),
+      );
+    });
+
+    test('saveBatch maps USP error to ServiceError', () async {
+      when(() => mockUsp.delete(any())).thenThrow(
+          'Delete failed: Protocol error: invalid path (code: 7004)');
+
+      final original = [
+        DhcpReservationUIModel(
+          instancePath: 'path.1.',
+          mac: 'AA:BB:CC:DD:EE:FF',
+          ip: '192.168.1.100',
+          enable: true,
+        ),
+      ];
+
+      expect(
+        () => service.saveBatch(original: original, current: []),
+        throwsA(isA<ServiceError>()),
+      );
     });
   });
 }

--- a/test/page/firewall/providers/usp_firewall_notifier_test.dart
+++ b/test/page/firewall/providers/usp_firewall_notifier_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/page/firewall/models/firewall_ui_model.dart';
 import 'package:privacy_gui/page/firewall/providers/firewall_data_provider.dart';
@@ -13,12 +14,12 @@ class MockUspFirewallService extends Mock implements UspFirewallService {}
 /// Test-only notifier that returns canned data instead of real fetch.
 class _TestFirewallDataNotifier extends FirewallDataNotifier {
   final FirewallData _testData;
-  final bool shouldThrow;
-  _TestFirewallDataNotifier(this._testData, {this.shouldThrow = false});
+  final ServiceError? errorToThrow;
+  _TestFirewallDataNotifier(this._testData, {this.errorToThrow});
 
   @override
   Future<FirewallData> build() async {
-    if (shouldThrow) throw Exception('data provider error');
+    if (errorToThrow != null) throw errorToThrow!;
     return _testData;
   }
 }
@@ -61,11 +62,13 @@ void main() {
   }
 
   group('UspFirewallNotifier', () {
-    test('build returns initial loading state', () {
+    test('build returns initial loading state', () async {
       final container = createContainer();
 
       final state = container.read(uspFirewallProvider);
       expect(state.status.isLoading, isTrue);
+
+      await Future.delayed(Duration.zero);
       container.dispose();
     });
 
@@ -149,28 +152,40 @@ void main() {
     });
 
     test('fetch error sets error status', () async {
-      final errorData = FirewallData(
-        firewallModel: const FirewallUIModel(),
-        ruleContext: FirewallRuleContext.empty,
-        ruleSummaries: const [],
-        dmzModel: const DmzUIModel.disabled(),
-        dmzSummaries: const [],
-      );
-      // Override firewallDataProvider to throw on read.
       final container = ProviderContainer(
         overrides: [
           uspFirewallServiceProvider.overrideWithValue(mockService),
           uspMutationLockProvider.overrideWithValue(UspMutationLock()),
-          firewallDataProvider.overrideWith(() {
-            return _TestFirewallDataNotifier(errorData, shouldThrow: true);
-          }),
+          firewallDataProvider.overrideWith(() => _TestFirewallDataNotifier(
+                testData,
+                errorToThrow: const NetworkError(message: 'timeout'),
+              )),
         ],
       );
       container.listen(uspFirewallProvider, (_, __) {});
       await Future.delayed(Duration.zero);
 
       final state = container.read(uspFirewallProvider);
-      expect(state.status.errorMessage, isNotNull);
+      expect(state.status.errorMessage, contains('Network error'));
+      container.dispose();
+    });
+
+    test('performSave rethrows ServiceError and clears isSaving', () async {
+      when(() => mockService.save(
+            original: any(named: 'original'),
+            pending: any(named: 'pending'),
+            context: any(named: 'context'),
+          )).thenThrow(const NetworkError(message: 'save failed'));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspFirewallProvider.notifier);
+      notifier.updateSetting((m) => m.copyWith(isIPv6FirewallEnabled: true));
+
+      await expectLater(notifier.save(), throwsA(isA<ServiceError>()));
+
+      expect(container.read(uspFirewallProvider).status.isSaving, isFalse);
       container.dispose();
     });
   });

--- a/test/page/instant_privacy/providers/instant_privacy_notifier_test.dart
+++ b/test/page/instant_privacy/providers/instant_privacy_notifier_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/page/instant_privacy/models/instant_privacy_device_ui_model.dart';
 import 'package:privacy_gui/page/instant_privacy/providers/instant_privacy_notifier.dart';
 import 'package:privacy_gui/page/instant_privacy/services/instant_privacy_service.dart';
@@ -62,7 +63,8 @@ void main() {
     });
 
     test('build error sets AsyncError', () async {
-      when(() => mockService.fetchAll()).thenThrow(Exception('fetch failed'));
+      when(() => mockService.fetchAll())
+          .thenThrow(const NetworkError(message: 'fetch failed'));
       final container = createContainer();
 
       try {
@@ -137,14 +139,14 @@ void main() {
       when(() => mockService.fetchAll())
           .thenAnswer((_) async => disabledResult);
       when(() => mockService.enable(any(), any()))
-          .thenThrow(Exception('enable failed'));
+          .thenThrow(const NetworkError(message: 'enable failed'));
 
       final container = createContainer();
       await container.read(uspInstantPrivacyProvider.future);
 
       expect(
         () => container.read(uspInstantPrivacyProvider.notifier).enable(),
-        throwsA(isA<Exception>()),
+        throwsA(isA<ServiceError>()),
       );
       await Future.delayed(Duration.zero);
 

--- a/test/page/instant_safety/providers/instant_safety_provider_test.dart
+++ b/test/page/instant_safety/providers/instant_safety_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/page/instant_safety/models/safe_browsing_ui_model.dart';
 import 'package:privacy_gui/page/instant_safety/providers/instant_safety_provider.dart';
@@ -111,14 +112,16 @@ void main() {
       container.dispose();
     });
 
-    test('build sets error state when service throws', () async {
-      when(() => mockService.fetch()).thenThrow(Exception('network error'));
+    test('build sets error state when service throws ServiceError', () async {
+      when(() => mockService.fetch())
+          .thenThrow(const NetworkError(message: 'timeout'));
 
       final container = createContainer();
       await Future.delayed(Duration.zero);
 
       final state = container.read(uspInstantSafetyProvider);
       expect(state.hasError, isTrue);
+      expect(state.error, isA<NetworkError>());
       container.dispose();
     });
 
@@ -208,7 +211,8 @@ void main() {
     test('save resets isSaving on error', () async {
       when(() => mockService.fetch()).thenAnswer(
           (_) async => const SafeBrowsingUIModel(type: SafeBrowsingType.off));
-      when(() => mockService.save(any())).thenThrow(Exception('save failed'));
+      when(() => mockService.save(any()))
+          .thenThrow(const NetworkError(message: 'save failed'));
 
       final container = createContainer();
       await Future.delayed(Duration.zero);
@@ -218,7 +222,7 @@ void main() {
 
       expect(
         () => notifier.save(),
-        throwsA(isA<Exception>()),
+        throwsA(isA<ServiceError>()),
       );
 
       await Future.delayed(Duration.zero);

--- a/test/page/instant_safety/services/usp_instant_safety_service_test.dart
+++ b/test/page/instant_safety/services/usp_instant_safety_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
 import 'package:privacy_gui/generated/lan_network_info.g.dart';
 import 'package:privacy_gui/page/instant_safety/models/safe_browsing_ui_model.dart';
@@ -132,6 +133,25 @@ void main() {
       final captured = verify(() => mockUsp.set(captureAny())).captured;
       final params = captured.first as Map<String, dynamic>;
       expect(params['Device.DHCPv4.Server.Pool.1.DNSServers'], '');
+    });
+  });
+
+  group('UspInstantSafetyService — error handling', () {
+    test('fetch maps USP error to ServiceError', () {
+      when(() => mockUsp.get(any()))
+          .thenThrow('Get failed: Transport error: Request timeout');
+
+      expect(() => service.fetch(), throwsA(isA<NetworkError>()));
+    });
+
+    test('save maps USP error to ServiceError', () {
+      when(() => mockUsp.set(any()))
+          .thenThrow('Set failed: Authentication error: Session expired');
+
+      expect(
+        () => service.save(SafeBrowsingType.openDNS),
+        throwsA(isA<SessionTokenExpiredError>()),
+      );
     });
   });
 }

--- a/test/page/internet_settings/providers/usp_internet_settings_notifier_test.dart
+++ b/test/page/internet_settings/providers/usp_internet_settings_notifier_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/core/usp/providers/usp_auth_coordinator.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
@@ -15,9 +17,12 @@ class MockUspService extends Mock implements UspService {}
 class MockUspInternetSettingsService extends Mock
     implements UspInternetSettingsService {}
 
+class MockUspAuthCoordinator extends Mock implements UspAuthCoordinator {}
+
 void main() {
   late MockUspService mockUsp;
   late MockUspInternetSettingsService mockService;
+  late MockUspAuthCoordinator mockAuthCoordinator;
 
   final testForm = UspInternetSettingsForm(
     connectionType: UspWanConnectionType.dhcp,
@@ -37,6 +42,7 @@ void main() {
   setUp(() {
     mockUsp = MockUspService();
     mockService = MockUspInternetSettingsService();
+    mockAuthCoordinator = MockUspAuthCoordinator();
     when(() => mockUsp.isAuthenticated).thenReturn(true);
   });
 
@@ -46,6 +52,7 @@ void main() {
         uspServiceProvider.overrideWithValue(mockUsp),
         uspInternetSettingsServiceProvider.overrideWithValue(mockService),
         uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+        uspAuthCoordinatorProvider.overrideWithValue(mockAuthCoordinator),
       ],
     );
     container.listen(uspInternetSettingsProvider, (_, __) {});
@@ -53,13 +60,14 @@ void main() {
   }
 
   group('UspInternetSettingsNotifier', () {
-    test('build returns initial loading state', () {
+    test('build returns initial loading state', () async {
       when(() => mockService.fetchSettings())
           .thenAnswer((_) async => testFetchResult);
       final container = createContainer();
 
       final state = container.read(uspInternetSettingsProvider);
       expect(state.status.isLoading, isTrue);
+      await Future.delayed(Duration.zero);
       container.dispose();
     });
 
@@ -80,7 +88,7 @@ void main() {
 
     test('fetch error sets error status', () async {
       when(() => mockService.fetchSettings())
-          .thenThrow(Exception('bridge unreachable'));
+          .thenThrow(const NetworkError(message: 'bridge unreachable'));
       final container = createContainer();
       await Future.delayed(Duration.zero);
 
@@ -273,11 +281,11 @@ void main() {
       container.dispose();
     });
 
-    test('performSave rethrows on error and clears isSaving', () async {
+    test('performSave rethrows ServiceError and clears isSaving', () async {
       when(() => mockService.fetchSettings())
           .thenAnswer((_) async => testFetchResult);
       when(() => mockService.saveAll(any(), any()))
-          .thenThrow(Exception('save failed'));
+          .thenThrow(const NetworkError(message: 'save failed'));
 
       final container = createContainer();
       await Future.delayed(Duration.zero);
@@ -285,7 +293,7 @@ void main() {
       final notifier = container.read(uspInternetSettingsProvider.notifier);
       notifier.updateField((f) => f.copyWith(mtu: 9000));
 
-      await expectLater(notifier.save(), throwsA(isA<Exception>()));
+      await expectLater(notifier.save(), throwsA(isA<ServiceError>()));
 
       expect(
           container.read(uspInternetSettingsProvider).status.isSaving, isFalse);
@@ -294,6 +302,7 @@ void main() {
 
     test('fetch with unauthenticated service sets error status', () async {
       when(() => mockUsp.isAuthenticated).thenReturn(false);
+      when(() => mockAuthCoordinator.restoreSession()).thenAnswer((_) async {});
       when(() => mockService.fetchSettings())
           .thenAnswer((_) async => testFetchResult);
 

--- a/test/page/internet_settings/providers/wan_data_provider_test.dart
+++ b/test/page/internet_settings/providers/wan_data_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
@@ -118,6 +119,7 @@ void main() {
 
       final state = container.read(wanDataProvider);
       expect(state.hasError, isTrue);
+      expect(state.error, isA<ConnectivityError>());
       container.dispose();
     });
 

--- a/test/page/internet_settings/providers/wan_data_provider_test.dart
+++ b/test/page/internet_settings/providers/wan_data_provider_test.dart
@@ -119,7 +119,7 @@ void main() {
 
       final state = container.read(wanDataProvider);
       expect(state.hasError, isTrue);
-      expect(state.error, isA<ConnectivityError>());
+      expect(state.error, isA<ServiceNotInitializedError>());
       container.dispose();
     });
 

--- a/test/page/internet_settings/services/usp_internet_settings_service_test.dart
+++ b/test/page/internet_settings/services/usp_internet_settings_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
 import 'package:privacy_gui/page/internet_settings/models/usp_internet_settings_form.dart';
 import 'package:privacy_gui/page/internet_settings/models/usp_wan_connection_type.dart';
@@ -308,6 +309,58 @@ void main() {
       await service.renewDhcpv6Lease();
 
       verify(() => mockUsp.operate('Device.DHCPv6.Client.1.Renew()')).called(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error handling
+  // ---------------------------------------------------------------------------
+
+  group('UspInternetSettingsService — error handling', () {
+    test('fetchSettings maps USP error to ServiceError', () async {
+      when(() => mockUsp.get(any()))
+          .thenThrow('Get failed: Transport error: HTTP error: HTTP 504');
+
+      expect(
+        () => service.fetchSettings(),
+        throwsA(isA<ServiceError>()),
+      );
+    });
+
+    test('saveAll maps USP error to ServiceError', () async {
+      when(() => mockUsp.set(any()))
+          .thenThrow('Set failed: Protocol error: invalid value (code: 9008)');
+
+      final form = UspInternetSettingsForm(
+        connectionType: UspWanConnectionType.dhcp,
+        mtu: 1500,
+      );
+      final edited = form.copyWith(mtu: 1400);
+
+      expect(
+        () => service.saveAll(form, edited),
+        throwsA(isA<ServiceError>()),
+      );
+    });
+
+    test('renewDhcpLease maps USP error to ServiceError', () async {
+      when(() => mockUsp.operate(any()))
+          .thenThrow('Operate failed: Transport error: Connection refused');
+
+      expect(
+        () => service.renewDhcpLease(),
+        throwsA(isA<ServiceError>()),
+      );
+    });
+
+    test('renewDhcpv6Lease maps USP error to ServiceError', () async {
+      when(() => mockUsp.operate(any()))
+          .thenThrow('Operate failed: Transport error: Connection refused');
+
+      expect(
+        () => service.renewDhcpv6Lease(),
+        throwsA(isA<ServiceError>()),
+      );
     });
   });
 }

--- a/test/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier_test.dart
+++ b/test/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/page/ipv6_port_service/models/ipv6_port_service_ui_model.dart';
 import 'package:privacy_gui/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier.dart';
@@ -51,13 +52,14 @@ void main() {
   }
 
   group('UspIpv6PortServiceNotifier', () {
-    test('build returns initial loading state', () {
+    test('build returns initial loading state', () async {
       when(() => mockService.fetch()).thenAnswer((_) async => [rule1]);
       final container = createContainer();
 
       final state = container.read(uspIpv6PortServiceProvider);
       expect(state.status.isLoading, isTrue);
       expect(state.settings.current.rules, isEmpty);
+      await Future.delayed(Duration.zero);
       container.dispose();
     });
 
@@ -74,7 +76,8 @@ void main() {
     });
 
     test('fetch error sets error status', () async {
-      when(() => mockService.fetch()).thenThrow(Exception('fetch failed'));
+      when(() => mockService.fetch())
+          .thenThrow(const NetworkError(message: 'fetch failed'));
       final container = createContainer();
       await Future.delayed(Duration.zero);
 
@@ -158,6 +161,26 @@ void main() {
           container.read(uspIpv6PortServiceProvider).settings.current.rules;
       expect(rules, hasLength(1));
       expect(rules[0].description, 'DNS');
+      container.dispose();
+    });
+
+    test('performSave rethrows ServiceError and clears isSaving', () async {
+      when(() => mockService.fetch()).thenAnswer((_) async => [rule1]);
+      when(() => mockService.saveBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).thenThrow(const NetworkError(message: 'save failed'));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspIpv6PortServiceProvider.notifier);
+      notifier.addRule(rule2);
+
+      await expectLater(notifier.save(), throwsA(isA<ServiceError>()));
+
+      expect(
+          container.read(uspIpv6PortServiceProvider).status.isSaving, isFalse);
       container.dispose();
     });
 

--- a/test/page/ipv6_port_service/services/usp_ipv6_port_service_service_test.dart
+++ b/test/page/ipv6_port_service/services/usp_ipv6_port_service_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
 import 'package:privacy_gui/generated/ipv6port_service.g.dart';
 import 'package:privacy_gui/page/ipv6_port_service/models/ipv6_port_service_ui_model.dart';
@@ -416,6 +417,44 @@ void main() {
       expect(result.deleted, 1);
       expect(result.added, 1);
       expect(result.updated, 1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error handling
+  // ---------------------------------------------------------------------------
+
+  group('UspIpv6PortServiceService — error handling', () {
+    test('fetch maps USP error to ServiceError', () async {
+      when(() => mockUsp.get(any()))
+          .thenThrow('Get failed: Transport error: HTTP error: HTTP 504');
+
+      expect(
+        () => service.fetch(),
+        throwsA(isA<ServiceError>()),
+      );
+    });
+
+    test('saveBatch maps USP error to ServiceError', () async {
+      when(() => mockUsp.delete(any())).thenThrow(
+          'Delete failed: Protocol error: invalid path (code: 7004)');
+
+      final original = [
+        Ipv6PortServiceRuleUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          description: 'SSH',
+          ipv6Address: '2001:db8::1',
+          protocol: 'TCP',
+          startPort: 22,
+          endPort: 22,
+        ),
+      ];
+
+      expect(
+        () => service.saveBatch(original: original, current: []),
+        throwsA(isA<ServiceError>()),
+      );
     });
   });
 }

--- a/test/page/local_network/providers/dhcp_data_provider_test.dart
+++ b/test/page/local_network/providers/dhcp_data_provider_test.dart
@@ -4,6 +4,7 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
@@ -118,7 +119,7 @@ void main() {
 
       expect(
         container.read(dhcpDataProvider.future),
-        throwsA(isA<StateError>()),
+        throwsA(isA<ServiceNotInitializedError>()),
       );
       container.dispose();
     });

--- a/test/page/local_network/providers/ethernet_data_provider_test.dart
+++ b/test/page/local_network/providers/ethernet_data_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
 import 'package:privacy_gui/generated/ethernet_interfaces.g.dart';
@@ -105,7 +106,7 @@ void main() {
 
       expect(
         container.read(ethernetDataProvider.future),
-        throwsA(isA<StateError>()),
+        throwsA(isA<ServiceNotInitializedError>()),
       );
       container.dispose();
     });

--- a/test/page/local_network/providers/lan_data_provider_test.dart
+++ b/test/page/local_network/providers/lan_data_provider_test.dart
@@ -69,7 +69,7 @@ void main() {
       container.dispose();
     });
 
-    test('build throws ConnectivityError when usp is null', () async {
+    test('build throws ServiceNotInitializedError when usp is null', () async {
       final container = ProviderContainer(
         overrides: [
           uspServiceProvider.overrideWithValue(null),
@@ -78,7 +78,7 @@ void main() {
 
       expect(
         container.read(lanDataProvider.future),
-        throwsA(isA<ConnectivityError>()),
+        throwsA(isA<ServiceNotInitializedError>()),
       );
       container.dispose();
     });

--- a/test/page/local_network/providers/lan_data_provider_test.dart
+++ b/test/page/local_network/providers/lan_data_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_service_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
 import 'package:privacy_gui/page/local_network/providers/lan_data_provider.dart';
@@ -68,7 +69,7 @@ void main() {
       container.dispose();
     });
 
-    test('build throws when usp is null', () async {
+    test('build throws ConnectivityError when usp is null', () async {
       final container = ProviderContainer(
         overrides: [
           uspServiceProvider.overrideWithValue(null),
@@ -77,7 +78,7 @@ void main() {
 
       expect(
         container.read(lanDataProvider.future),
-        throwsA(isA<StateError>()),
+        throwsA(isA<ConnectivityError>()),
       );
       container.dispose();
     });
@@ -130,6 +131,19 @@ void main() {
 
       const empty = LanData.empty();
       expect(data1, isNot(equals(empty)));
+      container.dispose();
+    });
+
+    test('fetch maps USP transport error to ServiceError', () async {
+      when(() => mockUsp.get(any()))
+          .thenThrow('Get failed: Transport error: Request timeout');
+
+      final container = createContainer();
+
+      expect(
+        container.read(lanDataProvider.future),
+        throwsA(isA<NetworkError>()),
+      );
       container.dispose();
     });
   });

--- a/test/page/local_network/providers/usp_local_network_notifier_test.dart
+++ b/test/page/local_network/providers/usp_local_network_notifier_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/page/_shared/models/lan_info_ui_model.dart';
 import 'package:privacy_gui/page/local_network/models/local_network_ui_model.dart';
@@ -14,12 +15,12 @@ class MockUspLocalNetworkService extends Mock
 /// Test-only notifier that returns canned data.
 class _TestLanDataNotifier extends LanDataNotifier {
   final LanData _testData;
-  final bool shouldThrow;
-  _TestLanDataNotifier(this._testData, {this.shouldThrow = false});
+  final ServiceError? errorToThrow;
+  _TestLanDataNotifier(this._testData, {this.errorToThrow});
 
   @override
   Future<LanData> build() async {
-    if (shouldThrow) throw Exception('lan data error');
+    if (errorToThrow != null) throw errorToThrow!;
     return _testData;
   }
 }
@@ -66,11 +67,14 @@ void main() {
   }
 
   group('UspLocalNetworkNotifier', () {
-    test('build returns initial loading state', () {
+    test('build returns initial loading state', () async {
       final container = createContainer();
 
       final state = container.read(uspLocalNetworkProvider);
       expect(state.status.isLoading, isTrue);
+
+      // Let microtask (Future.microtask in build) complete before disposing.
+      await Future.delayed(Duration.zero);
       container.dispose();
     });
 
@@ -175,15 +179,17 @@ void main() {
         overrides: [
           uspLocalNetworkServiceProvider.overrideWithValue(mockService),
           uspMutationLockProvider.overrideWithValue(UspMutationLock()),
-          lanDataProvider.overrideWith(
-              () => _TestLanDataNotifier(testLanData, shouldThrow: true)),
+          lanDataProvider.overrideWith(() => _TestLanDataNotifier(
+                testLanData,
+                errorToThrow: const NetworkError(message: 'timeout'),
+              )),
         ],
       );
       container.listen(uspLocalNetworkProvider, (_, __) {});
       await Future.delayed(Duration.zero);
 
       final state = container.read(uspLocalNetworkProvider);
-      expect(state.status.errorMessage, contains('lan data error'));
+      expect(state.status.errorMessage, contains('Network error'));
       container.dispose();
     });
 
@@ -203,6 +209,23 @@ void main() {
             original: any(named: 'original'),
             pending: any(named: 'pending'),
           )).called(1);
+      container.dispose();
+    });
+
+    test('performSave rethrows ServiceError and clears isSaving', () async {
+      when(() => mockService.save(
+            original: any(named: 'original'),
+            pending: any(named: 'pending'),
+          )).thenThrow(const NetworkError(message: 'save failed'));
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspLocalNetworkProvider.notifier);
+      notifier.updateSetting((m) => m.copyWith(hostName: 'NewRouter'));
+
+      await expectLater(notifier.save(), throwsA(isA<ServiceError>()));
+
+      expect(container.read(uspLocalNetworkProvider).status.isSaving, isFalse);
       container.dispose();
     });
   });

--- a/test/page/port_forwarding/providers/usp_port_forwarding_page_notifier_test.dart
+++ b/test/page/port_forwarding/providers/usp_port_forwarding_page_notifier_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/page/_shared/models/port_forwarding_rule_ui_model.dart';
 import 'package:privacy_gui/page/port_forwarding/models/port_triggering_rule_ui_model.dart';
@@ -70,7 +71,7 @@ void main() {
   }
 
   group('UspPortForwardingPageNotifier', () {
-    test('build returns initial loading state', () {
+    test('build returns initial loading state', () async {
       stubFetch();
       final container = createContainer();
 
@@ -78,6 +79,7 @@ void main() {
       expect(state.status.isLoading, isTrue);
       expect(state.settings.current.forwardingRules, isEmpty);
       expect(state.settings.current.triggeringRules, isEmpty);
+      await Future.delayed(Duration.zero);
       container.dispose();
     });
 
@@ -96,7 +98,7 @@ void main() {
 
     test('fetch error sets error status', () async {
       when(() => mockService.fetchForwardingRules())
-          .thenThrow(Exception('timeout'));
+          .thenThrow(const NetworkError(message: 'timeout'));
       when(() => mockService.fetchTriggeringRules())
           .thenAnswer((_) async => [pt1]);
       final container = createContainer();
@@ -277,6 +279,30 @@ void main() {
           .current
           .triggeringRules;
       expect(rules[0].enabled, isFalse);
+      container.dispose();
+    });
+
+    test('performSave rethrows ServiceError and clears isSaving', () async {
+      stubFetch();
+      when(() => mockService.saveForwardingBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).thenThrow(const NetworkError(message: 'save failed'));
+      when(() => mockService.saveTriggeringBatch(
+            original: any(named: 'original'),
+            current: any(named: 'current'),
+          )).thenAnswer((_) async => (added: 0, updated: 0, deleted: 0));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final notifier = container.read(uspPortForwardingPageProvider.notifier);
+      notifier.addForwardingRule(pf2);
+
+      await expectLater(notifier.save(), throwsA(isA<ServiceError>()));
+
+      expect(container.read(uspPortForwardingPageProvider).status.isSaving,
+          isFalse);
       container.dispose();
     });
 

--- a/test/page/port_forwarding/services/usp_port_forwarding_service_test.dart
+++ b/test/page/port_forwarding/services/usp_port_forwarding_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
 import 'package:privacy_gui/generated/port_forwarding.g.dart';
 import 'package:privacy_gui/generated/port_triggering.g.dart';
@@ -549,6 +550,74 @@ void main() {
 
       expect(result.deleted, 2);
       verify(() => mockUsp.delete(any())).called(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error handling
+  // ---------------------------------------------------------------------------
+
+  group('UspPortForwardingService — error handling', () {
+    test('fetchForwardingRules maps USP error to ServiceError', () async {
+      when(() => mockUsp.get(any()))
+          .thenThrow('Get failed: Transport error: HTTP error: HTTP 504');
+
+      expect(
+        () => service.fetchForwardingRules(),
+        throwsA(isA<ServiceError>()),
+      );
+    });
+
+    test('fetchTriggeringRules maps USP error to ServiceError', () async {
+      when(() => mockUsp.get(any()))
+          .thenThrow('Get failed: Transport error: HTTP error: HTTP 504');
+
+      expect(
+        () => service.fetchTriggeringRules(),
+        throwsA(isA<ServiceError>()),
+      );
+    });
+
+    test('saveForwardingBatch maps USP error to ServiceError', () async {
+      when(() => mockUsp.delete(any())).thenThrow(
+          'Delete failed: Protocol error: invalid path (code: 7004)');
+
+      final original = [
+        PortForwardingRuleUIModel(
+          instancePath: 'path.1.',
+          description: 'HTTP',
+          externalPort: 80,
+          internalPort: 80,
+          internalClient: '192.168.1.100',
+          protocol: 'TCP',
+          enabled: true,
+        ),
+      ];
+
+      expect(
+        () => service.saveForwardingBatch(original: original, current: []),
+        throwsA(isA<ServiceError>()),
+      );
+    });
+
+    test('saveTriggeringBatch maps USP error to ServiceError', () async {
+      when(() => mockUsp.delete(any())).thenThrow(
+          'Delete failed: Protocol error: invalid path (code: 7004)');
+
+      final original = [
+        PortTriggeringRuleUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          description: 'FTP',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+        ),
+      ];
+
+      expect(
+        () => service.saveTriggeringBatch(original: original, current: []),
+        throwsA(isA<ServiceError>()),
+      );
     });
   });
 }

--- a/test/page/static_routing/providers/usp_static_routing_notifier_test.dart
+++ b/test/page/static_routing/providers/usp_static_routing_notifier_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/page/static_routing/models/static_routing_ui_model.dart';
 import 'package:privacy_gui/page/static_routing/providers/usp_static_routing_notifier.dart';
@@ -53,13 +54,14 @@ void main() {
   }
 
   group('UspStaticRoutingNotifier', () {
-    test('build returns initial loading state', () {
+    test('build returns initial loading state', () async {
       when(() => mockService.fetch()).thenAnswer((_) async => [route1]);
       final container = createContainer();
 
       final state = container.read(uspStaticRoutingProvider);
       expect(state.status.isLoading, isTrue);
       expect(state.settings.current.routes, isEmpty);
+      await Future.delayed(Duration.zero);
       container.dispose();
     });
 
@@ -76,7 +78,8 @@ void main() {
     });
 
     test('fetch error sets error status', () async {
-      when(() => mockService.fetch()).thenThrow(Exception('connection lost'));
+      when(() => mockService.fetch())
+          .thenThrow(const NetworkError(message: 'connection lost'));
       final container = createContainer();
       await Future.delayed(Duration.zero);
 
@@ -163,12 +166,12 @@ void main() {
       container.dispose();
     });
 
-    test('performSave rethrows on error and clears isSaving', () async {
+    test('performSave rethrows ServiceError and clears isSaving', () async {
       when(() => mockService.fetch()).thenAnswer((_) async => [route1]);
       when(() => mockService.saveBatch(
             original: any(named: 'original'),
             current: any(named: 'current'),
-          )).thenThrow(Exception('save failed'));
+          )).thenThrow(const NetworkError(message: 'save failed'));
 
       final container = createContainer();
       await Future.delayed(Duration.zero);
@@ -176,7 +179,7 @@ void main() {
       final notifier = container.read(uspStaticRoutingProvider.notifier);
       notifier.addRoute(route2);
 
-      await expectLater(notifier.save(), throwsA(isA<Exception>()));
+      await expectLater(notifier.save(), throwsA(isA<ServiceError>()));
 
       expect(container.read(uspStaticRoutingProvider).status.isSaving, isFalse);
       container.dispose();

--- a/test/page/static_routing/services/usp_static_routing_service_test.dart
+++ b/test/page/static_routing/services/usp_static_routing_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
 import 'package:privacy_gui/generated/static_routing.g.dart';
 import 'package:privacy_gui/page/static_routing/models/static_routing_ui_model.dart';
@@ -425,6 +426,45 @@ void main() {
       expect(result.deleted, 1);
       expect(result.added, 1);
       expect(result.updated, 1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error handling
+  // ---------------------------------------------------------------------------
+
+  group('UspStaticRoutingService — error handling', () {
+    test('fetch maps USP error to ServiceError', () async {
+      when(() => mockUsp.get(any()))
+          .thenThrow('Get failed: Transport error: HTTP error: HTTP 504');
+
+      expect(
+        () => service.fetch(),
+        throwsA(isA<ServiceError>()),
+      );
+    });
+
+    test('saveBatch maps USP error to ServiceError', () async {
+      when(() => mockUsp.delete(any())).thenThrow(
+          'Delete failed: Protocol error: invalid path (code: 7004)');
+
+      final original = [
+        StaticRouteUIModel(
+          instancePath: 'path.1.',
+          enabled: true,
+          name: 'Route1',
+          destIpAddress: '10.0.0.0',
+          destSubnetMask: '255.255.255.0',
+          gatewayIpAddress: '192.168.1.1',
+          interfaceName: 'Internet',
+          interfacePath: 'Device.IP.Interface.2',
+        ),
+      ];
+
+      expect(
+        () => service.saveBatch(original: original, current: []),
+        throwsA(isA<ServiceError>()),
+      );
     });
   });
 }

--- a/test/page/system_log/providers/usp_system_log_notifier_test.dart
+++ b/test/page/system_log/providers/usp_system_log_notifier_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/page/system_log/models/log_file_ui_model.dart';
 import 'package:privacy_gui/page/system_log/providers/usp_system_log_notifier.dart';
 import 'package:privacy_gui/page/system_log/services/usp_system_log_service.dart';
@@ -75,6 +76,23 @@ void main() {
       await container.read(uspSystemLogProvider.future);
       final state = container.read(uspSystemLogProvider);
       expect(state.valueOrNull, isEmpty);
+      container.dispose();
+    });
+
+    test('build sets AsyncError with ServiceError when service throws',
+        () async {
+      when(() => mockService.fetch())
+          .thenThrow(const NetworkError(message: 'timeout'));
+      final container = createContainer();
+
+      try {
+        await container.read(uspSystemLogProvider.future);
+      } catch (_) {}
+
+      final state = container.read(uspSystemLogProvider);
+      expect(state.hasError, isTrue);
+      expect(state.error, isA<NetworkError>());
+      expect(state.error.toString(), 'Network error: timeout');
       container.dispose();
     });
   });

--- a/test/page/system_log/services/usp_system_log_service_test.dart
+++ b/test/page/system_log/services/usp_system_log_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/services/usp_service.dart';
 import 'package:privacy_gui/page/system_log/services/usp_system_log_service.dart';
 
@@ -60,6 +61,30 @@ void main() {
       expect(result[1].name, 'crashlog');
       expect(result[1].maximumSize, 65536);
       expect(result[1].persistent, isFalse);
+    });
+  });
+
+  group('UspSystemLogService — error handling', () {
+    test('fetch maps USP transport error to NetworkError', () {
+      when(() => mockUsp.get(any()))
+          .thenThrow('Get failed: Transport error: Request timeout');
+
+      expect(() => service.fetch(), throwsA(isA<NetworkError>()));
+    });
+
+    test('fetch maps USP protocol error to ResourceNotFoundError', () {
+      when(() => mockUsp.get(any())).thenThrow(
+        'Get failed: Protocol error: Decoding error: '
+        'Path (Device.DeviceInfo.VendorLogFile) does not exist (code: 7026)',
+      );
+
+      expect(() => service.fetch(), throwsA(isA<ResourceNotFoundError>()));
+    });
+
+    test('fetch maps non-USP error to UnexpectedError', () {
+      when(() => mockUsp.get(any())).thenThrow('random error');
+
+      expect(() => service.fetch(), throwsA(isA<UnexpectedError>()));
     });
   });
 }


### PR DESCRIPTION
## Summary
- Implement end-to-end USP error handling for all remaining feature pages:
  System Log, Admin, Local Network, Firewall, DHCP Reservations, IPv6 Port Service,
  Static Routing, Port Forwarding, Internet Settings, Devices, Instant Safety, Instant Privacy
- Add `mapUspErrorToServiceError()` to all USP service layers
- Narrow all provider catch clauses from generic `catch(e)` to `on ServiceError catch(e)`
- Replace `StateError` with `ConnectivityError` for null USP service checks in all data providers
- Move Admin reboot/factoryReset from notifier direct USP calls to service layer
- Add error detail display (`error.toString()`) to Instant Safety and Instant Privacy fetch error UI
- Add error detail to Admin view snackbars (timezone, password, reboot, factory reset)
- Add error path tests for all modified service and provider layers
- Fix all existing tests to use `ServiceError` instead of generic `Exception`

Tracking issue: #794

## Test plan
- [ ] All unit tests pass (`flutter test`)
- [ ] `flutter analyze` — no new issues in changed files
- [ ] `dart format` — all files formatted
- [ ] Verify error snackbar shows human-readable message on save failure
- [ ] Verify fetch error UI shows error detail with Retry button


🤖 Generated with [Claude Code](https://claude.com/claude-code)