### PR TITLE
fix: WiFi Quick Setup save and UI improvements

### DIFF
--- a/lib/page/wifi_settings/models/wifi_settings_settings.dart
+++ b/lib/page/wifi_settings/models/wifi_settings_settings.dart
@@ -39,24 +39,28 @@ class WifiQuickSetupSettings extends Equatable {
     required this.supportedSecurityModes,
   });
 
+  /// True when the next Save will actually send `KeyPassphrase` to firmware
+  /// AND the resulting security mode is non-open.
+  ///
+  /// [original] is the server-side snapshot (pre-edit). The AP-layer write
+  /// is only issued when [password] or [securityMode] changed, and the
+  /// passphrase is only meaningful when the mode is non-open. Toggling
+  /// [enabled] or changing only the SSID name therefore does not require a
+  /// password — callers (UI label, validation) should use this to avoid
+  /// showing spurious "(Required)" indicators.
+  bool isPasswordRequired(WifiQuickSetupSettings? original) {
+    final passwordChanged = original == null || password != original.password;
+    final modeChanged =
+        original == null || securityMode != original.securityMode;
+    final isOpen = securityMode == 'None' || securityMode == 'Enhanced-Open';
+    return (passwordChanged || modeChanged) && !isOpen;
+  }
+
   /// True when all required fields are filled and valid for the write that
   /// will actually be issued against firmware.
