### PR TITLE
fix: multiple UI and routing fixes for USP dashboard

### DIFF
--- a/lib/page/_shared/models/time_settings_ui_model.dart
+++ b/lib/page/_shared/models/time_settings_ui_model.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:privacy_gui/page/_shared/models/timezone_definitions.dart';
 
 /// Presentation Layer Model for time settings.
 class TimeSettingsUIModel extends Equatable {
@@ -22,10 +23,13 @@ class TimeSettingsUIModel extends Equatable {
 
   DateTime? get parsedLocalTime {
     if (currentLocalTime.isEmpty) return null;
-    final match = RegExp(r'(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})')
-        .firstMatch(currentLocalTime);
+    final match = RegExp(
+      r'(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})'
+      r'(?:Z|([+-])(\d{2}):(\d{2}))?',
+    ).firstMatch(currentLocalTime);
     if (match == null) return null;
-    return DateTime(
+
+    var dt = DateTime(
       int.parse(match[1]!),
       int.parse(match[2]!),
       int.parse(match[3]!),
@@ -33,6 +37,21 @@ class TimeSettingsUIModel extends Equatable {
       int.parse(match[5]!),
       int.parse(match[6]!),
     );
+
+    final hasOffset = match[7] != null;
+    if (hasOffset) {
+      final sign = match[7] == '+' ? 1 : -1;
+      final offsetMinutes =
+          sign * (int.parse(match[8]!) * 60 + int.parse(match[9]!));
+      dt = dt.subtract(Duration(minutes: offsetMinutes));
+
+      final tzInfo = matchTimezone(localTimeZone);
+      if (tzInfo != null) {
+        dt = dt.add(Duration(minutes: tzInfo.utcOffsetMinutes));
+      }
+    }
+
+    return dt;
   }
 
   String get formattedDateTime {

--- a/lib/page/admin/cards/usp_time_settings_card.dart
+++ b/lib/page/admin/cards/usp_time_settings_card.dart
@@ -22,10 +22,15 @@ class UspTimeSettingsCard extends ConsumerStatefulWidget {
 class _UspTimeSettingsCardState extends ConsumerState<UspTimeSettingsCard>
     with LocalTimeTicker {
   String? _lastRawTime;
+  String? _lastTimeZone;
 
   void _syncIfChanged(TimeData timeData) {
-    if (timeData.model.currentLocalTime == _lastRawTime) return;
+    if (timeData.model.currentLocalTime == _lastRawTime &&
+        timeData.model.localTimeZone == _lastTimeZone) {
+      return;
+    }
     _lastRawTime = timeData.model.currentLocalTime;
+    _lastTimeZone = timeData.model.localTimeZone;
     syncTime(timeData.model.parsedLocalTime, fetchedAt: timeData.fetchedAt);
   }
 

--- a/lib/page/admin/providers/usp_admin_notifier.dart
+++ b/lib/page/admin/providers/usp_admin_notifier.dart
@@ -17,7 +17,6 @@ class UspAdminNotifier extends AutoDisposeAsyncNotifier<UspAdminState> {
   @override
   Future<UspAdminState> build() async {
     try {
-      ref.invalidate(timeDataProvider);
       final timeData = await ref.watch(timeDataProvider.future);
       final adminUser = await _svc.fetchAdmin();
 

--- a/lib/page/admin/views/components/usp_timezone_card.dart
+++ b/lib/page/admin/views/components/usp_timezone_card.dart
@@ -33,7 +33,9 @@ class _UspTimezoneCardState extends State<UspTimezoneCard>
   void didUpdateWidget(UspTimezoneCard oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.timeSettings.currentLocalTime !=
-        widget.timeSettings.currentLocalTime) {
+            widget.timeSettings.currentLocalTime ||
+        oldWidget.timeSettings.localTimeZone !=
+            widget.timeSettings.localTimeZone) {
       syncTime(widget.timeSettings.parsedLocalTime,
           fetchedAt: widget.fetchedAt);
     }

--- a/lib/page/admin/views/usp_admin_view.dart
+++ b/lib/page/admin/views/usp_admin_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/page/admin/providers/usp_admin_notifier.dart';
@@ -158,10 +159,13 @@ class UspAdminView extends ConsumerWidget {
     );
     if (result == null || !context.mounted) return;
     try {
-      await ref.read(uspAdminProvider.notifier).updateTimezone(
-            localTimeZone: result.localTimeZone,
-            ntpServer1: result.ntpServer1,
-          );
+      await doSomethingWithSpinner(
+        context,
+        ref.read(uspAdminProvider.notifier).updateTimezone(
+              localTimeZone: result.localTimeZone,
+              ntpServer1: result.ntpServer1,
+            ),
+      );
       if (context.mounted) showSuccessSnackBar(context, 'Timezone updated');
     } catch (e) {
       if (context.mounted) {
@@ -200,7 +204,10 @@ class UspAdminView extends ConsumerWidget {
     );
     if (confirmed != true || !context.mounted) return;
     try {
-      await ref.read(uspAdminProvider.notifier).reboot();
+      await doSomethingWithSpinner(
+        context,
+        ref.read(uspAdminProvider.notifier).reboot(),
+      );
       if (context.mounted) showSuccessSnackBar(context, 'Reboot command sent');
     } catch (e) {
       if (context.mounted) showFailedSnackBar(context, 'Reboot failed: $e');
@@ -217,7 +224,10 @@ class UspAdminView extends ConsumerWidget {
     );
     if (confirmed != true || !context.mounted) return;
     try {
-      await ref.read(uspAdminProvider.notifier).factoryReset();
+      await doSomethingWithSpinner(
+        context,
+        ref.read(uspAdminProvider.notifier).factoryReset(),
+      );
       if (context.mounted) {
         showSuccessSnackBar(context, 'Factory reset command sent');
       }

--- a/lib/page/dashboard/models/usp_dashboard_preset.dart
+++ b/lib/page/dashboard/models/usp_dashboard_preset.dart
@@ -156,7 +156,7 @@ List<LayoutItem> _standardLayout() => [
       _item('traffic_analysis', x: 6, y: 12, w: 6, h: 5),
       _item('connected_devices', x: 0, y: 17, w: 6, h: 4),
       _item('wifi_status', x: 6, y: 17, w: 6, h: 6),
-      _item('time_settings', x: 0, y: 23, w: 6, h: 3),
+      _item('time_settings', x: 0, y: 23, w: 6, h: 2),
       _item('firewall_overview', x: 6, y: 23, w: 6, h: 4),
     ];
 
@@ -188,7 +188,7 @@ List<LayoutItem> _professionalLayout() => [
       _item('wifi_status', x: 0, y: 23, w: 6, h: 6),
       _item('wifi_performance', x: 6, y: 23, w: 6, h: 5),
       _item('firewall_overview', x: 0, y: 29, w: 6, h: 4),
-      _item('time_settings', x: 6, y: 29, w: 6, h: 3),
+      _item('time_settings', x: 6, y: 29, w: 6, h: 2),
       _item('dhcp_reservations', x: 0, y: 33, w: 6, h: 4),
       _item('port_forwarding', x: 6, y: 33, w: 6, h: 4),
     ];

--- a/lib/page/dhcp/views/components/usp_dhcp_reservations_detail_card.dart
+++ b/lib/page/dhcp/views/components/usp_dhcp_reservations_detail_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/page/_shared/models/dhcp_reservation_ui_model.dart';
+import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
 import 'package:privacy_gui/page/dhcp/providers/usp_dhcp_reservations_notifier.dart';
 import 'package:privacy_gui/page/dhcp/views/dialogs/dhcp_reservation_edit_dialog.dart';
 import 'package:ui_kit_library/ui_kit.dart';
@@ -94,10 +95,39 @@ class UspDhcpReservationsDetailCard extends ConsumerWidget {
     );
   }
 
+  ({List<AppAutoCompleteOption> mac, List<AppAutoCompleteOption> ip})
+      _buildDeviceOptions(WidgetRef ref) {
+    final devices =
+        ref.read(devicesDataProvider).valueOrNull?.deviceModels ?? [];
+    final macOptions = devices
+        .where((d) => d.mac.isNotEmpty)
+        .map((d) => AppAutoCompleteOption(
+              label: d.displayName,
+              value: d.mac,
+              subtitle: d.ip,
+              isActive: d.isActive,
+            ))
+        .toList();
+    final ipOptions = devices
+        .where((d) => d.ip.isNotEmpty)
+        .map((d) => AppAutoCompleteOption(
+              label: d.displayName,
+              value: d.ip,
+              subtitle: d.mac,
+              isActive: d.isActive,
+            ))
+        .toList();
+    return (mac: macOptions, ip: ipOptions);
+  }
+
   Future<void> _showAddDialog(BuildContext context, WidgetRef ref) async {
+    final options = _buildDeviceOptions(ref);
     final result = await showDialog<({String mac, String ip, bool enable})>(
       context: context,
-      builder: (_) => const DhcpReservationEditDialog(),
+      builder: (_) => DhcpReservationEditDialog(
+        macDeviceOptions: options.mac,
+        ipDeviceOptions: options.ip,
+      ),
     );
     if (result == null || !context.mounted) return;
     ref.read(uspDhcpReservationsProvider.notifier).addReservation(
@@ -114,9 +144,14 @@ class UspDhcpReservationsDetailCard extends ConsumerWidget {
     WidgetRef ref,
     DhcpReservationUIModel reservation,
   ) async {
+    final options = _buildDeviceOptions(ref);
     final result = await showDialog<({String mac, String ip, bool enable})>(
       context: context,
-      builder: (_) => DhcpReservationEditDialog(reservation: reservation),
+      builder: (_) => DhcpReservationEditDialog(
+        reservation: reservation,
+        macDeviceOptions: options.mac,
+        ipDeviceOptions: options.ip,
+      ),
     );
     if (result == null || !context.mounted) return;
     ref.read(uspDhcpReservationsProvider.notifier).editReservation(

--- a/lib/page/dhcp/views/dialogs/dhcp_reservation_edit_dialog.dart
+++ b/lib/page/dhcp/views/dialogs/dhcp_reservation_edit_dialog.dart
@@ -10,8 +10,15 @@ import 'package:ui_kit_library/ui_kit.dart';
 /// Returns a `({String mac, String ip, bool enable})` record on submit, or null on cancel.
 class DhcpReservationEditDialog extends StatefulWidget {
   final DhcpReservationUIModel? reservation;
+  final List<AppAutoCompleteOption> macDeviceOptions;
+  final List<AppAutoCompleteOption> ipDeviceOptions;
 
-  const DhcpReservationEditDialog({super.key, this.reservation});
+  const DhcpReservationEditDialog({
+    super.key,
+    this.reservation,
+    this.macDeviceOptions = const [],
+    this.ipDeviceOptions = const [],
+  });
 
   @override
   State<DhcpReservationEditDialog> createState() =>
@@ -78,18 +85,44 @@ class _DhcpReservationEditDialogState extends State<DhcpReservationEditDialog> {
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          AppTextField(
+          AppSelectAutoComplete(
+            options: widget.macDeviceOptions,
             controller: _macController,
-            hintText: 'MAC Address (e.g. AA:BB:CC:DD:EE:FF)',
-            onChanged: (_) => _validate(),
-            errorText: _errors['mac'],
+            onSelected: (value) {
+              final match = widget.macDeviceOptions
+                  .where((o) => o.value == value)
+                  .firstOrNull;
+              if (match?.subtitle != null) {
+                _ipController.text = match!.subtitle!;
+              }
+              _validate();
+            },
+            child: AppTextField(
+              controller: _macController,
+              hintText: 'MAC Address (e.g. AA:BB:CC:DD:EE:FF)',
+              onChanged: (_) => _validate(),
+              errorText: _errors['mac'],
+            ),
           ),
           AppGap.lg(),
-          AppTextField(
+          AppSelectAutoComplete(
+            options: widget.ipDeviceOptions,
             controller: _ipController,
-            hintText: 'IP Address (e.g. 192.168.1.100)',
-            onChanged: (_) => _validate(),
-            errorText: _errors['ip'],
+            onSelected: (value) {
+              final match = widget.ipDeviceOptions
+                  .where((o) => o.value == value)
+                  .firstOrNull;
+              if (match?.subtitle != null) {
+                _macController.text = match!.subtitle!;
+              }
+              _validate();
+            },
+            child: AppTextField(
+              controller: _ipController,
+              hintText: 'IP Address (e.g. 192.168.1.100)',
+              onChanged: (_) => _validate(),
+              errorText: _errors['ip'],
+            ),
           ),
           AppGap.lg(),
           Row(

--- a/lib/page/internet_settings/services/usp_internet_settings_service.dart
+++ b/lib/page/internet_settings/services/usp_internet_settings_service.dart
@@ -347,8 +347,9 @@ class UspInternetSettingsService {
           password: skipCredentials
               ? null
               : _diff(original.pppPassword, edited.pppPassword),
-          pppoeServiceName:
-              _diff(original.pppoeServiceName, edited.pppoeServiceName),
+          // pppoeServiceName — disabled: bbfdm rejects SET (fault 9001)
+          // pppoeServiceName:
+          //     _diff(original.pppoeServiceName, edited.pppoeServiceName),
           connectionTrigger:
               _diff(original.connectionTrigger, edited.connectionTrigger),
           idleDisconnectTime:

--- a/lib/page/internet_settings/views/sections/usp_ipv4_section.dart
+++ b/lib/page/internet_settings/views/sections/usp_ipv4_section.dart
@@ -39,7 +39,7 @@ class _UspIpv4SectionState extends ConsumerState<UspIpv4Section> {
   late TextEditingController _dns3Controller;
   late TextEditingController _pppUsernameController;
   late TextEditingController _pppPasswordController;
-  late TextEditingController _pppServiceNameController;
+  // late TextEditingController _pppServiceNameController;
   late TextEditingController _vlanIdController;
   late TextEditingController _idleTimeController;
 
@@ -59,8 +59,8 @@ class _UspIpv4SectionState extends ConsumerState<UspIpv4Section> {
     _dns3Controller = TextEditingController(text: form.dnsServer3);
     _pppUsernameController = TextEditingController(text: form.pppUsername);
     _pppPasswordController = TextEditingController(text: form.pppPassword);
-    _pppServiceNameController =
-        TextEditingController(text: form.pppoeServiceName);
+    // _pppServiceNameController =
+    //     TextEditingController(text: form.pppoeServiceName);
     _vlanIdController = TextEditingController(text: form.vlanId.toString());
     _idleTimeController =
         TextEditingController(text: form.idleDisconnectTime.toString());
@@ -84,7 +84,7 @@ class _UspIpv4SectionState extends ConsumerState<UspIpv4Section> {
     _syncIfDifferent(_dns3Controller, form.dnsServer3);
     _syncIfDifferent(_pppUsernameController, form.pppUsername);
     _syncIfDifferent(_pppPasswordController, form.pppPassword);
-    _syncIfDifferent(_pppServiceNameController, form.pppoeServiceName);
+    // _syncIfDifferent(_pppServiceNameController, form.pppoeServiceName);
     _syncIfDifferent(_vlanIdController, form.vlanId.toString());
     _syncIfDifferent(_idleTimeController, form.idleDisconnectTime.toString());
   }
@@ -105,7 +105,7 @@ class _UspIpv4SectionState extends ConsumerState<UspIpv4Section> {
     _dns3Controller.dispose();
     _pppUsernameController.dispose();
     _pppPasswordController.dispose();
-    _pppServiceNameController.dispose();
+    // _pppServiceNameController.dispose();
     _vlanIdController.dispose();
     _idleTimeController.dispose();
     super.dispose();
@@ -230,7 +230,8 @@ class _UspIpv4SectionState extends ConsumerState<UspIpv4Section> {
     if (!isEditing) {
       return [
         UspInfoRow(label: l.username, value: form.pppUsername),
-        UspInfoRow(label: l.serviceName, value: form.pppoeServiceName),
+        // ServiceName — disabled: bbfdm rejects SET (fault 9001)
+        // UspInfoRow(label: l.serviceName, value: form.pppoeServiceName),
         UspInfoRow(label: l.connectionMode, value: form.connectionTrigger),
         UspInfoRow(label: l.pppStatus, value: widget.state.pppConnectionStatus),
         if (form.vlanEnabled)
@@ -250,12 +251,13 @@ class _UspIpv4SectionState extends ConsumerState<UspIpv4Section> {
         obscureText: true,
         onChanged: (v) => _updateField((f) => f.copyWith(pppPassword: v)),
       ),
-      AppGap.md(),
-      AppTextFormField(
-        controller: _pppServiceNameController,
-        label: l.serviceNameOptional,
-        onChanged: (v) => _updateField((f) => f.copyWith(pppoeServiceName: v)),
-      ),
+      // ServiceName — disabled: bbfdm rejects SET (fault 9001)
+      // AppGap.md(),
+      // AppTextFormField(
+      //   controller: _pppServiceNameController,
+      //   label: l.serviceNameOptional,
+      //   onChanged: (v) => _updateField((f) => f.copyWith(pppoeServiceName: v)),
+      // ),
       AppGap.lg(),
       // Connection mode
       AppText.labelLarge(l.connectionMode),

--- a/lib/page/internet_settings/views/sections/usp_optional_section.dart
+++ b/lib/page/internet_settings/views/sections/usp_optional_section.dart
@@ -25,7 +25,6 @@ class UspOptionalSection extends ConsumerStatefulWidget {
 
 class _UspOptionalSectionState extends ConsumerState<UspOptionalSection> {
   late TextEditingController _mtuController;
-  late TextEditingController _macController;
 
   @override
   void initState() {
@@ -33,7 +32,6 @@ class _UspOptionalSectionState extends ConsumerState<UspOptionalSection> {
     final form = widget.state.edited;
     _mtuController =
         TextEditingController(text: form.mtu == 0 ? '' : form.mtu.toString());
-    _macController = TextEditingController(text: form.wanMacAddress);
   }
 
   @override
@@ -45,16 +43,12 @@ class _UspOptionalSectionState extends ConsumerState<UspOptionalSection> {
       if (_mtuController.text != mtuText) {
         _mtuController.text = mtuText;
       }
-      if (_macController.text != form.wanMacAddress) {
-        _macController.text = form.wanMacAddress;
-      }
     }
   }
 
   @override
   void dispose() {
     _mtuController.dispose();
-    _macController.dispose();
     super.dispose();
   }
 
@@ -122,27 +116,11 @@ class _UspOptionalSectionState extends ConsumerState<UspOptionalSection> {
           AppGap.lg(),
           AppDivider(),
           AppGap.lg(),
-          // MAC Address Clone
+          // MAC Address Clone — read-only until USP data model supports write
           AppText.labelLarge(l.macAddressClone),
           AppGap.md(),
           UspInfoRow(
               label: l.currentMac, value: widget.state.currentMacAddress),
-          AppGap.md(),
-          if (!isEditing) ...[
-            UspInfoRow(
-              label: l.cloneMac,
-              value:
-                  form.wanMacAddress.isEmpty ? l.disabled : form.wanMacAddress,
-            ),
-          ] else ...[
-            AppTextFormField(
-              controller: _macController,
-              label: l.macAddress,
-              hintText: 'AA:BB:CC:DD:EE:FF',
-              onChanged: (v) =>
-                  _updateField((f) => f.copyWith(wanMacAddress: v)),
-            ),
-          ],
         ],
       ),
     );

--- a/lib/page/internet_settings/views/sections/usp_optional_section.dart
+++ b/lib/page/internet_settings/views/sections/usp_optional_section.dart
@@ -113,14 +113,14 @@ class _UspOptionalSectionState extends ConsumerState<UspOptionalSection> {
                   _updateField((f) => f.copyWith(mtu: int.tryParse(v) ?? 0)),
             ),
           ],
-          AppGap.lg(),
-          AppDivider(),
-          AppGap.lg(),
-          // MAC Address Clone — read-only until USP data model supports write
-          AppText.labelLarge(l.macAddressClone),
-          AppGap.md(),
-          UspInfoRow(
-              label: l.currentMac, value: widget.state.currentMacAddress),
+          // MAC Address Clone — disabled: USP data model does not support write
+          // AppGap.lg(),
+          // AppDivider(),
+          // AppGap.lg(),
+          // AppText.labelLarge(l.macAddressClone),
+          // AppGap.md(),
+          // UspInfoRow(
+          //     label: l.currentMac, value: widget.state.currentMacAddress),
         ],
       ),
     );

--- a/lib/page/local_network/providers/usp_local_network_notifier.dart
+++ b/lib/page/local_network/providers/usp_local_network_notifier.dart
@@ -149,6 +149,11 @@ class UspLocalNetworkNotifier
     final current = state.settings.current;
     var newModel = updater(current.model);
 
+    // Apply sensible defaults when DHCP is toggled from disabled → enabled
+    if (!current.model.dhcpEnabled && newModel.dhcpEnabled) {
+      newModel = _svc.applyDhcpDefaults(newModel);
+    }
+
     // Auto-sync pool prefix when router IP changes
     if (newModel.ipAddress != current.model.ipAddress &&
         newModel.subnetMask.isNotEmpty) {

--- a/lib/page/local_network/services/usp_local_network_service.dart
+++ b/lib/page/local_network/services/usp_local_network_service.dart
@@ -157,6 +157,75 @@ class UspLocalNetworkService {
     return null;
   }
 
+  // ─── DHCP Defaults ─────────────────────────────────────────
+
+  static const _defaultLeaseTimeMinutes = 720; // 12 hours
+  static const _defaultPoolSize = 150;
+  static const _defaultPoolOffset = 100;
+
+  /// Compute sensible DHCP defaults when the user enables DHCP and the pool
+  /// fields are empty. Returns the model unchanged if defaults are not needed.
+  LocalNetworkUIModel applyDhcpDefaults(LocalNetworkUIModel model) {
+    final needPool = model.minAddress.isEmpty || model.maxAddress.isEmpty;
+    final needLease = model.leaseTimeMinutes < 1;
+
+    if (!needPool && !needLease) return model;
+
+    var result = model;
+
+    if (needPool &&
+        NetworkUtils.isValidIpAddress(model.ipAddress) &&
+        model.subnetMask.isNotEmpty) {
+      final pool = _computeDefaultPool(model.ipAddress, model.subnetMask);
+      if (pool != null) {
+        result = result.copyWith(
+          minAddress: model.minAddress.isEmpty ? pool.$1 : null,
+          maxAddress: model.maxAddress.isEmpty ? pool.$2 : null,
+        );
+      }
+    }
+
+    if (needLease) {
+      result = result.copyWith(leaseTimeMinutes: _defaultLeaseTimeMinutes);
+    }
+
+    return result;
+  }
+
+  (String, String)? _computeDefaultPool(String routerIp, String subnetMask) {
+    try {
+      final routerNum = NetworkUtils.ipToNum(routerIp);
+      final maskNum = NetworkUtils.ipToNum(subnetMask);
+      final networkNum = routerNum & maskNum;
+      final broadcastNum = networkNum | (~maskNum & 0xFFFFFFFF);
+      final lastUsable = broadcastNum - 1;
+      final usableCount = lastUsable - networkNum - 1;
+      if (usableCount < 2) return null;
+
+      final offset = usableCount > 200
+          ? _defaultPoolOffset
+          : (usableCount ~/ 4).clamp(2, _defaultPoolOffset);
+      final poolSize = (usableCount > 100 ? _defaultPoolSize : usableCount ~/ 2)
+          .clamp(1, _defaultPoolSize);
+
+      var startNum = networkNum + offset;
+      var endNum = startNum + poolSize - 1;
+
+      // Shift past router IP if it falls within the pool
+      if (routerNum >= startNum && routerNum <= endNum) {
+        startNum = routerNum + 1;
+        endNum = startNum + poolSize - 1;
+      }
+
+      if (endNum > lastUsable) endNum = lastUsable;
+      if (startNum > endNum) return null;
+
+      return (NetworkUtils.numToIp(startNum), NetworkUtils.numToIp(endNum));
+    } catch (_) {
+      return null;
+    }
+  }
+
   // ─── Prefix Lock ───────────────────────────────────────────
 
   /// How many octets to lock based on subnet mask.

--- a/lib/page/menu/views/usp_menu_view.dart
+++ b/lib/page/menu/views/usp_menu_view.dart
@@ -94,13 +94,13 @@ class UspMenuView extends StatelessWidget {
         iconData: Icons.tune,
         onTap: () => context.goNamed(RouteNamed.uspAdvancedSettings),
       ),
-      AppSectionItemData(
-        semanticLabel: 'menu-system-logs',
-        title: 'System Logs',
-        description: 'View router log files',
-        iconData: Icons.article_outlined,
-        onTap: () => context.goNamed(RouteNamed.uspSystemLog),
-      ),
+      // AppSectionItemData(
+      //   semanticLabel: 'menu-system-logs',
+      //   title: 'System Logs',
+      //   description: 'View router log files',
+      //   iconData: Icons.article_outlined,
+      //   onTap: () => context.goNamed(RouteNamed.uspSystemLog),
+      // ),
       AppSectionItemData(
         semanticLabel: 'menu-statistics',
         title: 'Statistics',

--- a/lib/route/router_provider.dart
+++ b/lib/route/router_provider.dart
@@ -118,8 +118,13 @@ class RouterNotifier extends ChangeNotifier {
   final Ref _ref;
   StreamSubscription? _errorSub;
   RouterNotifier(this._ref) {
-    _ref.listen(authProvider, (_, __) {
-      notifyListeners();
+    _ref.listen(authProvider, (previous, next) {
+      if (next.isLoading) return;
+      final prevType = previous?.value?.loginType;
+      final nextType = next.value?.loginType;
+      if (prevType != nextType) {
+        notifyListeners();
+      }
     });
   }
 

--- a/lib/route/router_provider.dart
+++ b/lib/route/router_provider.dart
@@ -117,7 +117,11 @@ final routerProvider = Provider<GoRouter>((ref) {
 class RouterNotifier extends ChangeNotifier {
   final Ref _ref;
   StreamSubscription? _errorSub;
-  RouterNotifier(this._ref);
+  RouterNotifier(this._ref) {
+    _ref.listen(authProvider, (_, __) {
+      notifyListeners();
+    });
+  }
 
   @override
   void dispose() {

--- a/test/page/_shared/models/time_settings_ui_model_test.dart
+++ b/test/page/_shared/models/time_settings_ui_model_test.dart
@@ -43,9 +43,32 @@ void main() {
         expect(m.parsedLocalTime, DateTime(2026, 4, 17, 22, 30, 15));
       });
 
-      test('extracts date/time ignoring timezone offset suffix', () {
-        final m = _model(currentLocalTime: '2026-04-17T08:00:00+08:00');
+      test('converts offset to target timezone (offset matches timezone)', () {
+        final m = _model(
+          currentLocalTime: '2026-04-17T08:00:00+08:00',
+          localTimeZone: 'UTC-8',
+        );
         expect(m.parsedLocalTime, DateTime(2026, 4, 17, 8, 0, 0));
+      });
+
+      test('converts stale offset to correct target timezone', () {
+        // Device returns +08:00 offset but timezone was changed to Alaska
+        final m = _model(
+          currentLocalTime: '2026-04-27T17:28:51+08:00',
+          localTimeZone: 'AKST9AKDT,M3.2.0/02:00,M11.1.0/02:00',
+        );
+        // UTC = 17:28:51 - 8h = 09:28:51, Alaska = UTC-9 = 00:28:51
+        expect(m.parsedLocalTime, DateTime(2026, 4, 27, 0, 28, 51));
+      });
+
+      test('converts negative offset to target timezone', () {
+        // Device returns -08:00 offset but timezone was changed to GMT+8
+        final m = _model(
+          currentLocalTime: '2026-04-27T01:29:04-08:00',
+          localTimeZone: 'UTC-8',
+        );
+        // UTC = 01:29:04 + 8h = 09:29:04, GMT+8 = UTC+8 = 17:29:04
+        expect(m.parsedLocalTime, DateTime(2026, 4, 27, 17, 29, 4));
       });
     });
 


### PR DESCRIPTION
## Summary

### Logout redirect
- RouterNotifier listens to authProvider state changes so GoRouter re-evaluates redirect guard on logout
- Filters intermediate loading states to prevent infinite redirect loops
- Fixes: clicking logout from GeneralSettingsWidget or idle timeout now correctly navigates to login page

### PPPoE / MAC clone UI
- Disable PPPoE service name and MAC clone input fields (USP backend does not yet support write)
- Hide MAC address clone edit UI entirely until backend is ready

### DHCP
- Add autocomplete for IP/MAC fields in DHCP reservation edit dialog
- Set sensible defaults for new reservation entries

### Timezone / local time
- Fix incorrect local time display after timezone change

### Menu
- Comment out System Logs menu item (not yet functional)

## Test plan
- [ ] Login → click logout from top-right settings popup → verify redirect to login page
- [ ] Login → logout → login again → verify no infinite redirect loop
- [ ] Verify PPPoE service name and MAC clone fields are disabled/hidden
- [ ] Verify DHCP reservation dialog has autocomplete and defaults
- [ ] Change timezone → verify local time updates correctly
- [ ] Verify System Logs is not visible in menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)