### PR TITLE
feat: improve device list UX and dashboard card layout

### DIFF
--- a/lib/page/devices/cards/usp_connected_devices_card.dart
+++ b/lib/page/devices/cards/usp_connected_devices_card.dart
@@ -87,40 +87,83 @@ class UspConnectedDevicesCard extends ConsumerWidget {
     );
 
     return Padding(
-      padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+      padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          UspStatusDot(isActive: device.isActive),
-          AppGap.sm(),
-          Icon(
-            deviceCategory.icon,
-            size: 28,
-            color: scheme.onSurface,
+          // Device icon (larger)
+          Container(
+            padding: const EdgeInsets.all(AppSpacing.sm),
+            decoration: BoxDecoration(
+              color: scheme.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(AppSpacing.sm),
+            ),
+            child: Icon(
+              deviceCategory.icon,
+              size: 32,
+              color: scheme.onSurface,
+            ),
           ),
-          AppGap.sm(),
-          // Name + parent node subtitle
+          AppGap.md(),
+          // Name + IP (subtitle)
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                AppText.bodyMedium(device.displayName),
-                if (device.parentNodeName != null)
-                  AppText.bodySmall(
-                    device.parentNodeName!,
-                    color: scheme.onSurfaceVariant,
-                  ),
+                AppText.bodyLarge(
+                  device.displayName,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                AppGap.xxs(),
+                AppText.bodySmall(
+                  device.ip,
+                  color: scheme.onSurfaceVariant,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ],
             ),
           ),
-          // Signal strength or Wired label
-          if (device.isWifi && device.signalStrength != null)
-            UspSignalStrengthIndicator(rssi: device.signalStrength!)
-          else if (!device.isWifi)
-            AppText.bodySmall(
-              'Wired',
-              color: scheme.onSurfaceVariant,
-            ),
+          AppGap.sm(),
+          // Parent node badge + Signal/Wired (stacked)
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              if (device.parentNodeName != null)
+                _buildParentNodeBadge(context, device.parentNodeName!),
+              AppGap.xxs(),
+              if (device.isWifi && device.signalStrength != null)
+                UspSignalStrengthIndicator(rssi: device.signalStrength!)
+              else
+                AppText.bodySmall(
+                  'Wired',
+                  color: scheme.onSurfaceVariant,
+                ),
+            ],
+          ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildParentNodeBadge(BuildContext context, String nodeName) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      constraints: const BoxConstraints(maxWidth: 120),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: 2,
+      ),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(AppSpacing.xs),
+      ),
+      child: AppText.labelSmall(
+        nodeName,
+        color: scheme.onSurfaceVariant,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
       ),
     );
   }

--- a/lib/page/devices/cards/usp_connected_devices_card.dart
+++ b/lib/page/devices/cards/usp_connected_devices_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/utils/device_classifier.dart';
 import 'package:privacy_gui/page/_shared/models/device_ui_model.dart';
 import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
 import 'package:privacy_gui/page/_shared/components/card_skeleton.dart';
@@ -17,6 +18,8 @@ class UspConnectedDevicesCard extends ConsumerWidget {
     this.onViewAll,
   });
 
+  static const _maxDisplayCount = 5;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final devices = this.devices ??
@@ -24,12 +27,13 @@ class UspConnectedDevicesCard extends ConsumerWidget {
     if (devices == null) return const CardSkeleton.list(rows: 3);
     final activeDevices = devices.where((d) => d.isActive).toList();
     final inactiveDevices = devices.where((d) => !d.isActive).toList();
+    final displayDevices = activeDevices.take(_maxDisplayCount).toList();
 
     return AppCard(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Header — fixed
+          // Header
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
@@ -56,27 +60,17 @@ class UspConnectedDevicesCard extends ConsumerWidget {
             ],
           ),
           AppGap.xl(),
-          // Device list — scrollable
-          if (devices.isEmpty)
-            AppText.bodyMedium('No devices found')
+          // Device list — only online devices, max 5
+          if (activeDevices.isEmpty)
+            AppText.bodyMedium('No devices online')
           else
             Expanded(
               child: SingleChildScrollView(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    if (activeDevices.isNotEmpty) ...[
-                      AppText.labelLarge('Online'),
-                      AppGap.sm(),
-                      ...activeDevices.map(_buildDeviceRow),
-                    ],
-                    if (inactiveDevices.isNotEmpty) ...[
-                      if (activeDevices.isNotEmpty) AppGap.lg(),
-                      AppText.labelLarge('Offline'),
-                      AppGap.sm(),
-                      ...inactiveDevices.map(_buildDeviceRow),
-                    ],
-                  ],
+                  children: displayDevices
+                      .map((d) => _buildDeviceRow(context, d))
+                      .toList(),
                 ),
               ),
             ),
