### PR TITLE
chore: add dart format pre-commit hook to Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,13 @@
             "type": "command",
             "command": "python3 .claude/hooks/pr_gate.py",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "if": "Bash(git commit *)",
+            "command": "staged=$(git diff --cached --name-only --diff-filter=ACM -- '*.dart'); if [ -n \"$staged\" ]; then if command -v fvm >/dev/null 2>&1; then echo \"$staged\" | xargs fvm dart format 2>/dev/null; else echo \"$staged\" | xargs dart format 2>/dev/null; fi; echo \"$staged\" | xargs git add; fi",
+            "timeout": 30,
+            "statusMessage": "Running dart format on staged files..."
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add a pre-commit hook in `.claude/settings.json` that automatically runs `dart format` on staged `.dart` files before committing
- Uses `fvm dart format` if available, falls back to `dart format`

## Test plan
- [ ] Verify hook triggers on `git commit` with staged `.dart` files
- [ ] Verify non-dart file commits are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)