### PR TITLE
feat: show YourNetworkStep for AutoParent devices in PnP flow

### DIFF
--- a/lib/page/instant_setup/data/pnp_provider.dart
+++ b/lib/page/instant_setup/data/pnp_provider.dart
@@ -33,7 +33,7 @@ import 'package:privacy_gui/providers/connectivity/mixin.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 final pnpProvider =
-    NotifierProvider<BasePnpNotifier, PnpState>(() => PnpNotifier());
+    NotifierProvider<BasePnpNotifier, PnpState>(() => MockPnpNotifier());
 
 abstract class BasePnpNotifier extends Notifier<PnpState> {
   @override
@@ -106,24 +106,47 @@ abstract class BasePnpNotifier extends Notifier<PnpState> {
 }
 
 class MockPnpNotifier extends BasePnpNotifier {
+  // Simulate Auto Parent case:
+  // - Router is already Master (isUnconfigured = false)
+  // - Not pre-paired (isPrePaired = false)
+  // - Should show YourNetworkStep for adding nodes
+
   @override
   Future checkAdminPassword(String? password) {
     if (password == 'Linksys123!') {
       return Future.delayed(const Duration(seconds: 1));
     }
-    return Future.delayed(const Duration(seconds: 3))
+    return Future.delayed(const Duration(seconds: 1))
         .then((value) => throw ExceptionInvalidAdminPassword());
   }
 
   @override
   Future checkInternetConnection([int retries = 1]) {
-    return Future.delayed(const Duration(seconds: 1))
-        .then((value) => throw ExceptionNoInternetConnection());
+    // Auto Parent: internet connected
+    return Future.delayed(const Duration(seconds: 1));
   }
 
   @override
   Future fetchDeviceInfo([bool clearCurrentSN = true]) {
-    return Future.delayed(const Duration(seconds: 1));
+    // Set mock device info to allow navigation to pnpConfig
+    // Delay state modification to avoid "modify provider while building" error
+    return Future.delayed(const Duration(seconds: 1)).then((_) {
+      state = state.copyWith(
+        deviceInfo: const NodeDeviceInfo(
+          manufacturer: 'Linksys',
+          modelNumber: 'MBE70',
+          hardwareVersion: '1',
+          description: 'Linksys Velop',
+          serialNumber: 'Mock12345678',
+          firmwareVersion: '1.0.0',
+          firmwareDate: '2024-01-01T00:00:00Z',
+          services: [
+            'http://linksys.com/jnap/guestnetwork/GuestNetwork',
+            'http://linksys.com/jnap/routerleds/RouterLEDs4',
+          ],
+        ),
+      );
+    });
   }
 
   @override
@@ -132,7 +155,7 @@ class MockPnpNotifier extends BasePnpNotifier {
         .then((value) => AutoConfigurationSettings(
               isAutoConfigurationSupported: true,
               userAcknowledgedAutoConfiguration: false,
-              autoConfigurationMethod: AutoConfigurationMethod.preConfigured,
+              autoConfigurationMethod: AutoConfigurationMethod.autoParent,
             ));
   }
 
@@ -143,7 +166,11 @@ class MockPnpNotifier extends BasePnpNotifier {
 
   @override
   Future fetchData() {
-    return Future.delayed(const Duration(seconds: 1));
+    // Simulate AutoParent case (not pre-paired)
+    return Future.delayed(const Duration(seconds: 1)).then((_) {
+      state = state.copyWith(isPrePaired: false);
+      logger.d('[PnP Mock]: fetchData - isPrePaired=${state.isPrePaired}');
+    });
   }
 
   @override
@@ -167,15 +194,13 @@ class MockPnpNotifier extends BasePnpNotifier {
   @override
   Future save() {
     return Future.delayed(const Duration(seconds: 5));
-    // .then((value) => throw ErrorNeedToReconnect());
   }
 
   @override
   Future checkRouterConfigured() {
-    state = state.copyWith(isUnconfigured: true);
-
-    return Future.delayed(const Duration(seconds: 1))
-        .then((value) => throw ExceptionRouterUnconfigured());
+    // Auto Parent: already configured as Master
+    state = state.copyWith(isUnconfigured: false);
+    return Future.delayed(const Duration(seconds: 1));
   }
 
   @override
@@ -367,7 +392,19 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
         .read(routerRepositoryProvider)
         .transaction(transaction, fetchRemote: true, retries: 10)
         .then((response) {
-      state = state.copyWith(data: Map.fromEntries(response.data));
+      final dataMap = Map.fromEntries(response.data);
+      state = state.copyWith(data: dataMap);
+      // Check if the device is pre-paired
+      final autoConfigResult =
+          (dataMap[JNAPAction.getAutoConfigurationSettings] as JNAPSuccess?)
+              ?.output;
+      if (autoConfigResult != null) {
+        final autoConfig = AutoConfigurationSettings.fromMap(autoConfigResult);
+        final isPrePaired = autoConfig.autoConfigurationMethod ==
+            AutoConfigurationMethod.preConfigured;
+        state = state.copyWith(isPrePaired: isPrePaired);
+        logger.d('[PnP]: isPrePaired=$isPrePaired');
+      }
     });
   }
 

--- a/lib/page/instant_setup/data/pnp_provider.dart
+++ b/lib/page/instant_setup/data/pnp_provider.dart
@@ -33,7 +33,7 @@ import 'package:privacy_gui/providers/connectivity/mixin.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 final pnpProvider =
-    NotifierProvider<BasePnpNotifier, PnpState>(() => MockPnpNotifier());
+    NotifierProvider<BasePnpNotifier, PnpState>(() => PnpNotifier());
 
 abstract class BasePnpNotifier extends Notifier<PnpState> {
   @override

--- a/lib/page/instant_setup/data/pnp_state.dart
+++ b/lib/page/instant_setup/data/pnp_state.dart
@@ -15,6 +15,7 @@ class PnpState extends Equatable {
   final Map<JNAPAction, JNAPResult> data;
   final List<RawDevice> childNodes;
   final bool forceLogin;
+  final bool isPrePaired;
 
   const PnpState({
     required this.deviceInfo,
@@ -24,6 +25,7 @@ class PnpState extends Equatable {
     this.data = const {},
     this.childNodes = const [],
     this.forceLogin = false,
+    this.isPrePaired = false,
   });
 
   PnpState copyWith({
@@ -34,6 +36,7 @@ class PnpState extends Equatable {
     Map<JNAPAction, JNAPResult>? data,
     List<RawDevice>? childNodes,
     bool? forceLogin,
+    bool? isPrePaired,
   }) {
     return PnpState(
       deviceInfo: deviceInfo ?? this.deviceInfo,
@@ -43,6 +46,7 @@ class PnpState extends Equatable {
       data: data ?? this.data,
       childNodes: childNodes ?? this.childNodes,
       forceLogin: forceLogin ?? this.forceLogin,
+      isPrePaired: isPrePaired ?? this.isPrePaired,
     );
   }
 
@@ -55,6 +59,7 @@ class PnpState extends Equatable {
         data,
         childNodes,
         forceLogin,
+        isPrePaired,
       ];
 
   bool get isRouterUnConfigured => isUnconfigured ?? false;

--- a/lib/page/instant_setup/pnp_setup_view.dart
+++ b/lib/page/instant_setup/pnp_setup_view.dart
@@ -3,7 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' as service;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/core/jnap/actions/better_action.dart';
 import 'package:privacy_gui/core/jnap/actions/jnap_service_supported.dart';
+import 'package:privacy_gui/core/jnap/models/auto_configuration_settings.dart';
 import 'package:privacy_gui/core/jnap/providers/firmware_update_provider.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
@@ -59,6 +61,7 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
   String _loadingMessage = '';
   String _loadingMessageSub = '';
   bool _isUnconfigured = false;
+  bool _isPrePaired = false;
   bool _needToReconnect = false;
   bool _hasNewFW = false;
   bool _forceLogin = false;
@@ -79,6 +82,7 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
       await ref.read(pnpProvider.notifier).fetchData();
     }).then((_) {
       _isUnconfigured = ref.read(pnpProvider).isRouterUnConfigured;
+      _isPrePaired = ref.read(pnpProvider).isPrePaired;
       _forceLogin = ref.read(pnpProvider).forceLogin;
       steps = buildSteps();
       logger.d(
@@ -162,9 +166,27 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
     final services = ref.read(pnpProvider).deviceInfo?.services;
     final isGuestWiFiSupport = serviceHelper.isSupportGuestNetwork(services);
     final isNightModeSupport = serviceHelper.isSupportLedMode(services);
+    // Show YourNetworkStep when unconfigured OR not pre-paired (AutoParent case)
+    final showYourNetwork = _isUnconfigured || !_isPrePaired;
+    // Determine if this is the last step before YourNetworkStep
+    final isLastBeforeYourNetwork =
+        !isGuestWiFiSupport && !isNightModeSupport && !showYourNetwork;
+    // Log PnP state for debugging
+    final autoConfigData = ref.read(pnpProvider.notifier).getData(JNAPAction.getAutoConfigurationSettings);
+    final autoConfigMethod = autoConfigData != null
+        ? AutoConfigurationSettings.fromMap(autoConfigData).autoConfigurationMethod?.name
+        : 'unknown';
+    logger.d('[PnP]: buildSteps state - '
+        'isUnconfigured=$_isUnconfigured, '
+        'isPrePaired=$_isPrePaired, '
+        'forceLogin=$_forceLogin, '
+        'showYourNetwork=$showYourNetwork, '
+        'autoConfigurationMethod=$autoConfigMethod, '
+        'isGuestWiFiSupport=$isGuestWiFiSupport, '
+        'isNightModeSupport=$isNightModeSupport');
     // Need a common way to figure out which step to save changes
-    return switch ((_forceLogin, _isUnconfigured)) {
-      (false, true) => [
+    return switch ((_forceLogin, _isUnconfigured, showYourNetwork)) {
+      (false, true, _) => [
           PersonalWiFiStep(
               saveChanges: !isGuestWiFiSupport && !isNightModeSupport
                   ? _saveChanges
@@ -175,17 +197,27 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
           if (isNightModeSupport) NightModeStep(saveChanges: _saveChanges),
           YourNetworkStep(saveChanges: _confirmAddedNodes),
         ],
-      (true, false) => [
+      (false, false, true) => [
+          PersonalWiFiStep(
+              saveChanges: !isGuestWiFiSupport && !isNightModeSupport
+                  ? null
+                  : null),
+          if (isGuestWiFiSupport)
+            GuestWiFiStep(saveChanges: !isNightModeSupport ? null : null),
+          if (isNightModeSupport) NightModeStep(saveChanges: null),
+          YourNetworkStep(saveChanges: _saveChanges),
+        ],
+      (true, false, _) => [
           PersonalWiFiStep(),
         ],
-      (true, true) => [
+      (true, true, _) => [
           PersonalWiFiStep(saveChanges: _saveChanges),
           YourNetworkStep(saveChanges: _confirmAddedNodes),
         ],
       _ => [
-          PersonalWiFiStep(),
-          if (isGuestWiFiSupport) GuestWiFiStep(),
-          if (isNightModeSupport) NightModeStep(),
+          PersonalWiFiStep(saveChanges: isLastBeforeYourNetwork ? _saveChanges : null),
+          if (isGuestWiFiSupport) GuestWiFiStep(saveChanges: !isNightModeSupport && !showYourNetwork ? _saveChanges : null),
+          if (isNightModeSupport) NightModeStep(saveChanges: !showYourNetwork ? _saveChanges : null),
         ],
     };
   }

--- a/test/page/instant_setup/localizations/pnp_setup_view_test.dart
+++ b/test/page/instant_setup/localizations/pnp_setup_view_test.dart
@@ -41,6 +41,7 @@ void main() async {
         deviceInfo:
             NodeDeviceInfo.fromJson(jsonDecode(testDeviceInfo)['output']),
         isUnconfigured: false,
+        isPrePaired: true,
         stepStateList: const {
           0: PnpStepState(status: StepViewStatus.data, data: {}),
           1: PnpStepState(status: StepViewStatus.data, data: {}),
@@ -412,6 +413,7 @@ void main() async {
     when(mockPnpNotifier.build()).thenReturn(PnpState(
       deviceInfo: NodeDeviceInfo.fromJson(jsonDecode(testDeviceInfo)['output']),
       isUnconfigured: false,
+      isPrePaired: true,
       stepStateList: const {
         0: PnpStepState(
           status: StepViewStatus.data,


### PR DESCRIPTION
## Summary

- Add `isPrePaired` field to PnpState to track pre-paired status
- Check `autoConfigurationMethod` in fetchData() to determine if device is PreConfigured
- Modify buildSteps() logic to show YourNetworkStep when `isUnconfigured || !isPrePaired`
- Update screenshot tests to include `isPrePaired` parameter

## Test plan

- [x] Verify PreConfigured device does NOT show Add Node step
- [x] Verify AutoParent device shows Add Node step
- [x] Verify unconfigured (retail) device shows Add Node step
- [x] Run screenshot tests: `./run_generate_loc_snapshots.sh --tags=loc --dart-define=locales="en" --dart-define=screens="1280"`

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)