### PR TITLE
refactor: logger system structured upgrade

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -239,8 +239,8 @@ class _LinksysAppState extends ConsumerState<LinksysApp>
     if (sseManager == null) return;
     final sseState = sseManager.connection.connectionState.value;
     if (sseState == SseConnectionState.suspended) {
-      logger
-          .d('[App]: Lifecycle resume: attempting SSE reconnect from suspended');
+      logger.d(
+          '[App]: Lifecycle resume: attempting SSE reconnect from suspended');
       sseManager.tryReconnect();
     }
   }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -96,7 +96,7 @@ class _LinksysAppState extends ConsumerState<LinksysApp>
   ///   and a responsive layout container.
   @override
   Widget build(BuildContext context) {
-    logger.d('App:: build: $_currentRoute');
+    logger.d('[App]: build: $_currentRoute');
 
     final appSettings = ref.watch(appSettingsProvider);
     final systemLocaleStr = Intl.getCurrentLocale();
@@ -226,7 +226,7 @@ class _LinksysAppState extends ConsumerState<LinksysApp>
   /// resumed, and stopping polling when it is paused.
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    logger.i('didChangeAppLifecycleState: ${state.name}');
+    logger.i('[App]: didChangeAppLifecycleState: ${state.name}');
     if (state == AppLifecycleState.resumed) {
       _tryResumeSse();
     }
@@ -240,7 +240,7 @@ class _LinksysAppState extends ConsumerState<LinksysApp>
     final sseState = sseManager.connection.connectionState.value;
     if (sseState == SseConnectionState.suspended) {
       logger
-          .d('[App] Lifecycle resume: attempting SSE reconnect from suspended');
+          .d('[App]: Lifecycle resume: attempting SSE reconnect from suspended');
       sseManager.tryReconnect();
     }
   }
@@ -252,7 +252,7 @@ class _LinksysAppState extends ConsumerState<LinksysApp>
   /// native splash screen, revealing the app's UI.
   _initAuth() {
     ref.read(authProvider.notifier).init().then((_) {
-      logger.d('init auth finish');
+      logger.d('[App]: init auth finish');
       FlutterNativeSplash.remove();
     });
   }

--- a/lib/components/layouts/root_container.dart
+++ b/lib/components/layouts/root_container.dart
@@ -34,7 +34,7 @@ class _AppRootContainerState extends ConsumerState<AppRootContainer> {
 
   @override
   Widget build(BuildContext context) {
-    logger.d('Root Container:: build: ${widget.route}');
+    logger.d('[App]: Root Container build: ${widget.route}');
 
     return LayoutBuilder(builder: ((context, constraints) {
       return IdleChecker(
@@ -61,7 +61,7 @@ class _AppRootContainerState extends ConsumerState<AppRootContainer> {
           if (ref.read(idleCheckerPauseProvider) == true) {
             return;
           }
-          logger.d('Idled!');
+          logger.d('[App]: Idled!');
           ref.read(authProvider.notifier).logout();
         },
         child: Container(

--- a/lib/components/shortcuts/dialogs.dart
+++ b/lib/components/shortcuts/dialogs.dart
@@ -34,7 +34,7 @@ Future<T?> doSomethingWithSpinner<T>(
         );
       }
     } catch (e) {
-      logger.w('Could not show spinner dialog: $e');
+      logger.w('[Dialog]: Could not show spinner dialog: $e');
     }
     completer.complete();
   });
@@ -50,7 +50,7 @@ Future<T?> doSomethingWithSpinner<T>(
       navigator?.pop();
     } catch (e) {
       logger.w(
-          'doSomethingWithSpinner failed to pop. This might be intentional if the caller pops a page. Error: $e');
+          '[Dialog]: doSomethingWithSpinner failed to pop. This might be intentional if the caller pops a page. Error: $e');
     }
   });
 }