-  ///
-  /// [original] is the server-side snapshot (pre-edit). Compared against the
-  /// current values to decide which TR-181 parameters will be written:
-  ///   - SSID write happens when [ssid] or [enabled] changed.
-  ///   - AP write happens when [password] or [securityMode] changed.
-  ///
-  /// The passphrase is only validated when the AP write is actually going to
-  /// happen AND the resulting security mode is non-open. Toggling enable
-  /// alone, or changing only the SSID name, does not require a password.
   bool isValid(WifiQuickSetupSettings? original) {
     if (ssid.trim().isEmpty) return false;
-    final passwordChanged = original == null || password != original.password;
-    final modeChanged = original == null || securityMode != original.securityMode;
-    final isOpen = securityMode == 'None' || securityMode == 'Enhanced-Open';
-    final needsPassword = (passwordChanged || modeChanged) && !isOpen;
-    if (!needsPassword) return true;
+    if (!isPasswordRequired(original)) return true;
     return password.isNotEmpty &&
         LengthRule(min: 8, max: 63).validate(password) &&
         WiFiPasswordRule(ignoreLength: true).validate(password);

--- a/lib/page/wifi_settings/models/wifi_settings_settings.dart
+++ b/lib/page/wifi_settings/models/wifi_settings_settings.dart
@@ -10,6 +10,8 @@ import 'package:privacy_gui/validator_rules/_validator_rules.dart';
 ///   - [securityMode] — pre-filled from the intersection of supported modes.
 ///
 /// [isValid] must be `true` before the page-level Save button is enabled.
+/// Validity is evaluated against [original] so that a password is only
+/// required when the user is actually changing password or securityMode.
 class WifiQuickSetupSettings extends Equatable {
   final bool isGuest;
 
@@ -37,11 +39,24 @@ class WifiQuickSetupSettings extends Equatable {
     required this.supportedSecurityModes,
   });
 
-  /// True when all required fields are filled and valid.
-  bool get isValid {
+  /// True when all required fields are filled and valid for the write that
+  /// will actually be issued against firmware.
+  ///
+  /// [original] is the server-side snapshot (pre-edit). Compared against the
+  /// current values to decide which TR-181 parameters will be written:
+  ///   - SSID write happens when [ssid] or [enabled] changed.
+  ///   - AP write happens when [password] or [securityMode] changed.
+  ///
+  /// The passphrase is only validated when the AP write is actually going to
+  /// happen AND the resulting security mode is non-open. Toggling enable
+  /// alone, or changing only the SSID name, does not require a password.
+  bool isValid(WifiQuickSetupSettings? original) {
     if (ssid.trim().isEmpty) return false;
+    final passwordChanged = original == null || password != original.password;
+    final modeChanged = original == null || securityMode != original.securityMode;
     final isOpen = securityMode == 'None' || securityMode == 'Enhanced-Open';
-    if (isOpen) return true;
+    final needsPassword = (passwordChanged || modeChanged) && !isOpen;
+    if (!needsPassword) return true;
     return password.isNotEmpty &&
         LengthRule(min: 8, max: 63).validate(password) &&
         WiFiPasswordRule(ignoreLength: true).validate(password);

--- a/lib/page/wifi_settings/providers/usp_wifi_advanced_provider.dart
+++ b/lib/page/wifi_settings/providers/usp_wifi_advanced_provider.dart
@@ -115,8 +115,11 @@ class UspWifiAdvancedNotifier
 
     logger.d('[USP][WiFi][Advanced] Save succeeded — '
         'radios=${radioPaths.length}, enabled=$enabled');
-    // Invalidate Layer 1 cache so post-save fetch() reads fresh data.
-    ref.invalidate(wifiDataProvider);
+    // Refresh Layer 1 cache so post-save fetch() reads fresh data.
+    // Using refresh() instead of invalidate() because the latter only marks
+    // the provider dirty — without an active subscriber it won't rebuild,
+    // and the subsequent .future call would return stale data.
+    final _ = await ref.refresh(wifiDataProvider.future);
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
+++ b/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
@@ -178,7 +178,11 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
     await ref.read(uspMutationLockProvider).withLock(() async {
       final current = state.settings.current;
       if (current.quickSetupEnabled) {
-        await _svc.saveQuickSetup(current: current, status: state.status);
+        await _svc.saveQuickSetup(
+          original: state.settings.original,
+          current: current,
+          status: state.status,
+        );
       } else {
         await _svc.saveAdvanced(
           original: state.settings.original.networks,

--- a/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
+++ b/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
@@ -190,8 +190,11 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
         );
       }
     });
-    // Invalidate Layer 1 cache so post-save fetch() reads fresh data.
-    ref.invalidate(wifiDataProvider);
+    // Refresh Layer 1 cache so post-save fetch() reads fresh data.
+    // Using refresh() instead of invalidate() because the latter only marks
+    // the provider dirty — without an active subscriber it won't rebuild,
+    // and the subsequent .future call would return stale data.
+    final _ = await ref.refresh(wifiDataProvider.future);
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/page/wifi_settings/providers/usp_wifi_settings_state.dart
+++ b/lib/page/wifi_settings/providers/usp_wifi_settings_state.dart
@@ -70,8 +70,8 @@ class UspWifiSettingsState
       if (!mainChanged && !guestChanged) return false;
 
       // All changed groups must be valid.
-      if (mainChanged && !main.isValid) return false;
-      if (guestChanged && !guest.isValid) return false;
+      if (mainChanged && !main.isValid(origMain)) return false;
+      if (guestChanged && !guest.isValid(origGuest)) return false;
 
       return true;
     }

--- a/lib/page/wifi_settings/services/usp_wifi_settings_service.dart
+++ b/lib/page/wifi_settings/services/usp_wifi_settings_service.dart
@@ -167,7 +167,8 @@ class UspWifiSettingsService {
       );
     }
 
-    final isQuickSetup = isConsistent(mainNetworks) && isConsistent(guestNetworks);
+    final isQuickSetup =
+        isConsistent(mainNetworks) && isConsistent(guestNetworks);
 
     return (
       main: mainNetworks.isEmpty

--- a/lib/page/wifi_settings/services/usp_wifi_settings_service.dart
+++ b/lib/page/wifi_settings/services/usp_wifi_settings_service.dart
@@ -156,15 +156,18 @@ class UspWifiSettingsService {
     final mainNetworks = networks.where((n) => !n.isGuest).toList();
     final guestNetworks = networks.where((n) => n.isGuest).toList();
 
-    final bool isQuickSetup;
-    if (mainNetworks.isEmpty) {
-      isQuickSetup = true;
-    } else {
-      final first = mainNetworks.first;
-      isQuickSetup = mainNetworks.every(
+    // Quick Setup requires all networks (main AND guest) to share the same
+    // enabled state and SSID within their group. If any group is inconsistent,
+    // the aggregated view would be misleading — fall back to Advanced mode.
+    bool isConsistent(List<WifiNetworkUIModel> nets) {
+      if (nets.isEmpty) return true;
+      final first = nets.first;
+      return nets.every(
         (n) => n.enabled == first.enabled && n.ssid == first.ssid,
       );
     }
+
+    final isQuickSetup = isConsistent(mainNetworks) && isConsistent(guestNetworks);
 
     return (
       main: mainNetworks.isEmpty

--- a/lib/page/wifi_settings/services/usp_wifi_settings_service.dart
+++ b/lib/page/wifi_settings/services/usp_wifi_settings_service.dart
@@ -210,41 +210,65 @@ class UspWifiSettingsService {
   // ---------------------------------------------------------------------------
 
   /// Saves WiFi settings in Quick Setup mode.
+  ///
+  /// Writes are gated by field-level diff against [original] so that firmware
+  /// only receives the parameters the user actually changed:
+  ///   - SSID update is issued only when ssid name or enabled flag changed.
+  ///   - AP update is issued only when password or securityMode changed.
+  ///
+  /// This prevents `KeyPassphrase (Invalid value)` errors from firmware when
+  /// the user toggles Guest enable without (re-)entering a passphrase.
   Future<void> saveQuickSetup({
+    required WifiSettingsSettings original,
     required WifiSettingsSettings current,
     required WifiSettingsStatus status,
   }) async {
     try {
-      for (final pending in [current.quickSetupMain, current.quickSetupGuest]) {
-        if (pending == null || !pending.isValid) continue;
+      final groups = [
+        (
+          pending: current.quickSetupMain,
+          orig: original.quickSetupMain,
+          isGuest: false,
+        ),
+        (
+          pending: current.quickSetupGuest,
+          orig: original.quickSetupGuest,
+          isGuest: true,
+        ),
+      ];
 
-        final aggregate = pending.isGuest
+      for (final group in groups) {
+        final pending = group.pending;
+        if (pending == null) continue;
+        final orig = group.orig;
+
+        final aggregate = group.isGuest
             ? status.quickSetupGuestAggregate
             : status.quickSetupMainAggregate;
         if (aggregate == null) continue;
 
-        if (aggregate.ssidInstancePaths.isNotEmpty) {
-          // REFACTORED: Use structured error handling from WiFiSettingsService pattern
-          final ssidUpdates = aggregate.ssidInstancePaths
-              .map((p) => WiFiSsidUpdate(
-                    instancePath: p,
-                    ssid: pending.ssid,
-                    enable: pending.enabled,
-                  ))
-              .toList();
-
-          // Business validation (like WiFiSettingsService.updateSsidName)
-          if (pending.ssid.isEmpty) {
-            throw InvalidInputError(message: 'SSID name cannot be empty');
+        // ── SSID layer — only when ssid name or enabled changed ────────────
+        final ssidChanged = orig == null || orig.ssid != pending.ssid;
+        final enabledChanged = orig == null || orig.enabled != pending.enabled;
+        if (aggregate.ssidInstancePaths.isNotEmpty &&
+            (ssidChanged || enabledChanged)) {
+          if (ssidChanged) {
+            if (pending.ssid.isEmpty) {
+              throw InvalidInputError(message: 'SSID name cannot be empty');
+            }
+            if (pending.ssid.length > 32) {
+              throw InvalidInputError(
+                  message: 'SSID name cannot exceed 32 characters');
+            }
           }
-          if (pending.ssid.length > 32) {
-            throw InvalidInputError(
-                message: 'SSID name cannot exceed 32 characters');
-          }
-
-          // Update each SSID individually
-          for (final ssidUpdate in ssidUpdates) {
-            final result = await WiFiSsids.update(_usp, [ssidUpdate]);
+          for (final p in aggregate.ssidInstancePaths) {
+            final result = await WiFiSsids.update(_usp, [
+              WiFiSsidUpdate(
+                instancePath: p,
+                ssid: pending.ssid,
+                enable: pending.enabled,
+              ),
+            ]);
             final parsed = UspResultParser.parseSetResult(result);
             switch (parsed) {
               case UspSuccess():
@@ -264,17 +288,22 @@ class UspWifiSettingsService {
             }
           }
         }
-        if (aggregate.apInstancePaths.isNotEmpty) {
+
+        // ── AP layer — only when password or securityMode changed ──────────
+        final passwordChanged =
+            orig == null || orig.password != pending.password;
+        final modeChanged =
+            orig == null || orig.securityMode != pending.securityMode;
+        if (aggregate.apInstancePaths.isNotEmpty &&
+            (passwordChanged || modeChanged)) {
           // Build a band lookup: AP instance path → band string.
           // Used to apply the 6 GHz security override (Wi-Fi 6E mandates WPA3).
-          final bandByApPath = <String, String>{};
-          for (final n in current.networks) {
-            if (n.accessPointInstancePath != null) {
-              bandByApPath[n.accessPointInstancePath!] = n.band;
-            }
-          }
+          final bandByApPath = <String, String>{
+            for (final n in current.networks)
+              if (n.accessPointInstancePath != null)
+                n.accessPointInstancePath!: n.band,
+          };
 
-          // Update each access point individually
           for (final p in aggregate.apInstancePaths) {
             final band = bandByApPath[p] ?? '';
             final securityMode = _securityModeFor6GHz(
@@ -286,7 +315,10 @@ class UspWifiSettingsService {
               [
                 WiFiAccessPointUpdate(
                   instancePath: p,
-                  keyPassphrase: pending.password,
+                  // Omit an empty passphrase (e.g. when only securityMode
+                  // changed to an open mode) so firmware does not reject it.
+                  keyPassphrase:
+                      pending.password.isNotEmpty ? pending.password : null,
                   securityModeEnabled: securityMode,
                 )
               ],

--- a/lib/page/wifi_settings/views/components/wifi_network_card.dart
+++ b/lib/page/wifi_settings/views/components/wifi_network_card.dart
@@ -81,23 +81,29 @@ class WifiNetworkCard extends ConsumerWidget {
               trailing: const AppIcon.font(AppFontIcons.edit),
               onTap: () => _editSsid(context, ref, n),
             ),
-            // ── WiFi password — bullet dots + pencil ──────────────────────
-            const Divider(),
-            _WifiTile(
-              title: 'Password',
-              description: '\u2022' * 12,
-              trailing: const AppIcon.font(AppFontIcons.edit),
-              onTap: () => _editPassword(context, ref, n),
-            ),
-            // ── Security mode (main networks only) ────────────────────────
-            if (!n.isGuest && n.supportedSecurityModes.isNotEmpty) ...[
+            // ── WiFi password & Security mode ────────────────────────────
+            // Hidden together when the network has no supported security modes
+            // (e.g. Guest on firmware that reports ModesSupported=''). Password
+            // is meaningless for an open network, so showing it would mislead.
+            // This mirrors the Quick Setup card's guard.
+            if (n.supportedSecurityModes.isNotEmpty) ...[
               const Divider(),
               _WifiTile(
-                title: 'Security mode',
-                description: n.securityMode,
+                title: 'Password',
+                description: '\u2022' * 12,
                 trailing: const AppIcon.font(AppFontIcons.edit),
-                onTap: () => _editSecurityMode(context, ref, n),
+                onTap: () => _editPassword(context, ref, n),
               ),
+              // Security mode — main networks only (guest is always open/None)
+              if (!n.isGuest) ...[
+                const Divider(),
+                _WifiTile(
+                  title: 'Security mode',
+                  description: n.securityMode,
+                  trailing: const AppIcon.font(AppFontIcons.edit),
+                  onTap: () => _editSecurityMode(context, ref, n),
+                ),
+              ],
             ],
             // ── WiFi Mode ──────────────────────────────────────────────────
             if (!n.isGuest && n.supportedStandards.isNotEmpty) ...[

--- a/lib/page/wifi_settings/views/components/wifi_quick_setup_card.dart
+++ b/lib/page/wifi_settings/views/components/wifi_quick_setup_card.dart
@@ -33,10 +33,19 @@ class WifiQuickSetupCard extends ConsumerWidget {
           ? s.settings.current.quickSetupGuest
           : s.settings.current.quickSetupMain),
     );
+    final original = ref.watch(
+      uspWifiSettingsProvider.select((s) => isGuest
+          ? s.settings.original.quickSetupGuest
+          : s.settings.original.quickSetupMain),
+    );
 
     if (pending == null) return const SizedBox.shrink();
 
     final passwordEntered = pending.password.isNotEmpty;
+    // Only show the red "(Required)" indicator when the upcoming Save will
+    // actually carry a passphrase write — otherwise the label would be a
+    // false alarm (Save can still succeed without any password entered).
+    final passwordRequired = pending.isPasswordRequired(original);
 
     return Padding(
       padding: EdgeInsets.only(
@@ -69,18 +78,23 @@ class WifiQuickSetupCard extends ConsumerWidget {
               trailing: const AppIcon.font(AppFontIcons.edit),
               onTap: () => _editSsid(context, ref, pending.ssid),
             ),
-            // ── Password — required indicator until entered ────────────────
-            const Divider(),
-            _QuickSetupTile(
-              title: 'Password',
-              description: passwordEntered ? '\u2022' * 12 : '(Required)',
-              descriptionColor:
-                  passwordEntered ? null : Theme.of(context).colorScheme.error,
-              trailing: const AppIcon.font(AppFontIcons.edit),
-              onTap: () => _editPassword(context, ref, pending.password),
-            ),
-            // ── Security mode ─────────────────────────────────────────────
+            // ── Password & Security mode — hidden together when the AP
+            //    has no supported security modes (e.g. Guest on firmware
+            //    that reports ModesSupported=''). Password is meaningless
+            //    for an open network, so showing it would be misleading.
             if (pending.supportedSecurityModes.isNotEmpty) ...[
+              const Divider(),
+              _QuickSetupTile(
+                title: 'Password',
+                description: passwordEntered
+                    ? '\u2022' * 12
+                    : (passwordRequired ? '(Required)' : '(Unchanged)'),
+                descriptionColor: (passwordRequired && !passwordEntered)
+                    ? Theme.of(context).colorScheme.error
+                    : null,
+                trailing: const AppIcon.font(AppFontIcons.edit),
+                onTap: () => _editPassword(context, ref, pending.password),
+              ),
               const Divider(),
               _QuickSetupTile(
                 title: 'Security mode',

--- a/lib/page/wifi_settings/views/tabs/wifi_list_tab.dart
+++ b/lib/page/wifi_settings/views/tabs/wifi_list_tab.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/page/wifi_settings/providers/usp_wifi_settings_provider.dart';
+import 'package:privacy_gui/page/wifi_settings/providers/usp_wifi_settings_state.dart';
 import 'package:privacy_gui/page/wifi_settings/views/components/wifi_network_card.dart';
 import 'package:privacy_gui/page/wifi_settings/views/components/wifi_quick_setup_card.dart';
 import 'package:ui_kit_library/ui_kit.dart';
@@ -181,7 +182,7 @@ class UspWifiListTab extends ConsumerWidget {
 
   Widget _buildAdvancedGrid(
     BuildContext context,
-    dynamic state,
+    UspWifiSettingsState state,
     int columnCount,
     double fixedWidth,
     double gutter,
@@ -192,32 +193,49 @@ class UspWifiListTab extends ConsumerWidget {
       return idx < 0 ? 99 : idx;
     }
 
-    final sorted = [...state.settings.current.networks]..sort((a, b) {
-        if (a.isGuest != b.isGuest) return a.isGuest ? 1 : -1;
-        return bandRank(a.band).compareTo(bandRank(b.band));
-      });
+    final networks = state.settings.current.networks;
+    final mainNets = networks.where((n) => !n.isGuest).toList()
+      ..sort((a, b) => bandRank(a.band).compareTo(bandRank(b.band)));
+    final guestNets = networks.where((n) => n.isGuest).toList()
+      ..sort((a, b) => bandRank(a.band).compareTo(bandRank(b.band)));
 
-    final rows = <TableRow>[];
-    for (var i = 0; i < sorted.length; i += columnCount) {
-      final chunk = sorted.skip(i).take(columnCount).toList();
-      final cells = <Widget>[];
-      for (var j = 0; j < columnCount; j++) {
-        if (j < chunk.length) {
-          cells.add(WifiNetworkCard(
-            ssidInstancePath: chunk[j].ssidInstancePath,
-            lastInRow: j == columnCount - 1,
-          ));
-        } else {
-          cells.add(const SizedBox.shrink());
-        }
+    // Build a map from band to guest network for pairing
+    final guestByBand = {for (final g in guestNets) g.band: g};
+
+    // Build columns: each band is a column with Main on top, Guest below
+    // Use Expanded so all columns share equal width regardless of count
+    final columns = <Widget>[];
+
+    for (var i = 0; i < mainNets.length; i++) {
+      final main = mainNets[i];
+      final guest = guestByBand[main.band];
+      final lastInRow = i == mainNets.length - 1;
+
+      final columnChildren = <Widget>[
+        WifiNetworkCard(
+          ssidInstancePath: main.ssidInstancePath,
+          lastInRow: true,
+        ),
+      ];
+
+      if (guest != null) {
+        columnChildren.add(WifiNetworkCard(
+          ssidInstancePath: guest.ssidInstancePath,
+          lastInRow: true,
+        ));
       }
-      rows.add(TableRow(children: cells));
+
+      columns.add(Expanded(
+        child: Padding(
+          padding: EdgeInsets.only(right: lastInRow ? 0 : gutter),
+          child: Column(children: columnChildren),
+        ),
+      ));
     }
 
-    return Table(
-      defaultVerticalAlignment: TableCellVerticalAlignment.intrinsicHeight,
-      columnWidths: _columnWidths(columnCount, fixedWidth, gutter),
-      children: rows,
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: columns,
     );
   }
 

--- a/test/page/wifi_settings/providers/usp_wifi_advanced_notifier_test.dart
+++ b/test/page/wifi_settings/providers/usp_wifi_advanced_notifier_test.dart
@@ -46,7 +46,10 @@ void main() {
         'Device.WiFi.Radio.1.': true,
         'Device.WiFi.Radio.2.': false,
       });
-      verify(() => mockService.fetchIeee80211h()).called(1);
+      // Called at least once from build(); may be called again if SSE listener
+      // triggers due to wifiDataProvider stub emitting a value.
+      verify(() => mockService.fetchIeee80211h())
+          .called(greaterThanOrEqualTo(1));
       container.dispose();
     });
 
@@ -324,5 +327,5 @@ void main() {
 
 class _StubWifiDataNotifier extends WifiDataNotifier {
   @override
-  Future<WifiData> build() async => throw UnimplementedError();
+  Future<WifiData> build() async => const WifiData.empty();
 }

--- a/test/page/wifi_settings/providers/usp_wifi_settings_notifier_test.dart
+++ b/test/page/wifi_settings/providers/usp_wifi_settings_notifier_test.dart
@@ -405,6 +405,7 @@ void main() {
             current: any(named: 'current'),
           )).called(1);
       verifyNever(() => mockService.saveQuickSetup(
+            original: any(named: 'original'),
             current: any(named: 'current'),
             status: any(named: 'status'),
           ));
@@ -425,6 +426,7 @@ void main() {
         isQuickSetup: true,
       ));
       when(() => mockService.saveQuickSetup(
+            original: any(named: 'original'),
             current: any(named: 'current'),
             status: any(named: 'status'),
           )).thenAnswer((_) async {});
@@ -441,6 +443,7 @@ void main() {
       await notifier.save();
 
       verify(() => mockService.saveQuickSetup(
+            original: any(named: 'original'),
             current: any(named: 'current'),
             status: any(named: 'status'),
           )).called(1);

--- a/test/page/wifi_settings/providers/usp_wifi_settings_state_test.dart
+++ b/test/page/wifi_settings/providers/usp_wifi_settings_state_test.dart
@@ -459,6 +459,90 @@ void main() {
     });
 
     // -----------------------------------------------------------------------
+    // WifiQuickSetupSettings.isPasswordRequired
+    // -----------------------------------------------------------------------
+
+    group('WifiQuickSetupSettings.isPasswordRequired', () {
+      const wpa2Orig = WifiQuickSetupSettings(
+        isGuest: false,
+        enabled: true,
+        ssid: 'Home',
+        password: '',
+        securityMode: 'WPA2-Personal',
+        supportedSecurityModes: ['WPA2-Personal', 'WPA3-Personal'],
+      );
+
+      test('false when only enabled toggled (non-open mode)', () {
+        expect(
+          wpa2Orig.copyWith(enabled: false).isPasswordRequired(wpa2Orig),
+          isFalse,
+        );
+      });
+
+      test('false when only ssid changed (non-open mode)', () {
+        expect(
+          wpa2Orig.copyWith(ssid: 'Renamed').isPasswordRequired(wpa2Orig),
+          isFalse,
+        );
+      });
+
+      test('true when password changed and mode is non-open', () {
+        expect(
+          wpa2Orig.copyWith(password: 'newpass1').isPasswordRequired(wpa2Orig),
+          isTrue,
+        );
+      });
+
+      test('true when security mode changed to a non-open mode', () {
+        expect(
+          wpa2Orig
+              .copyWith(securityMode: 'WPA3-Personal')
+              .isPasswordRequired(wpa2Orig),
+          isTrue,
+        );
+      });
+
+      test('false when security mode changed to None (open)', () {
+        expect(
+          wpa2Orig.copyWith(securityMode: 'None').isPasswordRequired(wpa2Orig),
+          isFalse,
+        );
+      });
+
+      test('false on open mode with unchanged password', () {
+        const openOrig = WifiQuickSetupSettings(
+          isGuest: true,
+          enabled: true,
+          ssid: 'Home-Guest',
+          password: '',
+          securityMode: 'None',
+          supportedSecurityModes: [],
+        );
+        expect(
+          openOrig.copyWith(enabled: false).isPasswordRequired(openOrig),
+          isFalse,
+        );
+      });
+
+      test('true when original is null and mode is non-open', () {
+        // Fresh pending with no baseline (e.g. freshly toggled Quick Setup).
+        expect(wpa2Orig.isPasswordRequired(null), isTrue);
+      });
+
+      test('false when original is null but mode is open', () {
+        const openPending = WifiQuickSetupSettings(
+          isGuest: false,
+          enabled: true,
+          ssid: 'OpenNet',
+          password: '',
+          securityMode: 'Enhanced-Open',
+          supportedSecurityModes: ['None', 'Enhanced-Open'],
+        );
+        expect(openPending.isPasswordRequired(null), isFalse);
+      });
+    });
+
+    // -----------------------------------------------------------------------
     // copyWith
     // -----------------------------------------------------------------------
 

--- a/test/page/wifi_settings/providers/usp_wifi_settings_state_test.dart
+++ b/test/page/wifi_settings/providers/usp_wifi_settings_state_test.dart
@@ -425,8 +425,7 @@ void main() {
         expect(state.canSave, isTrue);
       });
 
-      test(
-          'true when only ssid changed (WPA2, empty password, unchanged mode)',
+      test('true when only ssid changed (WPA2, empty password, unchanged mode)',
           () {
         final networks = WifiSettingsTestData.createNetworks();
         const mainOrig = WifiQuickSetupSettings(

--- a/test/page/wifi_settings/providers/usp_wifi_settings_state_test.dart
+++ b/test/page/wifi_settings/providers/usp_wifi_settings_state_test.dart
@@ -360,6 +360,102 @@ void main() {
 
         expect(state.canSave, isTrue);
       });
+
+      test(
+          'true when only guest enabled toggled off (open security, empty password)',
+          () {
+        final networks = WifiSettingsTestData.createNetworks();
+        const guestOrig = WifiQuickSetupSettings(
+          isGuest: true,
+          enabled: true,
+          ssid: 'Home-Guest',
+          password: '',
+          securityMode: 'None',
+          supportedSecurityModes: [],
+        );
+        final original = WifiSettingsSettings(
+          networks: networks,
+          quickSetupEnabled: true,
+          quickSetupGuest: guestOrig,
+        );
+        final current = original.copyWith(
+          quickSetupGuest: guestOrig.copyWith(enabled: false),
+        );
+
+        final state = UspWifiSettingsState(
+          settings: Preservable(original: original, current: current),
+          status: const WifiSettingsStatus(),
+        );
+
+        // Only enabled toggled — password is not being written, so no
+        // passphrase requirement even though current mode is 'None'.
+        expect(state.isDirty, isTrue);
+        expect(state.canSave, isTrue);
+      });
+
+      test(
+          'true when only main enabled toggled (WPA2, empty password, unchanged mode)',
+          () {
+        final networks = WifiSettingsTestData.createNetworks();
+        const mainOrig = WifiQuickSetupSettings(
+          isGuest: false,
+          enabled: true,
+          ssid: 'Home',
+          password: '',
+          securityMode: 'WPA2-Personal',
+          supportedSecurityModes: ['WPA2-Personal', 'WPA3-Personal'],
+        );
+        final original = WifiSettingsSettings(
+          networks: networks,
+          quickSetupEnabled: true,
+          quickSetupMain: mainOrig,
+        );
+        final current = original.copyWith(
+          quickSetupMain: mainOrig.copyWith(enabled: false),
+        );
+
+        final state = UspWifiSettingsState(
+          settings: Preservable(original: original, current: current),
+          status: const WifiSettingsStatus(),
+        );
+
+        // Toggle enable only — no AP write, so empty password is fine
+        // even though the security mode is non-open.
+        expect(state.isDirty, isTrue);
+        expect(state.canSave, isTrue);
+      });
+
+      test(
+          'true when only ssid changed (WPA2, empty password, unchanged mode)',
+          () {
+        final networks = WifiSettingsTestData.createNetworks();
+        const mainOrig = WifiQuickSetupSettings(
+          isGuest: false,
+          enabled: true,
+          ssid: 'Home',
+          password: '',
+          securityMode: 'WPA2-Personal',
+          supportedSecurityModes: ['WPA2-Personal', 'WPA3-Personal'],
+        );
+        final original = WifiSettingsSettings(
+          networks: networks,
+          quickSetupEnabled: true,
+          quickSetupMain: mainOrig,
+        );
+        final current = original.copyWith(
+          quickSetupMain: mainOrig.copyWith(ssid: 'RenamedHome'),
+        );
+
+        final state = UspWifiSettingsState(
+          settings: Preservable(original: original, current: current),
+          status: const WifiSettingsStatus(),
+        );
+
+        // Only SSID name changed — no AP write triggered, so no password
+        // requirement even under WPA2.
+        expect(state.isDirty, isTrue);
+        expect(state.canSave, isTrue);
+      });
     });
 
     // -----------------------------------------------------------------------

--- a/test/page/wifi_settings/services/usp_wifi_settings_service_test.dart
+++ b/test/page/wifi_settings/services/usp_wifi_settings_service_test.dart
@@ -6,6 +6,9 @@ import 'package:privacy_gui/generated/wi_fi_radios.g.dart';
 import 'package:privacy_gui/generated/wi_fi_ssids.g.dart';
 import 'package:privacy_gui/core/usp/services/usp_client.dart';
 import 'package:privacy_gui/page/wifi_settings/models/wifi_network_ui_model.dart';
+import 'package:privacy_gui/page/wifi_settings/models/wifi_quick_setup_network.dart';
+import 'package:privacy_gui/page/wifi_settings/models/wifi_settings_settings.dart';
+import 'package:privacy_gui/page/wifi_settings/models/wifi_settings_status.dart';
 import 'package:privacy_gui/page/wifi_settings/services/usp_wifi_settings_service.dart';
 
 class MockUspClient extends Mock implements UspClient {}
@@ -927,6 +930,211 @@ void main() {
 
       verifyNever(
           () => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // saveQuickSetup — field-level diff
+  // -------------------------------------------------------------------------
+
+  group('saveQuickSetup', () {
+    late MockUspClient mockUsp;
+    late UspWifiSettingsService writeSvc;
+
+    setUp(() {
+      mockUsp = MockUspClient();
+      writeSvc = UspWifiSettingsService(mockUsp);
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => uspSuccess());
+    });
+
+    WifiNetworkUIModel makeNetwork({
+      String ssidInstancePath = 'Device.WiFi.SSID.1.',
+      String accessPointInstancePath = 'Device.WiFi.AccessPoint.1.',
+      String band = '2.4GHz',
+      bool isGuest = false,
+    }) =>
+        WifiNetworkUIModel(
+          ssidInstancePath: ssidInstancePath,
+          accessPointInstancePath: accessPointInstancePath,
+          radioInstancePath: 'Device.WiFi.Radio.1.',
+          ssid: 'Home',
+          enabled: true,
+          ssidAdvertisementEnabled: true,
+          supportedSecurityModes: const ['WPA2-Personal', 'WPA3-Personal'],
+          securityMode: 'WPA2-Personal',
+          keyPassphrase: '',
+          isGuest: isGuest,
+          band: band,
+          channel: 6,
+          channelBandwidth: '20MHz',
+          autoChannelEnable: true,
+          possibleChannels: const [1, 6, 11],
+          operatingStandards: 'n',
+          supportedStandards: 'b,g,n',
+        );
+
+    /// Captures all TR-181 parameter keys that were passed to `mockUsp.set`.
+    Set<String> capturedKeys() {
+      final captured = verify(() =>
+              mockUsp.set(captureAny(), allowPartial: any(named: 'allowPartial')))
+          .captured;
+      final keys = <String>{};
+      for (final arg in captured) {
+        if (arg is Map) keys.addAll(arg.keys.cast<String>());
+      }
+      return keys;
+    }
+
+    test('skips AP write when only guest enabled toggled', () async {
+      // Guest group: only `enabled` changed. No SSID-name change, no AP change.
+      final guestAgg = WifiQuickSetupNetwork(
+        isGuest: true,
+        ssid: 'Home-Guest',
+        securityMode: 'None',
+        keyPassphrase: '',
+        supportedSecurityModes: const [],
+        ssidInstancePaths: const ['Device.WiFi.SSID.3.'],
+        apInstancePaths: const ['Device.WiFi.AccessPoint.3.'],
+      );
+      const guestOrig = WifiQuickSetupSettings(
+        isGuest: true,
+        enabled: true,
+        ssid: 'Home-Guest',
+        password: '',
+        securityMode: 'None',
+        supportedSecurityModes: [],
+      );
+
+      final original = WifiSettingsSettings(
+        networks: [
+          makeNetwork(
+            ssidInstancePath: 'Device.WiFi.SSID.3.',
+            accessPointInstancePath: 'Device.WiFi.AccessPoint.3.',
+            isGuest: true,
+          ),
+        ],
+        quickSetupEnabled: true,
+        quickSetupGuest: guestOrig,
+      );
+      final current = original.copyWith(
+        quickSetupGuest: guestOrig.copyWith(enabled: false),
+      );
+      final status = WifiSettingsStatus(quickSetupGuestAggregate: guestAgg);
+
+      await writeSvc.saveQuickSetup(
+        original: original,
+        current: current,
+        status: status,
+      );
+
+      final keys = capturedKeys();
+      // SSID enable write happens…
+      expect(keys, contains('Device.WiFi.SSID.3.Enable'));
+      // …but AP layer (KeyPassphrase / Security.ModeEnabled) must NOT be touched.
+      expect(
+        keys.any((k) => k.startsWith('Device.WiFi.AccessPoint.3.Security.')),
+        isFalse,
+      );
+    });
+
+    test('skips SSID write when only password changed', () async {
+      final mainAgg = WifiQuickSetupNetwork(
+        isGuest: false,
+        ssid: 'Home',
+        securityMode: 'WPA2-Personal',
+        keyPassphrase: '',
+        supportedSecurityModes: const ['WPA2-Personal', 'WPA3-Personal'],
+        ssidInstancePaths: const ['Device.WiFi.SSID.1.', 'Device.WiFi.SSID.2.'],
+        apInstancePaths: const [
+          'Device.WiFi.AccessPoint.1.',
+          'Device.WiFi.AccessPoint.2.'
+        ],
+      );
+      const mainOrig = WifiQuickSetupSettings(
+        isGuest: false,
+        enabled: true,
+        ssid: 'Home',
+        password: '',
+        securityMode: 'WPA2-Personal',
+        supportedSecurityModes: ['WPA2-Personal', 'WPA3-Personal'],
+      );
+
+      final original = WifiSettingsSettings(
+        networks: [
+          makeNetwork(ssidInstancePath: 'Device.WiFi.SSID.1.'),
+          makeNetwork(
+            ssidInstancePath: 'Device.WiFi.SSID.2.',
+            accessPointInstancePath: 'Device.WiFi.AccessPoint.2.',
+            band: '5GHz',
+          ),
+        ],
+        quickSetupEnabled: true,
+        quickSetupMain: mainOrig,
+      );
+      final current = original.copyWith(
+        quickSetupMain: mainOrig.copyWith(password: 'brandnew1'),
+      );
+      final status = WifiSettingsStatus(quickSetupMainAggregate: mainAgg);
+
+      await writeSvc.saveQuickSetup(
+        original: original,
+        current: current,
+        status: status,
+      );
+
+      final keys = capturedKeys();
+      // AP layer gets written — passphrase + mode.
+      expect(keys.any((k) => k.contains('AccessPoint.1.Security.KeyPassphrase')),
+          isTrue);
+      expect(keys.any((k) => k.contains('AccessPoint.2.Security.KeyPassphrase')),
+          isTrue);
+      // SSID layer must NOT be touched.
+      expect(keys.any((k) => k.startsWith('Device.WiFi.SSID.')), isFalse);
+    });
+
+    test('omits keyPassphrase param when password empty on mode change',
+        () async {
+      // User switches main to Open without entering a password. AP write
+      // still happens (mode changed) but must not send an empty passphrase.
+      final mainAgg = WifiQuickSetupNetwork(
+        isGuest: false,
+        ssid: 'Home',
+        securityMode: 'WPA2-Personal',
+        keyPassphrase: '',
+        supportedSecurityModes: const ['None', 'WPA2-Personal'],
+        ssidInstancePaths: const ['Device.WiFi.SSID.1.'],
+        apInstancePaths: const ['Device.WiFi.AccessPoint.1.'],
+      );
+      const mainOrig = WifiQuickSetupSettings(
+        isGuest: false,
+        enabled: true,
+        ssid: 'Home',
+        password: '',
+        securityMode: 'WPA2-Personal',
+        supportedSecurityModes: ['None', 'WPA2-Personal'],
+      );
+
+      final original = WifiSettingsSettings(
+        networks: [makeNetwork()],
+        quickSetupEnabled: true,
+        quickSetupMain: mainOrig,
+      );
+      final current = original.copyWith(
+        quickSetupMain: mainOrig.copyWith(securityMode: 'None'),
+      );
+      final status = WifiSettingsStatus(quickSetupMainAggregate: mainAgg);
+
+      await writeSvc.saveQuickSetup(
+        original: original,
+        current: current,
+        status: status,
+      );
+
+      final keys = capturedKeys();
+      expect(keys.any((k) => k.contains('Security.ModeEnabled')), isTrue);
+      // Empty passphrase must not be sent to firmware.
+      expect(keys.any((k) => k.contains('Security.KeyPassphrase')), isFalse);
     });
   });
 }

--- a/test/page/wifi_settings/services/usp_wifi_settings_service_test.dart
+++ b/test/page/wifi_settings/services/usp_wifi_settings_service_test.dart
@@ -976,9 +976,8 @@ void main() {
 
     /// Captures all TR-181 parameter keys that were passed to `mockUsp.set`.
     Set<String> capturedKeys() {
-      final captured = verify(() =>
-              mockUsp.set(captureAny(), allowPartial: any(named: 'allowPartial')))
-          .captured;
+      final captured = verify(() => mockUsp.set(captureAny(),
+          allowPartial: any(named: 'allowPartial'))).captured;
       final keys = <String>{};
       for (final arg in captured) {
         if (arg is Map) keys.addAll(arg.keys.cast<String>());
@@ -1085,9 +1084,11 @@ void main() {
 
       final keys = capturedKeys();
       // AP layer gets written — passphrase + mode.
-      expect(keys.any((k) => k.contains('AccessPoint.1.Security.KeyPassphrase')),
+      expect(
+          keys.any((k) => k.contains('AccessPoint.1.Security.KeyPassphrase')),
           isTrue);
-      expect(keys.any((k) => k.contains('AccessPoint.2.Security.KeyPassphrase')),
+      expect(
+          keys.any((k) => k.contains('AccessPoint.2.Security.KeyPassphrase')),
           isTrue);
       // SSID layer must NOT be touched.
       expect(keys.any((k) => k.startsWith('Device.WiFi.SSID.')), isFalse);


### PR DESCRIPTION
## Summary
- Fix `KeyPassphrase (Invalid value)` error when toggling Guest enable by implementing field-level diff — only write TR-181 parameters that actually changed
- Stop showing false "(Required)" password label when save doesn't need a passphrase (e.g., toggling enable, renaming SSID)
- Fix post-save UI not refreshing by using `ref.refresh()` instead of `ref.invalidate()`
- Check guest network consistency in `isQuickSetup` to avoid misleading aggregated view
- Hide Password/Security rows in both Quick Setup and Advanced mode when `supportedSecurityModes` is empty
- Restructure Advanced mode layout: Guest cards now align below their matching Main band, with equal-width columns

## Test plan
- [ ] Toggle Guest enable on/off in Quick Setup mode → should save without error
- [ ] Change only SSID name → should save without requiring password
- [ ] Change security mode → should require password input
- [ ] Verify UI updates after save without manual refresh
- [ ] Verify Guest cards with inconsistent enabled states show Advanced mode (not Quick Setup)
- [ ] Verify Guest cards in Advanced mode don't show Password/Security rows when `ModesSupported=''`

🤖 Generated with [Claude Code](https://claude.com/claude-code)