@@ -85,124 +79,49 @@ class UspConnectedDevicesCard extends ConsumerWidget {
     );
   }
 
-  Widget _buildDeviceRow(DeviceUIModel device) {
+  Widget _buildDeviceRow(BuildContext context, DeviceUIModel device) {
+    final scheme = Theme.of(context).colorScheme;
+    final deviceCategory = DeviceClassifier.classify(
+      hostname: device.hostName,
+      mac: device.mac,
+    );
+
     return Padding(
       padding: const EdgeInsets.only(bottom: AppSpacing.sm),
       child: Row(
         children: [
           UspStatusDot(isActive: device.isActive),
           AppGap.sm(),
-          _buildConnectionIcon(device),
+          Icon(
+            deviceCategory.icon,
+            size: 28,
+            color: scheme.onSurface,
+          ),
           AppGap.sm(),
-          // Name + subtitle
+          // Name + parent node subtitle
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 AppText.bodyMedium(device.displayName),
-                Builder(builder: (context) {
-                  final subtitle = _buildSubtitle(device);
-                  if (subtitle.isEmpty) return const SizedBox.shrink();
-                  return AppText.bodySmall(
-                    subtitle,
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  );
-                }),
+                if (device.parentNodeName != null)
+                  AppText.bodySmall(
+                    device.parentNodeName!,
+                    color: scheme.onSurfaceVariant,
+                  ),
               ],
             ),
           ),
-          // Signal strength or connection type badge
-          if (device.isActive && device.isWifi && device.signalStrength != null)
-            _buildSignalBadge(device.signalStrength!)
-          else if (device.isActive && !device.isWifi)
-            Builder(builder: (context) {
-              return AppText.bodySmall(
-                'Ethernet',
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              );
-            }),
-          AppGap.sm(),
-          // IP address
-          Builder(builder: (context) {
-            return SizedBox(
-              width: context.colWidth(2),
-              child: AppText.bodySmall(
-                device.ip,
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
-            );
-          }),
+          // Signal strength or Wired label
+          if (device.isWifi && device.signalStrength != null)
+            UspSignalStrengthIndicator(rssi: device.signalStrength!)
+          else if (!device.isWifi)
+            AppText.bodySmall(
+              'Wired',
+              color: scheme.onSurfaceVariant,
+            ),
         ],
       ),
     );
