### PR TITLE
feat: unify PnP and AutoParent first-time login into single PnP flow

### DIFF
--- a/lib/route/constants.dart
+++ b/lib/route/constants.dart
@@ -13,7 +13,6 @@ class RoutePath {
   static const localPasswordReset = 'localPasswordReset';
   static const cloudRALogin = 'cloudRALogin';
   static const cloudRAPin = 'cloudRAPin';
-  static const autoParentFirstLogin = '/autoParentFirstLogin';
   static const cloudLoginAuth = '/cloudLoginAuth';
 
   /// dashboard
@@ -156,7 +155,6 @@ class RouteNamed {
   static const localPasswordReset = 'localPasswordReset';
   static const cloudRALogin = 'cloudRALogin';
   static const cloudRAPin = 'cloudRAPin';
-  static const autoParentFirstLogin = 'autoParentFirstLogin';
   static const cloudLoginAuth = 'cloudLoginAuth';
 
   /// dashboard

--- a/lib/route/route_local_login.dart
+++ b/lib/route/route_local_login.dart
@@ -1,12 +1,5 @@
 part of 'router_provider.dart';
 
-final autoParentFirstLoginRoute = LinksysRoute(
-  name: RouteNamed.autoParentFirstLogin,
-  path: RoutePath.autoParentFirstLogin,
-  config: const LinksysRouteConfig(noNaviRail: true),
-  builder: (context, state) => const AutoParentFirstLoginView(),
-);
-
 final localLoginRoute = LinksysRoute(
   name: RouteNamed.localLoginPassword,
   path: RoutePath.localLoginPassword,

--- a/lib/route/router_provider.dart
+++ b/lib/route/router_provider.dart
@@ -8,7 +8,6 @@ import 'package:privacy_gui/constants/build_config.dart';
 import 'package:privacy_gui/constants/pref_key.dart';
 import 'package:privacy_gui/core/cache/linksys_cache_manager.dart';
 import 'package:privacy_gui/core/jnap/actions/better_action.dart';
-import 'package:privacy_gui/core/jnap/models/auto_configuration_settings.dart';
 import 'package:privacy_gui/core/jnap/models/device_info.dart';
 import 'package:privacy_gui/core/jnap/providers/dashboard_manager_provider.dart';
 import 'package:privacy_gui/core/jnap/providers/polling_provider.dart';
@@ -30,7 +29,6 @@ import 'package:privacy_gui/page/instant_setup/troubleshooter/views/isp_settings
 import 'package:privacy_gui/page/landing/_landing.dart';
 
 import 'package:privacy_gui/page/login/views/_views.dart';
-import 'package:privacy_gui/page/login/auto_parent/views/auto_parent_first_login_view.dart';
 import 'package:privacy_gui/page/login/views/local_reset_router_password_view.dart';
 import 'package:privacy_gui/page/login/views/login_cloud_auth_view.dart';
 import 'package:privacy_gui/page/instant_admin/_instant_admin.dart';
@@ -84,7 +82,6 @@ part 'route_menu.dart';
 enum LocalWhereToGo {
   pnp,
   login,
-  firstTimeLogin,
   ;
 }
 
@@ -98,7 +95,6 @@ final routerProvider = Provider<GoRouter>((ref) {
     initialLocation: '/',
     routes: [
       localLoginRoute,
-      autoParentFirstLoginRoute,
       cloudLoginAuthRoute,
       cloudLoginRoute,
       homeRoute,
@@ -132,9 +128,6 @@ final routerProvider = Provider<GoRouter>((ref) {
         return router._redirectLogic(state);
       } else if (state.matchedLocation.startsWith('/pnp')) {
         return router._goPnpPath(state);
-      } else if (state.matchedLocation.startsWith('/autoParentFirstLogin')) {
-        // bypass auto parent first login page
-        return state.uri.toString();
       }
       return router._redirectLogic(state);
     },
@@ -190,18 +183,7 @@ class RouterNotifier extends ChangeNotifier {
         }
         // AutoConfigurationSupported is true case -
 
-        // AutoParent case -
-        if (config.autoConfigurationMethod ==
-            AutoConfigurationMethod.autoParent) {
-          // AutoParent case -
-          // First Time Login -> AutoConfigurationSupported is true and userAcknowledgedAutoConfiguration is false
-          // Login -> else
-          return config.userAcknowledgedAutoConfiguration == false
-              ? LocalWhereToGo.firstTimeLogin
-              : LocalWhereToGo.login;
-        }
-
-        // Prepair case - Check isAutoConfigurationSupported and userAcknowledgedAutoConfiguration
+        // Check isAutoConfigurationSupported and userAcknowledgedAutoConfiguration
 
         final userAcknowledgedAutoConfiguration =
             config.userAcknowledgedAutoConfiguration;
@@ -231,12 +213,6 @@ class RouterNotifier extends ChangeNotifier {
       // PnP case -
       await _ref.read(authProvider.notifier).logout();
       return _goPnp(state.uri.query);
-    } else if (whereToGo == LocalWhereToGo.firstTimeLogin) {
-      // First Time Login case -
-      if (!_ref.read(autoParentFirstLoginStateProvider)) {
-        await _ref.read(authProvider.notifier).logout();
-      }
-      return _goFirstTimeLogin(state);
     } else {
       // Login case -
       return _authCheck(state);
@@ -294,12 +270,6 @@ class RouterNotifier extends ChangeNotifier {
     final path = '${RoutePath.pnp}?$queryParams';
     logger.i('[Route]: Go to PnP, URI=$path');
     return path;
-  }
-
-  FutureOr<String?> _goFirstTimeLogin(GoRouterState state) {
-    logger.i('[Route]: Mark First Time Login');
-    _ref.read(autoParentFirstLoginStateProvider.notifier).state = true;
-    return _authCheck(state);
   }
 
   Future<String?> _authCheck(GoRouterState state) {
@@ -437,13 +407,6 @@ class RouterNotifier extends ChangeNotifier {
 
   Future<String?> _prepareLocal(String? serialNumber) async {
     logger.i('[Prepare]: local - $serialNumber');
-    // If auto parent first login, then go to auto parent first login page
-    final autoParentFirstLogin = _ref.read(autoParentFirstLoginStateProvider);
-    if (autoParentFirstLogin) {
-      logger.i('[Prepare]: autoParentFirstLogin');
-      _ref.read(autoParentFirstLoginStateProvider.notifier).state = false;
-      return RoutePath.autoParentFirstLogin;
-    }
     if (isSerialNumberChanged(serialNumber)) {
       return null;
     }
@@ -475,7 +438,3 @@ class RouterNotifier extends ChangeNotifier {
   NodeDeviceInfo? _getStateDeviceInfo() =>
       _ref.read(dashboardManagerProvider).deviceInfo;
 }
-
-final autoParentFirstLoginStateProvider = StateProvider<bool>((ref) {
-  return false;
-});


### PR DESCRIPTION
## Summary

- Remove the separate AutoParent First-Time Login route and redirect logic, consolidating both AutoParent and PreConfigured devices into the existing PnP initialization flow
- Delete `autoParentFirstLoginRoute`, `autoParentFirstLoginStateProvider`, and related routing branches in `RouterNotifier`
- Clean up unused imports (`AutoConfigurationSettings`, `AutoParentFirstLoginView`) and the `LocalWhereToGo.firstTimeLogin` enum case

## Motivation

Previously, AutoParent devices had a dedicated first-time login path that diverged from the standard PnP flow. This added routing complexity without functional benefit — both paths ultimately lead to the same setup experience. Unifying them simplifies the router logic and reduces maintenance surface.

## Test plan

- [ ] AutoParent device: verify first-time setup goes through PnP flow correctly
- [ ] PreConfigured device: verify PnP flow is unchanged
- [ ] Returning user (AutoParent, `userAcknowledgedAutoConfiguration = true`): verify normal login flow
- [ ] Deep links and direct navigation: confirm no broken routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)