@@ -141,7 +141,7 @@ Future<T?> showSubmitAppDialog<T>(
               context.pop(value);
             }
           }).onError((error, stackTrace) {
-            logger.e('submit app error: $error', stackTrace: stackTrace);
+            logger.e('[Dialog]: submit app error: $error', stackTrace: stackTrace);
             setState(() {
               isLoading = false;
             });
@@ -343,7 +343,7 @@ Future<bool?> showUnsavedAlert(BuildContext context,
 
 Future<T?> showRouterNotFoundAlert<T>(BuildContext context, WidgetRef ref,
     {FutureOr<T?> Function()? onComplete}) {
-  logger.d('[RouterNotFound] show Router not found alert');
+  logger.d('[Dialog]: show Router not found alert');
   return showSimpleAppDialog<T>(context,
       dismissible: false,
       title: loc(context).routerNotFound,
@@ -368,14 +368,14 @@ Future<T?> showRouterNotFoundAlert<T>(BuildContext context, WidgetRef ref,
                 .read(sessionProvider.notifier)
                 .checkRouterIsBack()
                 .then((_) {
-              logger.d('[RouterNotFound] Found!');
+              logger.d('[Dialog]: Router found!');
               return onComplete?.call();
             }).then((value) {
               if (context.mounted) {
                 context.pop(value);
               }
             }).onError((_, __) {
-              logger.d('[RouterNotFound] Try again failed');
+              logger.d('[Dialog]: Router not found — try again failed');
             });
           },
         ),
@@ -384,7 +384,7 @@ Future<T?> showRouterNotFoundAlert<T>(BuildContext context, WidgetRef ref,
 
 Future<T?> showRedirectNewIpAlert<T>(
     BuildContext context, WidgetRef ref, String ip) {
-  logger.d('[RedirectNewIpAlert] show Redirect new IP alert');
+  logger.d('[Dialog]: show Redirect new IP alert');
   return showSimpleAppDialog<T>(context,
       dismissible: false,
       title: loc(context).redirect,

--- a/lib/components/shortcuts/dialogs.dart
+++ b/lib/components/shortcuts/dialogs.dart
@@ -141,7 +141,8 @@ Future<T?> showSubmitAppDialog<T>(
               context.pop(value);
             }
           }).onError((error, stackTrace) {
-            logger.e('[Dialog]: submit app error: $error', stackTrace: stackTrace);
+            logger.e('[Dialog]: submit app error: $error',
+                stackTrace: stackTrace);
             setState(() {
               isLoading = false;
             });

--- a/lib/constants/build_config.dart
+++ b/lib/constants/build_config.dart
@@ -111,7 +111,8 @@ class BuildConfig {
         forceCommandType = ForceCommand.local;
       }
       // Otherwise, keep ForceCommand.none (default)
-      logger.d('[Config]: Non-Web platforms: Force command type: $forceCommandType');
+      logger.d(
+          '[Config]: Non-Web platforms: Force command type: $forceCommandType');
     }
   }
 

--- a/lib/constants/build_config.dart
+++ b/lib/constants/build_config.dart
@@ -23,7 +23,7 @@ enum ForceCommand {
   none;
 
   static ForceCommand reslove(String type) {
-    logger.d('Force - $type');
+    logger.d('[Config]: Force - $type');
     if (type == 'local') {
       return ForceCommand.local;
     } else {
@@ -85,11 +85,11 @@ class BuildConfig {
 
   @pragma('vm:entry-point')
   static Future<void> load() async {
-    logger.d('load build configuration');
+    logger.d('[Config]: load build configuration');
     final prefs = await SharedPreferences.getInstance();
     final envStr = prefs.getString(pCloudEnv);
     cloudEnvTarget = CloudEnvironment.get(envStr ?? '') ?? cloudEnvTarget;
-    logger.d('Cloud Env: $cloudEnvTarget');
+    logger.d('[Config]: Cloud Env: $cloudEnvTarget');
 
     // For non-Web platforms (iOS/Android): determine force mode from bundle ID
     // Web uses String.fromEnvironment('force') set at compile time
@@ -111,7 +111,7 @@ class BuildConfig {
         forceCommandType = ForceCommand.local;
       }
       // Otherwise, keep ForceCommand.none (default)
-      logger.d('Non-Web platforms: Force command type: $forceCommandType');
+      logger.d('[Config]: Non-Web platforms: Force command type: $forceCommandType');
     }
   }
 

--- a/lib/constants/url_links.dart
+++ b/lib/constants/url_links.dart
@@ -78,6 +78,6 @@ void gotoOfficialWebUrl(String url, {Locale? locale}) {
   } else {
     websiteUrl = url;
   }
-  logger.i('open web url: $websiteUrl');
+  logger.i('[App]: open web url: $websiteUrl');
   openUrl(websiteUrl);
 }

--- a/lib/core/cloud/http/linksys_http_client.dart
+++ b/lib/core/cloud/http/linksys_http_client.dart
@@ -240,7 +240,7 @@ class LinksysHttpClient extends http.BaseClient {
       _logResponse(response, ignoreResponse: true);
       Storage.saveByteFile(savedPathUri, response.bodyBytes);
     } catch (e) {
-      logger.e('Download data failed!', error: e);
+      logger.e('[Cloud]: Download data failed!', error: e);
       return false;
     }
     return true;
@@ -316,7 +316,7 @@ class LinksysHttpClient extends http.BaseClient {
   Response _handleResponse(Response response) {
     // TODO Revisit - needs to considering about 500 internal server error, 502/503 bad requests
     if (response.statusCode >= 400 && response.body.isJsonFormat()) {
-      logger.i('Cloud Error: ${response.statusCode}, ${response.body}');
+      logger.i('[Cloud]: Error: ${response.statusCode}, ${response.body}');
       final error = ErrorResponse.fromJson(
           response.statusCode, json.decode(response.body));
       onError?.call(error);

--- a/lib/core/session/services/session_service.dart
+++ b/lib/core/session/services/session_service.dart
@@ -61,20 +61,20 @@ class SessionService {
   /// Fetches device info via USP.
   Future<NodeDeviceInfo> _fetchUspDeviceInfo() async {
     if (_usp == null) {
-      logger.e('[SessionService] USP not available');
+      logger.e('[SessionService]: USP not available');
       throw const ServiceNotInitializedError(
           message: 'USP service not available');
     }
     if (!_usp.isAuthenticated) {
-      logger.d('[SessionService] USP not authenticated');
+      logger.d('[SessionService]: USP not authenticated');
       throw const ConnectivityError(message: 'USP not authenticated');
     }
     try {
       final systemInfo = await SystemInfo.fetch(_usp);
-      logger.d('[SessionService] DeviceInfo fetched via USP');
+      logger.d('[SessionService]: DeviceInfo fetched via USP');
       return NodeDeviceInfo.fromUsp(systemInfo);
     } catch (e) {
-      logger.e('[SessionService] USP device info fetch failed: $e');
+      logger.e('[SessionService]: USP device info fetch failed: $e');
       throw ConnectivityError(message: e.toString());
     }
   }

--- a/lib/core/usp/errors/usp_error.dart
+++ b/lib/core/usp/errors/usp_error.dart
@@ -138,7 +138,7 @@ ServiceError mapUspErrorToServiceError(Object error) {
   final parsed = parseUspError(error);
   if (parsed == null) {
     final result = UnexpectedError(originalError: error);
-    logger.w('[USP:ServiceError] "$error" → ${result.runtimeType}');
+    logger.w('[USP][ServiceError]: "$error" → ${result.runtimeType}');
     return result;
   }
 
@@ -149,7 +149,7 @@ ServiceError mapUspErrorToServiceError(Object error) {
     UspErrorCategory.operation => _mapOperationError(parsed),
     UspErrorCategory.validation => InvalidInputError(message: parsed.message),
   };
-  logger.w('[USP:ServiceError] "$error" → ${result.runtimeType}');
+  logger.w('[USP][ServiceError]: "$error" → ${result.runtimeType}');
   return result;
 }
 

--- a/lib/core/usp/errors/usp_error.dart
+++ b/lib/core/usp/errors/usp_error.dart
@@ -1,4 +1,5 @@
 import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
 
 /// Error categories from the Rust WASM client's UspError hierarchy.
 enum UspErrorCategory {
@@ -136,16 +137,20 @@ UspError? parseUspError(Object error) {
 ServiceError mapUspErrorToServiceError(Object error) {
   final parsed = parseUspError(error);
   if (parsed == null) {
-    return UnexpectedError(originalError: error);
+    final result = UnexpectedError(originalError: error);
+    logger.w('[USP:ServiceError] "$error" → ${result.runtimeType}');
+    return result;
   }
 
-  return switch (parsed.category) {
+  final result = switch (parsed.category) {
     UspErrorCategory.auth => _mapAuthError(parsed),
     UspErrorCategory.transport => _mapTransportError(parsed),
     UspErrorCategory.protocol => _mapProtocolError(parsed),
     UspErrorCategory.operation => _mapOperationError(parsed),
     UspErrorCategory.validation => InvalidInputError(message: parsed.message),
   };
+  logger.w('[USP:ServiceError] "$error" → ${result.runtimeType}');
+  return result;
 }
 
 ServiceError _mapAuthError(UspError e) {

--- a/lib/core/usp/models/usp_operation_result.dart
+++ b/lib/core/usp/models/usp_operation_result.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
 
 /// USP 操作結果的 sealed class hierarchy
 ///
@@ -284,20 +284,12 @@ typedef UspOperateResult = UspOperationResult<Map<String, dynamic>>;
 
 /// 從 WASM 回傳的 Map 解析 USP 操作結果
 class UspResultParser {
+  static const _tag = '[USP:Parser]';
+
   /// 解析 SET 操作結果
   static UspSetResult parseSetResult(Map<String, dynamic> map) {
     final result = _parseGenericResult<void>(map);
-
-    // Debug logging to track parsing results
-    if (kDebugMode) {
-      final success = map['success'] as bool? ?? false;
-      print(
-          '[UspResultParser] SET parseResult: success=$success, result=${result.runtimeType}');
-      if (result is UspFailure) {
-        print('[UspResultParser] SET failure: ${result.errorSummary}');
-      }
-    }
-
+    _logResult('SET', result);
     return result;
   }
 
@@ -306,6 +298,12 @@ class UspResultParser {
   /// WASM v0.11.0 ADD 格式: {success, result: {data: {instances: [...]}}}
   /// 其中 instances 是創建的實例路徑字串陣列，需轉換為 [UspCreatedInstance]
   static UspAddResult parseAddResult(Map<String, dynamic> map) {
+    final result = _parseAddResultInternal(map);
+    _logResult('ADD', result);
+    return result;
+  }
+
+  static UspAddResult _parseAddResultInternal(Map<String, dynamic> map) {
     final success = map['success'] as bool? ?? false;
     final resultMap = map['result'] as Map<String, dynamic>? ?? {};
     final data = resultMap['data'] as Map<String, dynamic>? ?? {};
@@ -369,17 +367,23 @@ class UspResultParser {
 
   /// 解析 DELETE 操作結果
   static UspDeleteResult parseDeleteResult(Map<String, dynamic> map) {
-    return _parseGenericResult<void>(map);
+    final result = _parseGenericResult<void>(map);
+    _logResult('DELETE', result);
+    return result;
   }
 
   /// 解析 GET 操作結果
   static UspGetResult parseGetResult(Map<String, dynamic> map) {
-    return _parseGenericResult<Map<String, dynamic>>(map);
+    final result = _parseGenericResult<Map<String, dynamic>>(map);
+    _logResult('GET', result);
+    return result;
   }
 
   /// 解析 OPERATE 操作結果
   static UspOperateResult parseOperateResult(Map<String, dynamic> map) {
-    return _parseGenericResult<Map<String, dynamic>>(map);
+    final result = _parseGenericResult<Map<String, dynamic>>(map);
+    _logResult('OPERATE', result);
+    return result;
   }
 
   /// 解析 WASM v0.11.0 格式：{success, result: {data, error?}}
@@ -463,5 +467,23 @@ class UspResultParser {
         errorMessage: exception.toString(),
       )
     ]);
+  }
+
+  static void _logResult<T>(String op, UspOperationResult<T> result) {
+    switch (result) {
+      case UspSuccess(details: final details):
+        logger.d('$_tag $op → UspSuccess (${details.length} details)');
+      case UspPartialSuccess(
+          successes: final successes,
+          failures: final failures
+        ):
+        logger.w('$_tag $op → UspPartialSuccess '
+            '(${successes.length} successes, ${failures.length} failures: '
+            '${failures.map((f) => '${f.requestedPath}=${f.errorCode}').join(', ')})');
+      case UspFailure(errors: final errors):
+        logger.w('$_tag $op → UspFailure '
+            '(${errors.length} errors: '
+            '${errors.map((e) => '${e.requestedPath}=${e.errorCode}').join(', ')})');
+    }
   }
 }

--- a/lib/core/usp/models/usp_operation_result.dart
+++ b/lib/core/usp/models/usp_operation_result.dart
@@ -284,7 +284,7 @@ typedef UspOperateResult = UspOperationResult<Map<String, dynamic>>;
 
 /// 從 WASM 回傳的 Map 解析 USP 操作結果
 class UspResultParser {
-  static const _tag = '[USP:Parser]';
+  static const _tag = '[USP][Parser]:';
 
   /// 解析 SET 操作結果
   static UspSetResult parseSetResult(Map<String, dynamic> map) {

--- a/lib/core/usp/providers/sse_providers.dart
+++ b/lib/core/usp/providers/sse_providers.dart
@@ -39,7 +39,7 @@ final sseManagerProvider = Provider<SseManager?>((ref) {
   void forceLogout() {
     if (logoutTriggered) return;
     logoutTriggered = true;
-    logger.w('[USP][Auth]Force logout triggered — navigating to login');
+    logger.w('[USP][Auth]: Force logout triggered — navigating to login');
     ref.read(authProvider.notifier).logout();
   }
 
@@ -111,10 +111,10 @@ final sseBootstrapProvider = FutureProvider<void>((ref) async {
   // because SseConnectionManager has its own retry/backoff logic.
   try {
     await bridge.health().timeout(const Duration(seconds: 5));
-    logger.d('[USP][SSE][Bootstrap]Bridge health check passed');
+    logger.d('[USP][SSE][Bootstrap]: Bridge health check passed');
   } catch (e) {
     logger
-        .w('[USP][SSE][Bootstrap]Bridge health check failed: $e — continuing');
+        .w('[USP][SSE][Bootstrap]: Bridge health check failed: $e — continuing');
   }
 
   // Connect SSE only — core subscriptions are registered by the dashboard
@@ -123,6 +123,6 @@ final sseBootstrapProvider = FutureProvider<void>((ref) async {
   // which causes 503 errors due to the single-threaded OBUSPA backend.
   await manager.connect();
 
-  logger.d('[USP][SSE][Bootstrap]Complete — SSE connected, '
+  logger.d('[USP][SSE][Bootstrap]: Complete — SSE connected, '
       'core subscriptions deferred to orchestrator after domain ready');
 });

--- a/lib/core/usp/providers/sse_providers.dart
+++ b/lib/core/usp/providers/sse_providers.dart
@@ -113,8 +113,8 @@ final sseBootstrapProvider = FutureProvider<void>((ref) async {
     await bridge.health().timeout(const Duration(seconds: 5));
     logger.d('[USP][SSE][Bootstrap]: Bridge health check passed');
   } catch (e) {
-    logger
-        .w('[USP][SSE][Bootstrap]: Bridge health check failed: $e — continuing');
+    logger.w(
+        '[USP][SSE][Bootstrap]: Bridge health check failed: $e — continuing');
   }
 
   // Connect SSE only — core subscriptions are registered by the dashboard

--- a/lib/core/usp/providers/usp_auth_coordinator.dart
+++ b/lib/core/usp/providers/usp_auth_coordinator.dart
@@ -57,11 +57,11 @@ class UspAuthCoordinator {
     try {
       await _usp.login(password);
       _lastTokenRefresh = DateTime.now();
-      logger.d('[USP][Auth]USP login synced successfully');
+      logger.d('[USP][Auth]: USP login synced successfully');
     } catch (e) {
       // USP login failure does not affect JNAP — ProtocolResolver
       // will fall back to JNAP when isAuthenticated=false
-      logger.w('[USP][Auth]USP login failed after JNAP login: $e');
+      logger.w('[USP][Auth]: USP login failed after JNAP login: $e');
     }
   }
 
@@ -71,9 +71,9 @@ class UspAuthCoordinator {
     if (_usp == null || !_usp.isAuthenticated) return;
     try {
       await _usp.logout();
-      logger.d('[USP][Auth]USP logout synced successfully');
+      logger.d('[USP][Auth]: USP logout synced successfully');
     } catch (e) {
-      logger.w('[USP][Auth]USP logout failed: $e');
+      logger.w('[USP][Auth]: USP logout failed: $e');
     }
   }
 
@@ -83,11 +83,11 @@ class UspAuthCoordinator {
   /// stored password from FlutterSecureStorage and re-authenticates USP.
   Future<void> restoreSession() async {
     if (_usp == null) {
-      logger.w('[USP][Auth]restoreSession skipped: UspClient is null');
+      logger.w('[USP][Auth]: restoreSession skipped: UspClient is null');
       return;
     }
     if (_usp.isAuthenticated) {
-      logger.d('[USP][Auth]restoreSession skipped: already authenticated');
+      logger.d('[USP][Auth]: restoreSession skipped: already authenticated');
       return;
     }
     await _loginWithStoredPassword();
@@ -101,7 +101,7 @@ class UspAuthCoordinator {
   /// re-login unconditionally.
   Future<void> _forceRestoreSession() async {
     if (_usp == null) {
-      logger.w('[USP][Auth]forceRestoreSession skipped: UspClient is null');
+      logger.w('[USP][Auth]: forceRestoreSession skipped: UspClient is null');
       return;
     }
     await _loginWithStoredPassword();
@@ -112,17 +112,17 @@ class UspAuthCoordinator {
   Future<bool> _loginWithStoredPassword() async {
     final password = await _storage.read(key: pLocalPassword);
     if (password == null || password.isEmpty) {
-      logger.w('[USP][Auth]restoreSession skipped: no stored password');
+      logger.w('[USP][Auth]: restoreSession skipped: no stored password');
       return false;
     }
     try {
       await _usp!.login(password);
       _lastTokenRefresh = DateTime.now();
       logger.d(
-          '[USP][Auth]restoreSession login done, isAuthenticated=${_usp.isAuthenticated}');
+          '[USP][Auth]: restoreSession login done, isAuthenticated=${_usp.isAuthenticated}');
       return true;
     } catch (e) {
-      logger.w('[USP][Auth]restoreSession login failed: $e');
+      logger.w('[USP][Auth]: restoreSession login failed: $e');
       return false;
     }
   }
@@ -133,7 +133,7 @@ class UspAuthCoordinator {
   /// Returns true if USP login succeeds and is authenticated.
   Future<bool> tryUspLogin(String password) async {
     if (_usp == null) {
-      logger.w('[USP][Auth]tryUspLogin skipped: UspClient is null');
+      logger.w('[USP][Auth]: tryUspLogin skipped: UspClient is null');
       return false;
     }
     try {
@@ -141,11 +141,11 @@ class UspAuthCoordinator {
       final authenticated = _usp.isAuthenticated;
       if (authenticated) {
         _lastTokenRefresh = DateTime.now();
-        logger.d('[USP][Auth]USP standalone login succeeded');
+        logger.d('[USP][Auth]: USP standalone login succeeded');
       }
       return authenticated;
     } catch (e) {
-      logger.w('[USP][Auth]USP standalone login failed: $e');
+      logger.w('[USP][Auth]: USP standalone login failed: $e');
       return false;
     }
   }
@@ -175,15 +175,15 @@ class UspAuthCoordinator {
     try {
       await _usp.refreshToken();
       _lastTokenRefresh = DateTime.now();
-      logger.d('[USP][Auth]Proactive token refresh succeeded');
+      logger.d('[USP][Auth]: Proactive token refresh succeeded');
     } catch (e) {
       if (_isAuthError(e)) {
         _lastTokenRefresh = null; // Allow immediate retry if logout is delayed
-        logger.w('[USP][Auth]Proactive refresh got 401 — forcing logout: $e');
+        logger.w('[USP][Auth]: Proactive refresh got 401 — forcing logout: $e');
         onForceLogout?.call();
       } else {
         logger.w(
-            '[USP][Auth]Proactive refresh failed (non-auth, will retry): $e');
+            '[USP][Auth]: Proactive refresh failed (non-auth, will retry): $e');
       }
     } finally {
       _refreshInProgress = null;

--- a/lib/core/usp/services/bridge_request_throttler.dart
+++ b/lib/core/usp/services/bridge_request_throttler.dart
@@ -148,7 +148,7 @@ class BridgeRequestThrottler {
   void _dispatch(_PendingRequest<dynamic> pending) {
     _active++;
     _inFlight[pending.cacheKey] = pending;
-    logger.d('[Throttler] Dispatch (active=$_active, queue=${_queue.length}): '
+    logger.d('[Throttler]: Dispatch (active=$_active, queue=${_queue.length}): '
         '${pending.cacheKey}');
 
     Future<void>(() async {
@@ -167,7 +167,7 @@ class BridgeRequestThrottler {
           expiresAt: DateTime.now().add(pending.cacheTtl),
         );
       } on TimeoutException {
-        logger.w('[Throttler] Request timeout (${requestTimeout.inSeconds}s): '
+        logger.w('[Throttler]: Request timeout (${requestTimeout.inSeconds}s): '
             '${pending.cacheKey}');
         if (!pending.completer.isCompleted) {
           pending.completer.completeError(

--- a/lib/core/usp/services/sse_connection_manager.dart
+++ b/lib/core/usp/services/sse_connection_manager.dart
@@ -249,8 +249,9 @@ class SseConnectionManager {
   void _resetHeartbeatWatchdog() {
     _heartbeatWatchdog?.cancel();
     _heartbeatWatchdog = Timer(_heartbeatTimeout, () {
-      logger.w('[USP][SSE]: Heartbeat timeout (${_heartbeatTimeout.inSeconds}s) '
-          '— connection may be stale');
+      logger
+          .w('[USP][SSE]: Heartbeat timeout (${_heartbeatTimeout.inSeconds}s) '
+              '— connection may be stale');
       _sseSubscription?.cancel();
       _handleStreamEnd();
     });

--- a/lib/core/usp/services/sse_connection_manager.dart
+++ b/lib/core/usp/services/sse_connection_manager.dart
@@ -101,7 +101,7 @@ class SseConnectionManager {
 
     // Lock: if connect is already in progress, await it and return.
     if (_connectInProgress != null) {
-      logger.d('[USP][SSE]connect() already in progress — awaiting');
+      logger.d('[USP][SSE]: connect() already in progress — awaiting');
       await _connectInProgress!.future;
       return;
     }
@@ -115,7 +115,7 @@ class SseConnectionManager {
       _streamEndHandled = false;
       connectionState.value = SseConnectionState.connecting;
 
-      logger.d('[USP][SSE]Connecting...');
+      logger.d('[USP][SSE]: Connecting...');
 
       final stream = _bridge.notifications();
       _sseSubscription = stream.listen(
@@ -125,7 +125,7 @@ class SseConnectionManager {
       );
       _connectInProgress!.complete();
     } catch (e) {
-      logger.w('[USP][SSE]Failed to open stream: $e');
+      logger.w('[USP][SSE]: Failed to open stream: $e');
       if (!_connectInProgress!.isCompleted) {
         _connectInProgress!.completeError(e);
       }
@@ -149,7 +149,7 @@ class SseConnectionManager {
       onDisconnected?.call();
     }
     connectionState.value = SseConnectionState.disconnected;
-    logger.d('[USP][SSE]Disconnected (intentional)');
+    logger.d('[USP][SSE]: Disconnected (intentional)');
   }
 
   /// Attempts to reconnect from [SseConnectionState.suspended] or
@@ -164,7 +164,7 @@ class SseConnectionManager {
         state == SseConnectionState.reconnecting) {
       return false;
     }
-    logger.d('[USP][SSE]Manual reconnect requested (was: ${state.name})');
+    logger.d('[USP][SSE]: Manual reconnect requested (was: ${state.name})');
     _reconnectAttempt = 0;
     await connect();
     return true;
@@ -192,7 +192,7 @@ class SseConnectionManager {
     // these are synthetic events emitted before the Fetch returns and must
     // NOT trigger a connected transition or subscription re-registration.
     if (event.event == '_debug') {
-      logger.d('[USP][SSE]debug: ${event.data}');
+      logger.d('[USP][SSE]: debug: ${event.data}');
       return;
     }
 
@@ -203,7 +203,7 @@ class SseConnectionManager {
     if (connectionState.value != SseConnectionState.connected) {
       connectionState.value = SseConnectionState.connected;
       _reconnectAttempt = 0;
-      logger.d('[USP][SSE]Connected (event: ${event.event})');
+      logger.d('[USP][SSE]: Connected (event: ${event.event})');
       onConnected?.call();
     }
 
@@ -212,12 +212,12 @@ class SseConnectionManager {
   }
 
   void _onError(Object error) {
-    logger.w('[USP][SSE]Stream error: $error');
+    logger.w('[USP][SSE]: Stream error: $error');
     _handleStreamEnd();
   }
 
   void _onDone() {
-    logger.d('[USP][SSE]Stream done (server closed connection)');
+    logger.d('[USP][SSE]: Stream done (server closed connection)');
     _handleStreamEnd();
   }
 
@@ -249,7 +249,7 @@ class SseConnectionManager {
   void _resetHeartbeatWatchdog() {
     _heartbeatWatchdog?.cancel();
     _heartbeatWatchdog = Timer(_heartbeatTimeout, () {
-      logger.w('[USP][SSE]Heartbeat timeout (${_heartbeatTimeout.inSeconds}s) '
+      logger.w('[USP][SSE]: Heartbeat timeout (${_heartbeatTimeout.inSeconds}s) '
           '— connection may be stale');
       _sseSubscription?.cancel();
       _handleStreamEnd();
@@ -277,7 +277,7 @@ class SseConnectionManager {
 
     if (_reconnectAttempt > _maxRetries) {
       connectionState.value = SseConnectionState.suspended;
-      logger.w('[USP][SSE]Max retries ($_maxRetries) reached — suspended. '
+      logger.w('[USP][SSE]: Max retries ($_maxRetries) reached — suspended. '
           'Call tryReconnect() or wait for lifecycle resume.');
       return;
     }
@@ -285,7 +285,7 @@ class SseConnectionManager {
     connectionState.value = SseConnectionState.reconnecting;
 
     final delay = _nextBackoff;
-    logger.d('[USP][SSE]Reconnecting in ${delay.inSeconds}s '
+    logger.d('[USP][SSE]: Reconnecting in ${delay.inSeconds}s '
         '(attempt #$_reconnectAttempt/$_maxRetries)');
 
     _reconnectTimer = Timer(delay, () {

--- a/lib/core/usp/services/sse_event_router.dart
+++ b/lib/core/usp/services/sse_event_router.dart
@@ -67,10 +67,10 @@ class SseEventRouter {
         break;
       case 'turbo_channel':
         // Future: route to turbo channel coordinator
-        logger.d('[USP][SSE][Router]turbo_channel event: ${event.data}');
+        logger.d('[USP][SSE][Router]: turbo_channel event: ${event.data}');
         break;
       default:
-        logger.d('[USP][SSE][Router]Unknown event type: ${event.event}');
+        logger.d('[USP][SSE][Router]: Unknown event type: ${event.event}');
         break;
     }
   }
@@ -80,7 +80,7 @@ class SseEventRouter {
     try {
       json = jsonDecode(event.data) as Map<String, dynamic>;
     } catch (e) {
-      logger.w('[USP][SSE][Router]Failed to parse notification JSON: $e');
+      logger.w('[USP][SSE][Router]: Failed to parse notification JSON: $e');
       return;
     }
 
@@ -89,7 +89,7 @@ class SseEventRouter {
 
     if (subscriptionId == null || type == null) {
       logger
-          .w('[USP][SSE][Router]Notification missing subscription_id or type: '
+          .w('[USP][SSE][Router]: Notification missing subscription_id or type: '
               '${event.data}');
       return;
     }
@@ -100,7 +100,7 @@ class SseEventRouter {
       payload: json,
     );
 
-    logger.d('[USP][SSE][Router]Routing: $notification');
+    logger.d('[USP][SSE][Router]: Routing: $notification');
 
     // Route to subscription-specific handlers
     final handlers = _handlers[subscriptionId];
@@ -109,7 +109,7 @@ class SseEventRouter {
         try {
           handler(notification);
         } catch (e) {
-          logger.w('[USP][SSE][Router]Handler error for $subscriptionId: $e');
+          logger.w('[USP][SSE][Router]: Handler error for $subscriptionId: $e');
         }
       }
     }
@@ -119,7 +119,7 @@ class SseEventRouter {
       try {
         handler(notification);
       } catch (e) {
-        logger.w('[USP][SSE][Router]Wildcard handler error: $e');
+        logger.w('[USP][SSE][Router]: Wildcard handler error: $e');
       }
     }
   }

--- a/lib/core/usp/services/sse_event_router.dart
+++ b/lib/core/usp/services/sse_event_router.dart
@@ -88,9 +88,9 @@ class SseEventRouter {
     final type = json['type'] as String?;
 
     if (subscriptionId == null || type == null) {
-      logger
-          .w('[USP][SSE][Router]: Notification missing subscription_id or type: '
-              '${event.data}');
+      logger.w(
+          '[USP][SSE][Router]: Notification missing subscription_id or type: '
+          '${event.data}');
       return;
     }
 

--- a/lib/core/usp/services/sse_manager.dart
+++ b/lib/core/usp/services/sse_manager.dart
@@ -65,7 +65,7 @@ class SseManager {
       final authCheck = onHeartbeatAuth;
       if (authCheck != null) {
         authCheck().catchError((e) {
-          logger.w('[USP][SSE]Heartbeat auth check error: $e');
+          logger.w('[USP][SSE]: Heartbeat auth check error: $e');
         });
       }
     };
@@ -74,13 +74,13 @@ class SseManager {
     // First connect: registers core subscriptions set via setCoreSubscriptions().
     // Reconnect: re-registers existing subscriptions on the bridge.
     connection.onConnected = () {
-      logger.d('[USP][SSE]Connected — registering/re-registering '
+      logger.d('[USP][SSE]: Connected — registering/re-registering '
           'subscriptions on bridge');
       _registerOrResubscribe();
     };
 
     connection.onDisconnected = () {
-      logger.d('[USP][SSE]Disconnected');
+      logger.d('[USP][SSE]: Disconnected');
     };
 
     // Inject SSE delegate so codegen subscribe() routes through SSE
@@ -89,7 +89,7 @@ class SseManager {
     // Force SSE reconnect after full re-login to ensure the new session's
     // subscription routing is active (prevents silent notification failure).
     _usp.onTokenRefreshed = () {
-      logger.d('[USP][SSE]Token refreshed (full re-login) '
+      logger.d('[USP][SSE]: Token refreshed (full re-login) '
           '— forcing SSE reconnect');
       connection.disconnect().then((_) => connection.connect());
     };
@@ -98,7 +98,7 @@ class SseManager {
     // abortSse() is synchronous — critical because `beforeunload` does NOT
     // wait for async operations. disconnect() is best-effort async cleanup.
     _unloadHandler.onUnload = () {
-      logger.d('[USP][SSE]Page unload — aborting SSE');
+      logger.d('[USP][SSE]: Page unload — aborting SSE');
       _bridge.abortSse();
       connection.disconnect();
     };
@@ -242,10 +242,10 @@ class SseManager {
         // Small breathing room for embedded router between requests
         await Future.delayed(const Duration(milliseconds: 50));
       } catch (e) {
-        logger.w('[USP][SSE]Failed to register core sub $id: $e');
+        logger.w('[USP][SSE]: Failed to register core sub $id: $e');
       }
     }
-    logger.d('[USP][SSE]Registered ${registry.activeIds.length} '
+    logger.d('[USP][SSE]: Registered ${registry.activeIds.length} '
         'core subscriptions (deferred)');
   }
 

--- a/lib/core/usp/services/sse_operation_awaiter.dart
+++ b/lib/core/usp/services/sse_operation_awaiter.dart
@@ -123,8 +123,8 @@ class SseOperationAwaiter {
         ),
       );
 
-      logger
-          .d('[USP][SSE][Operate]: Completed $operateCommand: ${result.status}');
+      logger.d(
+          '[USP][SSE][Operate]: Completed $operateCommand: ${result.status}');
       return result;
     } finally {
       // Always cleanup: wildcard handler + subscription
@@ -133,7 +133,8 @@ class SseOperationAwaiter {
         try {
           await cleanupSubscription();
         } catch (e) {
-          logger.w('[USP][SSE][Operate]: Cleanup failed for $subscriptionId: $e');
+          logger
+              .w('[USP][SSE][Operate]: Cleanup failed for $subscriptionId: $e');
         }
       }
     }

--- a/lib/core/usp/services/sse_operation_awaiter.dart
+++ b/lib/core/usp/services/sse_operation_awaiter.dart
@@ -89,7 +89,7 @@ class SseOperationAwaiter {
       final operateResponse = await _usp.operate(operateCommand, args: args);
       final expectedKey = operateResponse['commandKey'] as String?;
 
-      logger.d('[USP][SSE][Operate]Starting $operateCommand '
+      logger.d('[USP][SSE][Operate]: Starting $operateCommand '
           '(sub=$subscriptionId, commandKey=$expectedKey)');
 
       // Step 3: Wildcard handler matches by commandKey (primary) or
@@ -106,7 +106,7 @@ class SseOperationAwaiter {
 
           if (matched) {
             logger.d(
-                '[USP][SSE][Operate]Matched OperationComplete for $expectedCmd '
+                '[USP][SSE][Operate]: Matched OperationComplete for $expectedCmd '
                 '(commandKey=${result.commandKey}, '
                 'sub=${notification.subscriptionId})');
             completer.complete(result);
@@ -124,7 +124,7 @@ class SseOperationAwaiter {
       );
 
       logger
-          .d('[USP][SSE][Operate]Completed $operateCommand: ${result.status}');
+          .d('[USP][SSE][Operate]: Completed $operateCommand: ${result.status}');
       return result;
     } finally {
       // Always cleanup: wildcard handler + subscription
@@ -133,7 +133,7 @@ class SseOperationAwaiter {
         try {
           await cleanupSubscription();
         } catch (e) {
-          logger.w('[USP][SSE][Operate]Cleanup failed for $subscriptionId: $e');
+          logger.w('[USP][SSE][Operate]: Cleanup failed for $subscriptionId: $e');
         }
       }
     }
@@ -156,7 +156,7 @@ class SseOperationAwaiter {
     Map<String, String> args,
     Duration timeout,
   ) async {
-    logger.d('[USP][SSE][Operate]SSE disconnected, using polling fallback '
+    logger.d('[USP][SSE][Operate]: SSE disconnected, using polling fallback '
         'for $operateCommand');
 
     // Fire the operate command
@@ -200,7 +200,7 @@ class SseOperationAwaiter {
           }
         }
       } catch (e) {
-        logger.w('[USP][SSE][Operate]Poll error: $e');
+        logger.w('[USP][SSE][Operate]: Poll error: $e');
       }
     }
 

--- a/lib/core/usp/services/sse_subscription_registry.dart
+++ b/lib/core/usp/services/sse_subscription_registry.dart
@@ -41,12 +41,12 @@ class SseSubscriptionRegistry {
     // Check for duplicate
     if (_subscriptions.containsKey(subscriptionId)) {
       logger
-          .d('[USP][SSE][Registry]Subscription $subscriptionId already exists, '
+          .d('[USP][SSE][Registry]: Subscription $subscriptionId already exists, '
               'skipping duplicate registration');
       return _subscriptions[subscriptionId]!;
     }
 
-    logger.d('[USP][SSE][Registry]Registering $subscriptionId '
+    logger.d('[USP][SSE][Registry]: Registering $subscriptionId '
         '(type=$notifType, ref=$referenceList)');
 
     await _bridge.subscribe(
@@ -63,7 +63,7 @@ class SseSubscriptionRegistry {
     );
     _subscriptions[subscriptionId] = record;
 
-    logger.d('[USP][SSE][Registry]Registered $subscriptionId');
+    logger.d('[USP][SSE][Registry]: Registered $subscriptionId');
     return record;
   }
 
@@ -74,16 +74,16 @@ class SseSubscriptionRegistry {
     final record = _subscriptions.remove(subscriptionId);
     if (record == null) {
       logger.d(
-          '[USP][SSE][Registry]Unregister $subscriptionId: not found, skipping');
+          '[USP][SSE][Registry]: Unregister $subscriptionId: not found, skipping');
       return;
     }
 
-    logger.d('[USP][SSE][Registry]Unregistering $subscriptionId');
+    logger.d('[USP][SSE][Registry]: Unregistering $subscriptionId');
 
     try {
       await _bridge.unsubscribe(subscriptionId: subscriptionId);
     } catch (e) {
-      logger.w('[USP][SSE][Registry]Bridge unsubscribe failed for '
+      logger.w('[USP][SSE][Registry]: Bridge unsubscribe failed for '
           '$subscriptionId: $e');
     }
   }
@@ -96,11 +96,11 @@ class SseSubscriptionRegistry {
   Future<void> resubscribeAll() async {
     if (_subscriptions.isEmpty) {
       logger.d(
-          '[USP][SSE][Registry]resubscribeAll: no subscriptions to re-register');
+          '[USP][SSE][Registry]: resubscribeAll: no subscriptions to re-register');
       return;
     }
 
-    logger.d('[USP][SSE][Registry]Re-registering ${_subscriptions.length} '
+    logger.d('[USP][SSE][Registry]: Re-registering ${_subscriptions.length} '
         'subscriptions on bridge');
 
     for (final record in _subscriptions.values) {
@@ -110,9 +110,9 @@ class SseSubscriptionRegistry {
           path: record.referenceList,
           notifType: _notifTypeToInt(record.notifType),
         );
-        logger.d('[USP][SSE][Registry]Re-registered ${record.subscriptionId}');
+        logger.d('[USP][SSE][Registry]: Re-registered ${record.subscriptionId}');
       } catch (e) {
-        logger.w('[USP][SSE][Registry]Failed to re-register '
+        logger.w('[USP][SSE][Registry]: Failed to re-register '
             '${record.subscriptionId}: $e');
       }
     }

--- a/lib/core/usp/services/sse_subscription_registry.dart
+++ b/lib/core/usp/services/sse_subscription_registry.dart
@@ -40,9 +40,9 @@ class SseSubscriptionRegistry {
   }) async {
     // Check for duplicate
     if (_subscriptions.containsKey(subscriptionId)) {
-      logger
-          .d('[USP][SSE][Registry]: Subscription $subscriptionId already exists, '
-              'skipping duplicate registration');
+      logger.d(
+          '[USP][SSE][Registry]: Subscription $subscriptionId already exists, '
+          'skipping duplicate registration');
       return _subscriptions[subscriptionId]!;
     }
 
@@ -110,7 +110,8 @@ class SseSubscriptionRegistry {
           path: record.referenceList,
           notifType: _notifTypeToInt(record.notifType),
         );
-        logger.d('[USP][SSE][Registry]: Re-registered ${record.subscriptionId}');
+        logger
+            .d('[USP][SSE][Registry]: Re-registered ${record.subscriptionId}');
       } catch (e) {
         logger.w('[USP][SSE][Registry]: Failed to re-register '
             '${record.subscriptionId}: $e');

--- a/lib/core/usp/services/usp_client.dart
+++ b/lib/core/usp/services/usp_client.dart
@@ -79,7 +79,7 @@ class UspClient {
   }
 
   static int _reqId = 0;
-  static const _tag = '[USPClient]';
+  static const _tag = '[USPClient]:';
   bool _lastCallRetried = false;
 
   String _idLabel(int id) => '#$id${_lastCallRetried ? '.retry' : ''}';

--- a/lib/core/usp/services/usp_client.dart
+++ b/lib/core/usp/services/usp_client.dart
@@ -164,8 +164,7 @@ class UspClient {
         try {
           onRefreshTokenSuccess?.call();
         } catch (cbError) {
-          logger.w(
-              '$_tag onRefreshTokenSuccess callback error: $cbError');
+          logger.w('$_tag onRefreshTokenSuccess callback error: $cbError');
         }
         _reauthInProgress!.complete();
         return;
@@ -402,13 +401,12 @@ class UspClient {
     _lastCallRetried = false;
     final sw = Stopwatch()..start();
 
-    logger.d(
-        '$_tag#$id SET_ORDERED${allowPartial ? ' (allowPartial)' : ''} →\n'
+    logger.d('$_tag#$id SET_ORDERED${allowPartial ? ' (allowPartial)' : ''} →\n'
         '${_prettyJson(parameterGroups)}');
 
     try {
-      final result = await _withAuthRetry(
-          () => _client.setOrdered(parameterGroups, allowPartial: allowPartial));
+      final result = await _withAuthRetry(() =>
+          _client.setOrdered(parameterGroups, allowPartial: allowPartial));
       sw.stop();
       final label = _idLabel(id);
       logger.d('$_tag$label SET_ORDERED ← (${sw.elapsedMilliseconds}ms)\n'
@@ -417,8 +415,7 @@ class UspClient {
     } catch (e) {
       sw.stop();
       final label = _idLabel(id);
-      logger.e(
-          '$_tag$label SET_ORDERED ✗ (${sw.elapsedMilliseconds}ms)\n  $e');
+      logger.e('$_tag$label SET_ORDERED ✗ (${sw.elapsedMilliseconds}ms)\n  $e');
       rethrow;
     }
   }
@@ -576,7 +573,10 @@ class UspClient {
     _lastCallRetried = false;
     final sw = Stopwatch()..start();
 
-    final payload = <String, dynamic>{'command': command, if (args.isNotEmpty) 'args': args};
+    final payload = <String, dynamic>{
+      'command': command,
+      if (args.isNotEmpty) 'args': args
+    };
     logger.d('$_tag#$id OPERATE →\n${_prettyMap(payload)}');
 
     try {
@@ -876,8 +876,7 @@ class UspClient {
               controller.add(parsed);
             }
           } catch (e) {
-            logger
-                .w('$_tag SSE subscribe re-fetch error for "$id": $e');
+            logger.w('$_tag SSE subscribe re-fetch error for "$id": $e');
           }
         });
       },

--- a/lib/core/usp/services/usp_client.dart
+++ b/lib/core/usp/services/usp_client.dart
@@ -79,6 +79,10 @@ class UspClient {
   }
 
   static int _reqId = 0;
+  static const _tag = '[USPClient]';
+  bool _lastCallRetried = false;
+
+  String _idLabel(int id) => '#$id${_lastCallRetried ? '.retry' : ''}';
 
   String get baseUrl => _baseUrl;
 
@@ -156,24 +160,24 @@ class UspClient {
       // Stage 1: quick token refresh (no password needed)
       try {
         await refreshToken();
-        logger.d('[USP][Service]Token refreshed successfully');
+        logger.d('$_tag Token refreshed successfully');
         try {
           onRefreshTokenSuccess?.call();
         } catch (cbError) {
           logger.w(
-              '[USP][Service]onRefreshTokenSuccess callback error: $cbError');
+              '$_tag onRefreshTokenSuccess callback error: $cbError');
         }
         _reauthInProgress!.complete();
         return;
       } catch (e) {
-        logger.w('[USP][Service]Token refresh failed: $e');
+        logger.w('$_tag Token refresh failed: $e');
       }
       // Stage 2: full re-login via stored password
       final reauth = onReauthRequired;
       if (reauth != null) {
         await reauth();
         didFullRelogin = true;
-        logger.d('[USP][Service]Full re-login succeeded');
+        logger.d('$_tag Full re-login succeeded');
       }
       _reauthInProgress!.complete();
     } catch (e) {
@@ -184,11 +188,11 @@ class UspClient {
       // Both Stage 1 (refreshToken) and Stage 2 (restoreSession) failed,
       // so the session is unrecoverable regardless of Stage 2 failure reason
       // (auth error, network error, or no stored password).
-      logger.w('[USP][Service]All reauth stages failed — forcing logout');
+      logger.w('$_tag All reauth stages failed — forcing logout');
       try {
         onForceLogout?.call();
       } catch (cbError) {
-        logger.w('[USP][Service]onForceLogout callback error: $cbError');
+        logger.w('$_tag onForceLogout callback error: $cbError');
       }
       rethrow;
     } finally {
@@ -208,8 +212,9 @@ class UspClient {
       return await action();
     } catch (e) {
       if (!_isAuthError(e)) rethrow;
-      logger.w('[USP][Service]401 detected, attempting reauth...');
+      logger.w('$_tag 401 detected, attempting reauth...');
       await reauth();
+      _lastCallRetried = true;
       return await action();
     }
   }
@@ -239,38 +244,48 @@ class UspClient {
 
   Future<Map<String, dynamic>> _rawGet(List<String> paths) async {
     final id = ++_reqId;
+    _lastCallRetried = false;
     final sw = Stopwatch()..start();
-    final rawMap = await _withAuthRetry(() => _client.get(paths));
-    sw.stop();
 
-    logger.d('[USP][Service]#$id GET ${_pathSummary(paths)} '
-        '${paths.length} paths → ${rawMap.length} keys (${sw.elapsedMilliseconds}ms)');
-    if (rawMap.isEmpty) {
-      logger.w('[USP][Service]#$id GET response EMPTY for paths: $paths');
-    } else {
-      logger.d('[USP][Service]#$id ← ${_mapSummary(rawMap)}');
-    }
+    logger.d('$_tag#$id GET →\n${_prettyList(paths)}');
 
-    final Map<String, dynamic> result = {};
+    try {
+      final rawMap = await _withAuthRetry(() => _client.get(paths));
+      sw.stop();
 
-    // Include all returned paths (may include extra child paths)
-    for (final entry in rawMap.entries) {
-      result[entry.key] = _coerceValue(entry.key, entry.value);
-    }
+      final label = _idLabel(id);
+      logger.d('$_tag$label GET ← (${sw.elapsedMilliseconds}ms)\n'
+          '${_prettyMap(rawMap)}');
 
-    // Ensure all requested non-wildcard paths exist in the result to prevent
-    // Null Cast errors in codegen. Wildcard search paths (containing '*') are
-    // expanded by the router into concrete instance paths, so the original
-    // wildcard path won't appear in the response — skip those.
-    for (final path in paths) {
-      if (path.contains('*')) continue;
-      if (!result.containsKey(path)) {
-        logger.w('[USP][Service]GET missing path in response: "$path"');
+      if (rawMap.isEmpty) {
+        logger.w('$_tag$label GET response EMPTY for paths: $paths');
       }
-      result.putIfAbsent(path, () => null);
-    }
 
-    return result;
+      final Map<String, dynamic> result = {};
+
+      for (final entry in rawMap.entries) {
+        result[entry.key] = _coerceValue(entry.key, entry.value);
+      }
+
+      // Ensure all requested non-wildcard paths exist in the result to prevent
+      // Null Cast errors in codegen. Wildcard search paths (containing '*') are
+      // expanded by the router into concrete instance paths, so the original
+      // wildcard path won't appear in the response — skip those.
+      for (final path in paths) {
+        if (path.contains('*')) continue;
+        if (!result.containsKey(path)) {
+          logger.w('$_tag$label GET missing path in response: "$path"');
+        }
+        result.putIfAbsent(path, () => null);
+      }
+
+      return result;
+    } catch (e) {
+      sw.stop();
+      final label = _idLabel(id);
+      logger.e('$_tag$label GET ✗ (${sw.elapsedMilliseconds}ms)\n  $e');
+      rethrow;
+    }
   }
 
   /// Coerce a raw string value from USP into the appropriate Dart type.
@@ -320,50 +335,52 @@ class UspClient {
 
   Future<Map<String, dynamic>> _singleSet(String path, String value) async {
     final id = ++_reqId;
+    _lastCallRetried = false;
     final sw = Stopwatch()..start();
-    final result = await _withAuthRetry(() => _client.set({path: value}));
-    sw.stop();
-    final shortPath = path.startsWith('Device.') ? path.substring(7) : path;
-    logger.d(
-        '[USP][Service]#$id SET $shortPath=$value (${sw.elapsedMilliseconds}ms)');
-    return result;
+    final params = {path: value};
+
+    logger.d('$_tag#$id SET →\n${_prettyMap(params)}');
+
+    try {
+      final result = await _withAuthRetry(() => _client.set({path: value}));
+      sw.stop();
+      final label = _idLabel(id);
+      logger.d('$_tag$label SET ← (${sw.elapsedMilliseconds}ms)\n'
+          '${_prettyMap(result)}');
+      return result;
+    } catch (e) {
+      sw.stop();
+      final label = _idLabel(id);
+      logger.e('$_tag$label SET ✗ (${sw.elapsedMilliseconds}ms)\n  $e');
+      rethrow;
+    }
   }
 
   Future<Map<String, dynamic>> _batchSet(Map<String, dynamic> parameters,
       {bool allowPartial = false}) async {
     final id = ++_reqId;
+    _lastCallRetried = false;
     final sw = Stopwatch()..start();
     final Map<String, String> stringParams =
         parameters.map((key, value) => MapEntry(key, value.toString()));
-    final result = await _withAuthRetry(
-        () => _client.set(stringParams, allowPartial: allowPartial));
-    sw.stop();
-    logger.d('[USP][Service]#$id SET ${_paramSummary(parameters)} '
-        '${parameters.length} params'
-        '${allowPartial ? ' (allowPartial)' : ''} (${sw.elapsedMilliseconds}ms)');
 
-    // Log result summary for WASM v0.11.0 format
-    final success = result['success'] as bool? ?? false;
-    final resultData =
-        result['result'] as Map<String, dynamic>? ?? <String, dynamic>{};
-    final data =
-        resultData['data'] as Map<String, dynamic>? ?? <String, dynamic>{};
-    final error = resultData['error'] as Map<String, dynamic>?;
-    final hasErrors = error != null;
-    logger.d(
-        '[USP][Service]#$id SET result: success=$success, errors=$hasErrors, dataKeys=${data.keys.length}');
+    logger.d('$_tag#$id SET${allowPartial ? ' (allowPartial)' : ''} →\n'
+        '${_prettyMap(parameters)}');
 
-    // Log detailed results in debug mode
-    if (kDebugMode) {
-      if (data.isNotEmpty) {
-        logger.d('[USP][Service]#$id SET data: ${data.keys.join(', ')}');
-      }
-      if (error != null) {
-        logger.d('[USP][Service]#$id SET errors: ${error.keys.join(', ')}');
-      }
+    try {
+      final result = await _withAuthRetry(
+          () => _client.set(stringParams, allowPartial: allowPartial));
+      sw.stop();
+      final label = _idLabel(id);
+      logger.d('$_tag$label SET ← (${sw.elapsedMilliseconds}ms)\n'
+          '${_prettyMap(result)}');
+      return result;
+    } catch (e) {
+      sw.stop();
+      final label = _idLabel(id);
+      logger.e('$_tag$label SET ✗ (${sw.elapsedMilliseconds}ms)\n  $e');
+      rethrow;
     }
-
-    return result;
   }
 
   // ===========================================================================
@@ -382,26 +399,28 @@ class UspClient {
       List<List<Map<String, String>>> parameterGroups,
       {bool allowPartial = false}) async {
     final id = ++_reqId;
+    _lastCallRetried = false;
     final sw = Stopwatch()..start();
-    final result = await _withAuthRetry(
-        () => _client.setOrdered(parameterGroups, allowPartial: allowPartial));
-    sw.stop();
 
-    final allParams = parameterGroups.expand((g) => g).toList();
-    final paths = allParams.map((p) => p['path'] ?? '').toList();
-    logger.d('[USP][Service]#$id SET_ORDERED ${_pathSummary(paths)} '
-        '${allParams.length} params (${parameterGroups.length} groups)'
-        '${allowPartial ? ' (allowPartial)' : ''} (${sw.elapsedMilliseconds}ms)');
-
-    final success = result['success'] as bool? ?? false;
-    final resultData =
-        result['result'] as Map<String, dynamic>? ?? <String, dynamic>{};
-    final error = resultData['error'] as Map<String, dynamic>?;
-    final hasErrors = error != null;
     logger.d(
-        '[USP][Service]#$id SET_ORDERED result: success=$success, errors=$hasErrors');
+        '$_tag#$id SET_ORDERED${allowPartial ? ' (allowPartial)' : ''} →\n'
+        '${_prettyJson(parameterGroups)}');
 
-    return result;
+    try {
+      final result = await _withAuthRetry(
+          () => _client.setOrdered(parameterGroups, allowPartial: allowPartial));
+      sw.stop();
+      final label = _idLabel(id);
+      logger.d('$_tag$label SET_ORDERED ← (${sw.elapsedMilliseconds}ms)\n'
+          '${_prettyMap(result)}');
+      return result;
+    } catch (e) {
+      sw.stop();
+      final label = _idLabel(id);
+      logger.e(
+          '$_tag$label SET_ORDERED ✗ (${sw.elapsedMilliseconds}ms)\n  $e');
+      rethrow;
+    }
   }
 
   // ===========================================================================
@@ -428,48 +447,53 @@ class UspClient {
   Future<Map<String, dynamic>> _singleAdd(
       String objectPath, Map<String, dynamic> parameters) async {
     final id = ++_reqId;
+    _lastCallRetried = false;
     final sw = Stopwatch()..start();
     final stringParams = parameters.map((k, v) => MapEntry(k, v.toString()));
-    final result = await _withAuthRetry(() => _client.add([
-          {'path': objectPath, 'params': stringParams}
-        ]));
-    sw.stop();
-    final shortPath =
-        objectPath.startsWith('Device.') ? objectPath.substring(7) : objectPath;
+    final payload = {'path': objectPath, 'params': stringParams};
 
-    // Extract created instance path for logging
-    final success = result['success'] as bool? ?? false;
-    final resultData =
-        result['result'] as Map<String, dynamic>? ?? <String, dynamic>{};
-    final data =
-        resultData['data'] as Map<String, dynamic>? ?? <String, dynamic>{};
-    String createdPath = 'unknown';
+    logger.d('$_tag#$id ADD →\n${_prettyMap(payload)}');
 
-    if (success && data.containsKey('instances')) {
-      final instances = data['instances'] as List? ?? [];
-      if (instances.isNotEmpty) {
-        createdPath = instances.first as String? ?? 'unknown';
-      }
+    try {
+      final result = await _withAuthRetry(() => _client.add([
+            {'path': objectPath, 'params': stringParams}
+          ]));
+      sw.stop();
+      final label = _idLabel(id);
+      logger.d('$_tag$label ADD ← (${sw.elapsedMilliseconds}ms)\n'
+          '${_prettyMap(result)}');
+      return result;
+    } catch (e) {
+      sw.stop();
+      final label = _idLabel(id);
+      logger.e('$_tag$label ADD ✗ (${sw.elapsedMilliseconds}ms)\n  $e');
+      rethrow;
     }
-
-    logger.d('[USP][Service]#$id ADD $shortPath — '
-        '${parameters.length} params → $createdPath (${sw.elapsedMilliseconds}ms)');
-
-    return result;
   }
 
   Future<Map<String, dynamic>> _batchAdd(List<Map<String, dynamic>> objects,
       {bool allowPartial = false}) async {
     final id = ++_reqId;
+    _lastCallRetried = false;
     final sw = Stopwatch()..start();
-    final result = await _withAuthRetry(
-        () => _client.add(objects, allowPartial: allowPartial));
-    sw.stop();
 
-    logger.d('[USP][Service]#$id ADD ${objects.length} objects'
-        '${allowPartial ? ' (allowPartial)' : ''} (${sw.elapsedMilliseconds}ms)');
+    logger.d('$_tag#$id ADD${allowPartial ? ' (allowPartial)' : ''} →\n'
+        '${_prettyJson(objects)}');
 
-    return result;
+    try {
+      final result = await _withAuthRetry(
+          () => _client.add(objects, allowPartial: allowPartial));
+      sw.stop();
+      final label = _idLabel(id);
+      logger.d('$_tag$label ADD ← (${sw.elapsedMilliseconds}ms)\n'
+          '${_prettyMap(result)}');
+      return result;
+    } catch (e) {
+      sw.stop();
+      final label = _idLabel(id);
+      logger.e('$_tag$label ADD ✗ (${sw.elapsedMilliseconds}ms)\n  $e');
+      rethrow;
+    }
   }
 
   // ===========================================================================
@@ -490,26 +514,49 @@ class UspClient {
 
   Future<Map<String, dynamic>> _singleDelete(String path) async {
     final id = ++_reqId;
+    _lastCallRetried = false;
     final sw = Stopwatch()..start();
-    final result = await _withAuthRetry(() => _client.delete([path]));
-    sw.stop();
-    final shortPath = path.startsWith('Device.') ? path.substring(7) : path;
-    logger.d(
-        '[USP][Service]#$id DELETE $shortPath (${sw.elapsedMilliseconds}ms)');
-    return result;
+
+    logger.d('$_tag#$id DELETE →\n${_prettyList([path])}');
+
+    try {
+      final result = await _withAuthRetry(() => _client.delete([path]));
+      sw.stop();
+      final label = _idLabel(id);
+      logger.d('$_tag$label DELETE ← (${sw.elapsedMilliseconds}ms)\n'
+          '${_prettyMap(result)}');
+      return result;
+    } catch (e) {
+      sw.stop();
+      final label = _idLabel(id);
+      logger.e('$_tag$label DELETE ✗ (${sw.elapsedMilliseconds}ms)\n  $e');
+      rethrow;
+    }
   }
 
   Future<Map<String, dynamic>> _batchDelete(List<String> paths,
       {bool allowPartial = false}) async {
     final id = ++_reqId;
+    _lastCallRetried = false;
     final sw = Stopwatch()..start();
-    final result = await _withAuthRetry(
-        () => _client.delete(paths, allowPartial: allowPartial));
-    sw.stop();
-    logger.d('[USP][Service]#$id DELETE ${_pathSummary(paths)} '
-        '${paths.length} paths'
-        '${allowPartial ? ' (allowPartial)' : ''} (${sw.elapsedMilliseconds}ms)');
-    return result;
+
+    logger.d('$_tag#$id DELETE${allowPartial ? ' (allowPartial)' : ''} →\n'
+        '${_prettyList(paths)}');
+
+    try {
+      final result = await _withAuthRetry(
+          () => _client.delete(paths, allowPartial: allowPartial));
+      sw.stop();
+      final label = _idLabel(id);
+      logger.d('$_tag$label DELETE ← (${sw.elapsedMilliseconds}ms)\n'
+          '${_prettyMap(result)}');
+      return result;
+    } catch (e) {
+      sw.stop();
+      final label = _idLabel(id);
+      logger.e('$_tag$label DELETE ✗ (${sw.elapsedMilliseconds}ms)\n  $e');
+      rethrow;
+    }
   }
 
   // ===========================================================================
@@ -526,23 +573,30 @@ class UspClient {
   Future<Map<String, dynamic>> operate(String command,
       {Map<String, String> args = const {}}) async {
     final id = ++_reqId;
+    _lastCallRetried = false;
     final sw = Stopwatch()..start();
-    final rawResponse =
-        await _withAuthRetry(() => _client.operate(command, args: args));
-    sw.stop();
 
-    // Extract commandKey and outputArgs from WASM v0.11.0 unified format:
-    // { success, result: { data: { commandKey, outputArgs }, error? } }
-    final response = _extractOperateResult(rawResponse);
+    final payload = <String, dynamic>{'command': command, if (args.isNotEmpty) 'args': args};
+    logger.d('$_tag#$id OPERATE →\n${_prettyMap(payload)}');
 
-    logger.d('[USP][Service]#$id OPERATE $command'
-        '${args.isNotEmpty ? ' — ${args.length} args' : ''}'
-        ' → key=${response['commandKey']}, ${response.length} output keys'
-        ' (${sw.elapsedMilliseconds}ms)');
-    if (response.isNotEmpty) {
-      logger.d('[USP][Service]#$id ← ${_mapSummary(response)}');
+    try {
+      final rawResponse =
+          await _withAuthRetry(() => _client.operate(command, args: args));
+      sw.stop();
+
+      // Extract commandKey and outputArgs from WASM v0.11.0 unified format:
+      // { success, result: { data: { commandKey, outputArgs }, error? } }
+      final response = _extractOperateResult(rawResponse);
+      final label = _idLabel(id);
+      logger.d('$_tag$label OPERATE ← (${sw.elapsedMilliseconds}ms)\n'
+          '${_prettyMap(response)}');
+      return response;
+    } catch (e) {
+      sw.stop();
+      final label = _idLabel(id);
+      logger.e('$_tag$label OPERATE ✗ (${sw.elapsedMilliseconds}ms)\n  $e');
+      rethrow;
     }
-    return response;
   }
 
   /// Extracts commandKey and outputArgs from WASM v0.11.0 unified format.
@@ -667,7 +721,7 @@ class UspClient {
 
     sw.stop();
     final recipient = verify['${instancePath}Recipient'] ?? '';
-    logger.d('[USP][Service]#$id CREATE_SUBSCRIPTION $instancePath '
+    logger.d('$_tag#$id CREATE_SUBSCRIPTION $instancePath '
         'type=$notifType ref=$referenceList → Recipient=$recipient '
         '(${sw.elapsedMilliseconds}ms)');
 
@@ -686,7 +740,7 @@ class UspClient {
     final shortPath = instancePath.startsWith('Device.')
         ? instancePath.substring(7)
         : instancePath;
-    logger.d('[USP][Service]#$id DELETE_SUBSCRIPTION $shortPath '
+    logger.d('$_tag#$id DELETE_SUBSCRIPTION $shortPath '
         '(${sw.elapsedMilliseconds}ms)');
   }
 
@@ -699,7 +753,7 @@ class UspClient {
     final sw = Stopwatch()..start();
     final subs = await _withAuthRetry(() => _client.listSubscriptions());
     sw.stop();
-    logger.d('[USP][Service]#$id LIST_SUBSCRIPTIONS → ${subs.length} entries '
+    logger.d('$_tag#$id LIST_SUBSCRIPTIONS → ${subs.length} entries '
         '(${sw.elapsedMilliseconds}ms)');
     return subs;
   }
@@ -736,7 +790,7 @@ class UspClient {
 
     if (instanceIds.isEmpty) {
       sw.stop();
-      logger.d('[USP][Service]#$id PURGE_SUBSCRIPTIONS → 0 (none found, '
+      logger.d('$_tag#$id PURGE_SUBSCRIPTIONS → 0 (none found, '
           '${sw.elapsedMilliseconds}ms)');
       return 0;
     }
@@ -746,7 +800,7 @@ class UspClient {
       final prefix = '$objectPath$instId.';
       final notifType = allParams['${prefix}NotifType'] ?? '?';
       final refList = allParams['${prefix}ReferenceList'] ?? '?';
-      logger.d('[USP][Service]#$id PURGE: $prefix '
+      logger.d('$_tag#$id PURGE: $prefix '
           '(type=$notifType, ref=$refList)');
     }
 
@@ -757,13 +811,13 @@ class UspClient {
         await _withAuthRetry(() => _client.delete([instancePath]));
         deleted++;
       } catch (e) {
-        logger.w('[USP][Service]#$id PURGE failed to delete '
+        logger.w('$_tag#$id PURGE failed to delete '
             '$instancePath: $e');
       }
     }
 
     sw.stop();
-    logger.d('[USP][Service]#$id PURGE_SUBSCRIPTIONS → deleted $deleted/'
+    logger.d('$_tag#$id PURGE_SUBSCRIPTIONS → deleted $deleted/'
         '${instanceIds.length} (${sw.elapsedMilliseconds}ms)');
     return deleted;
   }
@@ -823,7 +877,7 @@ class UspClient {
             }
           } catch (e) {
             logger
-                .w('[USP][Service]SSE subscribe re-fetch error for "$id": $e');
+                .w('$_tag SSE subscribe re-fetch error for "$id": $e');
           }
         });
       },
@@ -837,7 +891,7 @@ class UspClient {
         controller.add(parsed);
       }
     } catch (e) {
-      logger.w('[USP][Service]SSE subscribe initial fetch error for "$id": $e');
+      logger.w('$_tag SSE subscribe initial fetch error for "$id": $e');
     }
 
     return Subscription<T>(
@@ -874,7 +928,7 @@ class UspClient {
               controller.add(parsed);
             }
           } catch (e) {
-            logger.w('[USP][Service]Subscribe poll error for "$id": $e');
+            logger.w('$_tag Subscribe poll error for "$id": $e');
           }
         });
       },
@@ -916,51 +970,18 @@ class UspClient {
   // Log helpers
   // ===========================================================================
 
-  /// Abbreviates a list of paths for concise logging.
-  ///
-  /// Shows up to [max] paths with the `Device.` prefix stripped, followed by
-  /// `+N more` if there are additional paths.
-  static String _pathSummary(List<String> paths, {int max = 2}) {
-    if (paths.isEmpty) return '[]';
-    final shown = paths
-        .take(max)
-        .map((p) => p.startsWith('Device.') ? p.substring(7) : p)
-        .toList();
-    final remaining = paths.length - shown.length;
-    final suffix = remaining > 0 ? ', +$remaining more' : '';
-    return '[${shown.join(', ')}$suffix]';
+  static const _jsonEncoder = JsonEncoder.withIndent('  ');
+
+  static String _prettyList(List<String> list) {
+    return '  ${_jsonEncoder.convert(list).replaceAll('\n', '\n  ')}';
   }
 
-  /// Abbreviates a map of param keys for concise logging.
-  static String _paramSummary(Map<String, dynamic> params, {int max = 2}) {
-    if (params.isEmpty) return '[]';
-    final shown = params.keys
-        .take(max)
-        .map((p) => p.startsWith('Device.') ? p.substring(7) : p)
-        .toList();
-    final remaining = params.length - shown.length;
-    final suffix = remaining > 0 ? ', +$remaining more' : '';
-    return '[${shown.join(', ')}$suffix]';
+  static String _prettyMap(Map<String, dynamic> map) {
+    return '  ${_jsonEncoder.convert(map).replaceAll('\n', '\n  ')}';
   }
 
-  /// Converts a flat dot-path map into a nested JSON tree for logging.
-  ///
-  /// e.g. `{"Device.IP.Stats.BytesSent": "123"}` →
-  /// ```json
-  /// {"Device":{"IP":{"Stats":{"BytesSent":"123"}}}}
-  /// ```
-  static String _mapSummary(Map<String, dynamic> map) {
-    final nested = <String, dynamic>{};
-    for (final entry in map.entries) {
-      final segments = entry.key.split('.');
-      Map<String, dynamic> current = nested;
-      for (var i = 0; i < segments.length - 1; i++) {
-        current = current.putIfAbsent(segments[i], () => <String, dynamic>{})
-            as Map<String, dynamic>;
-      }
-      current[segments.last] = entry.value;
-    }
-    return const JsonEncoder.withIndent('  ').convert(nested);
+  static String _prettyJson(Object value) {
+    return '  ${_jsonEncoder.convert(value).replaceAll('\n', '\n  ')}';
   }
 
   void dispose() {

--- a/lib/core/usp/web/usp_client_wasm.dart
+++ b/lib/core/usp/web/usp_client_wasm.dart
@@ -39,7 +39,7 @@ JSAny? _buildOptions({bool allowPartial = false}) {
   return {'allowPartial': allowPartial}.jsify();
 }
 
-const _tag = '[USPClient:WASM]';
+const _tag = '[USPClient][WASM]:';
 
 // Bind to the UspClient class exported in usp_client.js (unified API)
 @JS('UspClient')

--- a/lib/core/usp/web/usp_client_wasm.dart
+++ b/lib/core/usp/web/usp_client_wasm.dart
@@ -2,9 +2,7 @@
 library usp_client;
 
 import 'dart:js_interop';
-import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 
 /// Safely converts dartify() LinkedMap<Object?, Object?> to Map<String, dynamic>.
@@ -40,6 +38,8 @@ JSAny? _buildOptions({bool allowPartial = false}) {
   if (!allowPartial) return null;
   return {'allowPartial': allowPartial}.jsify();
 }
+
+const _tag = '[USPClient:WASM]';
 
 // Bind to the UspClient class exported in usp_client.js (unified API)
 @JS('UspClient')
@@ -92,49 +92,23 @@ class UspClientWeb {
   late final UspClientJS _client;
 
   UspClientWeb(String baseUrl) {
-    if (kDebugMode) {
-      logger.d('[WASM]Creating UspClientJS with baseUrl: $baseUrl');
-    }
-    try {
-      _client = UspClientJS(baseUrl);
-      if (kDebugMode) {
-        logger.d('[WASM]UspClientJS created successfully');
-      }
-    } catch (e) {
-      if (kDebugMode) {
-        logger.d('[WASM]Failed to create UspClientJS: $e');
-      }
-      rethrow;
-    }
+    _client = UspClientJS(baseUrl);
   }
 
   bool get isAuthenticated {
     try {
-      final result = _client.isAuthenticated();
-      if (kDebugMode) {
-        logger.d('[WASM]isAuthenticated(): $result');
-      }
-      return result;
+      return _client.isAuthenticated();
     } catch (e) {
-      if (kDebugMode) {
-        logger.d('[WASM]isAuthenticated() exception: $e');
-      }
+      logger.e('$_tag isAuthenticated() exception: $e');
       return false;
     }
   }
 
   String? get sessionToken {
     try {
-      final result = _client.getToken();
-      if (kDebugMode) {
-        logger.d(
-            '[WASM]getToken(): ${result?.substring(0, 20)}...(${result?.length} chars)');
-      }
-      return result;
+      return _client.getToken();
     } catch (e) {
-      if (kDebugMode) {
-        logger.d('[WASM]getToken() exception: $e');
-      }
+      logger.e('$_tag getToken() exception: $e');
       return null;
     }
   }
@@ -149,18 +123,9 @@ class UspClientWeb {
 
   Future<void> login(String password) async {
     try {
-      if (kDebugMode) {
-        logger
-            .d('[WASM]login() called with password length: ${password.length}');
-      }
-      final result = await _client.login(password).toDart;
-      if (kDebugMode) {
-        logger.d('[WASM]login() raw response: ${result?.toString() ?? 'null'}');
-      }
+      await _client.login(password).toDart;
     } catch (e) {
-      if (kDebugMode) {
-        logger.d('[WASM]login() exception: $e');
-      }
+      logger.e('$_tag login() exception: $e');
       rethrow;
     }
   }
@@ -184,43 +149,21 @@ class UspClientWeb {
     try {
       resultJs = await _client.get(jsPaths).toDart;
     } catch (e) {
-      if (kDebugMode) {
-        logger.e('[WASM]GET JavaScript exception: $e');
-        logger.e('[WASM]GET Exception type: ${e.runtimeType}');
-        logger.e('[WASM]GET Requested paths: $paths');
-      }
+      logger.e('$_tag GET exception: $e');
       rethrow;
     }
 
-    if (kDebugMode) {
-      logger.d('[WASM]GET raw response: ${resultJs?.toString() ?? 'null'}');
-    }
-
     final map = resultJs.dartify() as Map?;
-
-    if (kDebugMode) {
-      logger.d('[WASM]GET dartified: ${jsonEncode(map)}');
-    }
-
     if (map == null) return {};
 
     // Parse unified format: {success, result: {data, error?}}
-    final success = map['success'] as bool? ?? false;
     final resultData = map['result'] as Map? ?? {};
     final data = resultData['data'] as Map? ?? {};
-
-    if (kDebugMode) {
-      logger.d('[WASM]GET parsing unified format, success: $success');
-    }
 
     final result = <String, String>{};
     for (final entry in data.entries) {
       final key = entry.key?.toString() ?? '';
-      final value = entry.value;
-      if (kDebugMode) {
-        logger.d('[WASM]GET data: $key = $value');
-      }
-      result[key] = value?.toString() ?? '';
+      result[key] = entry.value?.toString() ?? '';
     }
 
     return result;
@@ -232,31 +175,16 @@ class UspClientWeb {
 
   Future<Map<String, dynamic>> set(Map<String, String> parameters,
       {bool allowPartial = false}) async {
-    if (kDebugMode) {
-      logger.d(
-          '[WASM]SET called: ${parameters.length} params, allowPartial=$allowPartial');
-      logger.d('[WASM]SET params: ${parameters.toString()}');
-    }
-
     final result = await _client
         .set_(parameters.jsify()!, _buildOptions(allowPartial: allowPartial))
         .toDart;
-
-    if (kDebugMode) {
-      logger.d('[WASM]SET raw response: ${result?.toString() ?? 'null'}');
-    }
 
     if (result == null || result.isUndefinedOrNull) {
       throw StateError(
           'WASM client returned null/undefined - structured response required');
     }
 
-    final map = _safeConvertToStringDynamicMap(result.dartify());
-    if (kDebugMode) {
-      logger.d('[WASM]SET dartified: ${jsonEncode(map)}');
-    }
-
-    return map;
+    return _safeConvertToStringDynamicMap(result.dartify());
   }
 
   // ---------------------------------------------------------------------------
@@ -266,16 +194,6 @@ class UspClientWeb {
   Future<Map<String, dynamic>> setOrdered(
       List<List<Map<String, String>>> parameterGroups,
       {bool allowPartial = false}) async {
-    if (kDebugMode) {
-      logger.d(
-          '[WASM]SET_ORDERED called: ${parameterGroups.length} groups, allowPartial=$allowPartial');
-      for (var g = 0; g < parameterGroups.length; g++) {
-        for (var i = 0; i < parameterGroups[g].length; i++) {
-          logger.d('[WASM]SET_ORDERED[group$g][$i]: ${parameterGroups[g][i]}');
-        }
-      }
-    }
-
     final jsGroups = parameterGroups
         .map((group) => group
             .map((p) => {'path': p['path'], 'value': p['value']}.jsify()!)
@@ -286,22 +204,12 @@ class UspClientWeb {
 
     final result = await _client.setOrdered(jsGroups, allowPartial).toDart;
 
-    if (kDebugMode) {
-      logger
-          .d('[WASM]SET_ORDERED raw response: ${result?.toString() ?? 'null'}');
-    }
-
     if (result == null || result.isUndefinedOrNull) {
       throw StateError(
           'WASM client returned null/undefined - structured response required');
     }
 
-    final map = _safeConvertToStringDynamicMap(result.dartify());
-    if (kDebugMode) {
-      logger.d('[WASM]SET_ORDERED dartified: ${jsonEncode(map)}');
-    }
-
-    return map;
+    return _safeConvertToStringDynamicMap(result.dartify());
   }
 
   // ---------------------------------------------------------------------------
@@ -310,14 +218,6 @@ class UspClientWeb {
 
   Future<Map<String, dynamic>> add(List<Map<String, dynamic>> items,
       {bool allowPartial = false}) async {
-    if (kDebugMode) {
-      logger.d(
-          '[WASM]ADD called: ${items.length} items, allowPartial=$allowPartial');
-      for (var i = 0; i < items.length; i++) {
-        logger.d('[WASM]ADD[$i]: ${items[i]}');
-      }
-    }
-
     // Stringify all param values — Rust WASM expects JS strings, not
     // Number/Boolean.  Dart's jsify() preserves int→Number / bool→Boolean,
     // which Rust's JsValue::as_string() returns None for, falling back to
@@ -345,22 +245,12 @@ class UspClientWeb {
         .add(jsItems, _buildOptions(allowPartial: allowPartial))
         .toDart;
 
-    if (kDebugMode) {
-      logger.d('[WASM]ADD raw response: ${result?.toString() ?? 'null'}');
-    }
-
     if (result == null || result.isUndefinedOrNull) {
       throw StateError(
           'WASM client returned null/undefined - structured response required');
     }
 
-    final map = _safeConvertToStringDynamicMap(result.dartify());
-
-    if (kDebugMode) {
-      logger.d('[WASM]ADD dartified: ${jsonEncode(map)}');
-    }
-
-    return map;
+    return _safeConvertToStringDynamicMap(result.dartify());
   }
 
   // ---------------------------------------------------------------------------
@@ -369,14 +259,6 @@ class UspClientWeb {
 
   Future<Map<String, dynamic>> delete(List<String> paths,
       {bool allowPartial = false}) async {
-    if (kDebugMode) {
-      logger.d(
-          '[WASM]DELETE called: ${paths.length} paths, allowPartial=$allowPartial');
-      for (var i = 0; i < paths.length; i++) {
-        logger.d('[WASM]DELETE[$i]: ${paths[i]}');
-      }
-    }
-
     try {
       // Single path → pass as string; multiple → pass as array
       final JSAny jsPaths;
@@ -390,26 +272,14 @@ class UspClientWeb {
           .delete_(jsPaths, _buildOptions(allowPartial: allowPartial))
           .toDart;
 
-      if (kDebugMode) {
-        logger.d('[WASM]DELETE raw response: ${result?.toString() ?? 'null'}');
-      }
-
       if (result == null || result.isUndefinedOrNull) {
         throw StateError(
             'WASM client returned null/undefined - structured response required');
       }
 
-      final map = _safeConvertToStringDynamicMap(result.dartify());
-
-      if (kDebugMode) {
-        logger.d('[WASM]DELETE dartified: ${jsonEncode(map)}');
-      }
-
-      return map;
+      return _safeConvertToStringDynamicMap(result.dartify());
     } catch (e) {
-      if (kDebugMode) {
-        logger.d('[WASM]DELETE exception: $e');
-      }
+      logger.e('$_tag DELETE exception: $e');
       // Return WASM v0.11.0 unified format for consistency with UspResultParser
       return {
         'success': false,
@@ -431,30 +301,9 @@ class UspClientWeb {
   // OPERATE
   // ---------------------------------------------------------------------------
 
-  /// Execute a USP Operate command.
-  ///
-  /// Returns the WASM v0.11.0 unified format:
-  /// ```dart
-  /// {
-  ///   'success': true,
-  ///   'result': {
-  ///     'data': {
-  ///       'commandKey': 'uuid-string',
-  ///       'outputArgs': { ... }
-  ///     },
-  ///     'error': { ... }  // optional
-  ///   }
-  /// }
-  /// ```
-  ///
-  /// Use `UspResultParser.parseOperateResult()` to extract commandKey/outputArgs.
   Future<Map<String, dynamic>> operate(String command,
       {Map<String, String> args = const {}}) async {
     final result = await _client.operate(command, args.jsify()!).toDart;
-
-    if (kDebugMode) {
-      logger.d('[WASM]OPERATE raw response: ${result?.toString() ?? 'null'}');
-    }
 
     if (result == null || result.isUndefinedOrNull) {
       return {
@@ -464,11 +313,6 @@ class UspClientWeb {
     }
 
     final map = result.dartify() as Map?;
-
-    if (kDebugMode) {
-      logger.d('[WASM]OPERATE dartified: ${jsonEncode(map)}');
-    }
-
     if (map == null) {
       return {
         'success': false,
@@ -476,7 +320,6 @@ class UspClientWeb {
       };
     }
 
-    // Pass through the unified format for UspResultParser
     return Map<String, dynamic>.from(map);
   }
 
@@ -487,18 +330,9 @@ class UspClientWeb {
   Future<List<Map<String, dynamic>>> listSubscriptions() async {
     final result = await _client.listSubscriptions().toDart;
 
-    if (kDebugMode) {
-      logger.d('[WASM]LIST_SUBS raw response: ${result?.toString() ?? 'null'}');
-    }
-
     if (result == null || result.isUndefinedOrNull) return [];
 
     final list = result.dartify() as List?;
-
-    if (kDebugMode) {
-      logger.d('[WASM]LIST_SUBS dartified: ${jsonEncode(list)}');
-    }
-
     if (list == null) return [];
     return list
         .whereType<Map>()

--- a/lib/core/utils/bench_mark.dart
+++ b/lib/core/utils/bench_mark.dart
@@ -33,7 +33,7 @@ class BenchMarkLogger {
   void start() {
     _start = DateTime.now();
     if (kDebugMode && !recordOnly) {
-      logger.d('${describeIdentity(this)} - $name: start at <$_start>');
+      logger.d('[Benchmark]: ${describeIdentity(this)} - $name: start at <$_start>');
     }
   }
 
@@ -49,7 +49,7 @@ class BenchMarkLogger {
     int delta = _calcuteDeltaTime();
     if (kDebugMode && !recordOnly) {
       logger.d(
-          '${describeIdentity(this)} - $name: end at <$_end>, delta time is <$delta>');
+          '[Benchmark]: ${describeIdentity(this)} - $name: end at <$_end>, delta time is <$delta>');
     }
     return delta;
   }

--- a/lib/core/utils/bench_mark.dart
+++ b/lib/core/utils/bench_mark.dart
@@ -33,7 +33,8 @@ class BenchMarkLogger {
   void start() {
     _start = DateTime.now();
     if (kDebugMode && !recordOnly) {
-      logger.d('[Benchmark]: ${describeIdentity(this)} - $name: start at <$_start>');
+      logger.d(
+          '[Benchmark]: ${describeIdentity(this)} - $name: start at <$_start>');
     }
   }
 

--- a/lib/core/utils/fernet_manager.dart
+++ b/lib/core/utils/fernet_manager.dart
@@ -29,16 +29,16 @@ class FernetManager {
       Uint8List rawBytes = Uint8List.fromList(utf8.encode(rawKeyString));
       if (rawBytes.length != 32) {
         logger.e(
-            'Fernet Key must be 32 bytes long! Current length: ${rawBytes.length}');
+            '[Crypto]: Fernet Key must be 32 bytes long! Current length: ${rawBytes.length}');
         _encrypter = null;
         return;
       }
       String base64Key = base64Url.encode(rawBytes);
       final key = Key.fromBase64(base64Key);
       _encrypter = Encrypter(Fernet(key));
-      logger.d('FernetManager key updated successfully.');
+      logger.d('[Crypto]: FernetManager key updated successfully.');
     } catch (e) {
-      logger.e('Error updating FernetManager key: $e');
+      logger.e('[Crypto]: Error updating FernetManager key: $e');
       _encrypter = null;
     }
   }
@@ -53,27 +53,27 @@ class FernetManager {
 
   String? encrypt(String plainText) {
     if (_encrypter == null) {
-      logger.w('Fernet encrypter not initialized, cannot encrypt.');
+      logger.w('[Crypto]: Fernet encrypter not initialized, cannot encrypt.');
       return null;
     }
     try {
       return _encrypter!.encrypt(plainText).base64;
     } catch (e) {
-      logger.e('Fernet encryption failed: $e');
+      logger.e('[Crypto]: Fernet encryption failed: $e');
       return null;
     }
   }
 
   String? decrypt(String cipherTextBase64) {
     if (_encrypter == null) {
-      logger.w('Fernet encrypter not initialized, cannot decrypt.');
+      logger.w('[Crypto]: Fernet encrypter not initialized, cannot decrypt.');
       return null;
     }
     try {
       final encrypted = Encrypted.fromBase64(cipherTextBase64);
       return _encrypter!.decrypt(encrypted);
     } catch (e) {
-      logger.e('Fernet decryption failed: $e');
+      logger.e('[Crypto]: Fernet decryption failed: $e');
       return 'Decryption Error (Invalid Token or Key)';
     }
   }

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -53,13 +53,14 @@ class CustomOutput extends LogOutput {
       await _file.writeAsBytes("$processedOutput\n".codeUnits,
           mode: FileMode.writeOnlyAppend);
     } else if (kIsWeb && output.isNotEmpty) {
+      final stripped = _stripPrinterPrefix(output);
       _recordLog(
         MaskingUtils.encryptJNAPAuth(
           MaskingUtils.maskUsernamePasswordBodyValue(
             MaskingUtils.maskSensitiveJsonValues(
               MaskingUtils.maskSerialNumber(
                 MaskingUtils.maskMacAddress(
-                  MaskingUtils.replaceHttpScheme(output.toString()),
+                  MaskingUtils.replaceHttpScheme(stripped),
                 ),
               ),
             ),
@@ -69,6 +70,13 @@ class CustomOutput extends LogOutput {
       );
     }
   }
+}
+
+/// Strips the SimplePrinter prefix (e.g., `[D] TIME: 2026-05-07T... `) from
+/// log output, leaving only the raw message for cache storage.
+final _printerPrefixRegex = RegExp(r'^\[\w+\]\s*TIME:\s*\S+\s*');
+String _stripPrinterPrefix(String output) {
+  return output.replaceFirst(_printerPrefixRegex, '');
 }
 
 /// A cache to store log messages in memory, primarily for the web platform.
@@ -172,14 +180,16 @@ void _addLogWithTag(
 ///
 /// Returns a single string containing all the log messages for the given tag,
 /// separated by newlines.
-String _getWebLogByTag({String tag = appLogTag}) {
+String _getWebLogByTag({String tag = appLogTag, bool showLevel = true}) {
   final logList = _webLogCache[tag] ?? [];
-  // Sort log list by timestamp in ascending order
-  // And return the log list as a string with date time prefix and level
   return logList
       .sorted((a, b) => a.$1.compareTo(b.$1))
-      .map((e) =>
-          '${DateTime.fromMillisecondsSinceEpoch(e.$1).toIso8601String()} ${_levelPrefix(e.$3)}${e.$2}')
+      .map((e) {
+        final timestamp = DateTime.fromMillisecondsSinceEpoch(e.$1).toIso8601String();
+        return showLevel
+            ? '$timestamp ${_levelPrefix(e.$3)}${e.$2}'
+            : '$timestamp ${e.$2}';
+      })
       .join('\n');
 }
 
@@ -219,7 +229,7 @@ Future<String> outputFullWebLog(BuildContext context) async {
 ${await getPackageInfo()}
 $screenInfo
 ================================ View History ==================================
-${_getWebLogByTag(tag: routeLogTag)}
+${_getWebLogByTag(tag: routeLogTag, showLevel: false)}
 ============================== Custom Tag Summary ==============================
 ${keys.map((e) => '[$e]\n${_getWebLogByTag(tag: e)}').join('\n\n')}
 ============================== State Management ==============================

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -59,6 +59,7 @@ class CustomOutput extends LogOutput {
             ),
           ),
         ),
+        event.level,
       );
     }
   }
@@ -66,8 +67,8 @@ class CustomOutput extends LogOutput {
 
 /// A cache to store log messages in memory, primarily for the web platform.
 /// The key is the log tag, and the value is a list of tuples containing the
-/// timestamp and the log message.
-Map<String, List<(int, String)>> _webLogCache = {};
+/// timestamp, the log message, and the log level.
+Map<String, List<(int, String, Level)>> _webLogCache = {};
 
 /// A cache specifically for storing the latest state of different state management providers.
 /// The key is the provider's name, and the value is its string representation.
@@ -95,13 +96,14 @@ const routeLogTag = 'RouteChanged';
 /// custom tag list if a tag is present in the log message.
 ///
 /// [log] The log message string to record.
-void _recordLog(String log) async {
+/// [level] The severity level of this log entry.
+void _recordLog(String log, Level level) async {
   // Add every log message to the 'app' log list
-  _addLogWithTag(message: log);
+  _addLogWithTag(message: log, level: level);
   // If a custom tag is specified, add to its log list
   final record = _splitTagAndMessage(log);
   if (record != null) {
-    _addLogWithTag(message: record.$1, tag: record.$2);
+    _addLogWithTag(message: record.$1, tag: record.$2, level: level);
   }
 }
 
@@ -113,7 +115,11 @@ void _recordLog(String log) async {
 ///
 /// [message] The log message to add.
 /// [tag] The tag under which to store the message. Defaults to [appLogTag].
-void _addLogWithTag({required String message, String tag = appLogTag}) {
+/// [level] The severity level of this log entry. Defaults to [Level.debug].
+void _addLogWithTag(
+    {required String message,
+    String tag = appLogTag,
+    Level level = Level.debug}) {
   final logList = _webLogCache[tag] ?? [];
   final maxSize =
       tag == routeLogTag ? _maxLogSizeOfRouteTag : _maxLogSizeOfGeneralTag;
@@ -127,7 +133,7 @@ void _addLogWithTag({required String message, String tag = appLogTag}) {
     if (logList.length + 1 > maxSize) {
       logList.removeAt(0);
     }
-    logList.add((DateTime.now().millisecondsSinceEpoch, message));
+    logList.add((DateTime.now().millisecondsSinceEpoch, message, level));
     _webLogCache[tag] = logList;
   }
 }
@@ -163,12 +169,23 @@ void _addLogWithTag({required String message, String tag = appLogTag}) {
 String _getWebLogByTag({String tag = appLogTag}) {
   final logList = _webLogCache[tag] ?? [];
   // Sort log list by timestamp in ascending order
-  // And return the log list as a string with date time prefix
+  // And return the log list as a string with date time prefix and level
   return logList
       .sorted((a, b) => a.$1.compareTo(b.$1))
       .map((e) =>
-          '${DateTime.fromMillisecondsSinceEpoch(e.$1).toIso8601String()}: ${e.$2}')
+          '${DateTime.fromMillisecondsSinceEpoch(e.$1).toIso8601String()} ${_levelPrefix(e.$3)}${e.$2}')
       .join('\n');
+}
+
+String _levelPrefix(Level level) {
+  return switch (level) {
+    Level.debug => '[D]',
+    Level.info => '[I]',
+    Level.warning => '[W]',
+    Level.error => '[E]',
+    Level.fatal => '[F]',
+    _ => '[?]',
+  };
 }
 
 /// Public accessor for retrieving cached logs by tag.

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -46,9 +46,8 @@ class CustomOutput extends LogOutput {
     }
     if (!kIsWeb && output.isNotEmpty && _file.existsSync()) {
       final processedOutput = MaskingUtils.encryptJNAPAuth(
-          MaskingUtils.maskSensitiveJsonValues(
-              MaskingUtils.maskSerialNumber(
-                  MaskingUtils.maskMacAddress(output.toString()))));
+          MaskingUtils.maskSensitiveJsonValues(MaskingUtils.maskSerialNumber(
+              MaskingUtils.maskMacAddress(output.toString()))));
       await _file.writeAsBytes("$processedOutput\n".codeUnits,
           mode: FileMode.writeOnlyAppend);
     } else if (kIsWeb && output.isNotEmpty) {
@@ -179,15 +178,13 @@ void _addLogWithTag(
 /// separated by newlines.
 String _getWebLogByTag({String tag = appLogTag, bool showLevel = true}) {
   final logList = _webLogCache[tag] ?? [];
-  return logList
-      .sorted((a, b) => a.$1.compareTo(b.$1))
-      .map((e) {
-        final timestamp = DateTime.fromMillisecondsSinceEpoch(e.$1).toIso8601String();
-        return showLevel
-            ? '$timestamp ${_levelPrefix(e.$3)}${e.$2}'
-            : '$timestamp ${e.$2}';
-      })
-      .join('\n');
+  return logList.sorted((a, b) => a.$1.compareTo(b.$1)).map((e) {
+    final timestamp =
+        DateTime.fromMillisecondsSinceEpoch(e.$1).toIso8601String();
+    return showLevel
+        ? '$timestamp ${_levelPrefix(e.$3)}${e.$2}'
+        : '$timestamp ${e.$2}';
+  }).join('\n');
 }
 
 String _levelPrefix(Level level) {

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -156,7 +156,7 @@ void _addLogWithTag(
 ///
 /// Returns a tuple `(message, tag)` if successful, otherwise `null`.
 (String, String)? _splitTagAndMessage(String log) {
-  final match = RegExp(_logTagRegex).firstMatch(log);
+  final match = RegExp(_logTagRegex, dotAll: true).firstMatch(log);
   if (match == null) {
     return null;
   }

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -47,7 +47,9 @@ class CustomOutput extends LogOutput {
     if (!kIsWeb && output.isNotEmpty && _file.existsSync()) {
       final processedOutput = MaskingUtils.encryptJNAPAuth(
           MaskingUtils.maskSensitiveJsonValues(
-              MaskingUtils.replaceHttpScheme(output.toString())));
+              MaskingUtils.maskSerialNumber(
+                  MaskingUtils.maskMacAddress(
+                      MaskingUtils.replaceHttpScheme(output.toString())))));
       await _file.writeAsBytes("$processedOutput\n".codeUnits,
           mode: FileMode.writeOnlyAppend);
     } else if (kIsWeb && output.isNotEmpty) {
@@ -55,7 +57,11 @@ class CustomOutput extends LogOutput {
         MaskingUtils.encryptJNAPAuth(
           MaskingUtils.maskUsernamePasswordBodyValue(
             MaskingUtils.maskSensitiveJsonValues(
-              MaskingUtils.replaceHttpScheme(output.toString()),
+              MaskingUtils.maskSerialNumber(
+                MaskingUtils.maskMacAddress(
+                  MaskingUtils.replaceHttpScheme(output.toString()),
+                ),
+              ),
             ),
           ),
         ),

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -48,8 +48,7 @@ class CustomOutput extends LogOutput {
       final processedOutput = MaskingUtils.encryptJNAPAuth(
           MaskingUtils.maskSensitiveJsonValues(
               MaskingUtils.maskSerialNumber(
-                  MaskingUtils.maskMacAddress(
-                      MaskingUtils.replaceHttpScheme(output.toString())))));
+                  MaskingUtils.maskMacAddress(output.toString()))));
       await _file.writeAsBytes("$processedOutput\n".codeUnits,
           mode: FileMode.writeOnlyAppend);
     } else if (kIsWeb && output.isNotEmpty) {
@@ -59,9 +58,7 @@ class CustomOutput extends LogOutput {
           MaskingUtils.maskUsernamePasswordBodyValue(
             MaskingUtils.maskSensitiveJsonValues(
               MaskingUtils.maskSerialNumber(
-                MaskingUtils.maskMacAddress(
-                  MaskingUtils.replaceHttpScheme(stripped),
-                ),
+                MaskingUtils.maskMacAddress(stripped),
               ),
             ),
           ),

--- a/lib/demo/providers/demo_package_widget_loader.dart
+++ b/lib/demo/providers/demo_package_widget_loader.dart
@@ -21,7 +21,7 @@ class DemoPackageWidgetLoader extends PackageWidgetLoader {
     // Just load demo templates directly from assets
     final templates = await _loadDemoTemplates();
 
-    logger.d('[Demo][PkgWidgets] Loaded ${templates.length} demo templates');
+    logger.d('[Demo][PkgWidgets]: Loaded ${templates.length} demo templates');
     return templates;
   }
 
@@ -44,11 +44,11 @@ class DemoPackageWidgetLoader extends PackageWidgetLoader {
         final template = await _loadTemplateFromAsset(assetPath);
         if (template != null) {
           templates[template.widgetId] = template;
-          logger.d('[Demo][PkgWidgets] Loaded: ${template.widgetId} '
+          logger.d('[Demo][PkgWidgets]: Loaded: ${template.widgetId} '
               '(${template.displayName})');
         }
       } catch (e) {
-        logger.w('[Demo][PkgWidgets] Failed to load $assetPath: $e');
+        logger.w('[Demo][PkgWidgets]: Failed to load $assetPath: $e');
       }
     }
 
@@ -63,7 +63,7 @@ class DemoPackageWidgetLoader extends PackageWidgetLoader {
       final json = jsonDecode(jsonString) as Map<String, dynamic>;
       return PackageWidgetTemplate.fromJson(json);
     } catch (e) {
-      logger.w('[Demo][PkgWidgets] Failed to parse template $assetPath: $e');
+      logger.w('[Demo][PkgWidgets]: Failed to parse template $assetPath: $e');
       return null;
     }
   }

--- a/lib/di.dart
+++ b/lib/di.dart
@@ -48,9 +48,9 @@ void dependencySetup() {
       getIt.registerSingleton<UspClient>(UspClient(
         Uri.base.origin,
       ));
-      logger.d('[DI] UspClient registered (Web)');
+      logger.d('[DI]: UspClient registered (Web)');
     } catch (e) {
-      logger.w('[DI] UspClient registration failed: $e');
+      logger.w('[DI]: UspClient registration failed: $e');
     }
   }
 }

--- a/lib/framework/preservable_notifier_mixin.dart
+++ b/lib/framework/preservable_notifier_mixin.dart
@@ -95,7 +95,7 @@ class _PreservableDelegate<
   void onSseInvalidation() {
     if (!isDirty()) {
       unawaited(fetch(forceRemote: true).catchError((Object e, StackTrace st) {
-        logger.e('SSE invalidation fetch failed', error: e);
+        logger.e('[USP][SSE]: invalidation fetch failed', error: e);
         return _getState();
       }));
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -105,13 +105,10 @@ checkFirstLaunch() {
 initErrorHandler() {
   // Pass all uncaught errors from the framework to Crashlytics.
   FlutterError.onError = (FlutterErrorDetails details) {
-    logger.e('Uncaught Flutter Error:\n', error: details);
-    logger.e('Uncaught Flutter Error:\n', error: details.exception);
-    logger.e('Uncaught Flutter Error:\n', error: details.exceptionAsString());
+    logger.e('[App]: Uncaught Flutter Error', error: details.exception, stackTrace: details.stack);
   };
   PlatformDispatcher.instance.onError = (error, stack) {
-    logger.e('Uncaught Error:\n', error: error, stackTrace: stack);
-    logger.e(stack.toString());
+    logger.e('[App]: Uncaught Error', error: error, stackTrace: stack);
     return true;
   };
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -105,7 +105,8 @@ checkFirstLaunch() {
 initErrorHandler() {
   // Pass all uncaught errors from the framework to Crashlytics.
   FlutterError.onError = (FlutterErrorDetails details) {
-    logger.e('[App]: Uncaught Flutter Error', error: details.exception, stackTrace: details.stack);
+    logger.e('[App]: Uncaught Flutter Error',
+        error: details.exception, stackTrace: details.stack);
   };
   PlatformDispatcher.instance.onError = (error, stack) {
     logger.e('[App]: Uncaught Error', error: error, stackTrace: stack);

--- a/lib/page/_shared/providers/usp_device_analytics_notifier.dart
+++ b/lib/page/_shared/providers/usp_device_analytics_notifier.dart
@@ -51,7 +51,8 @@ class UspDeviceAnalyticsNotifier extends Notifier<DeviceAnalyticsState> {
         );
       }
     } catch (e) {
-      logger.w('[USP][Monitor][Analytics]: Failed to load persisted history: $e');
+      logger
+          .w('[USP][Monitor][Analytics]: Failed to load persisted history: $e');
     }
   }
 

--- a/lib/page/_shared/providers/usp_device_analytics_notifier.dart
+++ b/lib/page/_shared/providers/usp_device_analytics_notifier.dart
@@ -51,7 +51,7 @@ class UspDeviceAnalyticsNotifier extends Notifier<DeviceAnalyticsState> {
         );
       }
     } catch (e) {
-      logger.w('[USP][Monitor][Analytics]Failed to load persisted history: $e');
+      logger.w('[USP][Monitor][Analytics]: Failed to load persisted history: $e');
     }
   }
 
@@ -166,7 +166,7 @@ class UspDeviceAnalyticsNotifier extends Notifier<DeviceAnalyticsState> {
     try {
       await saveDeviceAnalytics(state);
     } catch (e) {
-      logger.w('[USP][Monitor][Analytics]Failed to persist: $e');
+      logger.w('[USP][Monitor][Analytics]: Failed to persist: $e');
     }
   }
 }

--- a/lib/page/_shared/providers/usp_system_monitor_notifier.dart
+++ b/lib/page/_shared/providers/usp_system_monitor_notifier.dart
@@ -72,7 +72,7 @@ class UspSystemMonitorNotifier extends Notifier<SystemMonitorState> {
         isFetching: false,
       );
     } catch (e) {
-      logger.w('[USP][Monitor][System]Fetch failed: $e');
+      logger.w('[USP][Monitor][System]: Fetch failed: $e');
       state = state.copyWith(isFetching: false);
     }
   }

--- a/lib/page/_shared/providers/usp_traffic_analysis_notifier.dart
+++ b/lib/page/_shared/providers/usp_traffic_analysis_notifier.dart
@@ -99,7 +99,7 @@ class UspTrafficAnalysisNotifier extends Notifier<TrafficAnalysisState> {
         lastTimestamp: () => now,
       );
     } catch (e) {
-      logger.w('[USP][Monitor][Traffic]Fetch failed: $e');
+      logger.w('[USP][Monitor][Traffic]: Fetch failed: $e');
       state = state.copyWith(isFetching: false);
     }
   }

--- a/lib/page/_shared/services/usp_pdf_service.dart
+++ b/lib/page/_shared/services/usp_pdf_service.dart
@@ -84,7 +84,7 @@ class UspPdfService {
         onLayout: (PdfPageFormat format) => doc.save(),
       );
     } catch (e) {
-      logger.e('[USP][Dashboard][PDF]Print error', error: e);
+      logger.e('[USP][Dashboard][PDF]: Print error', error: e);
     }
   }
 

--- a/lib/page/admin/providers/system_info_data_provider.dart
+++ b/lib/page/admin/providers/system_info_data_provider.dart
@@ -37,7 +37,7 @@ class SystemInfoDataNotifier extends AsyncNotifier<SystemInfoData> {
     final svc = ref.read(uspSystemInfoDataServiceProvider);
     final model = await svc.fetch();
 
-    logger.d('[USP][SystemInfoData] Fetched — '
+    logger.d('[USP][SystemInfoData]: Fetched — '
         'model=${model.modelName}, '
         'fw=${model.softwareVersion}');
 

--- a/lib/page/admin/providers/time_data_provider.dart
+++ b/lib/page/admin/providers/time_data_provider.dart
@@ -40,7 +40,7 @@ class TimeDataNotifier extends AsyncNotifier<TimeData> {
     final svc = ref.read(uspTimeDataServiceProvider);
     final model = await svc.fetch();
 
-    logger.d('[USP][TimeData] Fetched — '
+    logger.d('[USP][TimeData]: Fetched — '
         'enable: ${model.enable}, status: ${model.status}');
 
     return TimeData(model: model);

--- a/lib/page/admin/providers/usp_admin_notifier.dart
+++ b/lib/page/admin/providers/usp_admin_notifier.dart
@@ -26,7 +26,7 @@ class UspAdminNotifier extends AutoDisposeAsyncNotifier<UspAdminState> {
         timeFetchedAt: timeData.fetchedAt,
       );
     } on ServiceError catch (e) {
-      logger.e('[USP][Admin] Fetch failed', error: e);
+      logger.e('[USP][Admin]: Fetch failed', error: e);
       rethrow;
     }
   }
@@ -44,7 +44,7 @@ class UspAdminNotifier extends AutoDisposeAsyncNotifier<UspAdminState> {
         );
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][Admin] Password update failed', error: e);
+      logger.e('[USP][Admin]: Password update failed', error: e);
       rethrow;
     }
   }
@@ -69,7 +69,7 @@ class UspAdminNotifier extends AutoDisposeAsyncNotifier<UspAdminState> {
         );
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][Admin] Time settings update failed', error: e);
+      logger.e('[USP][Admin]: Time settings update failed', error: e);
       rethrow;
     }
     ref.invalidate(timeDataProvider);
@@ -88,7 +88,7 @@ class UspAdminNotifier extends AutoDisposeAsyncNotifier<UspAdminState> {
         );
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][Admin] Timezone update failed', error: e);
+      logger.e('[USP][Admin]: Timezone update failed', error: e);
       rethrow;
     }
     ref.invalidate(timeDataProvider);
@@ -104,7 +104,7 @@ class UspAdminNotifier extends AutoDisposeAsyncNotifier<UspAdminState> {
         await _svc.reboot();
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][Admin] Reboot failed', error: e);
+      logger.e('[USP][Admin]: Reboot failed', error: e);
       rethrow;
     }
   }
@@ -115,7 +115,7 @@ class UspAdminNotifier extends AutoDisposeAsyncNotifier<UspAdminState> {
         await _svc.factoryReset();
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][Admin] Factory reset failed', error: e);
+      logger.e('[USP][Admin]: Factory reset failed', error: e);
       rethrow;
     }
   }

--- a/lib/page/admin/services/usp_system_info_data_service.dart
+++ b/lib/page/admin/services/usp_system_info_data_service.dart
@@ -80,7 +80,7 @@ class UspSystemInfoDataService {
       return await FirmwareImages.fetch(_usp)
           .timeout(const Duration(seconds: 20));
     } catch (e) {
-      logger.w('[USP][SystemInfoData] Firmware images fetch failed: $e');
+      logger.w('[USP][SystemInfoData]: Firmware images fetch failed: $e');
       return FirmwareImages(items: []);
     }
   }

--- a/lib/page/apps/providers/apps_capability_provider.dart
+++ b/lib/page/apps/providers/apps_capability_provider.dart
@@ -13,10 +13,10 @@ final appsCapabilityProvider = FutureProvider<bool>((ref) async {
   try {
     final svc = ref.read(uspAppsServiceProvider);
     await svc.fetchApps().timeout(const Duration(seconds: 5));
-    logger.d('[Apps] capability check: supported');
+    logger.d('[Apps]: capability check: supported');
     return true;
   } catch (e) {
-    logger.d('[Apps] capability check failed: $e');
+    logger.d('[Apps]: capability check failed: $e');
     return false;
   }
 });

--- a/lib/page/apps/providers/usp_apps_notifier.dart
+++ b/lib/page/apps/providers/usp_apps_notifier.dart
@@ -47,7 +47,7 @@ class UspAppsNotifier extends AutoDisposeAsyncNotifier<UspAppsState> {
       _pollForChanges();
     });
 
-    logger.d('[USP][Apps] Loaded ${apps.length} apps, '
+    logger.d('[USP][Apps]: Loaded ${apps.length} apps, '
         'known=${_knownAppNames.length}, recent=${_recentNames.length}');
 
     return UspAppsState(
@@ -70,7 +70,7 @@ class UspAppsNotifier extends AutoDisposeAsyncNotifier<UspAppsState> {
 
       if (added.isEmpty && removed.isEmpty) return;
 
-      logger.d('[USP][Apps] Change detected — '
+      logger.d('[USP][Apps]: Change detected — '
           'added=$added, removed=$removed');
 
       // Mark added apps as "NEW"
@@ -101,7 +101,7 @@ class UspAppsNotifier extends AutoDisposeAsyncNotifier<UspAppsState> {
       ));
     } catch (e) {
       // Polling failure is non-fatal — just log and continue
-      logger.w('[USP][Apps] Poll error: $e');
+      logger.w('[USP][Apps]: Poll error: $e');
     }
   }
 }

--- a/lib/page/apps/services/usp_apps_service.dart
+++ b/lib/page/apps/services/usp_apps_service.dart
@@ -74,7 +74,7 @@ class UspAppsService {
   AppInfoUIModel _toModel(Map<String, dynamic> json, AppCategory category) {
     final rawLink = json['link'] as String? ?? '';
     final normalized = _normalizeLink(rawLink);
-    logger.d('[USP][Apps] _toModel: name=${json['name']}, '
+    logger.d('[USP][Apps]: _toModel: name=${json['name']}, '
         'rawLink="$rawLink", normalized="$normalized", baseUrl=$_baseUrl');
     return AppInfoUIModel(
       name: json['name'] as String? ?? 'Unknown',
@@ -142,12 +142,12 @@ class UspAppsService {
       final uri = Uri.parse(withScheme);
       final path = uri.path.isEmpty ? '/' : uri.path;
       final result = '$_baseUrl$path';
-      logger.d('[USP][Apps] _normalizeLink: '
+      logger.d('[USP][Apps]: _normalizeLink: '
           'raw="$link" → withScheme="$withScheme" → '
           'uri.host="${uri.host}", uri.path="${uri.path}" → result="$result"');
       return result;
     } catch (e) {
-      logger.w('[USP][Apps] _normalizeLink parse error: $e, link="$link"');
+      logger.w('[USP][Apps]: _normalizeLink parse error: $e, link="$link"');
       return '$_baseUrl/$link';
     }
   }

--- a/lib/page/dashboard/orchestrator/dashboard_orchestrator.dart
+++ b/lib/page/dashboard/orchestrator/dashboard_orchestrator.dart
@@ -93,7 +93,7 @@ class DashboardOrchestrator extends AsyncNotifier<DashboardOrchestratorState> {
     try {
       return await _buildImpl();
     } catch (e, st) {
-      logger.e('[USP][Orchestrator] build() failed: $e\n$st');
+      logger.e('[USP][Orchestrator]: build() failed: $e\n$st');
       rethrow;
     }
   }
@@ -126,7 +126,7 @@ class DashboardOrchestrator extends AsyncNotifier<DashboardOrchestratorState> {
 
     // Trigger all domain providers (fire-and-forget — each card shows its
     // own skeleton until its provider resolves).
-    logger.d('[USP][Orchestrator] Triggering domain providers');
+    logger.d('[USP][Orchestrator]: Triggering domain providers');
     ref.read(systemInfoDataProvider);
     ref.read(devicesDataProvider);
     ref.read(ethernetDataProvider);
@@ -155,7 +155,7 @@ class DashboardOrchestrator extends AsyncNotifier<DashboardOrchestratorState> {
               ),
             );
       }).catchError((e) {
-        logger.w('[USP][Orchestrator] System monitor snapshot failed: $e');
+        logger.w('[USP][Orchestrator]: System monitor snapshot failed: $e');
       }),
     );
 
@@ -192,7 +192,7 @@ class DashboardOrchestrator extends AsyncNotifier<DashboardOrchestratorState> {
     manager.setCoreSubscriptions(coreSubscriptions);
     await manager.registerDeferredSubscriptions(force: true);
     logger.d(
-        '[USP][Orchestrator]SSE subscriptions registered after domain ready');
+        '[USP][Orchestrator]: SSE subscriptions registered after domain ready');
   }
 
   /// Checks domain providers after a delay and invalidates any that are in
@@ -222,7 +222,7 @@ class DashboardOrchestrator extends AsyncNotifier<DashboardOrchestratorState> {
         }
       }
       if (failed.isNotEmpty) {
-        logger.d('[USP][Orchestrator] Retrying failed providers (attempt '
+        logger.d('[USP][Orchestrator]: Retrying failed providers (attempt '
             '${attempt + 1}/$maxRetryAttempts): ${failed.join(', ')}');
       }
       // Always schedule next retry — providers may still be loading at this

--- a/lib/page/dashboard/providers/package_widget_loader.dart
+++ b/lib/page/dashboard/providers/package_widget_loader.dart
@@ -39,7 +39,7 @@ class PackageWidgetLoader
     // the session — this await is essentially free on subsequent reads.
     final supported = await ref.watch(appsCapabilityProvider.future);
     if (!supported) {
-      logger.d('[USP][PkgWidgets] Router does not support apps — skipping');
+      logger.d('[USP][PkgWidgets]: Router does not support apps — skipping');
       return const {};
     }
 
@@ -74,12 +74,12 @@ class PackageWidgetLoader
         }
       }
     } catch (e) {
-      logger.w('[USP][PkgWidgets] Failed to load templates: $e');
+      logger.w('[USP][PkgWidgets]: Failed to load templates: $e');
       _lastFetchSuccess = false;
       return {};
     }
 
-    logger.d('[USP][PkgWidgets] Loaded ${templates.length} templates');
+    logger.d('[USP][PkgWidgets]: Loaded ${templates.length} templates');
     return templates;
   }
 
@@ -91,7 +91,7 @@ class PackageWidgetLoader
     try {
       final response = await http.get(Uri.parse('$baseUrl/api/apps.json'));
       if (response.statusCode != 200) {
-        logger.w('[USP][PkgWidgets] apps.json HTTP ${response.statusCode}');
+        logger.w('[USP][PkgWidgets]: apps.json HTTP ${response.statusCode}');
         _lastFetchSuccess = false;
         return null;
       }
@@ -115,7 +115,7 @@ class PackageWidgetLoader
       _lastFetchSuccess = true;
       return entries;
     } catch (e) {
-      logger.w('[USP][PkgWidgets] Failed to fetch apps.json: $e');
+      logger.w('[USP][PkgWidgets]: Failed to fetch apps.json: $e');
       _lastFetchSuccess = false;
       return null;
     }
@@ -129,18 +129,18 @@ class PackageWidgetLoader
           templateUrl.startsWith('http') ? templateUrl : '$baseUrl$templateUrl';
       final response = await http.get(Uri.parse(fullUrl));
       if (response.statusCode != 200) {
-        logger.w('[USP][PkgWidgets] Template HTTP '
+        logger.w('[USP][PkgWidgets]: Template HTTP '
             '${response.statusCode} for $templateUrl');
         return null;
       }
 
       final json = jsonDecode(response.body) as Map<String, dynamic>;
       final template = PackageWidgetTemplate.fromJson(json);
-      logger.d('[USP][PkgWidgets] Loaded: ${template.widgetId} '
+      logger.d('[USP][PkgWidgets]: Loaded: ${template.widgetId} '
           '(${template.displayName})');
       return template;
     } catch (e) {
-      logger.w('[USP][PkgWidgets] Failed to load template $templateUrl: $e');
+      logger.w('[USP][PkgWidgets]: Failed to load template $templateUrl: $e');
       return null;
     }
   }
@@ -164,7 +164,7 @@ class PackageWidgetLoader
 
       // Skip diff when fetch failed — cannot tell removed from unavailable.
       if (freshEntries == null || !_lastFetchSuccess) {
-        logger.d('[USP][PkgWidgets] Poll skipped (fetch failed)');
+        logger.d('[USP][PkgWidgets]: Poll skipped (fetch failed)');
         return;
       }
 
@@ -179,7 +179,7 @@ class PackageWidgetLoader
 
       // Fetch templates only for newly added widgets
       if (added.isNotEmpty) {
-        logger.d('[USP][PkgWidgets] New widgets detected: $added');
+        logger.d('[USP][PkgWidgets]: New widgets detected: $added');
         final baseUrl = Uri.base.origin;
         for (final id in added) {
           final templateUrl = freshEntries[id];
@@ -193,7 +193,7 @@ class PackageWidgetLoader
 
       // Clean up removed widgets from dashboard
       if (removed.isNotEmpty) {
-        logger.d('[USP][PkgWidgets] Removed widgets: $removed');
+        logger.d('[USP][PkgWidgets]: Removed widgets: $removed');
         for (final id in removed) {
           current.remove(id);
           ref
@@ -205,7 +205,7 @@ class PackageWidgetLoader
 
       state = AsyncData(current);
     } catch (e) {
-      logger.w('[USP][PkgWidgets] Poll error: $e');
+      logger.w('[USP][PkgWidgets]: Poll error: $e');
     }
   }
 

--- a/lib/page/dashboard/widgets/package_widget_renderer.dart
+++ b/lib/page/dashboard/widgets/package_widget_renderer.dart
@@ -86,7 +86,7 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
           .read(packageWidgetDataProvider(widget.template.widgetId).notifier)
           .setAll(data);
     } catch (e) {
-      logger.w('[USP][PkgWidget] Initial GET failed for '
+      logger.w('[USP][PkgWidget]: Initial GET failed for '
           '${widget.template.widgetId}: $e');
     }
 
@@ -110,7 +110,7 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
         onNotification: _handleNotification,
       );
     } catch (e) {
-      logger.w('[USP][PkgWidget] SSE subscribe failed for '
+      logger.w('[USP][PkgWidget]: SSE subscribe failed for '
           '${widget.template.widgetId}: $e');
     }
   }
@@ -145,7 +145,7 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
       // Security: only allow local CGI paths
       final uri = Uri.parse(ds.url);
       if (uri.hasAuthority || !ds.url.startsWith('/cgi-bin/')) {
-        logger.w('[HTTP][PkgWidget] Blocked non-local URL: ${ds.url}');
+        logger.w('[HTTP][PkgWidget]: Blocked non-local URL: ${ds.url}');
         return;
       }
 
@@ -183,10 +183,10 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
             .read(packageWidgetDataProvider(widget.template.widgetId).notifier)
             .setAll(mapped);
       } else {
-        logger.w('[HTTP][PkgWidget] ${ds.url} returned ${response.statusCode}');
+        logger.w('[HTTP][PkgWidget]: ${ds.url} returned ${response.statusCode}');
       }
     } catch (e) {
-      logger.w('[HTTP][PkgWidget] Fetch error for '
+      logger.w('[HTTP][PkgWidget]: Fetch error for '
           '${widget.template.widgetId}: $e');
     }
   }
@@ -201,7 +201,7 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
         (actionData[r'$action'] ?? actionData['action']) as String?;
     if (actionType == null) return;
 
-    logger.d('[PkgWidget] ${widget.template.widgetId} action: $actionType');
+    logger.d('[PkgWidget]: ${widget.template.widgetId} action: $actionType');
 
     switch (actionType) {
       case 'refresh_data':
@@ -211,17 +211,17 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
       case 'cgi_call':
         _handleCgiCallAction(actionData);
       default:
-        logger.d('[PkgWidget] Unhandled action: $actionData');
+        logger.d('[PkgWidget]: Unhandled action: $actionData');
     }
   }
 
   Future<void> _handleNavigationAction(String? destination) async {
     if (destination == null || destination.isEmpty) return;
     if (!mounted) return;
-    logger.d('[PkgWidget] Open app page: $destination');
+    logger.d('[PkgWidget]: Open app page: $destination');
     try {
       final url = Uri.parse('${Uri.base.origin}/$destination/');
-      logger.d('[PkgWidget] Full URL: $url');
+      logger.d('[PkgWidget]: Full URL: $url');
 
       final canLaunch = await canLaunchUrl(url);
       if (canLaunch) {
@@ -230,13 +230,13 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
           showSuccessSnackBar(context, 'Opened app page');
         }
       } else {
-        logger.w('[PkgWidget] Cannot launch URL: $url');
+        logger.w('[PkgWidget]: Cannot launch URL: $url');
         if (mounted) {
           showFailedSnackBar(context, 'Cannot open page');
         }
       }
     } catch (e) {
-      logger.w('[PkgWidget] Open page failed: $e');
+      logger.w('[PkgWidget]: Open page failed: $e');
       if (mounted) {
         showFailedSnackBar(context, 'Failed to open page');
       }
@@ -262,7 +262,7 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
     // Security: same whitelist as _fetchHttpData
     final uri = Uri.parse(url);
     if (uri.hasAuthority || !url.startsWith('/cgi-bin/')) {
-      logger.w('[CGI][PkgWidget] Blocked non-local URL: $url');
+      logger.w('[CGI][PkgWidget]: Blocked non-local URL: $url');
       return;
     }
 
@@ -299,11 +299,11 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
         showSuccessSnackBar(context, 'Action completed');
         _handleRefreshDataAction();
       } else {
-        logger.w('[CGI][PkgWidget] $url returned ${response.statusCode}');
+        logger.w('[CGI][PkgWidget]: $url returned ${response.statusCode}');
         showFailedSnackBar(context, 'Action failed (${response.statusCode})');
       }
     } catch (e) {
-      logger.w('[CGI][PkgWidget] Call error for '
+      logger.w('[CGI][PkgWidget]: Call error for '
           '${widget.template.widgetId}: $e');
       if (mounted) {
         showFailedSnackBar(context, 'Action failed');
@@ -321,7 +321,7 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
 
     try {
       logger
-          .d('[PkgWidget] Refreshing USP data for ${widget.template.widgetId}');
+          .d('[PkgWidget]: Refreshing USP data for ${widget.template.widgetId}');
       final data = await usp.get(subscription.paths);
       if (!mounted) return;
       ref
@@ -329,7 +329,7 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
           .setAll(data);
     } catch (e) {
       logger.w(
-          '[PkgWidget] USP refresh failed for ${widget.template.widgetId}: $e');
+          '[PkgWidget]: USP refresh failed for ${widget.template.widgetId}: $e');
     }
   }
 
@@ -381,7 +381,7 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
             : renderedWidget;
       }
     } catch (e) {
-      logger.w('[USP][PkgWidget] Render error '
+      logger.w('[USP][PkgWidget]: Render error '
           '${widget.template.widgetId}: $e');
       return AppCard(
         child: Center(
@@ -436,7 +436,7 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
             : renderedWidget;
       }
     } catch (e) {
-      logger.w('[USP][PkgWidget] Render error '
+      logger.w('[USP][PkgWidget]: Render error '
           '${widget.template.widgetId}: $e');
       return Center(
         child: AppText.bodySmall(

--- a/lib/page/dashboard/widgets/package_widget_renderer.dart
+++ b/lib/page/dashboard/widgets/package_widget_renderer.dart
@@ -183,7 +183,8 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
             .read(packageWidgetDataProvider(widget.template.widgetId).notifier)
             .setAll(mapped);
       } else {
-        logger.w('[HTTP][PkgWidget]: ${ds.url} returned ${response.statusCode}');
+        logger
+            .w('[HTTP][PkgWidget]: ${ds.url} returned ${response.statusCode}');
       }
     } catch (e) {
       logger.w('[HTTP][PkgWidget]: Fetch error for '
@@ -320,8 +321,8 @@ class _PackageWidgetRendererState extends ConsumerState<PackageWidgetRenderer> {
     if (usp == null) return;
 
     try {
-      logger
-          .d('[PkgWidget]: Refreshing USP data for ${widget.template.widgetId}');
+      logger.d(
+          '[PkgWidget]: Refreshing USP data for ${widget.template.widgetId}');
       final data = await usp.get(subscription.paths);
       if (!mounted) return;
       ref

--- a/lib/page/devices/providers/devices_data_provider.dart
+++ b/lib/page/devices/providers/devices_data_provider.dart
@@ -133,7 +133,7 @@ class DevicesDataNotifier extends AsyncNotifier<DevicesData> {
           .timeout(const Duration(seconds: 5));
     } catch (e) {
       logger.w(
-          '[USP][DevicesData] WiFi data unavailable, proceeding without: $e');
+          '[USP][DevicesData]: WiFi data unavailable, proceeding without: $e');
       wifiData = const WifiData.empty();
     }
 
@@ -148,7 +148,7 @@ class DevicesDataNotifier extends AsyncNotifier<DevicesData> {
       systemInfo: sysData?.model,
     );
 
-    logger.d('[USP][DevicesData] Fetched — '
+    logger.d('[USP][DevicesData]: Fetched — '
         'deviceModels: ${result.deviceModels.length}, '
         'nodeModels: ${result.nodeModels.length}');
 
@@ -187,7 +187,7 @@ class DevicesDataNotifier extends AsyncNotifier<DevicesData> {
       systemInfo: sysData?.model,
     );
 
-    logger.d('[USP][DevicesData] Mesh update — '
+    logger.d('[USP][DevicesData]: Mesh update — '
         'meshNodes: ${meshTopology.nodes.length}, '
         'nodeModels: ${rebuilt.nodeModels.length}');
 

--- a/lib/page/devices/services/usp_devices_data_service.dart
+++ b/lib/page/devices/services/usp_devices_data_service.dart
@@ -145,8 +145,8 @@ class UspDevicesDataService {
       }
       return _buildTopologyInfo(network);
     } catch (e) {
-      logger
-          .d('[USP][Dashboard]: DataElements not supported or fetch failed: $e');
+      logger.d(
+          '[USP][Dashboard]: DataElements not supported or fetch failed: $e');
       return MeshTopologyInfo.empty;
     }
   }

--- a/lib/page/devices/services/usp_devices_data_service.dart
+++ b/lib/page/devices/services/usp_devices_data_service.dart
@@ -140,13 +140,13 @@ class UspDevicesDataService {
       final network = await DataElementsNetwork.fetch(_usp);
       if (network.items.isEmpty) {
         logger.d(
-            '[USP][Dashboard]DataElements empty — not a mesh or unsupported');
+            '[USP][Dashboard]: DataElements empty — not a mesh or unsupported');
         return MeshTopologyInfo.empty;
       }
       return _buildTopologyInfo(network);
     } catch (e) {
       logger
-          .d('[USP][Dashboard]DataElements not supported or fetch failed: $e');
+          .d('[USP][Dashboard]: DataElements not supported or fetch failed: $e');
       return MeshTopologyInfo.empty;
     }
   }
@@ -180,7 +180,7 @@ class UspDevicesDataService {
       ));
     }
 
-    logger.d('[USP][Dashboard]Mesh nodes: ${nodes.length}, '
+    logger.d('[USP][Dashboard]: Mesh nodes: ${nodes.length}, '
         'client→node mappings: ${clientToNodeMap.length}');
     return MeshTopologyInfo(nodes: nodes, clientToNodeMap: clientToNodeMap);
   }

--- a/lib/page/dhcp/providers/usp_dhcp_reservations_notifier.dart
+++ b/lib/page/dhcp/providers/usp_dhcp_reservations_notifier.dart
@@ -64,7 +64,7 @@ class UspDhcpReservationsNotifier
     try {
       final reservations = await _svc.fetchReservations();
 
-      logger.d('[USP][DHCP][Reservations] Fetched — '
+      logger.d('[USP][DHCP][Reservations]: Fetched — '
           'total: ${reservations.length}');
 
       return (
@@ -72,7 +72,7 @@ class UspDhcpReservationsNotifier
         const DhcpReservationsStatus(),
       );
     } on ServiceError catch (e) {
-      logger.e('[USP][DHCP][Reservations] Fetch failed', error: e);
+      logger.e('[USP][DHCP][Reservations]: Fetch failed', error: e);
       return (
         null,
         DhcpReservationsStatus(errorMessage: '$e'),
@@ -100,7 +100,7 @@ class UspDhcpReservationsNotifier
           current: current,
         );
 
-        logger.d('[USP][DHCP][Reservations] Batch save — '
+        logger.d('[USP][DHCP][Reservations]: Batch save — '
             'added: ${result.added}, updated: ${result.updated}, '
             'deleted: ${result.deleted}');
       });
@@ -108,7 +108,7 @@ class UspDhcpReservationsNotifier
       // Invalidate Layer 1 provider to refresh dashboard card
       ref.invalidate(dhcpDataProvider);
     } on ServiceError catch (e) {
-      logger.e('[USP][DHCP][Reservations] Save failed', error: e);
+      logger.e('[USP][DHCP][Reservations]: Save failed', error: e);
       rethrow;
     } finally {
       state = state.copyWith(
@@ -128,7 +128,7 @@ class UspDhcpReservationsNotifier
         await _svc.immediateToggle(instancePath, enable);
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][DHCP] Immediate toggle failed', error: e);
+      logger.e('[USP][DHCP]: Immediate toggle failed', error: e);
       rethrow;
     }
     ref.invalidate(dhcpDataProvider);
@@ -145,7 +145,7 @@ class UspDhcpReservationsNotifier
         await _svc.immediateAdd(mac: mac, ip: ip, enable: enable);
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][DHCP] Immediate add failed', error: e);
+      logger.e('[USP][DHCP]: Immediate add failed', error: e);
       rethrow;
     }
     ref.invalidate(dhcpDataProvider);
@@ -158,7 +158,7 @@ class UspDhcpReservationsNotifier
         await _svc.immediateDelete(instancePath);
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][DHCP] Immediate delete failed', error: e);
+      logger.e('[USP][DHCP]: Immediate delete failed', error: e);
       rethrow;
     }
     ref.invalidate(dhcpDataProvider);

--- a/lib/page/dhcp/services/usp_dhcp_service.dart
+++ b/lib/page/dhcp/services/usp_dhcp_service.dart
@@ -173,7 +173,7 @@ class UspDhcpService {
             break;
           case UspPartialSuccess(:final successes, :final failures):
             logger.w(
-                '[DHCP] Batch delete partial: ${successes.length} ok, ${failures.length} failed');
+                '[DHCP]: Batch delete partial: ${successes.length} ok, ${failures.length} failed');
             break;
           case UspFailure(:final errorSummary, :final errors):
             throw UspCompleteFailureError(
@@ -198,7 +198,7 @@ class UspDhcpService {
             break;
           case UspPartialSuccess(:final successes, :final failures):
             logger.w(
-                '[DHCP] Batch add partial: ${successes.length} ok, ${failures.length} failed');
+                '[DHCP]: Batch add partial: ${successes.length} ok, ${failures.length} failed');
             break;
           case UspFailure(:final errorSummary, :final errors):
             throw UspCompleteFailureError(
@@ -237,7 +237,7 @@ class UspDhcpService {
             break;
           case UspPartialSuccess(:final successes, :final failures):
             logger.w(
-                '[DHCP] Batch update partial: ${successes.length} ok, ${failures.length} failed');
+                '[DHCP]: Batch update partial: ${successes.length} ok, ${failures.length} failed');
             break;
           case UspFailure(:final errorSummary, :final errors):
             throw UspCompleteFailureError(

--- a/lib/page/dmz/providers/usp_dmz_notifier.dart
+++ b/lib/page/dmz/providers/usp_dmz_notifier.dart
@@ -64,13 +64,13 @@ class UspDmzNotifier extends AutoDisposeNotifier<DmzFeatureState>
     try {
       final (settings, status) = await _svc.fetch();
 
-      logger.d('[USP][Firewall][DMZ] Fetched — '
+      logger.d('[USP][Firewall][DMZ]: Fetched — '
           'enabled: ${settings.model.isEnabled}, '
           'instancePath: ${settings.instancePath}');
 
       return (settings, status);
     } on ServiceError catch (e) {
-      logger.e('[USP][Firewall][DMZ] Fetch failed', error: e);
+      logger.e('[USP][Firewall][DMZ]: Fetch failed', error: e);
       return (
         null,
         DmzStatus(isLoading: false, errorMessage: '$e'),
@@ -96,18 +96,18 @@ class UspDmzNotifier extends AutoDisposeNotifier<DmzFeatureState>
         if (settings.isNewEntry && pending.isEnabled) {
           await _svc.add(model: pending);
           logger.d(
-              '[USP][Firewall][DMZ] Entry added — destIp: ${pending.destIp}');
+              '[USP][Firewall][DMZ]: Entry added — destIp: ${pending.destIp}');
         } else if (!settings.isNewEntry) {
           await _svc.update(
             instancePath: settings.instancePath!,
             model: pending,
           );
-          logger.d('[USP][Firewall][DMZ] Entry updated — '
+          logger.d('[USP][Firewall][DMZ]: Entry updated — '
               'enabled: ${pending.isEnabled}, destIp: ${pending.destIp}');
         }
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][Firewall][DMZ] Save failed', error: e);
+      logger.e('[USP][Firewall][DMZ]: Save failed', error: e);
       rethrow;
     } finally {
       state = state.copyWith(

--- a/lib/page/firewall/providers/firewall_data_provider.dart
+++ b/lib/page/firewall/providers/firewall_data_provider.dart
@@ -110,7 +110,7 @@ class FirewallDataNotifier extends AsyncNotifier<FirewallData> {
     final svc = ref.read(uspFirewallDataServiceProvider);
     final result = await svc.fetch();
 
-    logger.d('[USP][FirewallData] Fetched — '
+    logger.d('[USP][FirewallData]: Fetched — '
         'rules: ${result.ruleSummaries.length}, '
         'dmz: ${result.dmzSummaries.length}');
 

--- a/lib/page/firewall/providers/usp_firewall_notifier.dart
+++ b/lib/page/firewall/providers/usp_firewall_notifier.dart
@@ -66,7 +66,7 @@ class UspFirewallNotifier extends AutoDisposeNotifier<FirewallFeatureState>
       final uiModel = data.firewallModel;
       final ruleContext = data.ruleContext;
 
-      logger.d('[USP][Firewall] Fetched — '
+      logger.d('[USP][Firewall]: Fetched — '
           'spiV4: ${uiModel.isIPv4FirewallEnabled}, '
           'spiV6: ${uiModel.isIPv6FirewallEnabled}');
 
@@ -75,7 +75,7 @@ class UspFirewallNotifier extends AutoDisposeNotifier<FirewallFeatureState>
         const FirewallStatus(isLoading: false),
       );
     } on ServiceError catch (e) {
-      logger.e('[USP][Firewall] Fetch failed', error: e);
+      logger.e('[USP][Firewall]: Fetch failed', error: e);
       return (
         null,
         FirewallStatus(isLoading: false, errorMessage: '$e'),
@@ -103,13 +103,13 @@ class UspFirewallNotifier extends AutoDisposeNotifier<FirewallFeatureState>
           context: settings.ruleContext,
         );
 
-        logger.d('[USP][Firewall] Saved — $count rules updated');
+        logger.d('[USP][Firewall]: Saved — $count rules updated');
       });
 
       // Force data provider to re-fetch so dashboard card updates too.
       ref.invalidate(firewallDataProvider);
     } on ServiceError catch (e) {
-      logger.e('[USP][Firewall] Save failed', error: e);
+      logger.e('[USP][Firewall]: Save failed', error: e);
       rethrow;
     } finally {
       state = state.copyWith(

--- a/lib/page/instant_privacy/providers/instant_privacy_notifier.dart
+++ b/lib/page/instant_privacy/providers/instant_privacy_notifier.dart
@@ -19,7 +19,7 @@ class UspInstantPrivacyNotifier extends AsyncNotifier<UspInstantPrivacyState> {
     try {
       final result = await _svc.fetchAll();
 
-      logger.d('[USP][Privacy] Fetched — '
+      logger.d('[USP][Privacy]: Fetched — '
           'activeDevices: ${result.connectedDevices.length}, '
           'isEnabled: ${result.isEnabled}');
 
@@ -30,7 +30,7 @@ class UspInstantPrivacyNotifier extends AsyncNotifier<UspInstantPrivacyState> {
         macFilterContext: result.macFilterContext,
       );
     } on ServiceError catch (e) {
-      logger.e('[USP][Privacy] Fetch failed', error: e);
+      logger.e('[USP][Privacy]: Fetch failed', error: e);
       rethrow;
     }
   }
@@ -47,10 +47,10 @@ class UspInstantPrivacyNotifier extends AsyncNotifier<UspInstantPrivacyState> {
       await ref.read(uspMutationLockProvider).withLock(() async {
         await _svc.enable(macs, s.macFilterContext);
       });
-      logger.d('[USP][Privacy] Enabled — ${macs.length} MACs');
+      logger.d('[USP][Privacy]: Enabled — ${macs.length} MACs');
       ref.invalidateSelf();
     } on ServiceError catch (e) {
-      logger.e('[USP][Privacy] Enable failed', error: e);
+      logger.e('[USP][Privacy]: Enable failed', error: e);
       state = AsyncData(s.copyWith(isToggleLocked: false));
       rethrow;
     }
@@ -66,10 +66,10 @@ class UspInstantPrivacyNotifier extends AsyncNotifier<UspInstantPrivacyState> {
       await ref.read(uspMutationLockProvider).withLock(() async {
         await _svc.disable(s.macFilterContext);
       });
-      logger.d('[USP][Privacy] Disabled');
+      logger.d('[USP][Privacy]: Disabled');
       ref.invalidateSelf();
     } on ServiceError catch (e) {
-      logger.e('[USP][Privacy] Disable failed', error: e);
+      logger.e('[USP][Privacy]: Disable failed', error: e);
       state = AsyncData(s.copyWith(isToggleLocked: false));
       rethrow;
     }
@@ -89,10 +89,10 @@ class UspInstantPrivacyNotifier extends AsyncNotifier<UspInstantPrivacyState> {
         state = AsyncData(s.copyWith(isToggleLocked: false));
         return;
       }
-      logger.d('[USP][Privacy] addMac — $mac');
+      logger.d('[USP][Privacy]: addMac — $mac');
       ref.invalidateSelf();
     } on ServiceError catch (e) {
-      logger.e('[USP][Privacy] addMac failed', error: e);
+      logger.e('[USP][Privacy]: addMac failed', error: e);
       state = AsyncData(s.copyWith(isToggleLocked: false));
       rethrow;
     }

--- a/lib/page/instant_safety/providers/instant_safety_provider.dart
+++ b/lib/page/instant_safety/providers/instant_safety_provider.dart
@@ -65,14 +65,14 @@ class UspInstantSafetyNotifier extends AsyncNotifier<UspInstantSafetyState> {
       final svc = ref.read(uspInstantSafetyServiceProvider);
       final uiModel = await svc.fetch();
 
-      logger.d('[USP][Safety]Instant Safety fetched — type: ${uiModel.type}');
+      logger.d('[USP][Safety]: Instant Safety fetched — type: ${uiModel.type}');
 
       return UspInstantSafetyState(
         uiModel: uiModel,
         pendingType: uiModel.type,
       );
     } on ServiceError catch (e) {
-      logger.e('[USP][Safety] Fetch failed', error: e);
+      logger.e('[USP][Safety]: Fetch failed', error: e);
       rethrow;
     }
   }
@@ -96,12 +96,12 @@ class UspInstantSafetyNotifier extends AsyncNotifier<UspInstantSafetyState> {
         final svc = ref.read(uspInstantSafetyServiceProvider);
         await svc.save(s.pendingType);
       });
-      logger.d('[USP][Safety]Instant Safety saved — type: ${s.pendingType}');
+      logger.d('[USP][Safety]: Instant Safety saved — type: ${s.pendingType}');
 
       // Re-fetch to confirm the change took effect.
       ref.invalidateSelf();
     } on ServiceError catch (e) {
-      logger.e('[USP][Safety] Save failed', error: e);
+      logger.e('[USP][Safety]: Save failed', error: e);
       state = AsyncData(s.copyWith(isSaving: false));
       rethrow;
     }

--- a/lib/page/internet_settings/providers/usp_internet_settings_notifier.dart
+++ b/lib/page/internet_settings/providers/usp_internet_settings_notifier.dart
@@ -97,7 +97,7 @@ class UspInternetSettingsNotifier
       final service = ref.read(uspInternetSettingsServiceProvider);
       final result = await service.fetchSettings();
 
-      logger.d('[USP][Network][WAN] Fetched — '
+      logger.d('[USP][Network][WAN]: Fetched — '
           'raw addressingType: "${result.debugAddressingType}", '
           'bridgeEnabled: ${result.debugBridgeEnabled}, '
           'detected type: ${result.form.connectionType.name}, '
@@ -110,7 +110,7 @@ class UspInternetSettingsNotifier
       _preservedConnectionType = null;
       var form = result.form;
       if (savedType != null && form.connectionType != savedType) {
-        logger.w('[USP][Network][WAN] Transient type mismatch — '
+        logger.w('[USP][Network][WAN]: Transient type mismatch — '
             'fetched: ${form.connectionType.name}, '
             'preserving: ${savedType.name}');
         form = form.copyWith(connectionType: savedType);
@@ -126,7 +126,7 @@ class UspInternetSettingsNotifier
         ),
       );
     } on ServiceError catch (e) {
-      logger.e('[USP][Network][WAN] Fetch failed', error: e);
+      logger.e('[USP][Network][WAN]: Fetch failed', error: e);
       return (
         null,
         InternetSettingsStatus(isLoading: false, errorMessage: '$e'),
@@ -161,7 +161,7 @@ class UspInternetSettingsNotifier
           pppInstancePath: state.status.pppInstancePath,
           vlanInstancePath: state.status.vlanInstancePath,
         );
-        logger.d('[USP][Network][WAN] Save complete');
+        logger.d('[USP][Network][WAN]: Save complete');
       });
 
       // After save, exit edit mode (status will be updated by re-fetch)
@@ -172,7 +172,7 @@ class UspInternetSettingsNotifier
         ),
       );
     } on ServiceError catch (e) {
-      logger.e('[USP][Network][WAN] Save failed', error: e);
+      logger.e('[USP][Network][WAN]: Save failed', error: e);
       rethrow;
     } finally {
       state = state.copyWith(
@@ -254,12 +254,12 @@ class UspInternetSettingsNotifier
       );
       try {
         final service = ref.read(uspInternetSettingsServiceProvider);
-        logger.d('[USP][Network][WAN] Renewing DHCPv4 lease...');
+        logger.d('[USP][Network][WAN]: Renewing DHCPv4 lease...');
         await service.renewDhcpLease();
         // Wait for lease renewal to take effect before refreshing WAN status
         await Future.delayed(const Duration(seconds: 2));
       } on ServiceError catch (e) {
-        logger.e('[USP][Network][WAN] DHCP renew failed', error: e);
+        logger.e('[USP][Network][WAN]: DHCP renew failed', error: e);
         rethrow;
       } finally {
         state = state.copyWith(
@@ -277,10 +277,10 @@ class UspInternetSettingsNotifier
       );
       try {
         final service = ref.read(uspInternetSettingsServiceProvider);
-        logger.d('[USP][Network][WAN] Renewing DHCPv6 lease...');
+        logger.d('[USP][Network][WAN]: Renewing DHCPv6 lease...');
         await service.renewDhcpv6Lease();
       } on ServiceError catch (e) {
-        logger.e('[USP][Network][WAN] DHCPv6 renew failed', error: e);
+        logger.e('[USP][Network][WAN]: DHCPv6 renew failed', error: e);
         rethrow;
       } finally {
         state = state.copyWith(

--- a/lib/page/internet_settings/providers/wan_data_provider.dart
+++ b/lib/page/internet_settings/providers/wan_data_provider.dart
@@ -35,7 +35,7 @@ class WanDataNotifier extends AsyncNotifier<WanData> {
     final svc = ref.read(uspWanDataServiceProvider);
     final model = await svc.fetch();
 
-    logger.d('[USP][WanData] Fetched — ip=${model.ipAddress}, '
+    logger.d('[USP][WanData]: Fetched — ip=${model.ipAddress}, '
         'isUp=${model.isUp}, gateway=${model.gateway}');
     return WanData(model: model);
   }

--- a/lib/page/internet_settings/services/usp_internet_settings_service.dart
+++ b/lib/page/internet_settings/services/usp_internet_settings_service.dart
@@ -196,7 +196,7 @@ class UspInternetSettingsService {
     final isPppoe = edited.connectionType == UspWanConnectionType.pppoe;
 
     if (isPppoe && currentInstancePath == null) {
-      logger.d('[USP][WAN] Adding PPP.Interface instance for PPPoE');
+      logger.d('[USP][WAN]: Adding PPP.Interface instance for PPPoE');
       final result = await PppInterface.add(_usp, [{}]);
       final parsedResult = UspResultParser.parseAddResult(result);
       if (parsedResult is UspSuccess<List<String>>) {
@@ -227,7 +227,7 @@ class UspInternetSettingsService {
 
     if (!wasEnabled && isEnabled && currentInstancePath == null) {
       // Enabling VLAN and no instance exists — Add
-      logger.d('[USP][WAN] Adding VLANTermination instance');
+      logger.d('[USP][WAN]: Adding VLANTermination instance');
       final result = await VlanTermination.add(_usp, [{}]);
       // Extract instance path from structured response
       final parsedResult = UspResultParser.parseAddResult(result);
@@ -241,7 +241,7 @@ class UspInternetSettingsService {
     } else if (wasEnabled && !isEnabled && currentInstancePath != null) {
       // Disabling VLAN — Delete
       logger.d(
-          '[USP][WAN] Deleting VLANTermination instance $currentInstancePath');
+          '[USP][WAN]: Deleting VLANTermination instance $currentInstancePath');
       final deleteResult =
           await VlanTermination.delete(_usp, [currentInstancePath]);
       _handleDeleteResult(deleteResult);

--- a/lib/page/internet_settings/services/usp_wan_data_service.dart
+++ b/lib/page/internet_settings/services/usp_wan_data_service.dart
@@ -98,7 +98,7 @@ class UspWanDataService {
 
       return (gateway: gateway, ipv6Addresses: ipv6Addresses);
     } catch (e) {
-      logger.w('[USP][WanData] Gateway/IPv6 fetch failed: $e');
+      logger.w('[USP][WanData]: Gateway/IPv6 fetch failed: $e');
       return (gateway: '', ipv6Addresses: const <String>[]);
     }
   }

--- a/lib/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier.dart
+++ b/lib/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier.dart
@@ -58,14 +58,14 @@ class UspIpv6PortServiceNotifier
     try {
       final rules = await _svc.fetch();
 
-      logger.d('[USP][Firewall][IPv6Port] Fetched — ipv6: ${rules.length}');
+      logger.d('[USP][Firewall][IPv6Port]: Fetched — ipv6: ${rules.length}');
 
       return (
         Ipv6PortServiceRuleList(rules: rules),
         const Ipv6PortServiceStatus(),
       );
     } on ServiceError catch (e) {
-      logger.e('[USP][Firewall][IPv6Port] Fetch failed', error: e);
+      logger.e('[USP][Firewall][IPv6Port]: Fetch failed', error: e);
       return (
         null,
         Ipv6PortServiceStatus(errorMessage: '$e'),
@@ -93,12 +93,12 @@ class UspIpv6PortServiceNotifier
           current: current,
         );
 
-        logger.d('[USP][Firewall][IPv6Port] Batch save — '
+        logger.d('[USP][Firewall][IPv6Port]: Batch save — '
             'added: ${result.added}, updated: ${result.updated}, '
             'deleted: ${result.deleted}');
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][Firewall][IPv6Port] Save failed', error: e);
+      logger.e('[USP][Firewall][IPv6Port]: Save failed', error: e);
       rethrow;
     } finally {
       state = state.copyWith(

--- a/lib/page/ipv6_port_service/services/usp_ipv6_port_service_service.dart
+++ b/lib/page/ipv6_port_service/services/usp_ipv6_port_service_service.dart
@@ -59,7 +59,7 @@ class UspIpv6PortServiceService {
             break;
           case UspPartialSuccess(:final successes, :final failures):
             logger.w(
-                '[IPv6PortService] Batch delete partial: ${successes.length} ok, ${failures.length} failed');
+                '[IPv6PortService]: Batch delete partial: ${successes.length} ok, ${failures.length} failed');
             break;
           case UspFailure(:final errorSummary, :final errors):
             throw UspCompleteFailureError(
@@ -93,7 +93,7 @@ class UspIpv6PortServiceService {
             break;
           case UspPartialSuccess(:final successes, :final failures):
             logger.w(
-                '[IPv6PortService] Batch add partial: ${successes.length} ok, ${failures.length} failed');
+                '[IPv6PortService]: Batch add partial: ${successes.length} ok, ${failures.length} failed');
             break;
           case UspFailure(:final errorSummary, :final errors):
             throw UspCompleteFailureError(
@@ -136,7 +136,7 @@ class UspIpv6PortServiceService {
             break;
           case UspPartialSuccess(:final successes, :final failures):
             logger.w(
-                '[IPv6PortService] Batch update partial: ${successes.length} ok, ${failures.length} failed');
+                '[IPv6PortService]: Batch update partial: ${successes.length} ok, ${failures.length} failed');
             break;
           case UspFailure(:final errorSummary, :final errors):
             throw UspCompleteFailureError(

--- a/lib/page/local_network/providers/dhcp_data_provider.dart
+++ b/lib/page/local_network/providers/dhcp_data_provider.dart
@@ -59,7 +59,7 @@ class DhcpDataNotifier extends AsyncNotifier<DhcpData> {
 
     final result = await svc.fetch(hostNameByMac: hostNameByMac);
 
-    logger.d('[USP][DhcpData] Fetched — '
+    logger.d('[USP][DhcpData]: Fetched — '
         'clients: ${result.clientModels.length}, '
         'reservations: ${result.reservationModels.length}');
 

--- a/lib/page/local_network/providers/ethernet_data_provider.dart
+++ b/lib/page/local_network/providers/ethernet_data_provider.dart
@@ -55,7 +55,7 @@ class EthernetDataNotifier extends AsyncNotifier<EthernetData> {
 
     final result = await svc.fetch(deviceModels: deviceModels);
 
-    logger.d('[USP][Ethernet]Fetch complete — '
+    logger.d('[USP][Ethernet]: Fetch complete — '
         '${result.portModels.length} port models');
 
     return EthernetData(ethernetPortModels: result.portModels);

--- a/lib/page/local_network/providers/lan_data_provider.dart
+++ b/lib/page/local_network/providers/lan_data_provider.dart
@@ -42,7 +42,7 @@ class LanDataNotifier extends AsyncNotifier<LanData> {
     final svc = ref.read(uspLanDataServiceProvider);
     final model = await svc.fetch();
 
-    logger.d('[USP][LanData] Fetched — ip=${model.ipAddress}, '
+    logger.d('[USP][LanData]: Fetched — ip=${model.ipAddress}, '
         'dhcp=${model.dhcpEnabled}, ipv6=${model.ipv6Enabled}');
     return LanData(model: model);
   }

--- a/lib/page/local_network/providers/usp_local_network_notifier.dart
+++ b/lib/page/local_network/providers/usp_local_network_notifier.dart
@@ -75,7 +75,7 @@ class UspLocalNetworkNotifier
         dnsServer3: dnsParts.length > 2 ? dnsParts[2] : '',
       );
 
-      logger.d('[USP][Network][LAN] Fetched — '
+      logger.d('[USP][Network][LAN]: Fetched — '
           'ip: ${uiModel.ipAddress}, '
           'dhcp: ${uiModel.dhcpEnabled}, '
           'pool: ${uiModel.minAddress}-${uiModel.maxAddress}');
@@ -85,7 +85,7 @@ class UspLocalNetworkNotifier
         const LocalNetworkStatus(isLoading: false),
       );
     } on ServiceError catch (e) {
-      logger.e('[USP][Network][LAN] Fetch failed', error: e);
+      logger.e('[USP][Network][LAN]: Fetch failed', error: e);
       return (
         null,
         LocalNetworkStatus(isLoading: false, errorMessage: '$e'),
@@ -109,13 +109,13 @@ class UspLocalNetworkNotifier
 
       await ref.read(uspMutationLockProvider).withLock(() async {
         await _svc.save(original: o, pending: p);
-        logger.d('[USP][Network][LAN] Saved');
+        logger.d('[USP][Network][LAN]: Saved');
       });
 
       // Force data provider to re-fetch so dashboard card updates too.
       ref.invalidate(lanDataProvider);
     } on ServiceError catch (e) {
-      logger.e('[USP][Network][LAN] Save failed', error: e);
+      logger.e('[USP][Network][LAN]: Save failed', error: e);
       rethrow;
     } finally {
       state = state.copyWith(

--- a/lib/page/local_network/services/usp_ethernet_data_service.dart
+++ b/lib/page/local_network/services/usp_ethernet_data_service.dart
@@ -102,7 +102,7 @@ class UspEthernetDataService {
       }
       return map;
     } catch (e) {
-      logger.w('[USP][Ethernet]Bridge port map fetch failed: $e');
+      logger.w('[USP][Ethernet]: Bridge port map fetch failed: $e');
       return {};
     }
   }

--- a/lib/page/local_network/services/usp_lan_data_service.dart
+++ b/lib/page/local_network/services/usp_lan_data_service.dart
@@ -76,7 +76,7 @@ class UspLanDataService {
           .where((ip) => ip.isNotEmpty)
           .toList();
     } catch (e) {
-      logger.w('[USP][LanData] IPv6 addresses fetch failed: $e');
+      logger.w('[USP][LanData]: IPv6 addresses fetch failed: $e');
       return const <String>[];
     }
   }

--- a/lib/page/network_diagnostics/providers/usp_network_diagnostics_notifier.dart
+++ b/lib/page/network_diagnostics/providers/usp_network_diagnostics_notifier.dart
@@ -92,7 +92,7 @@ class UspNetworkDiagnosticsNotifier
 
       final pingResult = PingResult.fromOperateResult(result, s.host);
 
-      logger.d('[USP][Diagnostics]Ping complete — '
+      logger.d('[USP][Diagnostics]: Ping complete — '
           'avg=${pingResult.avgResponseTime}ms, '
           '${pingResult.successCount}/${pingResult.totalCount} success');
 
@@ -101,13 +101,13 @@ class UspNetworkDiagnosticsNotifier
         pingResult: pingResult,
       ));
     } on TimeoutException catch (e) {
-      logger.w('[USP][Diagnostics]Ping timeout: $e');
+      logger.w('[USP][Diagnostics]: Ping timeout: $e');
       state = AsyncData(state.requireValue.copyWith(
         status: DiagnosticStatus.error,
         errorMessage: 'Ping timed out — no response from ${s.host}',
       ));
     } catch (e) {
-      logger.w('[USP][Diagnostics]Ping failed: $e');
+      logger.w('[USP][Diagnostics]: Ping failed: $e');
       state = AsyncData(state.requireValue.copyWith(
         status: DiagnosticStatus.error,
         errorMessage: 'Ping failed: $e',
@@ -142,7 +142,7 @@ class UspNetworkDiagnosticsNotifier
 
       final traceResult = TracerouteResult.fromOperateResult(result, s.host);
 
-      logger.d('[USP][Diagnostics]Traceroute complete — '
+      logger.d('[USP][Diagnostics]: Traceroute complete — '
           '${traceResult.hops.length} hops');
 
       state = AsyncData(state.requireValue.copyWith(
@@ -150,13 +150,13 @@ class UspNetworkDiagnosticsNotifier
         tracerouteResult: traceResult,
       ));
     } on TimeoutException catch (e) {
-      logger.w('[USP][Diagnostics]Traceroute timeout: $e');
+      logger.w('[USP][Diagnostics]: Traceroute timeout: $e');
       state = AsyncData(state.requireValue.copyWith(
         status: DiagnosticStatus.error,
         errorMessage: 'Traceroute timed out — route to ${s.host} incomplete',
       ));
     } catch (e) {
-      logger.w('[USP][Diagnostics]Traceroute failed: $e');
+      logger.w('[USP][Diagnostics]: Traceroute failed: $e');
       state = AsyncData(state.requireValue.copyWith(
         status: DiagnosticStatus.error,
         errorMessage: 'Traceroute failed: $e',

--- a/lib/page/port_forwarding/providers/usp_port_forwarding_page_notifier.dart
+++ b/lib/page/port_forwarding/providers/usp_port_forwarding_page_notifier.dart
@@ -74,7 +74,7 @@ class UspPortForwardingPageNotifier
       final forwardingRules = results[0] as List<PortForwardingRuleUIModel>;
       final triggeringRules = results[1] as List<PortTriggeringRuleUIModel>;
 
-      logger.d('[USP][Firewall][PortForwarding] Fetched — '
+      logger.d('[USP][Firewall][PortForwarding]: Fetched — '
           'forwarding: ${forwardingRules.length}, '
           'triggering: ${triggeringRules.length}');
 
@@ -86,7 +86,7 @@ class UspPortForwardingPageNotifier
         const PortForwardingPageStatus(),
       );
     } on ServiceError catch (e) {
-      logger.e('[USP][Firewall][PortForwarding] Fetch failed', error: e);
+      logger.e('[USP][Firewall][PortForwarding]: Fetch failed', error: e);
       return (
         null,
         PortForwardingPageStatus(errorMessage: '$e'),
@@ -121,7 +121,7 @@ class UspPortForwardingPageNotifier
           current: currentPt,
         );
 
-        logger.d('[USP][Firewall][PortForwarding] Batch save — '
+        logger.d('[USP][Firewall][PortForwarding]: Batch save — '
             'PF added: ${pfResult.added}, updated: ${pfResult.updated}, '
             'deleted: ${pfResult.deleted} | '
             'PT added: ${ptResult.added}, updated: ${ptResult.updated}, '
@@ -132,7 +132,7 @@ class UspPortForwardingPageNotifier
       ref.invalidate(portForwardingDataProvider);
       ref.invalidate(portTriggeringDataProvider);
     } on ServiceError catch (e) {
-      logger.e('[USP][Firewall][PortForwarding] Save failed', error: e);
+      logger.e('[USP][Firewall][PortForwarding]: Save failed', error: e);
       rethrow;
     } finally {
       state = state.copyWith(
@@ -241,7 +241,7 @@ class UspPortForwardingPageNotifier
         await _svc.immediateToggleForwarding(instancePath, enabled);
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][PortFwd] Immediate toggle forwarding failed', error: e);
+      logger.e('[USP][PortFwd]: Immediate toggle forwarding failed', error: e);
       rethrow;
     }
     ref.invalidate(portForwardingDataProvider);
@@ -270,7 +270,7 @@ class UspPortForwardingPageNotifier
         );
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][PortFwd] Immediate add forwarding failed', error: e);
+      logger.e('[USP][PortFwd]: Immediate add forwarding failed', error: e);
       rethrow;
     }
     ref.invalidate(portForwardingDataProvider);
@@ -284,7 +284,7 @@ class UspPortForwardingPageNotifier
         await _svc.immediateToggleTriggering(instancePath, enabled);
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][PortFwd] Immediate toggle triggering failed', error: e);
+      logger.e('[USP][PortFwd]: Immediate toggle triggering failed', error: e);
       rethrow;
     }
     ref.invalidate(portTriggeringDataProvider);

--- a/lib/page/port_forwarding/services/usp_port_forwarding_service.dart
+++ b/lib/page/port_forwarding/services/usp_port_forwarding_service.dart
@@ -207,7 +207,8 @@ class UspPortForwardingService {
                 .w('[PortForwarding] Delete partial: ${f.first.errorMessage}');
           case UspFailure(errors: final e):
             failedOps++;
-            logger.w('[PortForwarding]: Delete failed: ${e.first.errorMessage}');
+            logger
+                .w('[PortForwarding]: Delete failed: ${e.first.errorMessage}');
         }
       }
 
@@ -276,7 +277,8 @@ class UspPortForwardingService {
                 .w('[PortForwarding] Update partial: ${f.first.errorMessage}');
           case UspFailure(errors: final e):
             failedOps++;
-            logger.w('[PortForwarding]: Update failed: ${e.first.errorMessage}');
+            logger
+                .w('[PortForwarding]: Update failed: ${e.first.errorMessage}');
         }
       }
 
@@ -336,7 +338,8 @@ class UspPortForwardingService {
                 .w('[PortTriggering]: Delete partial: ${f.first.errorMessage}');
           case UspFailure(errors: final e):
             failedOps++;
-            logger.w('[PortTriggering]: Delete failed: ${e.first.errorMessage}');
+            logger
+                .w('[PortTriggering]: Delete failed: ${e.first.errorMessage}');
         }
       }
 
@@ -428,7 +431,8 @@ class UspPortForwardingService {
                 .w('[PortTriggering]: Update partial: ${f.first.errorMessage}');
           case UspFailure(errors: final e):
             failedOps++;
-            logger.w('[PortTriggering]: Update failed: ${e.first.errorMessage}');
+            logger
+                .w('[PortTriggering]: Update failed: ${e.first.errorMessage}');
         }
       }
 

--- a/lib/page/port_forwarding/services/usp_port_forwarding_service.dart
+++ b/lib/page/port_forwarding/services/usp_port_forwarding_service.dart
@@ -207,7 +207,7 @@ class UspPortForwardingService {
                 .w('[PortForwarding] Delete partial: ${f.first.errorMessage}');
           case UspFailure(errors: final e):
             failedOps++;
-            logger.w('[PortForwarding] Delete failed: ${e.first.errorMessage}');
+            logger.w('[PortForwarding]: Delete failed: ${e.first.errorMessage}');
         }
       }
 
@@ -234,10 +234,10 @@ class UspPortForwardingService {
           case UspSuccess():
             break;
           case UspPartialSuccess(failures: final f):
-            logger.w('[PortForwarding] Add partial: ${f.first.errorMessage}');
+            logger.w('[PortForwarding]: Add partial: ${f.first.errorMessage}');
           case UspFailure(errors: final e):
             failedOps++;
-            logger.w('[PortForwarding] Add failed: ${e.first.errorMessage}');
+            logger.w('[PortForwarding]: Add failed: ${e.first.errorMessage}');
         }
       }
 
@@ -276,7 +276,7 @@ class UspPortForwardingService {
                 .w('[PortForwarding] Update partial: ${f.first.errorMessage}');
           case UspFailure(errors: final e):
             failedOps++;
-            logger.w('[PortForwarding] Update failed: ${e.first.errorMessage}');
+            logger.w('[PortForwarding]: Update failed: ${e.first.errorMessage}');
         }
       }
 
@@ -333,10 +333,10 @@ class UspPortForwardingService {
             break;
           case UspPartialSuccess(failures: final f):
             logger
-                .w('[PortTriggering] Delete partial: ${f.first.errorMessage}');
+                .w('[PortTriggering]: Delete partial: ${f.first.errorMessage}');
           case UspFailure(errors: final e):
             failedOps++;
-            logger.w('[PortTriggering] Delete failed: ${e.first.errorMessage}');
+            logger.w('[PortTriggering]: Delete failed: ${e.first.errorMessage}');
         }
       }
 
@@ -368,7 +368,7 @@ class UspPortForwardingService {
             }
           case UspPartialSuccess(failures: final f):
             logger.w(
-                '[PortTriggering] Add parent partial: ${f.first.errorMessage}');
+                '[PortTriggering]: Add parent partial: ${f.first.errorMessage}');
             final createdInstances = parsedResult.successes
                 .expand((s) => s.createdInstances ?? <UspCreatedInstance>[])
                 .toList();
@@ -378,7 +378,7 @@ class UspPortForwardingService {
           case UspFailure(errors: final e):
             failedOps++;
             logger.w(
-                '[PortTriggering] Add parent failed: ${e.first.errorMessage}');
+                '[PortTriggering]: Add parent failed: ${e.first.errorMessage}');
         }
 
         // Add forward rules only if parent was created
@@ -425,10 +425,10 @@ class UspPortForwardingService {
             break;
           case UspPartialSuccess(failures: final f):
             logger
-                .w('[PortTriggering] Update partial: ${f.first.errorMessage}');
+                .w('[PortTriggering]: Update partial: ${f.first.errorMessage}');
           case UspFailure(errors: final e):
             failedOps++;
-            logger.w('[PortTriggering] Update failed: ${e.first.errorMessage}');
+            logger.w('[PortTriggering]: Update failed: ${e.first.errorMessage}');
         }
       }
 

--- a/lib/page/static_routing/providers/usp_static_routing_notifier.dart
+++ b/lib/page/static_routing/providers/usp_static_routing_notifier.dart
@@ -65,7 +65,7 @@ class UspStaticRoutingNotifier
     try {
       final routes = await _svc.fetch();
 
-      logger.d('[USP][Network][Routing] Fetched — '
+      logger.d('[USP][Network][Routing]: Fetched — '
           'static: ${routes.length}');
 
       return (
@@ -73,7 +73,7 @@ class UspStaticRoutingNotifier
         const StaticRoutingStatus(),
       );
     } on ServiceError catch (e) {
-      logger.e('[USP][Network][Routing] Fetch failed', error: e);
+      logger.e('[USP][Network][Routing]: Fetch failed', error: e);
       return (
         null,
         StaticRoutingStatus(errorMessage: '$e'),
@@ -101,12 +101,12 @@ class UspStaticRoutingNotifier
           current: current,
         );
 
-        logger.d('[USP][Network][Routing] Batch save — '
+        logger.d('[USP][Network][Routing]: Batch save — '
             'added: ${result.added}, updated: ${result.updated}, '
             'deleted: ${result.deleted}');
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][Network][Routing] Save failed', error: e);
+      logger.e('[USP][Network][Routing]: Save failed', error: e);
       rethrow;
     } finally {
       state = state.copyWith(

--- a/lib/page/static_routing/services/usp_static_routing_service.dart
+++ b/lib/page/static_routing/services/usp_static_routing_service.dart
@@ -72,7 +72,7 @@ class UspStaticRoutingService {
             break;
           case UspPartialSuccess(:final successes, :final failures):
             logger.w(
-                '[StaticRouting] Batch delete partial: ${successes.length} ok, ${failures.length} failed');
+                '[StaticRouting]: Batch delete partial: ${successes.length} ok, ${failures.length} failed');
             break;
           case UspFailure(:final errorSummary, :final errors):
             throw UspCompleteFailureError(
@@ -104,7 +104,7 @@ class UspStaticRoutingService {
             break;
           case UspPartialSuccess(:final successes, :final failures):
             logger.w(
-                '[StaticRouting] Batch add partial: ${successes.length} ok, ${failures.length} failed');
+                '[StaticRouting]: Batch add partial: ${successes.length} ok, ${failures.length} failed');
             break;
           case UspFailure(:final errorSummary, :final errors):
             throw UspCompleteFailureError(
@@ -146,7 +146,7 @@ class UspStaticRoutingService {
             break;
           case UspPartialSuccess(:final successes, :final failures):
             logger.w(
-                '[StaticRouting] Batch update partial: ${successes.length} ok, ${failures.length} failed');
+                '[StaticRouting]: Batch update partial: ${successes.length} ok, ${failures.length} failed');
             break;
           case UspFailure(:final errorSummary, :final errors):
             throw UspCompleteFailureError(

--- a/lib/page/system_log/providers/usp_system_log_notifier.dart
+++ b/lib/page/system_log/providers/usp_system_log_notifier.dart
@@ -17,7 +17,7 @@ class UspSystemLogNotifier
       final svc = ref.read(uspSystemLogServiceProvider);
       return await svc.fetch();
     } on ServiceError catch (e) {
-      logger.e('[USP][SystemLog] Fetch failed', error: e);
+      logger.e('[USP][SystemLog]: Fetch failed', error: e);
       rethrow;
     }
   }

--- a/lib/page/wifi_settings/providers/usp_wifi_advanced_provider.dart
+++ b/lib/page/wifi_settings/providers/usp_wifi_advanced_provider.dart
@@ -60,14 +60,14 @@ class UspWifiAdvancedNotifier
     try {
       final ieee80211h = await _svc.fetchIeee80211h();
 
-      logger.d('[USP][WiFi][Advanced] Fetched — radios=${ieee80211h.length}');
+      logger.d('[USP][WiFi][Advanced]: Fetched — radios=${ieee80211h.length}');
 
       return (
         WifiAdvancedSettings(ieee80211hByRadio: ieee80211h),
         const WifiAdvancedStatus(),
       );
     } on ServiceError catch (e) {
-      logger.e('[USP][WiFi][Advanced] Fetch failed', error: e);
+      logger.e('[USP][WiFi][Advanced]: Fetch failed', error: e);
       return (
         null,
         WifiAdvancedStatus(errorMessage: '$e'),
@@ -87,7 +87,7 @@ class UspWifiAdvancedNotifier
     try {
       return await super.save();
     } on ServiceError catch (e) {
-      logger.e('[USP][WiFi][Advanced] Save failed', error: e);
+      logger.e('[USP][WiFi][Advanced]: Save failed', error: e);
       rethrow;
     } finally {
       state = state.copyWith(
@@ -113,7 +113,7 @@ class UspWifiAdvancedNotifier
       );
     });
 
-    logger.d('[USP][WiFi][Advanced] Save succeeded — '
+    logger.d('[USP][WiFi][Advanced]: Save succeeded — '
         'radios=${radioPaths.length}, enabled=$enabled');
     // Refresh Layer 1 cache so post-save fetch() reads fresh data.
     // Using refresh() instead of invalidate() because the latter only marks

--- a/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
+++ b/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
@@ -83,7 +83,7 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
       }
     }
 
-    logger.d('[USP][WiFi]Fetching WiFi data...');
+    logger.d('[USP][WiFi]: Fetching WiFi data...');
 
     // Read from WiFi Data Provider (Layer 1) to avoid duplicate fetch.
     // wifiDataProvider may throw (e.g. TimeoutException when the bridge is
@@ -93,7 +93,7 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
     try {
       wifiData = await ref.read(wifiDataProvider.future);
     } on ServiceError catch (e) {
-      logger.w('[USP][WiFi] WiFi data fetch failed: $e');
+      logger.w('[USP][WiFi]: WiFi data fetch failed: $e');
       return (
         null,
         WifiSettingsStatus(errorMessage: '$e'),
@@ -109,7 +109,7 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
 
     final quickSetup = _svc.buildQuickSetupNetworks(networks);
 
-    logger.d('[USP][WiFi]Loaded ${networks.length} networks, '
+    logger.d('[USP][WiFi]: Loaded ${networks.length} networks, '
         'isQuickSetup=${quickSetup.isQuickSetup}');
 
     // Preserve the current quickSetupEnabled flag across re-fetches so the
@@ -160,7 +160,7 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
       // super.save() calls performSave() → markAsSaved() → fetch().
       // fetch() rebuilds status with a fresh WifiSettingsStatus (isSaving = false).
     } on ServiceError catch (e) {
-      logger.e('[USP][WiFi] Save failed', error: e);
+      logger.e('[USP][WiFi]: Save failed', error: e);
       rethrow;
     } finally {
       state = state.copyWith(
@@ -332,7 +332,7 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
         await _svc.toggleRadio(instancePath, enable);
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][WiFi] Toggle radio failed', error: e);
+      logger.e('[USP][WiFi]: Toggle radio failed', error: e);
       rethrow;
     }
     ref.invalidate(wifiDataProvider);
@@ -353,7 +353,7 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
         );
       });
     } on ServiceError catch (e) {
-      logger.e('[USP][WiFi] Update radio channel failed', error: e);
+      logger.e('[USP][WiFi]: Update radio channel failed', error: e);
       rethrow;
     }
     ref.invalidate(wifiDataProvider);

--- a/lib/page/wifi_settings/providers/wifi_data_provider.dart
+++ b/lib/page/wifi_settings/providers/wifi_data_provider.dart
@@ -86,7 +86,7 @@ class WifiDataNotifier extends AsyncNotifier<WifiData> {
     final svc = ref.read(uspWifiDataServiceProvider);
     final result = await svc.fetch();
 
-    logger.d('[USP][WifiData] Fetched — '
+    logger.d('[USP][WifiData]: Fetched — '
         'clients: ${result.wifiClientMap.length}, '
         'radios: ${result.radioModels.length}');
 

--- a/lib/page/wifi_settings/services/usp_wifi_data_service.dart
+++ b/lib/page/wifi_settings/services/usp_wifi_data_service.dart
@@ -203,7 +203,7 @@ class UspWifiDataService {
   /// limitation), falls back to a broader parent-path fetch and manual parse.
   Future<Map<String, WifiClient>> _fetchWifiClients() async {
     final result = await WifiClients.fetch(_usp);
-    logger.d('[USP][Dashboard]WifiClients raw: ${result.items.length} items');
+    logger.d('[USP][Dashboard]: WifiClients raw: ${result.items.length} items');
 
     if (result.items.isNotEmpty) {
       return {
@@ -222,7 +222,7 @@ class UspWifiDataService {
       }
       return fallback;
     } catch (e) {
-      logger.d('[USP][Dashboard]WifiClients fallback failed: $e');
+      logger.d('[USP][Dashboard]: WifiClients fallback failed: $e');
       return {};
     }
   }
@@ -316,7 +316,7 @@ class UspWifiDataService {
             _normalizeBand(r.operatingFrequencyBand),
     };
 
-    logger.d('[USP][Dashboard]Connection detail: '
+    logger.d('[USP][Dashboard]: Connection detail: '
         '${apByPath.length} APs, ${ssidByPath.length} SSIDs, ${bandByRadioPath.length} radios');
 
     final result = <String, ClientConnectionDetail>{};

--- a/lib/page/wifi_settings/services/usp_wifi_settings_service.dart
+++ b/lib/page/wifi_settings/services/usp_wifi_settings_service.dart
@@ -53,7 +53,7 @@ class UspWifiSettingsService {
       radioByPath[_ensureTrailingDot(r.instancePath)] = r;
     }
 
-    logger.d('[USP][WiFi]Building networks: '
+    logger.d('[USP][WiFi]: Building networks: '
         '${ssids.items.length} SSIDs, '
         '${accessPoints.items.length} APs, '
         '${radios.items.length} radios');
@@ -91,7 +91,7 @@ class UspWifiSettingsService {
       final radioPath = _ensureTrailingDot(ssid.lowerLayers);
       final radio = radioByPath[radioPath];
 
-      logger.d('[USP][WiFi]SSID ${ssid.ssid}: '
+      logger.d('[USP][WiFi]: SSID ${ssid.ssid}: '
           'AP=${ap?.instancePath ?? "none"}, '
           'radio=${radio?.operatingFrequencyBand ?? "none"}');
 
@@ -650,7 +650,7 @@ String _normalizeBand(String rawBand) {
 int _ssidInstanceIndex(String instancePath) {
   final match = RegExp(r'Device\.WiFi\.SSID\.(\d+)').firstMatch(instancePath);
   if (match == null) {
-    logger.w('[USP][WiFi] Unexpected SSID path format: $instancePath — '
+    logger.w('[USP][WiFi]: Unexpected SSID path format: $instancePath — '
         'defaulting to index 0 (Main)');
     return 0;
   }

--- a/lib/providers/auth/auth_provider.dart
+++ b/lib/providers/auth/auth_provider.dart
@@ -74,7 +74,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         // Store password for session restore
         await const FlutterSecureStorage()
             .write(key: pLocalPassword, value: password);
-        logger.d('[Auth]localLogin: USP login succeeded');
+        logger.d('[Auth]: localLogin: USP login succeeded');
         return previousState.copyWith(
           localPassword: password,
           loginType: LoginType.local,
@@ -82,7 +82,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
       }
       throw Exception('USP login failed');
     }, (error) => guardError);
-    logger.d('[Auth]localLogin: done, state=$state');
+    logger.d('[Auth]: localLogin: done, state=$state');
   }
 
   /// Retrieves password hint from the router.
@@ -102,7 +102,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
 
   /// Performs logout, clearing credentials and resetting state.
   Future logout() async {
-    logger.d('[Auth]logout: starting');
+    logger.d('[Auth]: logout: starting');
     state = const AsyncValue.loading();
 
     state = await AsyncValue.guard(() async {
@@ -111,17 +111,17 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
       // must still be valid.
       final sseManager = ref.read(sseManagerProvider);
       if (sseManager != null) {
-        logger.d('[Auth]logout: disconnecting SSE');
+        logger.d('[Auth]: logout: disconnecting SSE');
         await sseManager.disconnect();
         await sseManager.registry.unregisterAll();
       }
 
       // Now safe to logout USP
-      logger.d('[Auth]logout: syncing USP logout');
+      logger.d('[Auth]: logout: syncing USP logout');
       await ref.read(uspAuthCoordinatorProvider).syncAfterLogout();
 
       // Clear credentials
-      logger.d('[Auth]logout: clearing credentials');
+      logger.d('[Auth]: logout: clearing credentials');
       await _authService.clearAllCredentials();
 
       // Clear RA-related prefs (legacy cleanup)
@@ -131,7 +131,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
 
       // Reset provider states
       ref.read(sessionProvider.notifier).clear();
-      logger.d('[Auth]logout: complete');
+      logger.d('[Auth]: logout: complete');
       return AuthState.empty();
     });
     ref.read(selectedNetworkIdProvider.notifier).state = null;

--- a/lib/route/router_logger.dart
+++ b/lib/route/router_logger.dart
@@ -13,7 +13,7 @@ class RouterLogger extends NavigatorObserver {
   /// route, is `previousRoute`.
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    logger.d('did push the page - ${route.settings.name}');
+    logger.d('[Route]: did push the page - ${route.settings.name}');
   }
 
   /// The [Navigator] popped `route`.
@@ -22,7 +22,7 @@ class RouterLogger extends NavigatorObserver {
   /// route, is `previousRoute`.
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    logger.d('did pop the page - $route');
+    logger.d('[Route]: did pop the page - $route');
   }
 
   /// The [Navigator] removed `route`.
@@ -36,12 +36,12 @@ class RouterLogger extends NavigatorObserver {
   /// to the bottommost route.
   @override
   void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    logger.d('did remove the page - $route');
+    logger.d('[Route]: did remove the page - $route');
   }
 
   /// The [Navigator] replaced `oldRoute` with `newRoute`.
   @override
   void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
-    logger.d('did replace the page - $newRoute');
+    logger.d('[Route]: did replace the page - $newRoute');
   }
 }

--- a/lib/util/app_utils.dart
+++ b/lib/util/app_utils.dart
@@ -47,7 +47,7 @@ class Utils {
         String.fromCharCodes(Uint8List.fromList(utf8.encode(value)));
     final b64 = base64Encode(utf8Encoded.codeUnits);
     final uriFull = Uri.encodeQueryComponent(b64);
-    logger.d('u: $utf8Encoded, b: $b64, i: $uriFull');
+    logger.d('[Util]: u: $utf8Encoded, b: $b64, i: $uriFull');
     return uriFull;
   }
 
@@ -55,7 +55,7 @@ class Utils {
     final uriBack = Uri.decodeComponent(encoded);
     final b64Back = String.fromCharCodes(base64Decode(uriBack));
     final utf8Back = utf8.decode(b64Back.codeUnits);
-    logger.d('i: $uriBack, b: $b64Back, u: $utf8Back');
+    logger.d('[Util]: i: $uriBack, b: $b64Back, u: $utf8Back');
     return utf8Back;
   }
 

--- a/lib/util/brand_utils.dart
+++ b/lib/util/brand_utils.dart
@@ -25,10 +25,10 @@ class BrandUtils {
     try {
       final manifestContent = await rootBundle.loadString('AssetManifest.json');
       final Map<String, dynamic> manifestMap = json.decode(manifestContent);
-      logger.d('Loaded AssetManifest.json: ${manifestMap.keys}');
+      logger.d('[Util]: Loaded AssetManifest.json: ${manifestMap.keys}');
       _manifestAssets = manifestMap.keys.toSet();
     } catch (e) {
-      logger.e('Failed to load AssetManifest.json', error: e);
+      logger.e('[Util]: Failed to load AssetManifest.json', error: e);
       _manifestAssets = {};
     }
   }

--- a/lib/util/error_code_helper.dart
+++ b/lib/util/error_code_helper.dart
@@ -23,7 +23,7 @@ import 'package:privacy_gui/core/utils/logger.dart';
 String? errorCodeHelper(BuildContext context, String? code,
     [String? generalErrorMessage]) {
   String unknownHandle(String code) {
-    logger.d('Unknown error: $code');
+    logger.d('[Util]: Unknown error: $code');
     return generalErrorMessage ?? loc(context).unknownErrorCode(code);
   }
 

--- a/lib/util/masking_utils.dart
+++ b/lib/util/masking_utils.dart
@@ -87,21 +87,4 @@ class MaskingUtils {
     });
   }
 
-  static String replaceHttpScheme(String raw) {
-    const pattern =
-        r'(https?:\/\/)?((www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b)([-a-zA-Z0-9()@:%_\+.~#?&\/\/=]*)';
-    RegExp regex = RegExp(pattern, multiLine: true);
-    String result = raw;
-    int idx = 0;
-    regex.allMatches(result).forEach((element) {
-      element.groups([1, 2, 4]).nonNulls.forEach((group) {
-            int start = raw.indexOf(group, idx);
-            int end = start + group.length;
-            final replaced = group.replaceAll(':', '-').replaceAll('.', '-');
-            result = result.replaceRange(start, end, replaced);
-            idx = end;
-          });
-    });
-    return result;
-  }
 }

--- a/lib/util/masking_utils.dart
+++ b/lib/util/masking_utils.dart
@@ -64,8 +64,7 @@ class MaskingUtils {
   }
 
   static String maskSerialNumber(String raw) {
-    final pattern = RegExp(
-        r'("?serialNumber"?\s*:\s*"?)([A-Za-z0-9]{4,})("?)',
+    final pattern = RegExp(r'("?serialNumber"?\s*:\s*"?)([A-Za-z0-9]{4,})("?)',
         caseSensitive: false);
     return raw.replaceAllMapped(pattern, (match) {
       final prefix = match.group(1)!;
@@ -77,8 +76,7 @@ class MaskingUtils {
   }
 
   static String maskMacAddress(String raw) {
-    final pattern = RegExp(
-        r'([0-9A-Fa-f]{2}[:\-]){5}[0-9A-Fa-f]{2}');
+    final pattern = RegExp(r'([0-9A-Fa-f]{2}[:\-]){5}[0-9A-Fa-f]{2}');
     return raw.replaceAllMapped(pattern, (match) {
       final mac = match.group(0)!;
       final separator = mac.contains(':') ? ':' : '-';
@@ -86,5 +84,4 @@ class MaskingUtils {
       return 'XX${separator}XX${separator}XX${separator}XX$separator${lastTwo[4]}$separator${lastTwo[5]}';
     });
   }
-
 }

--- a/lib/util/masking_utils.dart
+++ b/lib/util/masking_utils.dart
@@ -63,6 +63,30 @@ class MaskingUtils {
     });
   }
 
+  static String maskSerialNumber(String raw) {
+    final pattern = RegExp(
+        r'("?serialNumber"?\s*:\s*"?)([A-Za-z0-9]{4,})("?)',
+        caseSensitive: false);
+    return raw.replaceAllMapped(pattern, (match) {
+      final prefix = match.group(1)!;
+      final value = match.group(2)!;
+      final suffix = match.group(3)!;
+      if (value.length <= 4) return '$prefix****$suffix';
+      return '$prefix****${value.substring(value.length - 4)}$suffix';
+    });
+  }
+
+  static String maskMacAddress(String raw) {
+    final pattern = RegExp(
+        r'([0-9A-Fa-f]{2}[:\-]){5}[0-9A-Fa-f]{2}');
+    return raw.replaceAllMapped(pattern, (match) {
+      final mac = match.group(0)!;
+      final separator = mac.contains(':') ? ':' : '-';
+      final lastTwo = mac.split(RegExp(r'[:\-]'));
+      return 'XX${separator}XX${separator}XX${separator}XX$separator${lastTwo[4]}$separator${lastTwo[5]}';
+    });
+  }
+
   static String replaceHttpScheme(String raw) {
     const pattern =
         r'(https?:\/\/)?((www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b)([-a-zA-Z0-9()@:%_\+.~#?&\/\/=]*)';

--- a/lib/util/qr_code.dart
+++ b/lib/util/qr_code.dart
@@ -148,6 +148,6 @@ Future<void> printWiFiQRCode(BuildContext context, Uint8List imageBytes,
       onLayout: (PdfPageFormat format) => doc.save(),
     );
   } catch (e) {
-    logger.e('Print page error', error: e);
+    logger.e('[Util]: Print page error', error: e);
   }
 }

--- a/test/util/masking_utils_test.dart
+++ b/test/util/masking_utils_test.dart
@@ -68,6 +68,95 @@ void main() {
     });
   });
 
+  group('maskSerialNumber', () {
+    test('masks JSON format with double quotes', () {
+      const raw = '{"serialNumber": "ABC123456XYZ"}';
+      const expected = '{"serialNumber": "****6XYZ"}';
+      expect(MaskingUtils.maskSerialNumber(raw), expected);
+    });
+
+    test('masks JSON format without value quotes', () {
+      const raw = '"serialNumber": ABC123456XYZ';
+      const expected = '"serialNumber": ****6XYZ';
+      expect(MaskingUtils.maskSerialNumber(raw), expected);
+    });
+
+    test('masks format without any quotes', () {
+      const raw = 'serialNumber: ABC123456XYZ';
+      const expected = 'serialNumber: ****6XYZ';
+      expect(MaskingUtils.maskSerialNumber(raw), expected);
+    });
+
+    test('masks short serial number (<=4 chars) completely', () {
+      const raw = '{"serialNumber": "AB12"}';
+      const expected = '{"serialNumber": "****"}';
+      expect(MaskingUtils.maskSerialNumber(raw), expected);
+    });
+
+    test('masks multiple serial numbers', () {
+      const raw =
+          '{"serialNumber": "SERIAL001"}, {"serialNumber": "SERIAL002"}';
+      const expected =
+          '{"serialNumber": "****L001"}, {"serialNumber": "****L002"}';
+      expect(MaskingUtils.maskSerialNumber(raw), expected);
+    });
+
+    test('is case insensitive for key', () {
+      const raw = '{"SERIALNUMBER": "ABC123456XYZ"}';
+      const expected = '{"SERIALNUMBER": "****6XYZ"}';
+      expect(MaskingUtils.maskSerialNumber(raw), expected);
+    });
+
+    test('returns unchanged if no serial number found', () {
+      const raw = '{"deviceName": "MyRouter"}';
+      expect(MaskingUtils.maskSerialNumber(raw), raw);
+    });
+
+    test('handles empty string', () {
+      expect(MaskingUtils.maskSerialNumber(''), '');
+    });
+  });
+
+  group('maskMacAddress', () {
+    test('masks MAC with colon separator', () {
+      const raw = 'MAC: AA:BB:CC:DD:EE:FF';
+      const expected = 'MAC: XX:XX:XX:XX:EE:FF';
+      expect(MaskingUtils.maskMacAddress(raw), expected);
+    });
+
+    test('masks MAC with hyphen separator', () {
+      const raw = 'MAC: AA-BB-CC-DD-EE-FF';
+      const expected = 'MAC: XX-XX-XX-XX-EE-FF';
+      expect(MaskingUtils.maskMacAddress(raw), expected);
+    });
+
+    test('masks multiple MAC addresses', () {
+      const raw = 'src=AA:BB:CC:DD:EE:FF dst=11:22:33:44:55:66';
+      const expected = 'src=XX:XX:XX:XX:EE:FF dst=XX:XX:XX:XX:55:66';
+      expect(MaskingUtils.maskMacAddress(raw), expected);
+    });
+
+    test('handles mixed case', () {
+      const raw = 'aA:bB:cC:dD:eE:fF';
+      const expected = 'XX:XX:XX:XX:eE:fF';
+      expect(MaskingUtils.maskMacAddress(raw), expected);
+    });
+
+    test('returns unchanged if no MAC address found', () {
+      const raw = 'No MAC here, just IP 192.168.1.1';
+      expect(MaskingUtils.maskMacAddress(raw), raw);
+    });
+
+    test('handles empty string', () {
+      expect(MaskingUtils.maskMacAddress(''), '');
+    });
+
+    test('does not match invalid MAC formats', () {
+      const raw = 'Invalid: GG:HH:II:JJ:KK:LL';
+      expect(MaskingUtils.maskMacAddress(raw), raw);
+    });
+  });
+
   group('encryptJNAPAuth', () {
     setUp(() {
       FernetManager().resetForTest();

--- a/test/util/masking_utils_test.dart
+++ b/test/util/masking_utils_test.dart
@@ -66,7 +66,6 @@ void main() {
       final maskedJson = MaskingUtils.maskSensitiveJsonValues(rawJson);
       expect(maskedJson, rawJson);
     });
-
   });
 
   group('encryptJNAPAuth', () {

--- a/test/util/masking_utils_test.dart
+++ b/test/util/masking_utils_test.dart
@@ -67,43 +67,6 @@ void main() {
       expect(maskedJson, rawJson);
     });
 
-    test('replaceHttpScheme: replaces http scheme correctly', () {
-      const raw = 'https://www.example.com/path/to/resource';
-      const expected = 'https-//www-example-com/path/to/resource';
-      expect(MaskingUtils.replaceHttpScheme(raw), expected);
-    });
-
-    test('replaceHttpScheme: replaces https scheme correctly', () {
-      const raw = 'https://secure.example.com/login';
-      const expected = 'https-//secure-example-com/login';
-      expect(MaskingUtils.replaceHttpScheme(raw), expected);
-    });
-
-    test('replaceHttpScheme: handles naked domain URL', () {
-      expect(
-          MaskingUtils.replaceHttpScheme('www.google.com'), 'www-google-com');
-    });
-
-    test('replaceHttpScheme: handles missing scheme', () {
-      expect(MaskingUtils.replaceHttpScheme('//www.example.com/path'),
-          '//www-example-com/path');
-    });
-
-    test('replaceHttpScheme: handles empty string', () {
-      expect(MaskingUtils.replaceHttpScheme(''), '');
-    });
-
-    test('replaceHttpScheme: handles multiple occurrences', () {
-      const raw =
-          'https://example1.com:8080/path1 https://example2.com:443/path2';
-      const expected =
-          'https-//example1-com-8080/path1 https-//example2-com-443/path2';
-      expect(MaskingUtils.replaceHttpScheme(raw), expected);
-    });
-
-    test('replaceHttpScheme: handles invalid URL format', () {
-      expect(MaskingUtils.replaceHttpScheme('invalid_url'), 'invalid_url');
-    });
   });
 
   group('encryptJNAPAuth', () {


### PR DESCRIPTION
## Summary

Addresses the three core problems identified in #830 for the logger system.

### Problem 1: Tag system broken (FIXED)
- The existing regex `\[(\w*)\]:(.*)` required `[Tag]:` format, but 91.5% of logs used `[Tag]message` (missing colon) — all falling into the `app` catch-all cache
- Added `: ` after the closing `]` in ~250 logger calls across 77 files
- Added `[Tag]:` prefix to ~20 previously untagged calls (`[App]`, `[Config]`, `[Dialog]`, `[Util]`, `[Crypto]`, `[Benchmark]`, `[Route]`)
- Renamed tags containing `:` inside brackets (incompatible with `\w`) to nested brackets: `[USP:Parser]` → `[USP][Parser]`

### Problem 2: Export format is a raw dump (PARTIALLY ADDRESSED)
- Added log level indicator (`[D]`/`[W]`/`[E]`) to each cached log entry, visible in PDF export
- Decision: **not** adding a separate "Warnings & Errors" section — the Custom Tag Summary with level indicators is sufficient and avoids duplication
- Decision: **not** adding `exportStructuredReport()` API — existing `outputFullWebLog()` format is adequate after Problem 1 fix enables proper tag categorization

### Problem 3: Security — PII in log export (FIXED)
- Added `MaskingUtils.maskSerialNumber()` — only last 4 chars visible (`****3XYZ`)
- Added `MaskingUtils.maskMacAddress()` — only last 2 octets visible (`XX:XX:XX:XX:EE:FF`)
- **Removed `MaskingUtils.replaceHttpScheme()`** — its overly broad URL regex was matching TR-181 dot-paths (`Device.IP.Interface.2.Stats.BytesSent`) and replacing `.` with `-`, corrupting log export data. The trade-off is not worth it: it only obscured local router IPs (e.g., `192.168.1.1`) which are not privacy-sensitive — every router uses similar private network addresses.

### Additional: USP client logging refactor
- Unified USP request/response logging — one log per layer per request with pretty-printed JSON
- Prefixes: `[USPClient]:`, `[USPClient][WASM]:`, `[USP][Parser]:`, `[USP][ServiceError]:`
- Added try/catch on all UspClient methods to ensure error path always has a return log
- 401 retry marked with `#id.retry` suffix
- Stripped all verbose `kDebugMode`-only logs from `UspClientWasm` (kept only exception-level)

## Decisions & Trade-offs

| Item | Decision | Rationale |
|------|----------|-----------|
| Separate severity section in export | Not needed | Level indicator on each line is sufficient |
| `exportStructuredReport()` new API | Not needed | Existing format works after tag fix |
| `replaceHttpScheme` removal | Removed | Corrupts TR-181 paths; local IP is not privacy-sensitive |
| `LogEntry` class | Not needed | Tuple `(timestamp, message, Level)` is lighter |
| Fix regex vs fix all log calls | Fix all log calls (Approach A) | Consistent format across codebase |

## Test plan

- [x] `flutter analyze lib/` — 0 errors
- [x] `flutter test --tags "!golden,!loc,!ui"` — 2023 tests passed
- [x] `dart format` — all files formatted
