### PR TITLE
feat: proactive JWT token refresh via SSE heartbeat

### DIFF
--- a/doc/architecture/proactive-token-refresh-plan.md
+++ b/doc/architecture/proactive-token-refresh-plan.md
@@ -1,0 +1,446 @@
+# Plan: Proactive Token Refresh + Unified Connection State Management
+
+## Context
+
+The USP WASM client's JWT token TTL is **15 minutes** (confirmed by decoding the actual router JWT: `exp - iat = 900s`). Currently, token refresh is only triggered reactively upon receiving a 401 (`_withAuthRetry` -> `reauth()`). The `UspAuthCoordinator.ensureAuth()` method exists but is **never called**.
+
+Users report "Linksys Now does not re-refresh the token" — operations fail after prolonged idle.
+
+Additionally, when the router is unreachable (reboot, network switch), the app lacks a unified "waiting for recovery" state, causing background activities to send invalid requests with no UI guidance.
+
+## Router Configuration (confirmed 2026-04-20)
+
+```
+JWT payload: { iat: T, exp: T+900 }  -> TTL = 15 minutes
+usp-bridge.main.session_grace_period = 30s
+usp-bridge.main.heartbeat_interval = 30s
+Bridge health endpoint: GET /api/v1/health (no auth required)
+Router identity: Device.DeviceInfo.SerialNumber (auth required)
+```
+
+---
+
+## Part 1: Application-Layer Connection State Machine
+
+### State Definition
+
+```dart
+enum AppConnectionState {
+  /// Normal operation — all background activities running
+  authenticated,
+
+  /// Router unreachable — all background activities stopped, recovery probing in progress
+  /// UI: full-screen prompt "Please reconnect to your router network" (future implementation)
+  waitingForRecovery,
+
+  /// Auth unrecoverable — navigate to login page
+  loggedOut,
+}
+```
+
+### State Transitions
+
+```
+                    +---------------+
+          +---------| authenticated |---------+
+          |         +-------+-------+         |
+          |                 |                 |
+          |  Consecutive    |  401 + reauth   |
+          |  network        |  failure        |
+          |  failures       |                 |
+          |  exceed         |                 |
+          |  threshold      |                 |
+          |  or known op    |                 |
+          |  (reboot etc)   |                 |
+          v                 |                 v
++------------------+        |        +----------+
+|waitingForRecovery|        +------->| loggedOut |
+|                  |                 |          |
+| Stop all bg      |                 +----------+
+| Start recovery   |                      ^
+| probe            |                      |
+|                  |  serial mismatch     |
+| health OK        |---------------------+
+| + login OK       |
+| + serial match   |
+|       |          |
+|       v          |
+|  -> authenticated|
++------------------+
+```
+
+### Conditions to Enter `waitingForRecovery`
+
+| Trigger Type | Condition | Delay |
+|-------------|-----------|-------|
+| **Natural** | SSE `suspended` + polling consecutive N network errors | Immediate (SSE suspended already went through backoff) |
+| **Operational** | User initiates reboot / firmware upgrade | Configurable (e.g., ~5s after reboot) |
+
+### Behavior on Entry
+
+1. **Stop all background activities:**
+   - Polling timers (Traffic Analysis 5s, System Monitor 30s, Apps 5s, etc.)
+   - SSE reconnect (`SseConnectionManager` stops backoff retry)
+   - Heartbeat `ensureAuth()` (SSE disconnected, naturally not triggered)
+   - Throttler queue cleared (cancel queued requests)
+
+2. **Start recovery probe loop** (see below)
+
+### Recovery Probe Flow
+
+```
+Every N seconds (configurable, default 5s):
+
+  Step 1: Is the bridge reachable?
+    GET /api/v1/health (no auth, lightweight)
+    -> Fail -> Continue waiting, retry next interval
+
+  Step 2: Can we log in?
+    restoreSession() (login with locally stored password)
+    * After reboot, session is cleared — refreshToken will fail, so login directly
+    -> Fail -> Continue waiting (possibly a different router with different password, or router not fully booted)
+
+  Step 3: Is it the same router?
+    GET Device.DeviceInfo.SerialNumber
+    Compare with serial number stored in local storage
+    -> Match    -> Restore: reconnect SSE, restart polling -> authenticated
+    -> Mismatch -> Different router -> force logout -> loggedOut
+```
+
+### Router Fingerprint Storage
+
+- **When to store:** During Dashboard initialization (after `systemInfoProvider` fetch succeeds)
+- **Where to store:** `FlutterSecureStorage` (same secure storage as password)
+- **What to store:** `Device.DeviceInfo.SerialNumber`
+- **When to clear:** On `logout()`
+
+### Maximum Wait Time
+
+**Unlimited — stay on the waiting screen and let the user decide when to give up.**
+
+The user can manually return to the login page via a UI button (to be added in future UI implementation).
+
+---
+
+## Part 2: Unified Fault Handling Rules
+
+### Fault Classification & Behavior
+
+| Fault Type | Meaning | Behavior |
+|-----------|---------|----------|
+| **401** -> reauth success | Token expired but recoverable | Resume normally, no logout |
+| **401** -> reauth failure | Session unrecoverable | **Force logout** |
+| **Network error** | Cannot reach server | SSE banner -> accumulate -> **waitingForRecovery** |
+| **Server error** (503/504) | Bridge busy | Retry, no logout, no waiting |
+| **WASM/JS exception** | Client internal error | Error state, no logout |
+
+### Behavior Matrix by Trigger Source
+
+| Trigger Source | Error Type | Behavior |
+|---------------|------------|----------|
+| Heartbeat refresh | Success | Update timestamp |
+| Heartbeat refresh | 401 | **Force logout** |
+| Heartbeat refresh | Network error | Skip, retry next heartbeat |
+| Polling / user action | 401 -> reauth success | Resume normally |
+| Polling / user action | 401 -> reauth failure | **Force logout** |
+| Polling / user action | Network error | Provider error state -> accumulate -> **waitingForRecovery** |
+| SSE reconnect | 401 -> reauth failure | **Force logout** |
+| SSE reconnect | Network error | Banner + backoff -> suspended -> **waitingForRecovery** |
+| Connected to different router | 401 -> reauth failure | **Force logout** |
+| Recovery probe serial mismatch | — | **Force logout** |
+| User-triggered reboot | — | **waitingForRecovery** (configurable delay) |
+
+### Banner vs waitingForRecovery vs Force Logout
+
+```
+Network error occurs
+  -> SSE: connecting -> reconnecting -> suspended (backoff exhausted)
+  -> Polling: consecutive failures accumulate
+  -> Brief disconnect: Banner shows -> reconnect succeeds -> Banner disappears (no waiting)
+  -> Sustained disconnect: SSE suspended -> enter waitingForRecovery -> full-screen prompt
+
+401 occurs
+  -> reauth success: Resume normally (no UI impact)
+  -> reauth failure: Force logout -> login page (skip waiting, logout immediately)
+```
+
+---
+
+## Part 3: Proactive Token Refresh Implementation (5 files)
+
+### 1. `lib/core/usp/services/usp_client.dart`
+
+**Added:**
+- `bool get isReauthInProgress => _reauthInProgress != null;`
+- `VoidCallback? onForceLogout;`
+- `VoidCallback? onRefreshTokenSuccess;`
+
+**Modified `reauth()` catch block (~line 160):**
+
+```dart
+} catch (e) {
+  if (!_reauthInProgress!.isCompleted) {
+    _reauthInProgress!.completeError(e);
+  }
+  logger.w('[USP][Service]All reauth stages failed — forcing logout');
+  onForceLogout?.call();
+  rethrow;
+}
+```
+
+**Modified `reauth()` after Stage 1 success (~line 146):**
+
+```dart
+await refreshToken();
+logger.d('[USP][Service]Token refreshed successfully');
+onRefreshTokenSuccess?.call();
+_reauthInProgress!.complete();
+return;
+```
+
+### 2. `lib/core/usp/providers/usp_auth_coordinator.dart`
+
+**Added fields:**
+```dart
+DateTime? _lastTokenRefresh;
+Completer<void>? _refreshInProgress;
+VoidCallback? onForceLogout;
+static const Duration _refreshThreshold = Duration(minutes: 12);
+```
+
+**Modified constructor:**
+```dart
+UspAuthCoordinator(this._usp, this._storage) {
+  _usp?.onReauthRequired = () => _forceRestoreSession();
+  _usp?.onRefreshTokenSuccess = () {
+    _lastTokenRefresh = DateTime.now();
+  };
+}
+```
+
+**Update `_lastTokenRefresh = DateTime.now()` at all login success points:**
+- `syncAfterLocalLogin()` — after `_usp.login()` succeeds
+- `_loginWithStoredPassword()` — after `_usp.login()` succeeds
+- `tryUspLogin()` — after `authenticated == true`
+
+**Reset in `syncAfterLogout()`:** `_lastTokenRefresh = null;`
+
+**Added `_forceRestoreSession()`** — bypasses `isAuthenticated` guard (WASM may still report authenticated after 401 since it checks token existence, not validity).
+
+**Rewritten `ensureAuth()` — distinguishes 401 from network error:**
+```dart
+static bool _isAuthError(Object error) {
+  return error.toString().contains('HTTP 401');
+}
+
+Future<void> ensureAuth() async {
+  if (_usp == null || !_usp.isAuthenticated) return;
+  if (_usp.isReauthInProgress) return;
+  if (_refreshInProgress != null) return;
+
+  final last = _lastTokenRefresh;
+  if (last != null && DateTime.now().difference(last) < _refreshThreshold) {
+    return;
+  }
+
+  _refreshInProgress = Completer<void>();
+  try {
+    await _usp.refreshToken();
+    _lastTokenRefresh = DateTime.now();
+    logger.d('[USP][Auth]Proactive token refresh succeeded');
+  } catch (e) {
+    if (_isAuthError(e)) {
+      logger.w('[USP][Auth]Proactive refresh got 401 — forcing logout: $e');
+      onForceLogout?.call();
+    } else {
+      logger.w('[USP][Auth]Proactive refresh failed (non-auth, will retry): $e');
+    }
+  } finally {
+    _refreshInProgress = null;
+  }
+}
+```
+
+### 3. `lib/core/usp/services/sse_event_router.dart`
+
+**Added:** `VoidCallback? onHeartbeat;`
+
+**Modified `routeEvent()`:**
+```dart
+case 'heartbeat':
+  onHeartbeat?.call();
+  break;
+case 'connected':
+  break;
+```
+
+**`dispose()` includes:** `onHeartbeat = null;`
+
+### 4. `lib/core/usp/services/sse_manager.dart`
+
+**Added:** `Future<void> Function()? onHeartbeatAuth;`
+
+**Constructor wiring:**
+```dart
+router.onHeartbeat = () {
+  final authCheck = onHeartbeatAuth;
+  if (authCheck != null) {
+    authCheck().catchError((e) {
+      logger.w('[USP][SSE]Heartbeat auth check error: $e');
+    });
+  }
+};
+```
+
+**`dispose()` includes:** `router.onHeartbeat = null; onHeartbeatAuth = null;`
+
+### 5. `lib/core/usp/providers/sse_providers.dart`
+
+**Modified `sseManagerProvider`:**
+
+```dart
+final sseManagerProvider = Provider<SseManager?>((ref) {
+  final usp = ref.watch(uspClientProvider);
+  final bridge = ref.watch(uspBridgeClientProvider);
+  if (usp == null || bridge == null) return null;
+
+  final manager = SseManager(usp: usp, bridge: bridge);
+
+  final authCoordinator = ref.read(uspAuthCoordinatorProvider);
+  manager.onHeartbeatAuth = () => authCoordinator.ensureAuth();
+
+  bool logoutTriggered = false;
+  void forceLogout() {
+    if (logoutTriggered) return;
+    logoutTriggered = true;
+    logger.w('[USP]Force logout triggered');
+    ref.read(authProvider.notifier).logout();
+  }
+  authCoordinator.onForceLogout = forceLogout;
+  usp.onForceLogout = forceLogout;
+
+  ref.onDispose(() {
+    authCoordinator.onForceLogout = null;
+    usp.onForceLogout = null;
+    manager.dispose();
+  });
+
+  return manager;
+});
+```
+
+**Added imports:**
+```dart
+import 'package:privacy_gui/providers/auth/auth_provider.dart';
+import 'package:privacy_gui/core/usp/providers/usp_auth_coordinator.dart';
+```
+
+---
+
+## Part 4: Callback Chains
+
+### Proactive Path (Heartbeat)
+
+```
+Bridge SSE stream (heartbeat every 30s)
+  -> SseConnectionManager._onEvent()
+    -> onEvent (= router.routeEvent)
+      -> SseEventRouter case 'heartbeat' -> onHeartbeat()
+        -> SseManager: onHeartbeatAuth()
+          -> UspAuthCoordinator.ensureAuth()
+            -> elapsed < 12 min? return
+            -> elapsed >= 12 min? refreshToken()
+              -> Success: update _lastTokenRefresh
+              -> Fail 401: onForceLogout -> loggedOut
+              -> Fail network: skip, retry next heartbeat
+```
+
+### Reactive Path (401 Reauth)
+
+```
+CRUD / Polling -> HTTP 401
+  -> _withAuthRetry -> reauth()
+    -> Stage 1: refreshToken()
+      -> Success: onRefreshTokenSuccess -> update _lastTokenRefresh
+    -> Stage 2: onReauthRequired -> _forceRestoreSession()
+      -> Success: _lastTokenRefresh updated
+    -> Both fail: onForceLogout() -> loggedOut
+```
+
+### Recovery Path (waitingForRecovery)
+
+```
+Enter waitingForRecovery state
+  -> Stop all polling / SSE reconnect
+  -> Start recovery probe (configurable interval, default 5s)
+    -> health OK -> restoreSession OK -> GET serial
+      -> match: restore -> authenticated
+      -> mismatch: force logout -> loggedOut
+    -> health fail: continue waiting
+```
+
+---
+
+## Part 5: Race Condition Guards
+
+| Scenario | Guard |
+|----------|-------|
+| Heartbeat and 401 reauth simultaneous | `ensureAuth()` checks `_usp.isReauthInProgress` -> skip |
+| Consecutive heartbeats stacking | `_refreshInProgress` Completer guard -> skip |
+| 401 triggers onForceLogout during logout | `logoutTriggered` bool guard -> skip |
+| Both paths call refreshToken simultaneously | Acceptable — refreshToken is idempotent |
+| User action during waitingForRecovery | UI blocks (full-screen modal), background stopped |
+
+---
+
+## Part 6: `_lastTokenRefresh` Update Points
+
+| Event | Update Location |
+|-------|----------------|
+| Initial login (tryUspLogin) | `UspAuthCoordinator.tryUspLogin()` |
+| Sync login (syncAfterLocalLogin) | `UspAuthCoordinator.syncAfterLocalLogin()` |
+| Session restore (restoreSession) | `UspAuthCoordinator._loginWithStoredPassword()` |
+| Proactive refresh (heartbeat) | `UspAuthCoordinator.ensureAuth()` |
+| Reactive refresh (401 Stage 1) | `UspClient.reauth()` -> `onRefreshTokenSuccess` callback |
+| Logout | `UspAuthCoordinator.syncAfterLogout()` -> reset to `null` |
+
+---
+
+## Part 7: Implementation Phases
+
+### Phase 1 (this implementation): Proactive Token Refresh + Force Logout
+
+- Modify 5 files (Part 3)
+- Fault rules: unrecoverable 401 = force logout, network error = no logout
+- Router fingerprint storage (store serial number to secure storage on login)
+
+### Phase 2 (future): waitingForRecovery State
+
+- Add `AppConnectionState` state machine + provider
+- Recovery probe loop (health -> login -> serial comparison)
+- Operational triggers (reboot and other known operations enter waiting directly)
+- Mechanism to stop all background activities
+- UI: full-screen modal "Please reconnect to your router network"
+
+---
+
+## Part 8: Verification
+
+### Phase 1 Verification
+
+1. `flutter analyze lib/core/usp/` — zero errors
+2. Manual testing:
+   - Wait >12 minutes after login -> log shows `Proactive token refresh succeeded`
+   - Continuous operation -> no extra refresh triggered within 12 minutes
+   - SSH kill session -> next poll or heartbeat triggers 401 -> auto logout
+   - Unplug network cable -> SSE banner shows, force logout NOT triggered
+   - Network restored + token not expired -> SSE reconnects -> banner disappears
+   - Network restored + token expired -> SSE reconnect 401 -> reauth success/failure
+3. Edge case: Connect to different router (same IP) -> 401 -> reauth failure -> force logout
+
+### Phase 2 Verification (future)
+
+1. User-triggered reboot -> enter waiting state -> router finishes restarting -> auto recovery
+2. Switch WiFi to different network -> enter waiting -> switch back to correct WiFi -> serial match -> recovery
+3. Switch back to different router (same IP + same password) -> serial mismatch -> force logout
+4. User manually returns to login page while in waiting state

