### PR TITLE
feat: add semantic labels for E2E locators, upgrade ui_kit to v2.18.1

### DIFF
--- a/lib/components/shortcuts/dialogs.dart
+++ b/lib/components/shortcuts/dialogs.dart
@@ -323,6 +323,7 @@ Future<bool?> showUnsavedAlert(BuildContext context,
     actions: [
       AppButton.text(
         label: loc(context).goBack,
+        semanticLabel: 'unsaved-go-back',
         key: const Key('unsavedAlert_goBackButton'),
         onTap: () {
           context.pop();
@@ -330,6 +331,7 @@ Future<bool?> showUnsavedAlert(BuildContext context,
       ),
       AppButton.dangerText(
         label: loc(context).discardChanges,
+        semanticLabel: 'unsaved-discard',
         key: const Key('unsavedAlert_discardButton'),
         onTap: () {
           context.pop(true);

--- a/lib/components/styled/menus/widgets/app_menu_card.dart
+++ b/lib/components/styled/menus/widgets/app_menu_card.dart
@@ -10,6 +10,7 @@ class AppMenuCard extends StatelessWidget {
     this.onTap,
     this.status,
     this.isBeta = false,
+    this.semanticLabel,
   });
 
   final IconData? iconData;
@@ -18,10 +19,11 @@ class AppMenuCard extends StatelessWidget {
   final VoidCallback? onTap;
   final bool? status;
   final bool isBeta;
+  final String? semanticLabel;
 
   @override
   Widget build(BuildContext context) {
-    return AppCard(
+    final card = AppCard(
       onTap: onTap,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,
@@ -91,5 +93,13 @@ class AppMenuCard extends StatelessWidget {
         ],
       ),
     );
+    if (semanticLabel != null) {
+      return Semantics(
+        label: semanticLabel,
+        button: true,
+        child: card,
+      );
+    }
+    return card;
   }
 }

--- a/lib/page/dashboard/views/dialogs/preset_selection_dialog.dart
+++ b/lib/page/dashboard/views/dialogs/preset_selection_dialog.dart
@@ -56,11 +56,16 @@ class _PresetSelectionDialogState extends State<_PresetSelectionDialog> {
             final isSelected = _selected == preset;
             return Padding(
               padding: const EdgeInsets.only(bottom: 8),
-              child: _PresetCard(
-                preset: preset,
-                isSelected: isSelected,
-                onTap: () => setState(() => _selected = preset),
-                colorScheme: colorScheme,
+              child: Semantics(
+                label: 'preset-${preset.name}',
+                button: true,
+                selected: isSelected,
+                child: _PresetCard(
+                  preset: preset,
+                  isSelected: isSelected,
+                  onTap: () => setState(() => _selected = preset),
+                  colorScheme: colorScheme,
+                ),
               ),
             );
           }),
@@ -68,10 +73,12 @@ class _PresetSelectionDialogState extends State<_PresetSelectionDialog> {
       ),
       actions: [
         AppButton(
+          semanticLabel: 'preset-cancel',
           label: 'Cancel',
           onTap: () => Navigator.pop(context),
         ),
         AppButton.primary(
+          semanticLabel: 'preset-apply',
           label: 'Apply',
           onTap: _selected != null
               ? () => Navigator.pop(context, _selected)

--- a/lib/page/login/views/login_local_view.dart
+++ b/lib/page/login/views/login_local_view.dart
@@ -244,7 +244,8 @@ class _LoginViewState extends ConsumerState<LoginLocalView> {
               children: [
                 AppText.headlineSmall(loc(context).login),
                 AppGap.xxxl(),
-                SizedBox(
+                Semantics(
+                  label: 'login-password-input',
                   child: AppPasswordInput(
                     controller: _passwordController,
                     hintText: loc(context).routerPassword,
@@ -285,6 +286,7 @@ class _LoginViewState extends ConsumerState<LoginLocalView> {
                 AppGap.xxxl(),
                 AppButton(
                   key: const Key('loginLocalView_loginButton'),
+                  semanticLabel: 'login-submit-button',
                   label: loc(context).login,
                   variant: SurfaceVariant.highlight,
                   size: AppButtonSize.small,

--- a/lib/page/menu/views/usp_menu_view.dart
+++ b/lib/page/menu/views/usp_menu_view.dart
@@ -46,54 +46,63 @@ class UspMenuView extends StatelessWidget {
   List<AppSectionItemData> _buildMenuItems(BuildContext context) {
     return [
       AppSectionItemData(
+        semanticLabel: 'menu-wifi-settings',
         title: 'WiFi Settings',
         description: 'Networks, security, MAC filtering',
         iconData: Icons.wifi,
         onTap: () => context.goNamed(RouteNamed.uspWifiSettings),
       ),
       AppSectionItemData(
+        semanticLabel: 'menu-topology',
         title: 'Topology',
         description: 'View network topology and mesh nodes',
         iconData: Icons.account_tree,
         onTap: () => context.goNamed(RouteNamed.uspTopology),
       ),
       AppSectionItemData(
+        semanticLabel: 'menu-devices',
         title: 'Devices',
         description: 'View and manage connected devices',
         iconData: Icons.devices,
         onTap: () => context.goNamed(RouteNamed.uspDeviceList),
       ),
       AppSectionItemData(
+        semanticLabel: 'menu-instant-safety',
         title: 'Instant Safety',
         description: 'Safe browsing with OpenDNS',
         iconData: Icons.shield_outlined,
         onTap: () => context.goNamed(RouteNamed.uspInstantSafety),
       ),
       AppSectionItemData(
+        semanticLabel: 'menu-instant-privacy',
         title: 'Instant Privacy',
         description: 'Lock network to currently connected devices',
         iconData: Icons.lock_outlined,
         onTap: () => context.goNamed(RouteNamed.uspInstantPrivacy),
       ),
       AppSectionItemData(
+        semanticLabel: 'menu-administration',
         title: 'Administration',
         description: 'Password, timezone, reboot',
         iconData: Icons.admin_panel_settings,
         onTap: () => context.goNamed(RouteNamed.uspAdmin),
       ),
       AppSectionItemData(
+        semanticLabel: 'menu-advanced-settings',
         title: 'Advanced Settings',
         description: 'Firewall, local network, DMZ, port forwarding, routing',
         iconData: Icons.tune,
         onTap: () => context.goNamed(RouteNamed.uspAdvancedSettings),
       ),
       AppSectionItemData(
+        semanticLabel: 'menu-system-logs',
         title: 'System Logs',
         description: 'View router log files',
         iconData: Icons.article_outlined,
         onTap: () => context.goNamed(RouteNamed.uspSystemLog),
       ),
       AppSectionItemData(
+        semanticLabel: 'menu-statistics',
         title: 'Statistics',
         description: 'Network, device, and system analytics',
         iconData: Icons.bar_chart,
@@ -134,6 +143,7 @@ class UspMenuView extends StatelessWidget {
             title: item.title,
             description: item.description,
             onTap: item.onTap,
+            semanticLabel: item.semanticLabel,
           );
         },
       ),

--- a/lib/page/models/app_section_item_data.dart
+++ b/lib/page/models/app_section_item_data.dart
@@ -12,6 +12,7 @@ class AppSectionItemData {
   final bool isBeta;
   final bool disabledOnBridge;
   final VoidCallback? onTap;
+  final String? semanticLabel;
 
   const AppSectionItemData({
     this.iconData,
@@ -21,5 +22,6 @@ class AppSectionItemData {
     this.status,
     this.isBeta = false,
     this.disabledOnBridge = false,
+    this.semanticLabel,
   });
 }

--- a/lib/page/wifi_settings/views/components/wifi_network_card.dart
+++ b/lib/page/wifi_settings/views/components/wifi_network_card.dart
@@ -549,31 +549,31 @@ class _WifiTile extends StatelessWidget {
     return Semantics(
       label: semanticLabel,
       child: InkWell(
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
-        child: Row(
-          children: [
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  AppText.bodyMedium(title),
-                  if (description != null) ...[
-                    AppGap.xs(),
-                    AppText.labelLarge(description!),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    AppText.bodyMedium(title),
+                    if (description != null) ...[
+                      AppGap.xs(),
+                      AppText.labelLarge(description!),
+                    ],
                   ],
-                ],
+                ),
               ),
-            ),
-            if (trailing != null) ...[
-              AppGap.md(),
-              trailing!,
+              if (trailing != null) ...[
+                AppGap.md(),
+                trailing!,
+              ],
             ],
-          ],
+          ),
         ),
       ),
-    ),
     );
   }
 }

--- a/lib/page/wifi_settings/views/components/wifi_network_card.dart
+++ b/lib/page/wifi_settings/views/components/wifi_network_card.dart
@@ -58,16 +58,24 @@ class WifiNetworkCard extends ConsumerWidget {
             _WifiTile(
               title: n.isGuest ? 'Guest' : 'Main',
               description: n.bandDisplayName,
-              trailing: AppSwitch(
-                value: n.enabled,
-                onChanged: (v) => ref
-                    .read(uspWifiSettingsProvider.notifier)
-                    .updateNetworkField(ssidInstancePath, enabled: v),
+              trailing: Semantics(
+                label: 'wifi-enable-${n.band}',
+                toggled: n.enabled,
+                enabled: true,
+                child: ExcludeSemantics(
+                  child: AppSwitch(
+                    value: n.enabled,
+                    onChanged: (v) => ref
+                        .read(uspWifiSettingsProvider.notifier)
+                        .updateNetworkField(ssidInstancePath, enabled: v),
+                  ),
+                ),
               ),
             ),
             // ── WiFi name ─────────────────────────────────────────────────
             const Divider(),
             _WifiTile(
+              semanticLabel: 'wifi-name-${n.band}',
               title: 'Name',
               description: n.ssid.isNotEmpty ? n.ssid : '(No SSID)',
               trailing: const AppIcon.font(AppFontIcons.edit),
@@ -110,14 +118,21 @@ class WifiNetworkCard extends ConsumerWidget {
               const Divider(),
               _WifiTile(
                 title: 'Broadcast SSID',
-                trailing: AppSwitch(
-                  value: n.ssidAdvertisementEnabled,
-                  onChanged: n.accessPointInstancePath != null
-                      ? (v) => ref
-                          .read(uspWifiSettingsProvider.notifier)
-                          .updateNetworkField(ssidInstancePath,
-                              broadcastSsid: v)
-                      : null,
+                trailing: Semantics(
+                  label: 'wifi-broadcast-${n.band}',
+                  toggled: n.ssidAdvertisementEnabled,
+                  enabled: n.accessPointInstancePath != null,
+                  child: ExcludeSemantics(
+                    child: AppSwitch(
+                      value: n.ssidAdvertisementEnabled,
+                      onChanged: n.accessPointInstancePath != null
+                          ? (v) => ref
+                              .read(uspWifiSettingsProvider.notifier)
+                              .updateNetworkField(ssidInstancePath,
+                                  broadcastSsid: v)
+                          : null,
+                    ),
+                  ),
                 ),
               ),
               const Divider(),
@@ -519,17 +534,21 @@ class _WifiTile extends StatelessWidget {
   final String? description;
   final Widget? trailing;
   final VoidCallback? onTap;
+  final String? semanticLabel;
 
   const _WifiTile({
     required this.title,
     this.description,
     this.trailing,
     this.onTap,
+    this.semanticLabel,
   });
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
+    return Semantics(
+      label: semanticLabel,
+      child: InkWell(
       onTap: onTap,
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
@@ -554,6 +573,7 @@ class _WifiTile extends StatelessWidget {
           ],
         ),
       ),
+    ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,11 +63,11 @@ dependencies:
   ui_kit_library:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.17.0
+      ref: v2.18.1
   generative_ui:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.17.0
+      ref: v2.18.1
       path: generative_ui
   flutter_blue_plus: ^1.4.0
   crypto: ^3.0.2


### PR DESCRIPTION
## Summary
- **Semantic labels for E2E test locators**: Added `Semantics` wrappers to login (password input, submit button), onboarding presets (cards, cancel, apply), menu cards (9 items), WiFi switches (via `Semantics+ExcludeSemantics` pattern), name tiles, broadcast switches, and dirty guard dialog buttons
- **ui_kit upgrade**: v2.17.0 → v2.18.1 (for `AppButton.semanticLabel` support)

## Test plan
- [x] All 104 E2E tests passing across 16 suites (verified in external e2e repo)
- [x] dart format clean, flutter analyze clean (changed files)
- [x] No merge conflicts with base branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)