### PR TITLE
feat(firmware-update): add OTA firmware update support

### DIFF
--- a/lib/constants/cloud_const.dart
+++ b/lib/constants/cloud_const.dart
@@ -10,6 +10,7 @@ const kCloudAware = 'CLOUD_AWARE_URL';
 const kCloudAwarePort = 'CLOUD_AWARE_PORT';
 const kCloudAwareKey = 'CLOUD_AWARE_KEY';
 const kCloudAwareScheme = 'CLOUD_AWARE_SCHEME';
+const kFirmwareOtaBase = 'FIRMWARE_OTA_BASE_URL';
 
 const linksysCloudBaseUrl = 'linksyssmartwifi.com';
 const linksysCloudStatusBaseUrl = 'cloudhealth.lswf.net/cloud-availability';
@@ -25,6 +26,7 @@ const kCloudEnvironmentConfigProd = {
   kCloudAwarePort: 3000,
   kCloudAwareKey: '339ec1249258dfd7e689',
   kCloudAwareScheme: 'https',
+  kFirmwareOtaBase: 'https://update.linksys.com',
 };
 // Linksys QA
 const kCloudEnvironmentConfigQa = {
@@ -37,6 +39,7 @@ const kCloudEnvironmentConfigQa = {
   kCloudAwarePort: 80,
   kCloudAwareKey: '372851d642c0f179905e',
   kCloudAwareScheme: 'http',
+  kFirmwareOtaBase: 'https://update-stage.linksys.com',
 };
 // Linksys DEV
 const kCloudEnvironmentConfigDev = {
@@ -49,6 +52,7 @@ const kCloudEnvironmentConfigDev = {
   kCloudAwarePort: 80,
   kCloudAwareKey: 'efeb0fd364285aaa1201',
   kCloudAwareScheme: 'http',
+  kFirmwareOtaBase: 'https://update-stage.linksys.com',
 };
 const Map<CloudEnvironment, dynamic> kCloudEnvironmentMap = {
   CloudEnvironment.prod: kCloudEnvironmentConfigProd,
@@ -121,6 +125,9 @@ const kDeviceUpload =
 const kTickets = '/cloud/v1/tickets';
 const kGetTicketDetails = '/cloud/v1/tickets/$kTicketId';
 const kCreateTicketUpload = '/cloud/v1/tickets/$kTicketId/uploads';
+
+// Firmware OTA
+const kFirmwareOtaEndpoint = '/api/v2/fw/update';
 
 // NEW smart device
 const kSmartDeviceAssociate = '/cloud/v1/smart-devices/associate';

--- a/lib/page/firmware_update/models/firmware_ota_info.dart
+++ b/lib/page/firmware_update/models/firmware_ota_info.dart
@@ -1,0 +1,79 @@
+import 'package:equatable/equatable.dart';
+
+/// Response model from the Linksys firmware update cloud API.
+///
+/// When an update is available, all fields are populated.
+/// When no update is available, the API returns an empty response body.
+class FirmwareOtaInfo extends Equatable {
+  final String version;
+  final DateTime releaseDate;
+  final String downloadUrl;
+  final String checksum;
+  final String checkInterval;
+  final String checkTime;
+
+  const FirmwareOtaInfo({
+    required this.version,
+    required this.releaseDate,
+    required this.downloadUrl,
+    required this.checksum,
+    required this.checkInterval,
+    required this.checkTime,
+  });
+
+  factory FirmwareOtaInfo.fromJson(Map<String, dynamic> json) {
+    return FirmwareOtaInfo(
+      version: json['version'] as String? ?? '',
+      releaseDate: DateTime.tryParse(json['release_date'] as String? ?? '') ??
+          DateTime.now(),
+      downloadUrl: json['download_url'] as String? ?? '',
+      checksum: json['checksum'] as String? ?? '',
+      checkInterval: json['check_interval'] as String? ?? '',
+      checkTime: json['check_time'] as String? ?? '',
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        version,
+        releaseDate,
+        downloadUrl,
+        checksum,
+        checkInterval,
+        checkTime,
+      ];
+}
+
+/// Query parameters required for the firmware OTA check API.
+class FirmwareOtaCheckParams extends Equatable {
+  final String macAddress;
+  final String installedVersion;
+  final String modelNumber;
+  final String hardwareVersion;
+  final String ipAddress;
+
+  const FirmwareOtaCheckParams({
+    required this.macAddress,
+    required this.installedVersion,
+    required this.modelNumber,
+    required this.hardwareVersion,
+    required this.ipAddress,
+  });
+
+  Map<String, String> toQueryParams() => {
+        'mac_address': macAddress,
+        'installed_version': installedVersion,
+        'model_number': modelNumber,
+        'hardware_version': hardwareVersion,
+        'ip_address': ipAddress,
+      };
+
+  @override
+  List<Object?> get props => [
+        macAddress,
+        installedVersion,
+        modelNumber,
+        hardwareVersion,
+        ipAddress,
+      ];
+}

--- a/lib/page/firmware_update/models/firmware_ota_info.dart
+++ b/lib/page/firmware_update/models/firmware_ota_info.dart
@@ -6,7 +6,7 @@ import 'package:equatable/equatable.dart';
 /// When no update is available, the API returns an empty response body.
 class FirmwareOtaInfo extends Equatable {
   final String version;
-  final DateTime releaseDate;
+  final DateTime? releaseDate;
   final String downloadUrl;
   final String checksum;
   final String checkInterval;
@@ -14,7 +14,7 @@ class FirmwareOtaInfo extends Equatable {
 
   const FirmwareOtaInfo({
     required this.version,
-    required this.releaseDate,
+    this.releaseDate,
     required this.downloadUrl,
     required this.checksum,
     required this.checkInterval,
@@ -24,8 +24,7 @@ class FirmwareOtaInfo extends Equatable {
   factory FirmwareOtaInfo.fromJson(Map<String, dynamic> json) {
     return FirmwareOtaInfo(
       version: json['version'] as String? ?? '',
-      releaseDate: DateTime.tryParse(json['release_date'] as String? ?? '') ??
-          DateTime.now(),
+      releaseDate: DateTime.tryParse(json['release_date'] as String? ?? ''),
       downloadUrl: json['download_url'] as String? ?? '',
       checksum: json['checksum'] as String? ?? '',
       checkInterval: json['check_interval'] as String? ?? '',

--- a/lib/page/firmware_update/models/firmware_update_phase.dart
+++ b/lib/page/firmware_update/models/firmware_update_phase.dart
@@ -1,5 +1,6 @@
 enum FirmwareUpdatePhase {
   idle,
+  checkingOta,
   picking,
   validating,
   uploading,

--- a/lib/page/firmware_update/models/firmware_update_state.dart
+++ b/lib/page/firmware_update/models/firmware_update_state.dart
@@ -66,6 +66,7 @@ class FirmwareUpdateState extends Equatable {
     String? errorMessage,
     UploadMethod? uploadMethod,
     FirmwareOtaInfo? otaInfo,
+    bool clearOtaInfo = false,
     bool? otaUpToDate,
   }) {
     return FirmwareUpdateState(
@@ -81,7 +82,7 @@ class FirmwareUpdateState extends Equatable {
       rebootRemaining: rebootRemaining ?? this.rebootRemaining,
       errorMessage: errorMessage ?? this.errorMessage,
       uploadMethod: uploadMethod ?? this.uploadMethod,
-      otaInfo: otaInfo ?? this.otaInfo,
+      otaInfo: clearOtaInfo ? null : (otaInfo ?? this.otaInfo),
       otaUpToDate: otaUpToDate ?? this.otaUpToDate,
     );
   }

--- a/lib/page/firmware_update/models/firmware_update_state.dart
+++ b/lib/page/firmware_update/models/firmware_update_state.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_image_ui_model.dart';
+import 'package:privacy_gui/page/firmware_update/models/firmware_ota_info.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_update_phase.dart';
 import 'package:privacy_gui/page/firmware_update/services/firmware_upload_strategy.dart';
 
@@ -19,6 +20,12 @@ class FirmwareUpdateState extends Equatable {
   /// The upload method used for the current/last upload (null if not started).
   final UploadMethod? uploadMethod;
 
+  /// OTA check result: available update info, or null if up to date / not checked.
+  final FirmwareOtaInfo? otaInfo;
+
+  /// Whether OTA check has been performed and no update was found.
+  final bool otaUpToDate;
+
   const FirmwareUpdateState({
     this.phase = FirmwareUpdatePhase.idle,
     this.activeBank,
@@ -32,6 +39,8 @@ class FirmwareUpdateState extends Equatable {
     this.rebootRemaining,
     this.errorMessage,
     this.uploadMethod,
+    this.otaInfo,
+    this.otaUpToDate = false,
   });
 
   double get uploadProgress =>
@@ -56,6 +65,8 @@ class FirmwareUpdateState extends Equatable {
     Duration? rebootRemaining,
     String? errorMessage,
     UploadMethod? uploadMethod,
+    FirmwareOtaInfo? otaInfo,
+    bool? otaUpToDate,
   }) {
     return FirmwareUpdateState(
       phase: phase ?? this.phase,
@@ -70,6 +81,8 @@ class FirmwareUpdateState extends Equatable {
       rebootRemaining: rebootRemaining ?? this.rebootRemaining,
       errorMessage: errorMessage ?? this.errorMessage,
       uploadMethod: uploadMethod ?? this.uploadMethod,
+      otaInfo: otaInfo ?? this.otaInfo,
+      otaUpToDate: otaUpToDate ?? this.otaUpToDate,
     );
   }
 
@@ -87,5 +100,7 @@ class FirmwareUpdateState extends Equatable {
         rebootRemaining,
         errorMessage,
         uploadMethod,
+        otaInfo,
+        otaUpToDate,
       ];
 }

--- a/lib/page/firmware_update/providers/firmware_update_notifier.dart
+++ b/lib/page/firmware_update/providers/firmware_update_notifier.dart
@@ -141,7 +141,7 @@ class FirmwareUpdateNotifier extends AutoDisposeNotifier<FirmwareUpdateState> {
       FirmwareOtaCheckParams params) async {
     _setState(state.copyWith(
       phase: FirmwareUpdatePhase.checkingOta,
-      otaInfo: null,
+      clearOtaInfo: true,
       otaUpToDate: false,
       errorMessage: null,
     ));
@@ -157,7 +157,7 @@ class FirmwareUpdateNotifier extends AutoDisposeNotifier<FirmwareUpdateState> {
       } else {
         _setState(state.copyWith(
           phase: FirmwareUpdatePhase.idle,
-          otaInfo: null,
+          clearOtaInfo: true,
           otaUpToDate: true,
         ));
       }

--- a/lib/page/firmware_update/providers/firmware_update_notifier.dart
+++ b/lib/page/firmware_update/providers/firmware_update_notifier.dart
@@ -7,11 +7,13 @@ import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/core/usp/providers/bridge_request_throttler_provider.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_image_ui_model.dart';
+import 'package:privacy_gui/page/firmware_update/models/firmware_ota_info.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_update_phase.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_update_state.dart';
 import 'package:privacy_gui/page/firmware_update/providers/firmware_banks_data_provider.dart';
 import 'package:privacy_gui/page/firmware_update/services/firmware_file_picker_service.dart';
 import 'package:privacy_gui/page/firmware_update/services/firmware_local_upload_service.dart';
+import 'package:privacy_gui/page/firmware_update/services/firmware_ota_check_service.dart';
 import 'package:privacy_gui/page/firmware_update/services/firmware_validation_service.dart';
 import 'package:privacy_gui/page/firmware_update/services/usp_firmware_update_service.dart';
 
@@ -38,6 +40,8 @@ class FirmwareUpdateNotifier extends AutoDisposeNotifier<FirmwareUpdateState> {
       ref.read(firmwareValidationServiceProvider);
   FirmwareLocalUploadService get _uploader =>
       ref.read(firmwareLocalUploadServiceProvider);
+  FirmwareOtaCheckService get _otaChecker =>
+      ref.read(firmwareOtaCheckServiceProvider);
 
   /// Holds the picked image bytes off-state. Kept off [FirmwareUpdateState]
   /// because a 70 MB Uint8List does not belong in an equatable comparison
@@ -75,6 +79,43 @@ class FirmwareUpdateNotifier extends AutoDisposeNotifier<FirmwareUpdateState> {
     } on ServiceError catch (e) {
       logger.e('[FirmwareUpdate] loadBanks failed', error: e);
       _fail(e.toString());
+      rethrow;
+    }
+  }
+
+  /// Check for OTA firmware updates from the cloud.
+  ///
+  /// Returns the [FirmwareOtaInfo] if an update is available, or `null` if
+  /// the device is already on the latest version.
+  /// Throws [FirmwareOtaCheckException] on API errors.
+  Future<FirmwareOtaInfo?> checkForOtaUpdate(
+      FirmwareOtaCheckParams params) async {
+    _setState(state.copyWith(
+      phase: FirmwareUpdatePhase.checkingOta,
+      otaInfo: null,
+      otaUpToDate: false,
+      errorMessage: null,
+    ));
+
+    try {
+      final info = await _otaChecker.checkForUpdate(params);
+      if (info != null) {
+        _setState(state.copyWith(
+          phase: FirmwareUpdatePhase.idle,
+          otaInfo: info,
+          otaUpToDate: false,
+        ));
+      } else {
+        _setState(state.copyWith(
+          phase: FirmwareUpdatePhase.idle,
+          otaInfo: null,
+          otaUpToDate: true,
+        ));
+      }
+      return info;
+    } on FirmwareOtaCheckException catch (e) {
+      logger.e('[FirmwareUpdate] OTA check failed', error: e);
+      _setState(state.copyWith(phase: FirmwareUpdatePhase.idle));
       rethrow;
     }
   }
@@ -178,6 +219,26 @@ class FirmwareUpdateNotifier extends AutoDisposeNotifier<FirmwareUpdateState> {
       _setState(state.copyWith(phase: FirmwareUpdatePhase.installing));
     } on ServiceError catch (e) {
       logger.e('[FirmwareUpdate] triggerInstall failed', error: e);
+      _fail(e.toString());
+      rethrow;
+    }
+  }
+
+  Future<void> triggerOtaInstall({
+    required int targetInstance,
+    required String firmwareUrl,
+  }) async {
+    _setState(state.copyWith(phase: FirmwareUpdatePhase.triggering));
+    try {
+      await ref.read(uspMutationLockProvider).withLock(() async {
+        await _svc.triggerOtaDownload(
+          targetInstance: targetInstance,
+          firmwareUrl: firmwareUrl,
+        );
+      });
+      _setState(state.copyWith(phase: FirmwareUpdatePhase.installing));
+    } on ServiceError catch (e) {
+      logger.e('[FirmwareUpdate] triggerOtaInstall failed', error: e);
       _fail(e.toString());
       rethrow;
     }

--- a/lib/page/firmware_update/providers/firmware_update_notifier.dart
+++ b/lib/page/firmware_update/providers/firmware_update_notifier.dart
@@ -6,7 +6,10 @@ import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/core/usp/providers/bridge_request_throttler_provider.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/page/admin/providers/system_info_data_provider.dart';
+import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_image_ui_model.dart';
+import 'package:privacy_gui/page/topology/models/node_ui_model.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_ota_info.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_update_phase.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_update_state.dart';
@@ -16,6 +19,7 @@ import 'package:privacy_gui/page/firmware_update/services/firmware_local_upload_
 import 'package:privacy_gui/page/firmware_update/services/firmware_ota_check_service.dart';
 import 'package:privacy_gui/page/firmware_update/services/firmware_validation_service.dart';
 import 'package:privacy_gui/page/firmware_update/services/usp_firmware_update_service.dart';
+import 'package:privacy_gui/page/internet_settings/providers/wan_data_provider.dart';
 
 final firmwareUpdateNotifierProvider =
     AutoDisposeNotifierProvider<FirmwareUpdateNotifier, FirmwareUpdateState>(
@@ -81,6 +85,51 @@ class FirmwareUpdateNotifier extends AutoDisposeNotifier<FirmwareUpdateState> {
       _fail(e.toString());
       rethrow;
     }
+  }
+
+  /// Build OTA check parameters from device data providers.
+  ///
+  /// Returns `null` if required data is unavailable (e.g., master node not found).
+  Future<FirmwareOtaCheckParams?> buildOtaCheckParams() async {
+    try {
+      final devicesData = await ref.read(devicesDataProvider.future);
+      final masterNode = devicesData.nodeModels.master;
+      if (masterNode == null) {
+        logger.w('[FirmwareUpdate] Master node not found');
+        return null;
+      }
+
+      final systemInfoData = await ref.read(systemInfoDataProvider.future);
+      final hardwareVersion =
+          _parseHardwareVersion(systemInfoData.model.hardwareVersion);
+
+      final wanData = await ref.read(wanDataProvider.future);
+      final ipAddress = wanData.model.ipAddress;
+
+      return FirmwareOtaCheckParams(
+        macAddress: _formatMacAddress(masterNode.deviceId),
+        installedVersion: masterNode.softwareVersion,
+        modelNumber: masterNode.model,
+        hardwareVersion: hardwareVersion,
+        ipAddress: ipAddress,
+      );
+    } catch (e) {
+      logger.e('[FirmwareUpdate] Failed to build OTA check params', error: e);
+      return null;
+    }
+  }
+
+  String _formatMacAddress(String mac) {
+    return mac.toUpperCase().replaceAll(':', '-');
+  }
+
+  String _parseHardwareVersion(String hwVersion) {
+    var version = hwVersion;
+    if (version.toUpperCase().startsWith('V')) {
+      version = version.substring(1);
+    }
+    final parsed = int.tryParse(version);
+    return parsed?.toString() ?? version;
   }
 
   /// Check for OTA firmware updates from the cloud.

--- a/lib/page/firmware_update/services/firmware_ota_check_service.dart
+++ b/lib/page/firmware_update/services/firmware_ota_check_service.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/constants/_constants.dart';
+import 'package:privacy_gui/core/cloud/http/linksys_http_client.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/page/firmware_update/models/firmware_ota_info.dart';
+
+final firmwareOtaCheckServiceProvider = Provider<FirmwareOtaCheckService>(
+  (ref) => FirmwareOtaCheckService(),
+);
+
+class FirmwareOtaCheckException implements Exception {
+  final String message;
+  FirmwareOtaCheckException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+/// Service for checking firmware updates from the Linksys cloud.
+class FirmwareOtaCheckService {
+  final LinksysHttpClient _client;
+
+  FirmwareOtaCheckService({LinksysHttpClient? client})
+      : _client = client ?? LinksysHttpClient();
+
+  /// Check for firmware updates.
+  ///
+  /// Returns [FirmwareOtaInfo] if an update is available, or `null` if
+  /// the device is already on the latest version (API returns empty body).
+  Future<FirmwareOtaInfo?> checkForUpdate(FirmwareOtaCheckParams params) async {
+    final baseUrl = cloudEnvironmentConfig[kFirmwareOtaBase] as String;
+    final uri = Uri.parse('$baseUrl$kFirmwareOtaEndpoint')
+        .replace(queryParameters: params.toQueryParams());
+
+    logger.d('[FirmwareOta] Checking for update at $uri');
+
+    try {
+      final response = await _client.get(uri);
+
+      if (response.statusCode != 200) {
+        logger.w('[FirmwareOta] API returned status ${response.statusCode}');
+        throw FirmwareOtaCheckException(
+          'Failed to check for updates: HTTP ${response.statusCode}',
+        );
+      }
+
+      if (response.body.isEmpty) {
+        logger.d('[FirmwareOta] No update available (empty response)');
+        return null;
+      }
+
+      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      final info = FirmwareOtaInfo.fromJson(json);
+      logger.d('[FirmwareOta] Update available: ${info.version}');
+      return info;
+    } on FirmwareOtaCheckException {
+      rethrow;
+    } catch (e) {
+      logger.e('[FirmwareOta] Error checking for update', error: e);
+      throw FirmwareOtaCheckException('Failed to check for updates: $e');
+    }
+  }
+}

--- a/lib/page/firmware_update/services/firmware_ota_check_service.dart
+++ b/lib/page/firmware_update/services/firmware_ota_check_service.dart
@@ -34,7 +34,7 @@ class FirmwareOtaCheckService {
     final uri = Uri.parse('$baseUrl$kFirmwareOtaEndpoint')
         .replace(queryParameters: params.toQueryParams());
 
-    logger.d('[FirmwareOta] Checking for update at $uri');
+    logger.d('[FirmwareOta] Checking for update at ${uri.path}');
 
     try {
       final response = await _client.get(uri);

--- a/lib/page/firmware_update/services/usp_firmware_update_service.dart
+++ b/lib/page/firmware_update/services/usp_firmware_update_service.dart
@@ -71,6 +71,25 @@ class UspFirmwareUpdateService {
     }
   }
 
+  Future<void> triggerOtaDownload({
+    required int targetInstance,
+    required String firmwareUrl,
+    bool autoActivate = true,
+  }) async {
+    try {
+      await FirmwareOperations.download(
+        _usp,
+        targetInstance,
+        url: firmwareUrl,
+        autoActivate: autoActivate ? 'true' : 'false',
+      );
+    } on ServiceError {
+      rethrow;
+    } catch (e) {
+      throw mapUspErrorToServiceError(e);
+    }
+  }
+
   Future<String> pollStatus(int instance) async {
     try {
       final images = await FirmwareImages.fetch(_usp);

--- a/lib/page/firmware_update/views/firmware_update_view.dart
+++ b/lib/page/firmware_update/views/firmware_update_view.dart
@@ -11,12 +11,17 @@ import 'package:privacy_gui/page/_shared/models/system_info_ui_model.dart'
     hide FirmwareImageUIModel;
 import 'package:privacy_gui/page/admin/providers/system_info_data_provider.dart';
 import 'package:privacy_gui/page/admin/views/dialogs/confirm_action_dialog.dart';
+import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_image_ui_model.dart';
+import 'package:privacy_gui/page/firmware_update/models/firmware_ota_info.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_update_phase.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_update_state.dart';
 import 'package:privacy_gui/page/firmware_update/providers/firmware_banks_data_provider.dart';
 import 'package:privacy_gui/page/firmware_update/providers/firmware_update_notifier.dart';
 import 'package:privacy_gui/page/firmware_update/services/firmware_local_upload_service.dart';
+import 'package:privacy_gui/page/firmware_update/services/firmware_ota_check_service.dart';
+import 'package:privacy_gui/page/internet_settings/providers/wan_data_provider.dart';
+import 'package:privacy_gui/page/topology/models/node_ui_model.dart';
 import 'package:privacy_gui/page/firmware_update/views/dialogs/firmware_update_recovery_dialog.dart';
 import 'package:privacy_gui/page/shell/usp_top_bar.dart';
 import 'package:privacy_gui/route/constants.dart';
@@ -35,9 +40,13 @@ class FirmwareUpdateView extends ConsumerStatefulWidget {
 }
 
 class _FirmwareUpdateViewState extends ConsumerState<FirmwareUpdateView> {
-  /// Delay after triggering install before showing recovery dialog.
+  /// Delay after triggering local install before showing recovery dialog.
   /// Router typically takes ~60-90 seconds to write firmware before reboot.
-  static const _installDelayBeforeReboot = Duration(seconds: 60);
+  static const _localInstallDelayBeforeReboot = Duration(seconds: 60);
+
+  /// Delay after triggering OTA install before showing recovery dialog.
+  /// Router needs to download (~50-100MB) + flash, typically ~120 seconds.
+  static const _otaInstallDelayBeforeReboot = Duration(seconds: 120);
 
   @override
   void initState() {
@@ -85,6 +94,11 @@ class _FirmwareUpdateViewState extends ConsumerState<FirmwareUpdateView> {
           isLoadingBanks: isLoadingBanks,
         ),
         AppGap.xl(),
+        _OtaCheckCard(
+          state: state,
+          onCheck: () => _onCheckForUpdates(context),
+        ),
+        AppGap.xl(),
         _buildActionCard(context, state),
         AppGap.xl(),
         _buildWarningNote(context),
@@ -95,6 +109,7 @@ class _FirmwareUpdateViewState extends ConsumerState<FirmwareUpdateView> {
   Widget _buildActionCard(BuildContext context, FirmwareUpdateState state) {
     switch (state.phase) {
       case FirmwareUpdatePhase.idle:
+      case FirmwareUpdatePhase.checkingOta:
         return _buildIdleCard(context, state);
       case FirmwareUpdatePhase.picking:
       case FirmwareUpdatePhase.validating:
@@ -339,6 +354,140 @@ class _FirmwareUpdateViewState extends ConsumerState<FirmwareUpdateView> {
     );
   }
 
+  Future<void> _onCheckForUpdates(BuildContext context) async {
+    try {
+      final params = await _buildOtaCheckParams();
+      if (params == null) {
+        if (context.mounted) {
+          showFailedSnackBar(context, 'Unable to gather device information');
+        }
+        return;
+      }
+
+      final notifier = ref.read(firmwareUpdateNotifierProvider.notifier);
+      final info = await notifier.checkForOtaUpdate(params);
+
+      if (!context.mounted) return;
+
+      if (info != null) {
+        // Update available - show dialog
+        await _showOtaUpdateDialog(context, info);
+      }
+      // If info is null, state.otaUpToDate is true, UI will show "Up to date"
+    } on FirmwareOtaCheckException catch (e) {
+      if (context.mounted) {
+        showFailedSnackBar(context, e.message);
+      }
+    }
+  }
+
+  Future<FirmwareOtaCheckParams?> _buildOtaCheckParams() async {
+    try {
+      final devicesData = await ref.read(devicesDataProvider.future);
+      final masterNode = devicesData.nodeModels.master;
+      if (masterNode == null) {
+        logger.w('[FirmwareUpdate] Master node not found');
+        return null;
+      }
+
+      final systemInfoData = await ref.read(systemInfoDataProvider.future);
+      final hardwareVersion =
+          _parseHardwareVersion(systemInfoData.model.hardwareVersion);
+
+      final wanData = await ref.read(wanDataProvider.future);
+      final ipAddress = wanData.model.ipAddress;
+
+      return FirmwareOtaCheckParams(
+        macAddress: _formatMacAddress(masterNode.deviceId),
+        installedVersion: masterNode.softwareVersion,
+        modelNumber: masterNode.model,
+        hardwareVersion: hardwareVersion,
+        ipAddress: ipAddress,
+      );
+    } catch (e) {
+      logger.e('[FirmwareUpdate] Failed to build OTA check params', error: e);
+      return null;
+    }
+  }
+
+  String _formatMacAddress(String mac) {
+    return mac.toUpperCase().replaceAll(':', '-');
+  }
+
+  String _parseHardwareVersion(String hwVersion) {
+    var version = hwVersion;
+    if (version.toUpperCase().startsWith('V')) {
+      version = version.substring(1);
+    }
+    final parsed = int.tryParse(version);
+    return parsed?.toString() ?? version;
+  }
+
+  Future<void> _showOtaUpdateDialog(
+      BuildContext context, FirmwareOtaInfo info) async {
+    final state = ref.read(firmwareUpdateNotifierProvider);
+    final currentVersion = state.activeBank?.version ?? '—';
+    final target = state.targetBank;
+
+    if (target == null) {
+      showFailedSnackBar(context, 'No target bank available');
+      return;
+    }
+
+    final confirmed = await showConfirmActionDialog(
+      context,
+      title: 'Update Available',
+      message: 'Current: $currentVersion\n'
+          'Available: ${info.version}\n\n'
+          'Do you want to update now?',
+      confirmLabel: 'Update',
+    );
+
+    if (confirmed != true || !context.mounted) return;
+
+    final notifier = ref.read(firmwareUpdateNotifierProvider.notifier);
+
+    try {
+      await notifier.triggerOtaInstall(
+        targetInstance: target.instance,
+        firmwareUrl: info.downloadUrl,
+      );
+    } catch (e, st) {
+      logger.e('[FirmwareUpdate] triggerOtaInstall error: $e',
+          error: e, stackTrace: st);
+      if (context.mounted) {
+        showFailedSnackBar(context, 'Failed to start OTA update');
+      }
+      return;
+    }
+
+    if (!context.mounted) return;
+
+    // Wait for OTA download + flash before entering recovery
+    await Future<void>.delayed(_otaInstallDelayBeforeReboot);
+    if (!context.mounted) return;
+
+    // Hand off to the shared recovery framework
+    final expectedVersion = info.version;
+    notifier.enterRecoveryWaiting();
+    await showFirmwareUpdateRecoveryDialog(context, ref);
+    if (!context.mounted) return;
+
+    final connState = ref.read(appConnectionStateProvider);
+    if (connState != AppConnectionState.authenticated) {
+      return;
+    }
+
+    try {
+      await notifier.verify(
+        expectedVersion: expectedVersion,
+        expectedActiveInstance: target.instance,
+      );
+    } catch (_) {
+      // Notifier already transitioned to `failed` and surfaced the message.
+    }
+  }
+
   Future<void> _onPickFile(BuildContext context) async {
     final notifier = ref.read(firmwareUpdateNotifierProvider.notifier);
     final ok = await notifier.pickAndValidateFile();
@@ -393,7 +542,7 @@ class _FirmwareUpdateViewState extends ConsumerState<FirmwareUpdateView> {
     // reboot. The actual flash write is happening in the background on the
     // router; we have no status feedback (B2 blocker), so a fixed delay is
     // the best we can do.
-    await Future<void>.delayed(_installDelayBeforeReboot);
+    await Future<void>.delayed(_localInstallDelayBeforeReboot);
     if (!context.mounted) return;
 
     // Hand off to the shared recovery framework. The dialog blocks until the
@@ -419,6 +568,70 @@ class _FirmwareUpdateViewState extends ConsumerState<FirmwareUpdateView> {
     } catch (_) {
       // Notifier already transitioned to `failed` and surfaced the message.
     }
+  }
+}
+
+/// Card for checking OTA firmware updates.
+class _OtaCheckCard extends StatelessWidget {
+  const _OtaCheckCard({
+    required this.state,
+    required this.onCheck,
+  });
+
+  final FirmwareUpdateState state;
+  final VoidCallback onCheck;
+
+  @override
+  Widget build(BuildContext context) {
+    final isChecking = state.phase == FirmwareUpdatePhase.checkingOta;
+    final scheme = Theme.of(context).colorScheme;
+
+    return AppCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          AppText.titleMedium('OTA Update'),
+          AppGap.md(),
+          Row(
+            children: [
+              if (isChecking)
+                AppButton.primaryOutline(
+                  label: 'Checking...',
+                  onTap: null,
+                  icon: const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                )
+              else
+                AppButton.primaryOutline(
+                  label: 'Check for Updates',
+                  onTap: onCheck,
+                ),
+              if (state.otaUpToDate && !isChecking) ...[
+                AppGap.md(),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.check_circle,
+                      size: 18,
+                      color: scheme.primary,
+                    ),
+                    AppGap.sm(),
+                    AppText.bodyMedium(
+                      'Your firmware is up to date',
+                      color: scheme.primary,
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/lib/page/firmware_update/views/firmware_update_view.dart
+++ b/lib/page/firmware_update/views/firmware_update_view.dart
@@ -1,17 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
-import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/core/connection/models/app_connection_state.dart';
 import 'package:privacy_gui/core/connection/providers/app_connection_state_provider.dart';
 import 'package:privacy_gui/core/utils/device_image_helper.dart';
 import 'package:privacy_gui/core/utils/icon_rules.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/page/_shared/models/system_info_ui_model.dart'
     hide FirmwareImageUIModel;
 import 'package:privacy_gui/page/admin/providers/system_info_data_provider.dart';
 import 'package:privacy_gui/page/admin/views/dialogs/confirm_action_dialog.dart';
-import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_image_ui_model.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_ota_info.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_update_phase.dart';
@@ -20,8 +19,6 @@ import 'package:privacy_gui/page/firmware_update/providers/firmware_banks_data_p
 import 'package:privacy_gui/page/firmware_update/providers/firmware_update_notifier.dart';
 import 'package:privacy_gui/page/firmware_update/services/firmware_local_upload_service.dart';
 import 'package:privacy_gui/page/firmware_update/services/firmware_ota_check_service.dart';
-import 'package:privacy_gui/page/internet_settings/providers/wan_data_provider.dart';
-import 'package:privacy_gui/page/topology/models/node_ui_model.dart';
 import 'package:privacy_gui/page/firmware_update/views/dialogs/firmware_update_recovery_dialog.dart';
 import 'package:privacy_gui/page/shell/usp_top_bar.dart';
 import 'package:privacy_gui/route/constants.dart';
@@ -355,8 +352,10 @@ class _FirmwareUpdateViewState extends ConsumerState<FirmwareUpdateView> {
   }
 
   Future<void> _onCheckForUpdates(BuildContext context) async {
+    final notifier = ref.read(firmwareUpdateNotifierProvider.notifier);
+
     try {
-      final params = await _buildOtaCheckParams();
+      final params = await notifier.buildOtaCheckParams();
       if (params == null) {
         if (context.mounted) {
           showFailedSnackBar(context, 'Unable to gather device information');
@@ -364,63 +363,18 @@ class _FirmwareUpdateViewState extends ConsumerState<FirmwareUpdateView> {
         return;
       }
 
-      final notifier = ref.read(firmwareUpdateNotifierProvider.notifier);
       final info = await notifier.checkForOtaUpdate(params);
 
       if (!context.mounted) return;
 
       if (info != null) {
-        // Update available - show dialog
         await _showOtaUpdateDialog(context, info);
       }
-      // If info is null, state.otaUpToDate is true, UI will show "Up to date"
     } on FirmwareOtaCheckException catch (e) {
       if (context.mounted) {
         showFailedSnackBar(context, e.message);
       }
     }
-  }
-
-  Future<FirmwareOtaCheckParams?> _buildOtaCheckParams() async {
-    try {
-      final devicesData = await ref.read(devicesDataProvider.future);
-      final masterNode = devicesData.nodeModels.master;
-      if (masterNode == null) {
-        logger.w('[FirmwareUpdate] Master node not found');
-        return null;
-      }
-
-      final systemInfoData = await ref.read(systemInfoDataProvider.future);
-      final hardwareVersion =
-          _parseHardwareVersion(systemInfoData.model.hardwareVersion);
-
-      final wanData = await ref.read(wanDataProvider.future);
-      final ipAddress = wanData.model.ipAddress;
-
-      return FirmwareOtaCheckParams(
-        macAddress: _formatMacAddress(masterNode.deviceId),
-        installedVersion: masterNode.softwareVersion,
-        modelNumber: masterNode.model,
-        hardwareVersion: hardwareVersion,
-        ipAddress: ipAddress,
-      );
-    } catch (e) {
-      logger.e('[FirmwareUpdate] Failed to build OTA check params', error: e);
-      return null;
-    }
-  }
-
-  String _formatMacAddress(String mac) {
-    return mac.toUpperCase().replaceAll(':', '-');
-  }
-
-  String _parseHardwareVersion(String hwVersion) {
-    var version = hwVersion;
-    if (version.toUpperCase().startsWith('V')) {
-      version = version.substring(1);
-    }
-    final parsed = int.tryParse(version);
-    return parsed?.toString() ?? version;
   }
 
   Future<void> _showOtaUpdateDialog(

--- a/test/page/firmware_update/models/firmware_ota_info_test.dart
+++ b/test/page/firmware_update/models/firmware_ota_info_test.dart
@@ -52,7 +52,7 @@ void main() {
       expect(info.downloadUrl, '');
     });
 
-    test('fromJson handles invalid date format', () {
+    test('fromJson handles invalid date format with null', () {
       final json = {
         'version': '1.0.0',
         'release_date': 'not-a-date',
@@ -65,8 +65,21 @@ void main() {
       final info = FirmwareOtaInfo.fromJson(json);
 
       expect(info.version, '1.0.0');
-      // Invalid date should fallback to DateTime.now() (just verify it doesn't throw)
-      expect(info.releaseDate, isA<DateTime>());
+      expect(info.releaseDate, isNull);
+    });
+
+    test('fromJson handles missing release_date with null', () {
+      final json = {
+        'version': '1.0.0',
+        'download_url': 'http://example.com/fw.img',
+        'checksum': '123',
+        'check_interval': 'daily',
+        'check_time': '06:00:00Z',
+      };
+
+      final info = FirmwareOtaInfo.fromJson(json);
+
+      expect(info.releaseDate, isNull);
     });
 
     test('equality works correctly', () {

--- a/test/page/firmware_update/models/firmware_ota_info_test.dart
+++ b/test/page/firmware_update/models/firmware_ota_info_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/firmware_update/models/firmware_ota_info.dart';
+
+void main() {
+  group('FirmwareOtaInfo', () {
+    test('fromJson parses complete response correctly', () {
+      final json = {
+        'version': '1.0.10.25092307',
+        'release_date': '2025-09-23T17:06:26Z',
+        'download_url': 'http://download.linksys.com/updates/firmware.img',
+        'checksum': '1022217387',
+        'check_interval': 'daily',
+        'check_time': '06:00:00Z',
+      };
+
+      final info = FirmwareOtaInfo.fromJson(json);
+
+      expect(info.version, '1.0.10.25092307');
+      expect(info.releaseDate, DateTime.utc(2025, 9, 23, 17, 6, 26));
+      expect(
+          info.downloadUrl, 'http://download.linksys.com/updates/firmware.img');
+      expect(info.checksum, '1022217387');
+      expect(info.checkInterval, 'daily');
+      expect(info.checkTime, '06:00:00Z');
+    });
+
+    test('fromJson handles missing fields with defaults', () {
+      final json = <String, dynamic>{};
+
+      final info = FirmwareOtaInfo.fromJson(json);
+
+      expect(info.version, '');
+      expect(info.downloadUrl, '');
+      expect(info.checksum, '');
+      expect(info.checkInterval, '');
+      expect(info.checkTime, '');
+    });
+
+    test('fromJson handles null values', () {
+      final json = {
+        'version': null,
+        'release_date': null,
+        'download_url': null,
+        'checksum': null,
+        'check_interval': null,
+        'check_time': null,
+      };
+
+      final info = FirmwareOtaInfo.fromJson(json);
+
+      expect(info.version, '');
+      expect(info.downloadUrl, '');
+    });
+
+    test('fromJson handles invalid date format', () {
+      final json = {
+        'version': '1.0.0',
+        'release_date': 'not-a-date',
+        'download_url': 'http://example.com/fw.img',
+        'checksum': '123',
+        'check_interval': 'daily',
+        'check_time': '06:00:00Z',
+      };
+
+      final info = FirmwareOtaInfo.fromJson(json);
+
+      expect(info.version, '1.0.0');
+      // Invalid date should fallback to DateTime.now() (just verify it doesn't throw)
+      expect(info.releaseDate, isA<DateTime>());
+    });
+
+    test('equality works correctly', () {
+      final info1 = FirmwareOtaInfo(
+        version: '1.0.0',
+        releaseDate: DateTime.utc(2025, 1, 1),
+        downloadUrl: 'http://example.com/fw.img',
+        checksum: '123',
+        checkInterval: 'daily',
+        checkTime: '06:00:00Z',
+      );
+
+      final info2 = FirmwareOtaInfo(
+        version: '1.0.0',
+        releaseDate: DateTime.utc(2025, 1, 1),
+        downloadUrl: 'http://example.com/fw.img',
+        checksum: '123',
+        checkInterval: 'daily',
+        checkTime: '06:00:00Z',
+      );
+
+      final info3 = FirmwareOtaInfo(
+        version: '2.0.0',
+        releaseDate: DateTime.utc(2025, 1, 1),
+        downloadUrl: 'http://example.com/fw.img',
+        checksum: '123',
+        checkInterval: 'daily',
+        checkTime: '06:00:00Z',
+      );
+
+      expect(info1, equals(info2));
+      expect(info1, isNot(equals(info3)));
+    });
+  });
+
+  group('FirmwareOtaCheckParams', () {
+    test('toQueryParams returns correct map', () {
+      const params = FirmwareOtaCheckParams(
+        macAddress: '74-12-13-21-56-3A',
+        installedVersion: '1.2.1.26052809',
+        modelNumber: 'M60-US',
+        hardwareVersion: '1',
+        ipAddress: '118.163.122.211',
+      );
+
+      final queryParams = params.toQueryParams();
+
+      expect(queryParams, {
+        'mac_address': '74-12-13-21-56-3A',
+        'installed_version': '1.2.1.26052809',
+        'model_number': 'M60-US',
+        'hardware_version': '1',
+        'ip_address': '118.163.122.211',
+      });
+    });
+
+    test('equality works correctly', () {
+      const params1 = FirmwareOtaCheckParams(
+        macAddress: '74-12-13-21-56-3A',
+        installedVersion: '1.2.1',
+        modelNumber: 'M60-US',
+        hardwareVersion: '1',
+        ipAddress: '192.168.1.1',
+      );
+
+      const params2 = FirmwareOtaCheckParams(
+        macAddress: '74-12-13-21-56-3A',
+        installedVersion: '1.2.1',
+        modelNumber: 'M60-US',
+        hardwareVersion: '1',
+        ipAddress: '192.168.1.1',
+      );
+
+      const params3 = FirmwareOtaCheckParams(
+        macAddress: 'AA-BB-CC-DD-EE-FF',
+        installedVersion: '1.2.1',
+        modelNumber: 'M60-US',
+        hardwareVersion: '1',
+        ipAddress: '192.168.1.1',
+      );
+
+      expect(params1, equals(params2));
+      expect(params1, isNot(equals(params3)));
+    });
+  });
+}

--- a/test/page/firmware_update/providers/firmware_update_notifier_test.dart
+++ b/test/page/firmware_update/providers/firmware_update_notifier_test.dart
@@ -16,12 +16,17 @@ import 'package:privacy_gui/core/usp/services/usp_client.dart';
 import 'package:privacy_gui/page/firmware_update/models/firmware_update_phase.dart';
 import 'package:privacy_gui/page/firmware_update/providers/firmware_banks_data_provider.dart';
 import 'package:privacy_gui/page/firmware_update/providers/firmware_update_notifier.dart';
+import 'package:privacy_gui/page/firmware_update/models/firmware_ota_info.dart';
 import 'package:privacy_gui/page/firmware_update/services/firmware_file_picker_service.dart';
 import 'package:privacy_gui/page/firmware_update/services/firmware_local_upload_service.dart';
+import 'package:privacy_gui/page/firmware_update/services/firmware_ota_check_service.dart';
 import 'package:privacy_gui/page/firmware_update/services/usp_firmware_update_service.dart';
 import 'package:privacy_gui/providers/auth/auth_provider.dart';
 
 import '../../../mocks/test_data/firmware_update_test_data.dart';
+
+class MockFirmwareOtaCheckService extends Mock
+    implements FirmwareOtaCheckService {}
 
 class MockUspClient extends Mock implements UspClient {}
 
@@ -74,15 +79,24 @@ void main() {
   late MockUspClient mockUsp;
   late MockUspFirmwareUpdateService mockService;
   late MockFirmwareLocalUploadService mockUploader;
+  late MockFirmwareOtaCheckService mockOtaChecker;
 
   setUpAll(() {
     registerFallbackValue(Uint8List(0));
+    registerFallbackValue(const FirmwareOtaCheckParams(
+      macAddress: '',
+      installedVersion: '',
+      modelNumber: '',
+      hardwareVersion: '',
+      ipAddress: '',
+    ));
   });
 
   setUp(() {
     mockUsp = MockUspClient();
     mockService = MockUspFirmwareUpdateService();
     mockUploader = MockFirmwareLocalUploadService();
+    mockOtaChecker = MockFirmwareOtaCheckService();
     when(() => mockUsp.isAuthenticated).thenReturn(true);
     when(() => mockUploader.totalFragmentsFor(any())).thenReturn(32);
   });
@@ -90,6 +104,7 @@ void main() {
   ProviderContainer createContainer({
     FirmwareFilePickerService? picker,
     FirmwareLocalUploadService? uploader,
+    FirmwareOtaCheckService? otaChecker,
     AsyncValue<FirmwareBanksData>? banksData,
   }) {
     final container = ProviderContainer(
@@ -99,6 +114,8 @@ void main() {
         uspMutationLockProvider.overrideWithValue(UspMutationLock()),
         firmwareLocalUploadServiceProvider
             .overrideWithValue(uploader ?? mockUploader),
+        firmwareOtaCheckServiceProvider
+            .overrideWithValue(otaChecker ?? mockOtaChecker),
         if (picker != null)
           firmwareFilePickerServiceProvider.overrideWithValue(picker),
         if (banksData != null)
@@ -550,6 +567,160 @@ void main() {
         AppConnectionState.waitingForRecovery,
       );
       verify(() => mockSseManager.disconnect()).called(1);
+    });
+
+    // ════════════════════════════════════════════════════════════════════════
+    // OTA Check Tests
+    // ════════════════════════════════════════════════════════════════════════
+
+    group('checkForOtaUpdate', () {
+      const testParams = FirmwareOtaCheckParams(
+        macAddress: '74-12-13-21-56-3A',
+        installedVersion: '1.2.1',
+        modelNumber: 'M60-US',
+        hardwareVersion: '1',
+        ipAddress: '192.168.1.1',
+      );
+
+      test(
+          'transitions idle → checkingOta → idle with otaInfo when update available',
+          () async {
+        final otaInfo = FirmwareOtaInfo(
+          version: '1.0.10.25092307',
+          releaseDate: DateTime.utc(2025, 9, 23),
+          downloadUrl: 'http://download.linksys.com/updates/firmware.img',
+          checksum: '1022217387',
+          checkInterval: 'daily',
+          checkTime: '06:00:00Z',
+        );
+        when(() => mockOtaChecker.checkForUpdate(any()))
+            .thenAnswer((_) async => otaInfo);
+
+        final container = createContainer();
+        addTearDown(container.dispose);
+        final notifier =
+            container.read(firmwareUpdateNotifierProvider.notifier);
+
+        final result = await notifier.checkForOtaUpdate(testParams);
+
+        expect(result, equals(otaInfo));
+        final state = container.read(firmwareUpdateNotifierProvider);
+        expect(state.phase, FirmwareUpdatePhase.idle);
+        expect(state.otaInfo, equals(otaInfo));
+        expect(state.otaUpToDate, isFalse);
+      });
+
+      test(
+          'transitions idle → checkingOta → idle with otaUpToDate when no update',
+          () async {
+        when(() => mockOtaChecker.checkForUpdate(any()))
+            .thenAnswer((_) async => null);
+
+        final container = createContainer();
+        addTearDown(container.dispose);
+        final notifier =
+            container.read(firmwareUpdateNotifierProvider.notifier);
+
+        final result = await notifier.checkForOtaUpdate(testParams);
+
+        expect(result, isNull);
+        final state = container.read(firmwareUpdateNotifierProvider);
+        expect(state.phase, FirmwareUpdatePhase.idle);
+        expect(state.otaInfo, isNull);
+        expect(state.otaUpToDate, isTrue);
+      });
+
+      test('rethrows FirmwareOtaCheckException and returns to idle', () async {
+        when(() => mockOtaChecker.checkForUpdate(any()))
+            .thenThrow(FirmwareOtaCheckException('API error'));
+
+        final container = createContainer();
+        addTearDown(container.dispose);
+        final notifier =
+            container.read(firmwareUpdateNotifierProvider.notifier);
+
+        await expectLater(
+          notifier.checkForOtaUpdate(testParams),
+          throwsA(isA<FirmwareOtaCheckException>()),
+        );
+
+        final state = container.read(firmwareUpdateNotifierProvider);
+        expect(state.phase, FirmwareUpdatePhase.idle);
+        expect(state.otaInfo, isNull);
+      });
+
+      test('clears previous otaInfo and error on new check', () async {
+        when(() => mockOtaChecker.checkForUpdate(any()))
+            .thenAnswer((_) async => null);
+
+        final container = createContainer();
+        addTearDown(container.dispose);
+        final notifier =
+            container.read(firmwareUpdateNotifierProvider.notifier);
+
+        // Simulate previous state with otaInfo
+        notifier.debugSeedBanks(
+          active: FirmwareUpdateTestData.activeBank(),
+        );
+
+        await notifier.checkForOtaUpdate(testParams);
+
+        final state = container.read(firmwareUpdateNotifierProvider);
+        expect(state.otaInfo, isNull);
+        expect(state.errorMessage, isNull);
+      });
+    });
+
+    group('triggerOtaInstall', () {
+      test('transitions triggering → installing on success', () async {
+        when(() => mockService.triggerOtaDownload(
+              targetInstance: any(named: 'targetInstance'),
+              firmwareUrl: any(named: 'firmwareUrl'),
+            )).thenAnswer((_) async {});
+
+        final container = createContainer();
+        addTearDown(container.dispose);
+        final notifier =
+            container.read(firmwareUpdateNotifierProvider.notifier);
+
+        await notifier.triggerOtaInstall(
+          targetInstance: 2,
+          firmwareUrl: 'http://example.com/fw.img',
+        );
+
+        expect(
+          container.read(firmwareUpdateNotifierProvider).phase,
+          FirmwareUpdatePhase.installing,
+        );
+        verify(() => mockService.triggerOtaDownload(
+              targetInstance: 2,
+              firmwareUrl: 'http://example.com/fw.img',
+            )).called(1);
+      });
+
+      test('transitions to failed on ServiceError', () async {
+        when(() => mockService.triggerOtaDownload(
+              targetInstance: any(named: 'targetInstance'),
+              firmwareUrl: any(named: 'firmwareUrl'),
+            )).thenThrow(const NetworkError(message: 'Download failed'));
+
+        final container = createContainer();
+        addTearDown(container.dispose);
+        final notifier =
+            container.read(firmwareUpdateNotifierProvider.notifier);
+
+        await expectLater(
+          notifier.triggerOtaInstall(
+            targetInstance: 2,
+            firmwareUrl: 'http://example.com/fw.img',
+          ),
+          throwsA(isA<NetworkError>()),
+        );
+
+        final state = container.read(firmwareUpdateNotifierProvider);
+        expect(state.phase, FirmwareUpdatePhase.failed);
+        expect(state.errorMessage, contains('Network error'));
+      });
     });
   });
 }

--- a/test/page/firmware_update/services/firmware_ota_check_service_test.dart
+++ b/test/page/firmware_update/services/firmware_ota_check_service_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/cloud/http/linksys_http_client.dart';
+import 'package:privacy_gui/page/firmware_update/models/firmware_ota_info.dart';
+import 'package:privacy_gui/page/firmware_update/services/firmware_ota_check_service.dart';
+
+class MockLinksysHttpClient extends Mock implements LinksysHttpClient {}
+
+class FakeUri extends Fake implements Uri {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeUri());
+  });
+
+  group('FirmwareOtaCheckService', () {
+    late MockLinksysHttpClient mockClient;
+    late FirmwareOtaCheckService service;
+
+    const testParams = FirmwareOtaCheckParams(
+      macAddress: '74-12-13-21-56-3A',
+      installedVersion: '1.2.1.26052809',
+      modelNumber: 'M60-US',
+      hardwareVersion: '1',
+      ipAddress: '118.163.122.211',
+    );
+
+    setUp(() {
+      mockClient = MockLinksysHttpClient();
+      service = FirmwareOtaCheckService(client: mockClient);
+    });
+
+    test('returns FirmwareOtaInfo when update is available', () async {
+      const responseBody = '''
+{
+  "version": "1.0.10.25092307",
+  "release_date": "2025-09-23T17:06:26Z",
+  "download_url": "http://download.linksys.com/updates/firmware.img",
+  "checksum": "1022217387",
+  "check_interval": "daily",
+  "check_time": "06:00:00Z"
+}
+''';
+      when(() => mockClient.get(any())).thenAnswer(
+        (_) async => http.Response(responseBody, 200),
+      );
+
+      final result = await service.checkForUpdate(testParams);
+
+      expect(result, isNotNull);
+      expect(result!.version, '1.0.10.25092307');
+      expect(result.downloadUrl,
+          'http://download.linksys.com/updates/firmware.img');
+      expect(result.checksum, '1022217387');
+    });
+
+    test('returns null when no update available (empty body)', () async {
+      when(() => mockClient.get(any())).thenAnswer(
+        (_) async => http.Response('', 200),
+      );
+
+      final result = await service.checkForUpdate(testParams);
+
+      expect(result, isNull);
+    });
+
+    test('throws FirmwareOtaCheckException on non-200 status', () async {
+      when(() => mockClient.get(any())).thenAnswer(
+        (_) async => http.Response('Server Error', 500),
+      );
+
+      expect(
+        () => service.checkForUpdate(testParams),
+        throwsA(isA<FirmwareOtaCheckException>().having(
+          (e) => e.message,
+          'message',
+          contains('HTTP 500'),
+        )),
+      );
+    });
+
+    test('throws FirmwareOtaCheckException on 404', () async {
+      when(() => mockClient.get(any())).thenAnswer(
+        (_) async => http.Response('Not Found', 404),
+      );
+
+      expect(
+        () => service.checkForUpdate(testParams),
+        throwsA(isA<FirmwareOtaCheckException>().having(
+          (e) => e.message,
+          'message',
+          contains('HTTP 404'),
+        )),
+      );
+    });
+
+    test('throws FirmwareOtaCheckException on invalid JSON', () async {
+      when(() => mockClient.get(any())).thenAnswer(
+        (_) async => http.Response('not valid json', 200),
+      );
+
+      expect(
+        () => service.checkForUpdate(testParams),
+        throwsA(isA<FirmwareOtaCheckException>()),
+      );
+    });
+
+    test('throws FirmwareOtaCheckException on network error', () async {
+      when(() => mockClient.get(any())).thenThrow(
+        Exception('Network unreachable'),
+      );
+
+      expect(
+        () => service.checkForUpdate(testParams),
+        throwsA(isA<FirmwareOtaCheckException>().having(
+          (e) => e.message,
+          'message',
+          contains('Network unreachable'),
+        )),
+      );
+    });
+
+    test('constructs correct URI with query parameters', () async {
+      Uri? capturedUri;
+      when(() => mockClient.get(any())).thenAnswer((invocation) async {
+        capturedUri = invocation.positionalArguments[0] as Uri;
+        return http.Response('', 200);
+      });
+
+      await service.checkForUpdate(testParams);
+
+      expect(capturedUri, isNotNull);
+      expect(capturedUri!.queryParameters['mac_address'], '74-12-13-21-56-3A');
+      expect(
+          capturedUri!.queryParameters['installed_version'], '1.2.1.26052809');
+      expect(capturedUri!.queryParameters['model_number'], 'M60-US');
+      expect(capturedUri!.queryParameters['hardware_version'], '1');
+      expect(capturedUri!.queryParameters['ip_address'], '118.163.122.211');
+    });
+  });
+
+  group('FirmwareOtaCheckException', () {
+    test('toString returns message', () {
+      final exception = FirmwareOtaCheckException('Test error message');
+      expect(exception.toString(), 'Test error message');
+    });
+  });
+}

--- a/test/page/firmware_update/services/usp_firmware_update_service_test.dart
+++ b/test/page/firmware_update/services/usp_firmware_update_service_test.dart
@@ -136,6 +136,55 @@ void main() {
     });
   });
 
+  group('triggerOtaDownload', () {
+    test('invokes FirmwareImage.{i}.Download() with https:// URL', () async {
+      when(() => mockUsp.operate(any(), args: any(named: 'args')))
+          .thenAnswer((_) async => <String, dynamic>{'success': true});
+
+      await service.triggerOtaDownload(
+        targetInstance: 2,
+        firmwareUrl: 'https://download.linksys.com/updates/firmware.img',
+      );
+
+      final captured = verify(
+        () => mockUsp.operate(captureAny(), args: captureAny(named: 'args')),
+      ).captured;
+      expect(captured[0], 'Device.DeviceInfo.FirmwareImage.2.Download()');
+      final args = captured[1] as Map<String, String>;
+      expect(args['URL'], 'https://download.linksys.com/updates/firmware.img');
+      expect(args['AutoActivate'], 'true');
+    });
+
+    test('passes AutoActivate=false when requested', () async {
+      when(() => mockUsp.operate(any(), args: any(named: 'args')))
+          .thenAnswer((_) async => <String, dynamic>{'success': true});
+
+      await service.triggerOtaDownload(
+        targetInstance: 2,
+        firmwareUrl: 'https://example.com/fw.img',
+        autoActivate: false,
+      );
+
+      final captured = verify(
+        () => mockUsp.operate(any(), args: captureAny(named: 'args')),
+      ).captured;
+      expect((captured.first as Map<String, String>)['AutoActivate'], 'false');
+    });
+
+    test('maps USP error to ServiceError', () {
+      when(() => mockUsp.operate(any(), args: any(named: 'args')))
+          .thenThrow('Operate failed: Transport error: Request timeout');
+
+      expect(
+        () => service.triggerOtaDownload(
+          targetInstance: 2,
+          firmwareUrl: 'https://example.com/fw.img',
+        ),
+        throwsA(isA<NetworkError>()),
+      );
+    });
+  });
+
   group('pollStatus', () {
     test('returns the status field of the matching instance', () async {
       when(() => mockUsp.get(any()))


### PR DESCRIPTION
## Summary

Add OTA (Over-The-Air) firmware update functionality that allows users to check for available firmware updates from the Linksys cloud API and trigger remote downloads directly to the router.

### Key Changes

- **Cloud API Integration**: New `FirmwareOtaCheckService` calls `GET /api/v2/fw/update` with device parameters (MAC, version, model, hardware version, IP) to check for available updates
- **OTA Download Trigger**: New `triggerOtaDownload()` method in `UspFirmwareUpdateService` sends firmware URL to router via `FirmwareImage.{i}.Download()`
- **State Machine Extension**: Added `checkingOta` phase and OTA-related state fields (`otaInfo`, `otaUpToDate`)
- **UI**: Added "OTA Update" card with "Check for Updates" button and update-available dialog

### Shared Flow with Local Upload

OTA and local manual upload share the same flow from `FirmwareImage.{i}.Download()` onwards:

```
Local:  chunked push → file:///tmp/obuspa/firmware.img
                                    ↓
                          Download(url=file://...)
                                    ↓
OTA:    cloud check → https://download.linksys.com/...
                                    ↓
                          Download(url=https://...)
                                    ↓
                    [shared] flash → reboot → recovery → verify
```

The only difference is:
- **Local**: App uploads chunks first, then triggers `Download(url=file://...)`
- **OTA**: App triggers `Download(url=https://...)`, router pulls directly from cloud

### Timing

| Path | Install Delay | Reason |
|------|---------------|--------|
| Local | 60s | Flash only (upload has separate progress bar) |
| OTA | 120s | Download (~50-100MB) + flash |

### SSE OperationComplete

Tested whether firmware sends `OperationComplete` event for `FirmwareImage.Download()` to enable real-time completion detection. **Result: Not supported** — firmware does not send the event despite the operation being marked as `async` in TR-181 schema. Fixed wait times are required.

### Test Coverage

Added 24 new tests covering:
- `FirmwareOtaInfo` model (JSON parsing, query params)
- `FirmwareOtaCheckService` (HTTP calls, error handling)
- `triggerOtaDownload()` service method
- `checkForOtaUpdate()` / `triggerOtaInstall()` notifier methods

## Test plan

- [x] Check for updates when device is up-to-date (should show "Up to date")
- [x] Check for updates when update is available (should show dialog)
- [x] Trigger OTA update and verify recovery flow completes
- [x] Verify bank flip after OTA update
- [x] Run `flutter test test/page/firmware_update/`

🤖 Generated with [Claude Code](https://claude.ai/code)