-  }
-
-  /// Builds the subtitle line: "MAC · 5GHz MyNetwork · via MR7500"
-  String _buildSubtitle(DeviceUIModel device) {
-    final parts = <String>[];
-
-    // MAC (only if hostname is shown as primary)
-    if (device.hostName.isNotEmpty) parts.add(device.mac);
-
-    // Band + SSID or Ethernet
-    if (device.isWifi) {
-      final bandSsid = [
-        if (device.band != null && device.band!.isNotEmpty) device.band!,
-        if (device.ssidName != null && device.ssidName!.isNotEmpty)
-          device.ssidName!,
-      ].join(' ');
-      if (bandSsid.isNotEmpty) parts.add(bandSsid);
-    } else if (device.isActive) {
-      parts.add('Ethernet');
-    }
-
-    // Parent node
-    if (device.parentNodeName != null) {
-      parts.add('via ${device.parentNodeName}');
-    }
-
-    return parts.join(' · ');
-  }
-
-  Widget _buildConnectionIcon(DeviceUIModel device) {
-    return Builder(builder: (context) {
-      if (!device.isWifi) {
-        return Icon(
-          Icons.settings_ethernet,
-          size: 18,
-          color: device.isActive
-              ? Theme.of(context).colorScheme.onSurface
-              : Theme.of(context).colorScheme.onSurfaceVariant,
-        );
-      }
-      return Icon(
-        _wifiIconForSignal(device.signalStrength),
-        size: 18,
-        color: device.isActive
-            ? _signalColor(context, device.signalStrength)
-            : Theme.of(context).colorScheme.onSurfaceVariant,
-      );
-    });
-  }
-
-  Widget _buildSignalBadge(int rssi) {
-    return UspSignalStrengthIndicator(rssi: rssi);
-  }
-
-  static IconData _wifiIconForSignal(int? rssi) {
-    if (rssi == null) return Icons.wifi;
-    if (rssi >= -50) return Icons.wifi;
-    if (rssi >= -60) return Icons.wifi_2_bar;
-    if (rssi >= -70) return Icons.wifi_2_bar;
-    return Icons.wifi_1_bar;
-  }
-
-  static Color _signalColor(BuildContext context, int? rssi) {
-    final scheme = Theme.of(context).colorScheme;
-    if (rssi == null) return scheme.onSurfaceVariant;
-    if (rssi >= -50) return Colors.green;
-    if (rssi >= -60) return Colors.lightGreen;
-    if (rssi >= -70) return Colors.orange;
-    return scheme.error;
   }
 }

--- a/lib/page/devices/views/components/usp_device_list_tile.dart
+++ b/lib/page/devices/views/components/usp_device_list_tile.dart
@@ -55,6 +55,9 @@ class UspDeviceListTile extends StatelessWidget {
       mac: device.mac,
     );
 
+    // Offline devices are not tappable
+    final effectiveOnTap = device.isActive ? onTap : null;
+
     final content = Row(
       children: [
         UspStatusDot(isActive: device.isActive),
@@ -87,46 +90,47 @@ class UspDeviceListTile extends StatelessWidget {
                   ),
                 ],
               ),
-              if (subtitle.isNotEmpty || hasSignal) ...[
-                AppGap.xs(),
-                // Secondary row: subtitle ↔ signal
-                Row(
-                  children: [
-                    Expanded(
-                      child: AppText.bodySmall(
-                        subtitle,
-                        color: scheme.onSurfaceVariant,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
+              AppGap.xs(),
+              // Secondary row: subtitle ↔ signal (always render for consistent height)
+              Row(
+                children: [
+                  Expanded(
+                    child: AppText.bodySmall(
+                      subtitle.isNotEmpty ? subtitle : ' ',
+                      color: scheme.onSurfaceVariant,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                     ),
-                    if (hasSignal) ...[
-                      AppGap.sm(),
-                      UspSignalStrengthIndicator(
-                        rssi: device.signalStrength!,
-                      ),
-                    ],
+                  ),
+                  if (hasSignal) ...[
+                    AppGap.sm(),
+                    UspSignalStrengthIndicator(
+                      rssi: device.signalStrength!,
+                    ),
                   ],
-                ),
-              ],
+                ],
+              ),
             ],
           ),
         ),
