### PR TITLE
chore(build): add theme_studio parameter to build_web.sh

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,9 @@
                 "--dart-define",
                 "force=local",
                 "--dart-define",
-                "custom_layout=true"
+                "custom_layout=true",
+                "--dart-define",
+                "theme_studio=true"
             ],
             "program": "lib/main.dart"
         },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,13 +22,14 @@ flutter run                       # Run on connected device/emulator
 
 ### Building
 ```bash
-# Web build with parameters: buildNumber, force, href, cloud, picker, ca, themeSource, themeJson
-./build_web.sh <buildNumber> <force> <href> <cloud> <picker> <ca> [themeSource] [themeJson]
+# Web build with parameters: buildNumber, force, href, cloud, picker, ca, themeSource, themeJson, themeStudio
+./build_web.sh <buildNumber> <force> <href> <cloud> <picker> <ca> [themeSource] [themeJson] [themeStudio]
 
 # Examples:
 ./build_web.sh 100 false "/" prod false true                           # Default theme
 ./build_web.sh 100 false "/" prod false true cicd '{"style":"neo"}'    # Override theme with JSON
 ./build_web.sh 100 false "/" prod false true network "https://..."     # Load theme from network
+./build_web.sh 100 false "/" qa false true "" "" true                  # Enable theme studio
 ```
 
 ### Testing

--- a/build_web.sh
+++ b/build_web.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Usage:
+#   ./build_web.sh <buildNumber> <force> <href> <cloud> <picker> <ca> [themeSource] [themeJson] [themeStudio]
+#
+# Examples:
+#   ./build_web.sh 100 false "/" prod false true                        # Default theme
+#   ./build_web.sh 100 false "/" prod false true cicd '{"style":"neo"}' # Override theme
+#   ./build_web.sh 100 false "/" qa false true "" "" true               # Enable theme studio
+
 # Detect fvm: use fvm flutter if available, otherwise use flutter directly
 if command -v fvm > /dev/null 2>&1 && [ -f ".fvmrc" ]; then
   FLUTTER="fvm flutter"
@@ -13,22 +21,39 @@ function buildWebApp() {
   echo "start building web app #${buildNumber}-${force}-${cloud}"
   echo "base href is ${href}"
 
-  if [ "$cloud" == "qa" ]; then
-    $FLUTTER build web --target=lib/main.dart --base-href="/${href}" --build-number="${buildNumber}" --dart-define=force="${force}" --dart-define=cloud_env="${cloud}" --dart-define=enable_env_picker="${picker}" --dart-define=ca="${ca}" --dart-define=THEME_SOURCE="${themeSource}" --dart-define=THEME_JSON="${themeJson}" $enableHTMLRenderer
-  else
-    $FLUTTER build web --target=lib/main.dart --base-href="/${href}" --build-number="${buildNumber}" --dart-define=force="${force}" --dart-define=cloud_env="${cloud}" --dart-define=enable_env_picker="${picker}" --dart-define=ca="${ca}" --dart-define=THEME_SOURCE="${themeSource}" --dart-define=THEME_JSON="${themeJson}" $enableHTMLRenderer
-  fi
-  # rm -rf ./build/web/canvasKit
+  $FLUTTER build web --target=lib/main.dart --base-href="/${href}" \
+    --build-number="${buildNumber}" \
+    --dart-define=force="${force}" \
+    --dart-define=cloud_env="${cloud}" \
+    --dart-define=enable_env_picker="${picker}" \
+    --dart-define=ca="${ca}" \
+    $themeSourceFlag $themeJsonFlag $themeStudioFlag $enableHTMLRenderer
 }
 
-buildNumber=$1
-force=$2
-href=$3
-cloud=$4
-picker=$5
-ca=$6
-themeSource=$7
-themeJson=$8
+buildNumber=${1}
+force=${2}
+href=${3}
+cloud=${4}
+picker=${5}
+ca=${6}
+themeSource=${7}
+themeJson=${8}
+themeStudio=${9}
+
+themeSourceFlag=""
+if [ "$themeSource" != "" ]; then
+    themeSourceFlag="--dart-define=THEME_SOURCE=${themeSource}"
+fi
+
+themeJsonFlag=""
+if [ "$themeJson" != "" ]; then
+    themeJsonFlag="--dart-define=THEME_JSON=${themeJson}"
+fi
+
+themeStudioFlag=""
+if [ "$themeStudio" == "true" ]; then
+    themeStudioFlag="--dart-define=theme_studio=true"
+fi
 
 enableHTMLRenderer=""
 if [ "$FlutterVersion" == "3.27.1" ]; then


### PR DESCRIPTION
## Summary
- Add optional `themeStudio` flag as 9th parameter to `build_web.sh`
- Simplify redundant qa/prod branch logic in build script
- Add usage examples in script header
- Update CLAUDE.md with new parameter documentation
- Enable `theme_studio=true` in VSCode launch config for local dev

## Test plan
- [ ] Run `./build_web.sh 100 false "/" qa false true "" "" true` and verify theme studio is enabled
- [ ] Run without themeStudio param and verify build still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)