### PR TITLE
fix: extend UI idle timeout from 5 to 15 minutes

### DIFF
--- a/lib/page/components/layouts/root_container.dart
+++ b/lib/page/components/layouts/root_container.dart
@@ -45,7 +45,7 @@ class _AppRootContainerState extends ConsumerState<AppRootContainer> {
 
     return LayoutBuilder(builder: ((context, constraints) {
       return IdleChecker(
-        idleTime: const Duration(minutes: 5),
+        idleTime: const Duration(minutes: 15),
         onIdle: () {
           // not for debug
           if (!kReleaseMode) {


### PR DESCRIPTION
## Summary

Extends the UI idle timeout in `root_container.dart` from 5 minutes to 15 minutes. Addresses [LinksysNow#4](https://github.com/linksys/LinksysNow/issues/4) — field installers were being logged out 3-4 times during typical installation workflows under the previous 5-minute timeout. 15 minutes is a more typical value for this kind of admin UI.

## Change

```diff
- idleTime: const Duration(minutes: 5),
+ idleTime: const Duration(minutes: 15),
```

Single line change in [`lib/page/components/layouts/root_container.dart`](lib/page/components/layouts/root_container.dart).

## Why this is safe — areas verified to be unaffected

### Cloud session tokens — unaffected
[`auth_provider.dart` `checkSessionToken` / `handleSessionTokenError` / `refreshToken`](lib/providers/auth/auth_provider.dart) handle token expiry **reactively**: when a request finds the token expired, `NeedToRefreshTokenException` is thrown and the refresh token is used to obtain a new one automatically. This path is independent of the idle timer — the user does not perceive token expiry, and the idle timer value has no influence on this flow.

### RA (Remote Assistance) sessions — unaffected
[`ra_session_provider.dart` `startMonitorSession` / `pollSessionInfo`](lib/providers/auth/ra_session_provider.dart) actively polls the server every 5 seconds. When the server reports the RA session has expired (or the user revokes it from their side), `authProvider.logout()` is called directly. This server-driven termination runs in parallel to the idle timer and is unchanged. The RA session's hard upper bound is enforced server-side, so its security posture is unaffected by extending the client-side idle window.

### PWA standalone mode — unaffected
[`idle_checker.dart` `_resetTimer`](lib/page/components/layouts/idle_checker.dart) returns early in PWA standalone mode (`pwaService.isStandalone`). The idle timer is not started at all in this mode, so changing the duration has no effect on installed-PWA users.

### Existing `idleCheckerPauseProvider` usage — unaffected
The `addNodes` flow in [`add_wired_nodes_provider.dart`](lib/page/nodes/providers/add_wired_nodes_provider.dart) sets `pause = true` during auto-onboarding. Since the pause check is independent of the timer duration, this flow continues to work the same way.

### Tests — none broken
`grep` of `test/` finds no references to `Duration(minutes: 5)`, `idleTime`, or `IdleChecker`. The previous value was not covered by tests, so there is nothing to update.

## Security considerations

15 minutes is a common value for admin/management UIs and remains within typical industry practice for this class of application. The actual protection against an unattended physical session is provided primarily by OS-level screen lock and physical access controls; the in-app idle timer is a supplementary defense.