-        AppGap.sm(),
-        AppIcon.font(
-          Icons.chevron_right,
-          size: 18,
-          color: scheme.onSurfaceVariant,
-        ),
+        // Only show chevron for online (tappable) devices
+        if (device.isActive) ...[
+          AppGap.sm(),
+          AppIcon.font(
+            Icons.chevron_right,
+            size: 18,
+            color: scheme.onSurfaceVariant,
+          ),
+        ],
       ],
     );
 
     final Widget tile;
     if (variant == DeviceListTileVariant.card) {
-      tile = AppCard(onTap: onTap, child: content);
+      tile = AppCard(onTap: effectiveOnTap, child: content);
     } else {
       final flatContent = InkWell(
-        onTap: onTap,
+        onTap: effectiveOnTap,
         borderRadius: BorderRadius.circular(AppSpacing.xs),
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),

--- a/lib/page/devices/views/usp_device_detail_view.dart
+++ b/lib/page/devices/views/usp_device_detail_view.dart
@@ -86,7 +86,8 @@ class _UspDeviceDetailViewState extends ConsumerState<UspDeviceDetailView> {
         AppGap.lg(),
         _buildConnectionStatusCard(context, device),
         AppGap.lg(),
-        if (device.isWifi) ...[
+        // Only show WiFi details for active WiFi devices
+        if (device.isWifi && device.isActive) ...[
           _buildWifiDetailsCard(context, device),
           AppGap.lg(),
         ],
@@ -105,7 +106,8 @@ class _UspDeviceDetailViewState extends ConsumerState<UspDeviceDetailView> {
         ),
         AppGap.gutter(),
         DetailGridRow(
-          left: device.isWifi
+          // Only show WiFi details for active WiFi devices
+          left: device.isWifi && device.isActive
               ? _buildWifiDetailsCard(context, device)
               : _buildNetworkAddressesCard(context, device),
           right: _buildDhcpCard(context, ref, device, detail, isLoading),
@@ -378,6 +380,7 @@ class _UspDeviceDetailViewState extends ConsumerState<UspDeviceDetailView> {
   Widget _buildDhcpCard(BuildContext context, WidgetRef ref,
       DeviceUIModel device, DeviceDetailState detail, bool isLoading) {
     final colorScheme = Theme.of(context).colorScheme;
+    final hasValidIpv4 = _hasValidIpv4(device.ip);
 
     return AppCard(
       child: Column(
@@ -436,14 +439,16 @@ class _UspDeviceDetailViewState extends ConsumerState<UspDeviceDetailView> {
               child: Row(
                 children: [
                   Icon(
-                    Icons.info_outline,
+                    hasValidIpv4 ? Icons.info_outline : Icons.warning_amber,
                     color: colorScheme.onSurfaceVariant,
                     size: 20,
                   ),
                   AppGap.sm(),
                   Expanded(
                     child: AppText.bodyMedium(
-                      'No reservation. IP may change on reconnect.',
+                      hasValidIpv4
+                          ? 'No reservation. IP may change on reconnect.'
+                          : 'No IPv4 address. Cannot create reservation.',
                       color: colorScheme.onSurfaceVariant,
                     ),
                   ),
@@ -454,12 +459,24 @@ class _UspDeviceDetailViewState extends ConsumerState<UspDeviceDetailView> {
             AppButton.primary(
               label: 'Reserve IP Address',
               isLoading: isLoading,
-              onTap: isLoading ? null : () => _reserveIp(context, ref, device),
+              onTap: isLoading || !hasValidIpv4
+                  ? null
+                  : () => _reserveIp(context, ref, device),
             ),
           ],
         ],
       ),
     );
+  }
+
+  bool _hasValidIpv4(String ip) {
+    if (ip.isEmpty) return false;
+    final parts = ip.split('.');
+    if (parts.length != 4) return false;
+    return parts.every((part) {
+      final value = int.tryParse(part);
+      return value != null && value >= 0 && value <= 255;
+    });
   }
 
   // ===========================================================================

--- a/lib/page/devices/views/usp_device_detail_view.dart
+++ b/lib/page/devices/views/usp_device_detail_view.dart
@@ -13,6 +13,7 @@ import 'package:privacy_gui/page/dhcp/providers/usp_dhcp_reservations_notifier.d
 import 'package:privacy_gui/page/devices/providers/device_detail_provider.dart';
 import 'package:privacy_gui/page/devices/views/components/usp_signal_strength_indicator.dart';
 import 'package:privacy_gui/page/shell/usp_top_bar.dart';
+import 'package:privacy_gui/util/network_utils.dart';
 import 'package:privacy_gui/util/wifi_signal_utils.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
@@ -341,24 +342,25 @@ class _UspDeviceDetailViewState extends ConsumerState<UspDeviceDetailView> {
   }
 
   // ===========================================================================
-  // Network Addresses Card (for Ethernet devices on desktop)
+  // Network Addresses Card (for non-active or wired devices on desktop)
   // ===========================================================================
 
   Widget _buildNetworkAddressesCard(
       BuildContext context, DeviceUIModel device) {
+    final isWifi = device.isWifi;
     return AppCard(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const DetailCardHeader(
-            icon: Icons.cable,
+          DetailCardHeader(
+            icon: isWifi ? Icons.wifi_off : Icons.cable,
             title: 'Network Details',
           ),
           AppGap.xl(),
-          const DetailInfoTile(
-            icon: Icons.settings_ethernet,
+          DetailInfoTile(
+            icon: isWifi ? Icons.wifi : Icons.settings_ethernet,
             label: 'Connection Type',
-            value: 'Ethernet (Wired)',
+            value: isWifi ? 'WiFi (Wireless)' : 'Ethernet (Wired)',
           ),
           if (device.parentNodeName != null) ...[
             AppGap.md(),
@@ -380,7 +382,7 @@ class _UspDeviceDetailViewState extends ConsumerState<UspDeviceDetailView> {
   Widget _buildDhcpCard(BuildContext context, WidgetRef ref,
       DeviceUIModel device, DeviceDetailState detail, bool isLoading) {
     final colorScheme = Theme.of(context).colorScheme;
-    final hasValidIpv4 = _hasValidIpv4(device.ip);
+    final hasValidIpv4 = NetworkUtils.isValidIpAddress(device.ip);
 
     return AppCard(
       child: Column(
@@ -467,16 +469,6 @@ class _UspDeviceDetailViewState extends ConsumerState<UspDeviceDetailView> {
         ],
       ),
     );
-  }
-
-  bool _hasValidIpv4(String ip) {
-    if (ip.isEmpty) return false;
-    final parts = ip.split('.');
-    if (parts.length != 4) return false;
-    return parts.every((part) {
-      final value = int.tryParse(part);
-      return value != null && value >= 0 && value <= 255;
-    });
   }
 
   // ===========================================================================

--- a/lib/page/topology/views/usp_topology_view.dart
+++ b/lib/page/topology/views/usp_topology_view.dart
@@ -40,7 +40,7 @@ class _UspTopologyViewState extends ConsumerState<UspTopologyView> {
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: (childContext, constraints) {
         return asyncDevices.when(
-          loading: () => const Center(child: CircularProgressIndicator()),
+          loading: () => const Center(child: AppLoader()),
           error: (error, _) => Center(
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -187,6 +187,9 @@ class _UspTopologyViewState extends ConsumerState<UspTopologyView> {
       GoRouter router, String nodeId, MeshTopology topology) {
     final node = topology.nodes.where((n) => n.id == nodeId).firstOrNull;
     if (node == null) return;
+
+    // Offline nodes are not navigable
+    if (node.status == MeshNodeStatus.offline) return;
 
     if (node.type == MeshNodeType.gateway ||
         node.type == MeshNodeType.extender) {


### PR DESCRIPTION
## Summary
- Offline devices are no longer tappable in device list and topology view
- Hide WiFi details card for offline devices in detail view
- Disable DHCP reservation when device has no valid IPv4
- Simplify dashboard connected devices card: max 5 online devices, device type icons (size 28), parent node as subtitle
- Ensure consistent tile height for offline devices
- Replace `CircularProgressIndicator` with `AppLoader` in topology view

## Test plan
- [x] Verify offline devices cannot be tapped in device list
- [x] Verify offline devices cannot be tapped in topology view
- [x] Verify WiFi details card is hidden for offline devices
- [x] Verify DHCP reservation button is disabled when no IPv4
- [x] Verify dashboard card shows max 5 online devices with correct layout
- [x] Verify tile height is consistent between online and offline devices

🤖 Generated with [Claude Code](https://claude.ai/code)