--- a/lib/core/usp/providers/sse_providers.dart
+++ b/lib/core/usp/providers/sse_providers.dart
@@ -2,11 +2,13 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/core/usp/providers/usp_auth_coordinator.dart';
 import 'package:privacy_gui/core/usp/providers/usp_client_provider.dart';
 import 'package:privacy_gui/core/usp/services/sse_connection_manager.dart';
 import 'package:privacy_gui/core/usp/services/sse_manager.dart';
 import 'package:privacy_gui/core/usp/services/sse_operation_awaiter.dart';
 import 'package:privacy_gui/core/usp/services/usp_bridge_client.dart';
+import 'package:privacy_gui/providers/auth/auth_provider.dart';
 
 /// Provides [UspBridgeClient] instance — depends on [UspClient].
 final uspBridgeClientProvider = Provider<UspBridgeClient?>((ref) {
@@ -27,7 +29,29 @@ final sseManagerProvider = Provider<SseManager?>((ref) {
   if (usp == null || bridge == null) return null;
 
   final manager = SseManager(usp: usp, bridge: bridge);
-  ref.onDispose(() => manager.dispose());
+
+  // Wire proactive token refresh on SSE heartbeat
+  final authCoordinator = ref.read(uspAuthCoordinatorProvider);
+  manager.onHeartbeatAuth = () => authCoordinator.ensureAuth();
+
+  // Wire force logout — shared guard prevents duplicate triggers
+  bool logoutTriggered = false;
+  void forceLogout() {
+    if (logoutTriggered) return;
+    logoutTriggered = true;
+    logger.w('[USP][Auth]Force logout triggered — navigating to login');
+    ref.read(authProvider.notifier).logout();
+  }
+
+  authCoordinator.onForceLogout = forceLogout;
+  usp.onForceLogout = forceLogout;
+
+  ref.onDispose(() {
+    authCoordinator.onForceLogout = null;
+    usp.onForceLogout = null;
+    manager.dispose();
+  });
+
   return manager;
 });
 

--- a/lib/core/usp/providers/usp_auth_coordinator.dart
+++ b/lib/core/usp/providers/usp_auth_coordinator.dart
@@ -182,7 +182,8 @@ class UspAuthCoordinator {
         logger.w('[USP][Auth]Proactive refresh got 401 — forcing logout: $e');
         onForceLogout?.call();
       } else {
-        logger.w('[USP][Auth]Proactive refresh failed (non-auth, will retry): $e');
+        logger.w(
+            '[USP][Auth]Proactive refresh failed (non-auth, will retry): $e');
       }
     } finally {
       _refreshInProgress = null;

--- a/lib/core/usp/providers/usp_auth_coordinator.dart
+++ b/lib/core/usp/providers/usp_auth_coordinator.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:privacy_gui/constants/pref_key.dart';
@@ -15,6 +18,7 @@ import 'package:privacy_gui/core/usp/services/usp_client.dart';
 /// - [syncAfterLocalLogin]: Auto-login USP after successful JNAP local login
 /// - [syncAfterLogout]: Logout USP when JNAP logs out
 /// - [restoreSession]: Re-authenticate USP using stored password on page reload
+/// - [ensureAuth]: Proactive token refresh triggered by SSE heartbeat
 ///
 /// USP login failure never blocks JNAP operations — [ProtocolResolver] falls
 /// back to JNAP when `isAuthenticated` is false.
@@ -22,8 +26,29 @@ class UspAuthCoordinator {
   final UspClient? _usp;
   final FlutterSecureStorage _storage;
 
+  DateTime? _lastTokenRefresh;
+  Completer<void>? _refreshInProgress;
+
+  /// Called when proactive refresh gets 401 — session externally terminated.
+  VoidCallback? onForceLogout;
+
+  /// Proactive refresh threshold. Must be less than JWT TTL (15 min).
+  /// At 12 min, the worst-case margin is ~2:30 (heartbeat at 12:29 + refresh).
+  static const Duration _refreshThreshold = Duration(minutes: 12);
+
+  // Matches WASM error format "Transport error: HTTP error: HTTP 401"
+  // and simplified format "HTTP 401 Unauthorized". Avoids false positives
+  // on non-401 status codes (e.g., "HTTP 500").
+  static final _authErrorPattern = RegExp(r'HTTP (?:error: HTTP )?401');
+  static bool _isAuthError(Object error) {
+    return _authErrorPattern.hasMatch(error.toString());
+  }
+
   UspAuthCoordinator(this._usp, this._storage) {
-    _usp?.onReauthRequired = () => restoreSession();
+    _usp?.onReauthRequired = () => _forceRestoreSession();
+    _usp?.onRefreshTokenSuccess = () {
+      _lastTokenRefresh = DateTime.now();
+    };
   }
 
   /// Called after JNAP localLogin succeeds — auto-sync USP authentication.
@@ -31,6 +56,7 @@ class UspAuthCoordinator {
     if (_usp == null) return;
     try {
       await _usp.login(password);
+      _lastTokenRefresh = DateTime.now();
       logger.d('[USP][Auth]USP login synced successfully');
     } catch (e) {
       // USP login failure does not affect JNAP — ProtocolResolver
@@ -41,6 +67,7 @@ class UspAuthCoordinator {
 
   /// Called during JNAP logout — sync logout USP.
   Future<void> syncAfterLogout() async {
+    _lastTokenRefresh = null;
     if (_usp == null || !_usp.isAuthenticated) return;
     try {
       await _usp.logout();
@@ -63,17 +90,40 @@ class UspAuthCoordinator {
       logger.d('[USP][Auth]restoreSession skipped: already authenticated');
       return;
     }
+    await _loginWithStoredPassword();
+  }
+
+  /// Force restore session — bypasses [isAuthenticated] guard.
+  ///
+  /// Used as [UspClient.onReauthRequired] callback. After a 401, the WASM
+  /// client may still report isAuthenticated=true (token exists in memory
+  /// but is expired/revoked). This method skips the guard and attempts
+  /// re-login unconditionally.
+  Future<void> _forceRestoreSession() async {
+    if (_usp == null) {
+      logger.w('[USP][Auth]forceRestoreSession skipped: UspClient is null');
+      return;
+    }
+    await _loginWithStoredPassword();
+  }
+
+  /// Shared login logic — reads stored password and calls [UspClient.login].
+  /// Returns true if login succeeded, false otherwise. Never throws.
+  Future<bool> _loginWithStoredPassword() async {
     final password = await _storage.read(key: pLocalPassword);
     if (password == null || password.isEmpty) {
       logger.w('[USP][Auth]restoreSession skipped: no stored password');
-      return;
+      return false;
     }
     try {
-      await _usp.login(password);
+      await _usp!.login(password);
+      _lastTokenRefresh = DateTime.now();
       logger.d(
           '[USP][Auth]restoreSession login done, isAuthenticated=${_usp.isAuthenticated}');
+      return true;
     } catch (e) {
       logger.w('[USP][Auth]restoreSession login failed: $e');
+      return false;
     }
   }
 
@@ -90,6 +140,7 @@ class UspAuthCoordinator {
       await _usp.login(password);
       final authenticated = _usp.isAuthenticated;
       if (authenticated) {
+        _lastTokenRefresh = DateTime.now();
         logger.d('[USP][Auth]USP standalone login succeeded');
       }
       return authenticated;
@@ -99,14 +150,42 @@ class UspAuthCoordinator {
     }
   }
 
-  /// Called periodically (e.g., every polling cycle) to keep USP token alive.
+  /// Proactive token refresh — called on every SSE heartbeat (~30s).
+  ///
+  /// Strategy: Only refreshes when elapsed time ≥ [_refreshThreshold] (12 min)
+  /// to avoid unnecessary network calls. On 401, triggers force logout instead
+  /// of attempting [restoreSession], because:
+  /// - SSE heartbeat arriving means the connection is live
+  /// - A 401 on proactive refresh means the session was externally terminated
+  ///   (e.g., SSH killed the session on the router)
+  /// - Force logout is cleaner than silent re-login in this scenario
+  ///
+  /// Network errors are silently skipped — the next heartbeat will retry.
   Future<void> ensureAuth() async {
     if (_usp == null || !_usp.isAuthenticated) return;
+    if (_usp.isReauthInProgress) return;
+    if (_refreshInProgress != null) return;
+
+    final last = _lastTokenRefresh;
+    if (last != null && DateTime.now().difference(last) < _refreshThreshold) {
+      return;
+    }
+
+    _refreshInProgress = Completer<void>();
     try {
       await _usp.refreshToken();
+      _lastTokenRefresh = DateTime.now();
+      logger.d('[USP][Auth]Proactive token refresh succeeded');
     } catch (e) {
-      logger.w('[USP][Auth]USP token refresh failed, attempting restore: $e');
-      await restoreSession();
+      if (_isAuthError(e)) {
+        _lastTokenRefresh = null; // Allow immediate retry if logout is delayed
+        logger.w('[USP][Auth]Proactive refresh got 401 — forcing logout: $e');
+        onForceLogout?.call();
+      } else {
+        logger.w('[USP][Auth]Proactive refresh failed (non-auth, will retry): $e');
+      }
+    } finally {
+      _refreshInProgress = null;
     }
   }
 }

--- a/lib/core/usp/services/sse_event_router.dart
+++ b/lib/core/usp/services/sse_event_router.dart
@@ -18,6 +18,10 @@ export 'package:privacy_gui/core/usp/models/sse_notification.dart';
 /// Events that are not `notification` type (heartbeat, connected, turbo_channel)
 /// are silently ignored — they are handled by [SseConnectionManager].
 class SseEventRouter {
+  /// Called on every SSE heartbeat event. Set by [SseManager] to trigger
+  /// proactive token refresh via [UspAuthCoordinator.ensureAuth].
+  VoidCallback? onHeartbeat;
+
   /// subscription_id → list of handlers
   final Map<String, List<SseNotificationHandler>> _handlers = {};
 
@@ -57,8 +61,9 @@ class SseEventRouter {
         _routeNotification(event);
         break;
       case 'heartbeat':
+        onHeartbeat?.call();
+        break;
       case 'connected':
-        // Handled by SseConnectionManager. No routing needed.
         break;
       case 'turbo_channel':
         // Future: route to turbo channel coordinator
@@ -127,6 +132,7 @@ class SseEventRouter {
 
   /// Removes all handlers.
   void dispose() {
+    onHeartbeat = null;
     _handlers.clear();
     _wildcardHandlers.clear();
   }

--- a/lib/core/usp/services/sse_manager.dart
+++ b/lib/core/usp/services/sse_manager.dart
@@ -45,6 +45,10 @@ class SseManager {
       [];
   bool _coreSubsDeferred = false;
 
+  /// Delegate for proactive auth check on heartbeat. Set by provider layer
+  /// to wire [UspAuthCoordinator.ensureAuth].
+  Future<void> Function()? onHeartbeatAuth;
+
   SseManager({
     required UspClient usp,
     required UspBridgeClient bridge,
@@ -55,6 +59,16 @@ class SseManager {
         router = SseEventRouter() {
     // Wire connection events to router
     connection.onEvent = router.routeEvent;
+
+    // Wire heartbeat → proactive auth check (fire-and-forget)
+    router.onHeartbeat = () {
+      final authCheck = onHeartbeatAuth;
+      if (authCheck != null) {
+        authCheck().catchError((e) {
+          logger.w('[USP][SSE]Heartbeat auth check error: $e');
+        });
+      }
+    };
 
     // On connect (first or reconnect): register/re-register subscriptions.
     // First connect: registers core subscriptions set via setCoreSubscriptions().
@@ -254,6 +268,8 @@ class SseManager {
     _unloadHandler.unregister();
     _usp.onSseSubscribe = null;
     _usp.onTokenRefreshed = null;
+    router.onHeartbeat = null;
+    onHeartbeatAuth = null;
     // Synchronous abort first — critical for hot restart where async may not complete.
     _bridge.abortSse();
     await connection.disconnect();

--- a/lib/core/usp/services/usp_client.dart
+++ b/lib/core/usp/services/usp_client.dart
@@ -86,14 +86,27 @@ class UspClient {
 
   String? get sessionToken => _client.sessionToken;
 
+  /// Whether a [reauth] call is currently in progress.
+  /// Used by [UspAuthCoordinator.ensureAuth] to avoid overlapping refresh.
+  bool get isReauthInProgress => _reauthInProgress != null;
+
   /// Callback for full re-authentication when token refresh fails.
   /// Set by [UspAuthCoordinator] to provide re-login via stored password.
   Future<void> Function()? onReauthRequired;
 
-  /// Called after [reauth] completes successfully (either refreshToken or
-  /// full re-login). Set by [SseManager] to force SSE reconnect with the
-  /// new token, preventing silent subscription routing failures.
+  /// Called after [reauth] Stage 2 (full re-login) succeeds.
+  /// Set by [SseManager] to force SSE reconnect with the new session token.
+  /// NOT called after Stage 1 (refreshToken) — same session, no SSE reconnect needed.
   VoidCallback? onTokenRefreshed;
+
+  /// Called after [reauth] Stage 1 (refreshToken) succeeds.
+  /// Set by [UspAuthCoordinator] to update [_lastTokenRefresh] timestamp.
+  /// NOT related to SSE reconnect — see [onTokenRefreshed] for that.
+  VoidCallback? onRefreshTokenSuccess;
+
+  /// Called when all reauth stages fail — session is unrecoverable.
+  /// Set by provider layer to trigger navigation to login screen.
+  VoidCallback? onForceLogout;
 
   /// SSE subscription delegate. Set by [SseManager] to route subscriptions
   /// through SSE instead of polling. When null, falls back to polling.
@@ -144,6 +157,11 @@ class UspClient {
       try {
         await refreshToken();
         logger.d('[USP][Service]Token refreshed successfully');
+        try {
+          onRefreshTokenSuccess?.call();
+        } catch (cbError) {
+          logger.w('[USP][Service]onRefreshTokenSuccess callback error: $cbError');
+        }
         _reauthInProgress!.complete();
         return;
       } catch (e) {
@@ -160,6 +178,16 @@ class UspClient {
     } catch (e) {
       if (!_reauthInProgress!.isCompleted) {
         _reauthInProgress!.completeError(e);
+      }
+      // The original trigger was a confirmed 401 (token expired/revoked).
+      // Both Stage 1 (refreshToken) and Stage 2 (restoreSession) failed,
+      // so the session is unrecoverable regardless of Stage 2 failure reason
+      // (auth error, network error, or no stored password).
+      logger.w('[USP][Service]All reauth stages failed — forcing logout');
+      try {
+        onForceLogout?.call();
+      } catch (cbError) {
+        logger.w('[USP][Service]onForceLogout callback error: $cbError');
       }
       rethrow;
     } finally {

--- a/lib/core/usp/services/usp_client.dart
+++ b/lib/core/usp/services/usp_client.dart
@@ -160,7 +160,8 @@ class UspClient {
         try {
           onRefreshTokenSuccess?.call();
         } catch (cbError) {
-          logger.w('[USP][Service]onRefreshTokenSuccess callback error: $cbError');
+          logger.w(
+              '[USP][Service]onRefreshTokenSuccess callback error: $cbError');
         }
         _reauthInProgress!.complete();
         return;

--- a/lib/providers/auth/auth_provider.dart
+++ b/lib/providers/auth/auth_provider.dart
@@ -44,7 +44,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
       );
 
       logger.d(
-          '[Auth]: admin password: ${localPassword != null}. Login type = $loginType');
+          '[Auth]init: hasPassword=${localPassword != null}, loginType=$loginType');
 
       // Restore USP session on page reload / app restart (local login only)
       if (loginType == LoginType.local) {
@@ -74,7 +74,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         // Store password for session restore
         await const FlutterSecureStorage()
             .write(key: pLocalPassword, value: password);
-        logger.d('[Auth]: USP login succeeded');
+        logger.d('[Auth]localLogin: USP login succeeded');
         return previousState.copyWith(
           localPassword: password,
           loginType: LoginType.local,
@@ -82,7 +82,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
       }
       throw Exception('USP login failed');
     }, (error) => guardError);
-    logger.d('[Auth]: Local login done: Auth state = $state');
+    logger.d('[Auth]localLogin: done, state=$state');
   }
 
   /// Retrieves password hint from the router.
@@ -102,7 +102,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
 
   /// Performs logout, clearing credentials and resetting state.
   Future logout() async {
-    logger.d('[Prepare]: Logout');
+    logger.d('[Auth]logout: starting');
     state = const AsyncValue.loading();
 
     state = await AsyncValue.guard(() async {
@@ -111,14 +111,17 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
       // must still be valid.
       final sseManager = ref.read(sseManagerProvider);
       if (sseManager != null) {
+        logger.d('[Auth]logout: disconnecting SSE');
         await sseManager.disconnect();
         await sseManager.registry.unregisterAll();
       }
 
       // Now safe to logout USP
+      logger.d('[Auth]logout: syncing USP logout');
       await ref.read(uspAuthCoordinatorProvider).syncAfterLogout();
 
       // Clear credentials
+      logger.d('[Auth]logout: clearing credentials');
       await _authService.clearAllCredentials();
 
       // Clear RA-related prefs (legacy cleanup)
@@ -128,6 +131,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
 
       // Reset provider states
       ref.read(sessionProvider.notifier).clear();
+      logger.d('[Auth]logout: complete');
       return AuthState.empty();
     });
     ref.read(selectedNetworkIdProvider.notifier).state = null;

--- a/test/core/usp/providers/usp_auth_coordinator_test.dart
+++ b/test/core/usp/providers/usp_auth_coordinator_test.dart
@@ -1,0 +1,382 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/providers/usp_auth_coordinator.dart';
+import 'package:privacy_gui/core/usp/services/usp_client.dart';
+
+/// Mock that stores callback fields (mocktail Mock swallows setter calls).
+class TestUspClient extends Mock implements UspClient {
+  @override
+  Future<void> Function()? onReauthRequired;
+
+  @override
+  VoidCallback? onRefreshTokenSuccess;
+
+  @override
+  VoidCallback? onForceLogout;
+}
+
+class MockSecureStorage extends Mock implements FlutterSecureStorage {}
+
+void main() {
+  late TestUspClient mockUsp;
+  late MockSecureStorage mockStorage;
+  late UspAuthCoordinator coordinator;
+
+  setUp(() {
+    mockUsp = TestUspClient();
+    mockStorage = MockSecureStorage();
+
+    // Default stubs
+    when(() => mockUsp.isAuthenticated).thenReturn(true);
+    when(() => mockUsp.isReauthInProgress).thenReturn(false);
+    when(() => mockUsp.refreshToken()).thenAnswer((_) async {});
+
+    coordinator = UspAuthCoordinator(mockUsp, mockStorage);
+  });
+
+  // ---------------------------------------------------------------------------
+  // ensureAuth — threshold gating
+  // ---------------------------------------------------------------------------
+  group('ensureAuth — threshold', () {
+    test('refreshes when _lastTokenRefresh is null', () async {
+      await coordinator.ensureAuth();
+
+      verify(() => mockUsp.refreshToken()).called(1);
+    });
+
+    test('skips refresh when elapsed < 12 minutes', () async {
+      // First call sets _lastTokenRefresh
+      await coordinator.ensureAuth();
+      reset(mockUsp);
+      when(() => mockUsp.isAuthenticated).thenReturn(true);
+      when(() => mockUsp.isReauthInProgress).thenReturn(false);
+      when(() => mockUsp.refreshToken()).thenAnswer((_) async {});
+
+      // Immediate second call — well within 12 min
+      await coordinator.ensureAuth();
+
+      verifyNever(() => mockUsp.refreshToken());
+    });
+
+    test('refreshes when elapsed >= 12 minutes', () async {
+      // First call to set _lastTokenRefresh
+      await coordinator.ensureAuth();
+      verify(() => mockUsp.refreshToken()).called(1);
+
+      // Simulate time passage by calling syncAfterLogout + re-login
+      // (which resets _lastTokenRefresh to null)
+      when(() => mockUsp.logout()).thenAnswer((_) async {});
+      await coordinator.syncAfterLogout();
+
+      // Now _lastTokenRefresh is null → next call should refresh
+      when(() => mockUsp.isAuthenticated).thenReturn(true);
+      when(() => mockUsp.isReauthInProgress).thenReturn(false);
+      await coordinator.ensureAuth();
+
+      verify(() => mockUsp.refreshToken()).called(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ensureAuth — refresh success
+  // ---------------------------------------------------------------------------
+  group('ensureAuth — success', () {
+    test('updates _lastTokenRefresh on success', () async {
+      await coordinator.ensureAuth();
+
+      verify(() => mockUsp.refreshToken()).called(1);
+
+      // Second immediate call should skip (timestamp was set)
+      await coordinator.ensureAuth();
+      verifyNever(() => mockUsp.refreshToken());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ensureAuth — 401 error triggers force logout
+  // ---------------------------------------------------------------------------
+  group('ensureAuth — 401 error', () {
+    test('calls onForceLogout on HTTP 401', () async {
+      when(() => mockUsp.refreshToken())
+          .thenThrow(Exception('HTTP 401 Unauthorized'));
+
+      bool logoutCalled = false;
+      coordinator.onForceLogout = () => logoutCalled = true;
+
+      await coordinator.ensureAuth();
+
+      expect(logoutCalled, isTrue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ensureAuth — network error does NOT trigger force logout
+  // ---------------------------------------------------------------------------
+  group('ensureAuth — network error', () {
+    test('does NOT call onForceLogout on network error', () async {
+      when(() => mockUsp.refreshToken())
+          .thenThrow(Exception('SocketException: Connection refused'));
+
+      bool logoutCalled = false;
+      coordinator.onForceLogout = () => logoutCalled = true;
+
+      await coordinator.ensureAuth();
+
+      expect(logoutCalled, isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ensureAuth — guards
+  // ---------------------------------------------------------------------------
+  group('ensureAuth — guards', () {
+    test('skips when usp is not authenticated', () async {
+      when(() => mockUsp.isAuthenticated).thenReturn(false);
+
+      await coordinator.ensureAuth();
+
+      verifyNever(() => mockUsp.refreshToken());
+    });
+
+    test('skips when reauth is in progress', () async {
+      when(() => mockUsp.isReauthInProgress).thenReturn(true);
+
+      await coordinator.ensureAuth();
+
+      verifyNever(() => mockUsp.refreshToken());
+    });
+
+    test('concurrent ensureAuth calls do not stack', () async {
+      final completer = Completer<void>();
+      when(() => mockUsp.refreshToken())
+          .thenAnswer((_) => completer.future);
+
+      // Launch two concurrent calls
+      final f1 = coordinator.ensureAuth();
+      final f2 = coordinator.ensureAuth();
+
+      completer.complete();
+      await f1;
+      await f2;
+
+      // refreshToken should only be called once
+      verify(() => mockUsp.refreshToken()).called(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // _lastTokenRefresh — login paths
+  // ---------------------------------------------------------------------------
+  group('_lastTokenRefresh updates on login paths', () {
+    test('syncAfterLocalLogin updates timestamp', () async {
+      when(() => mockUsp.login(any())).thenAnswer((_) async {});
+
+      await coordinator.syncAfterLocalLogin('password');
+
+      // Immediate ensureAuth should skip (timestamp just set)
+      await coordinator.ensureAuth();
+      verifyNever(() => mockUsp.refreshToken());
+    });
+
+    test('tryUspLogin updates timestamp on success', () async {
+      when(() => mockUsp.login(any())).thenAnswer((_) async {});
+
+      await coordinator.tryUspLogin('password');
+
+      // Immediate ensureAuth should skip
+      await coordinator.ensureAuth();
+      verifyNever(() => mockUsp.refreshToken());
+    });
+
+    test('restoreSession updates timestamp on success', () async {
+      when(() => mockUsp.isAuthenticated).thenReturn(false);
+      when(() => mockStorage.read(key: any(named: 'key')))
+          .thenAnswer((_) async => 'storedPassword');
+      when(() => mockUsp.login(any())).thenAnswer((_) async {});
+
+      await coordinator.restoreSession();
+
+      // Re-stub isAuthenticated for ensureAuth check
+      when(() => mockUsp.isAuthenticated).thenReturn(true);
+
+      // Immediate ensureAuth should skip
+      await coordinator.ensureAuth();
+      verifyNever(() => mockUsp.refreshToken());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // syncAfterLogout resets _lastTokenRefresh
+  // ---------------------------------------------------------------------------
+  group('syncAfterLogout', () {
+    test('resets _lastTokenRefresh', () async {
+      // Set timestamp via login
+      when(() => mockUsp.login(any())).thenAnswer((_) async {});
+      await coordinator.syncAfterLocalLogin('password');
+
+      // Logout resets it
+      when(() => mockUsp.logout()).thenAnswer((_) async {});
+      await coordinator.syncAfterLogout();
+
+      // ensureAuth should now refresh (timestamp is null)
+      await coordinator.ensureAuth();
+      verify(() => mockUsp.refreshToken()).called(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // _forceRestoreSession bypasses isAuthenticated guard
+  // ---------------------------------------------------------------------------
+  group('forceRestoreSession (onReauthRequired)', () {
+    test('bypasses isAuthenticated guard', () async {
+      // WASM client still reports authenticated after 401
+      when(() => mockUsp.isAuthenticated).thenReturn(true);
+      when(() => mockStorage.read(key: any(named: 'key')))
+          .thenAnswer((_) async => 'storedPassword');
+      when(() => mockUsp.login(any())).thenAnswer((_) async {});
+
+      // Trigger onReauthRequired (which coordinator wired to _forceRestoreSession)
+      final onReauth = mockUsp.onReauthRequired;
+      expect(onReauth, isNotNull);
+      await onReauth!();
+
+      // Should have called login despite isAuthenticated=true
+      verify(() => mockUsp.login('storedPassword')).called(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // onRefreshTokenSuccess callback
+  // ---------------------------------------------------------------------------
+  group('onRefreshTokenSuccess wiring', () {
+    test('constructor wires onRefreshTokenSuccess to update timestamp',
+        () async {
+      // Verify callback was set
+      expect(mockUsp.onRefreshTokenSuccess, isNotNull);
+
+      // Simulate Stage 1 refresh success in reauth
+      mockUsp.onRefreshTokenSuccess!();
+
+      // ensureAuth should now skip (timestamp was just set)
+      await coordinator.ensureAuth();
+      verifyNever(() => mockUsp.refreshToken());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ensureAuth — 401 resets _lastTokenRefresh
+  // ---------------------------------------------------------------------------
+  group('ensureAuth — 401 resets timestamp', () {
+    test('resets _lastTokenRefresh on 401 so next call retries immediately',
+        () async {
+      // Make refreshToken throw 401
+      when(() => mockUsp.refreshToken())
+          .thenThrow(Exception('HTTP 401 Unauthorized'));
+      coordinator.onForceLogout = () {};
+
+      // ensureAuth gets 401 — should reset _lastTokenRefresh
+      await coordinator.ensureAuth();
+      verify(() => mockUsp.refreshToken()).called(1);
+
+      // Immediately call again — should attempt refresh because
+      // _lastTokenRefresh was reset to null on 401
+      when(() => mockUsp.refreshToken()).thenAnswer((_) async {});
+      await coordinator.ensureAuth();
+      verify(() => mockUsp.refreshToken()).called(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // _isAuthError — pattern matching
+  // ---------------------------------------------------------------------------
+  group('_isAuthError pattern matching', () {
+    test('matches actual WASM error format', () async {
+      when(() => mockUsp.refreshToken()).thenThrow(
+          Exception('Get failed: Transport error: HTTP error: HTTP 401'));
+
+      bool logoutCalled = false;
+      coordinator.onForceLogout = () => logoutCalled = true;
+
+      await coordinator.ensureAuth();
+
+      expect(logoutCalled, isTrue);
+    });
+
+    test('does NOT match HTTP 500', () async {
+      when(() => mockUsp.refreshToken())
+          .thenThrow(Exception('HTTP 500 Internal Server Error'));
+
+      bool logoutCalled = false;
+      coordinator.onForceLogout = () => logoutCalled = true;
+
+      await coordinator.ensureAuth();
+
+      expect(logoutCalled, isFalse);
+    });
+
+    test('does NOT match HTTP 403', () async {
+      when(() => mockUsp.refreshToken())
+          .thenThrow(Exception('HTTP error: HTTP 403 Forbidden'));
+
+      bool logoutCalled = false;
+      coordinator.onForceLogout = () => logoutCalled = true;
+
+      await coordinator.ensureAuth();
+
+      expect(logoutCalled, isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // _loginWithStoredPassword — silent failure
+  // ---------------------------------------------------------------------------
+  group('_loginWithStoredPassword — silent failure', () {
+    test('restoreSession does not throw when login fails', () async {
+      when(() => mockUsp.isAuthenticated).thenReturn(false);
+      when(() => mockStorage.read(key: any(named: 'key')))
+          .thenAnswer((_) async => 'storedPassword');
+      when(() => mockUsp.login(any()))
+          .thenThrow(Exception('Connection refused'));
+
+      // Should not throw
+      await coordinator.restoreSession();
+    });
+
+    test('forceRestoreSession does not throw when login fails', () async {
+      when(() => mockStorage.read(key: any(named: 'key')))
+          .thenAnswer((_) async => 'storedPassword');
+      when(() => mockUsp.login(any()))
+          .thenThrow(Exception('Connection refused'));
+
+      // Trigger _forceRestoreSession via onReauthRequired
+      final onReauth = mockUsp.onReauthRequired;
+      expect(onReauth, isNotNull);
+
+      // Should not throw
+      await onReauth!();
+    });
+
+    test('returns false and does not update timestamp on failure', () async {
+      when(() => mockUsp.isAuthenticated).thenReturn(false);
+      when(() => mockStorage.read(key: any(named: 'key')))
+          .thenAnswer((_) async => 'storedPassword');
+      when(() => mockUsp.login(any()))
+          .thenThrow(Exception('Connection refused'));
+
+      await coordinator.restoreSession();
+
+      // Re-stub for ensureAuth check
+      when(() => mockUsp.isAuthenticated).thenReturn(true);
+      when(() => mockUsp.isReauthInProgress).thenReturn(false);
+      when(() => mockUsp.refreshToken()).thenAnswer((_) async {});
+
+      // ensureAuth should refresh (timestamp was NOT set)
+      await coordinator.ensureAuth();
+      verify(() => mockUsp.refreshToken()).called(1);
+    });
+  });
+}

--- a/test/core/usp/providers/usp_auth_coordinator_test.dart
+++ b/test/core/usp/providers/usp_auth_coordinator_test.dart
@@ -152,8 +152,7 @@ void main() {
 
     test('concurrent ensureAuth calls do not stack', () async {
       final completer = Completer<void>();
-      when(() => mockUsp.refreshToken())
-          .thenAnswer((_) => completer.future);
+      when(() => mockUsp.refreshToken()).thenAnswer((_) => completer.future);
 
       // Launch two concurrent calls
       final f1 = coordinator.ensureAuth();


### PR DESCRIPTION
## Summary

- Proactively refresh USP JWT on every SSE heartbeat (30s) when elapsed time exceeds 12-minute threshold, eliminating 401-induced request delays
- Force logout on unrecoverable 401 (session externally terminated); silently skip on network errors
- Shared `forceLogout` callback wired from both proactive (heartbeat) and reactive (reauth failure) paths with duplicate-trigger guard

## Changes

| File | Change |
|------|--------|
| `lib/core/usp/services/usp_client.dart` | `isReauthInProgress` getter, guarded `onRefreshTokenSuccess`/`onForceLogout` callbacks |
| `lib/core/usp/providers/usp_auth_coordinator.dart` | `ensureAuth()` with 12-min threshold, `_forceRestoreSession` bypass, regex-based `_isAuthError`, timestamp reset on 401 |
| `lib/core/usp/services/sse_event_router.dart` | `onHeartbeat` callback on heartbeat event |
| `lib/core/usp/services/sse_manager.dart` | `onHeartbeatAuth` fire-and-forget delegate |
| `lib/core/usp/providers/sse_providers.dart` | Wire heartbeat → ensureAuth, shared forceLogout for both paths |
| `lib/providers/auth/auth_provider.dart` | Step-by-step logout logging in `[Auth]method:` format |
| `doc/architecture/proactive-token-refresh-plan.md` | Full architecture doc (Phase 1 + Phase 2 plan) |

## Test plan

- [x] `flutter analyze` — zero errors
- [x] 22/22 unit tests pass (`test/core/usp/providers/usp_auth_coordinator_test.dart`)
- [x] Token refresh observed on live router — proactive refresh every ~12 min, no 401 during session
- [ ] SSH kill session → next heartbeat triggers 401 → auto logout
- [ ] Unplug network → SSE banner shows, force logout NOT triggered

## Related Issues

- Closes #821
- Parent: #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)