### PR TITLE
refactor(i18n): replace notifier error strings with ServiceError objects

### DIFF
--- a/lib/core/errors/service_error.dart
+++ b/lib/core/errors/service_error.dart
@@ -252,6 +252,55 @@ final class ConnectivityError extends ServiceError {
 }
 
 // ============================================================================
+// Timeout Errors
+// ============================================================================
+
+/// Operation timed out before completing.
+///
+/// Used for diagnostic operations (ping, traceroute, nslookup, speed test)
+/// where we have a known timeout threshold and the operation didn't complete
+/// in time.
+final class DiagnosticTimeoutError extends ServiceError {
+  /// The operation that timed out (e.g. 'ping', 'traceroute', 'speedTest').
+  final String operation;
+
+  /// Optional target host involved in the operation.
+  final String? host;
+
+  const DiagnosticTimeoutError({required this.operation, this.host});
+
+  @override
+  String toString() {
+    final target = host != null ? ' to $host' : '';
+    return '$operation timed out$target';
+  }
+}
+
+// ============================================================================
+// Diagnostic Errors
+// ============================================================================
+
+/// Diagnostic operation failed with a specific status from the router.
+///
+/// Used for speed test download/upload failures where the router returns
+/// a status code indicating the failure reason.
+final class SpeedTestStatusError extends ServiceError {
+  /// The status code returned by the router (e.g. 'Error_NoResponse').
+  final String status;
+
+  /// Optional target host or URL involved.
+  final String? target;
+
+  const SpeedTestStatusError({required this.status, this.target});
+
+  @override
+  String toString() {
+    final t = target != null ? ' ($target)' : '';
+    return 'Diagnostic failed: $status$t';
+  }
+}
+
+// ============================================================================
 // Side Effect Error (Operation succeeded but device recovery timed out)
 // ============================================================================
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1167,5 +1167,43 @@
   "failedToLoadSettings": "Failed to load settings",
   "retry": "Retry",
   "pppStatus": "PPP Status",
-  "dhcpv6": "DHCPv6"
+  "dhcpv6": "DHCPv6",
+  "diagnosticTimeout": "{operation} timed out — no response from {host}",
+  "@diagnosticTimeout": {
+    "placeholders": {
+      "operation": {
+        "type": "String",
+        "example": "Ping"
+      },
+      "host": {
+        "type": "String",
+        "example": "8.8.8.8"
+      }
+    }
+  },
+  "diagnosticsUnavailable": "Unable to run diagnostics",
+  "routerLostConnection": "Router lost connection",
+  "diagnosticInvalidHost": "Invalid host: {host}",
+  "@diagnosticInvalidHost": {
+    "placeholders": {
+      "host": {
+        "type": "String",
+        "example": "google.com"
+      }
+    }
+  },
+  "diagnosticUnexpectedError": "Diagnostic failed — please try again",
+  "speedTestStatusError": "Speed test failed: {status} ({target})",
+  "@speedTestStatusError": {
+    "placeholders": {
+      "status": {
+        "type": "String",
+        "example": "Error_NoResponse"
+      },
+      "target": {
+        "type": "String",
+        "example": "speedtest.example.com"
+      }
+    }
+  }
 }

--- a/lib/page/dhcp/models/dhcp_reservations_status.dart
+++ b/lib/page/dhcp/models/dhcp_reservations_status.dart
@@ -1,29 +1,31 @@
 import 'package:equatable/equatable.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 
 /// Transient status for the DHCP Reservations page notifier.
 class DhcpReservationsStatus extends Equatable {
   final bool isLoading;
   final bool isSaving;
-  final String? errorMessage;
+  final ServiceError? error;
 
   const DhcpReservationsStatus({
     this.isLoading = false,
     this.isSaving = false,
-    this.errorMessage,
+    this.error,
   });
 
   DhcpReservationsStatus copyWith({
     bool? isLoading,
     bool? isSaving,
-    String? errorMessage,
+    ServiceError? error,
+    bool clearError = false,
   }) {
     return DhcpReservationsStatus(
       isLoading: isLoading ?? this.isLoading,
       isSaving: isSaving ?? this.isSaving,
-      errorMessage: errorMessage,
+      error: clearError ? null : (error ?? this.error),
     );
   }
 
   @override
-  List<Object?> get props => [isLoading, isSaving, errorMessage];
+  List<Object?> get props => [isLoading, isSaving, error];
 }

--- a/lib/page/dhcp/providers/usp_dhcp_reservations_notifier.dart
+++ b/lib/page/dhcp/providers/usp_dhcp_reservations_notifier.dart
@@ -75,7 +75,7 @@ class UspDhcpReservationsNotifier
       logger.e('[USP][DHCP][Reservations]: Fetch failed', error: e);
       return (
         null,
-        DhcpReservationsStatus(errorMessage: '$e'),
+        DhcpReservationsStatus(error: e),
       );
     }
   }

--- a/lib/page/dhcp/views/usp_dhcp_detail_view.dart
+++ b/lib/page/dhcp/views/usp_dhcp_detail_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
+import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/_shared/models/dhcp_client_ui_model.dart';
 import 'package:privacy_gui/page/_shared/models/dhcp_reservation_ui_model.dart';
@@ -55,9 +56,8 @@ class UspDhcpDetailView extends ConsumerWidget {
           );
         }
 
-        if (reservationStatus.errorMessage != null) {
-          return _buildError(
-              childContext, ref, reservationStatus.errorMessage!);
+        if (reservationStatus.error != null) {
+          return _buildError(childContext, ref, reservationStatus.error!);
         }
 
         if (asyncDhcp.hasError && asyncDhcp.valueOrNull == null) {
@@ -100,12 +100,12 @@ class UspDhcpDetailView extends ConsumerWidget {
           AppIcon.font(Icons.error_outline,
               size: 48, color: Theme.of(context).colorScheme.error),
           AppGap.xl(),
-          AppText.titleMedium('Unable to load DHCP data'),
+          AppText.titleMedium(loc(context).failedToLoadSettings),
           AppGap.md(),
           AppText.bodyMedium(error.toString()),
           AppGap.xxl(),
           AppButton(
-            label: 'Retry',
+            label: loc(context).retry,
             onTap: () {
               ref.invalidate(dhcpDataProvider);
               ref

--- a/lib/page/dmz/models/dmz_status.dart
+++ b/lib/page/dmz/models/dmz_status.dart
@@ -1,33 +1,35 @@
 import 'package:equatable/equatable.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 
 /// Transient (non-editable) status for the DMZ feature page.
 class DmzStatus extends Equatable {
   final bool isLoading;
   final bool isSaving;
-  final String? errorMessage;
+  final ServiceError? error;
   final Map<String, String> fieldErrors;
 
   const DmzStatus({
     this.isLoading = true,
     this.isSaving = false,
-    this.errorMessage,
+    this.error,
     this.fieldErrors = const {},
   });
 
   DmzStatus copyWith({
     bool? isLoading,
     bool? isSaving,
-    String? errorMessage,
+    ServiceError? error,
+    bool clearError = false,
     Map<String, String>? fieldErrors,
   }) {
     return DmzStatus(
       isLoading: isLoading ?? this.isLoading,
       isSaving: isSaving ?? this.isSaving,
-      errorMessage: errorMessage,
+      error: clearError ? null : (error ?? this.error),
       fieldErrors: fieldErrors ?? this.fieldErrors,
     );
   }
 
   @override
-  List<Object?> get props => [isLoading, isSaving, errorMessage, fieldErrors];
+  List<Object?> get props => [isLoading, isSaving, error, fieldErrors];
 }

--- a/lib/page/dmz/providers/usp_dmz_notifier.dart
+++ b/lib/page/dmz/providers/usp_dmz_notifier.dart
@@ -73,7 +73,7 @@ class UspDmzNotifier extends AutoDisposeNotifier<DmzFeatureState>
       logger.e('[USP][Firewall][DMZ]: Fetch failed', error: e);
       return (
         null,
-        DmzStatus(isLoading: false, errorMessage: '$e'),
+        DmzStatus(isLoading: false, error: e),
       );
     }
   }

--- a/lib/page/dmz/views/usp_dmz_view.dart
+++ b/lib/page/dmz/views/usp_dmz_view.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/dmz/models/dmz_feature_state.dart';
 import 'package:privacy_gui/page/dmz/models/dmz_ui_model.dart';
@@ -69,8 +71,8 @@ class _UspDmzViewState extends ConsumerState<UspDmzView> {
         if (status.isLoading) {
           return const Center(child: AppLoader());
         }
-        if (status.errorMessage != null) {
-          return _buildError(context, ref);
+        if (status.error != null) {
+          return _buildError(context, ref, status.error!);
         }
         _syncControllers(state);
         return _buildContent(context, ref, state);
@@ -101,7 +103,7 @@ class _UspDmzViewState extends ConsumerState<UspDmzView> {
   // Error
   // ---------------------------------------------------------------------------
 
-  Widget _buildError(BuildContext context, WidgetRef ref) {
+  Widget _buildError(BuildContext context, WidgetRef ref, ServiceError error) {
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -109,10 +111,12 @@ class _UspDmzViewState extends ConsumerState<UspDmzView> {
           AppIcon.font(Icons.error_outline,
               size: 48, color: Theme.of(context).colorScheme.error),
           AppGap.xl(),
-          AppText.titleMedium('Unable to load DMZ settings'),
+          AppText.titleMedium(loc(context).failedToLoadSettings),
           AppGap.md(),
+          AppText.bodyMedium(error.toString()),
+          AppGap.xl(),
           AppButton(
-            label: 'Retry',
+            label: loc(context).retry,
             onTap: () =>
                 ref.read(uspDmzProvider.notifier).fetch(forceRemote: true),
           ),

--- a/lib/page/firewall/models/firewall_status.dart
+++ b/lib/page/firewall/models/firewall_status.dart
@@ -1,29 +1,31 @@
 import 'package:equatable/equatable.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 
 /// Transient (non-editable) status for the firewall feature page.
 class FirewallStatus extends Equatable {
   final bool isLoading;
   final bool isSaving;
-  final String? errorMessage;
+  final ServiceError? error;
 
   const FirewallStatus({
     this.isLoading = true,
     this.isSaving = false,
-    this.errorMessage,
+    this.error,
   });
 
   FirewallStatus copyWith({
     bool? isLoading,
     bool? isSaving,
-    String? errorMessage,
+    ServiceError? error,
+    bool clearError = false,
   }) {
     return FirewallStatus(
       isLoading: isLoading ?? this.isLoading,
       isSaving: isSaving ?? this.isSaving,
-      errorMessage: errorMessage,
+      error: clearError ? null : (error ?? this.error),
     );
   }
 
   @override
-  List<Object?> get props => [isLoading, isSaving, errorMessage];
+  List<Object?> get props => [isLoading, isSaving, error];
 }

--- a/lib/page/firewall/providers/usp_firewall_notifier.dart
+++ b/lib/page/firewall/providers/usp_firewall_notifier.dart
@@ -78,7 +78,7 @@ class UspFirewallNotifier extends AutoDisposeNotifier<FirewallFeatureState>
       logger.e('[USP][Firewall]: Fetch failed', error: e);
       return (
         null,
-        FirewallStatus(isLoading: false, errorMessage: '$e'),
+        FirewallStatus(isLoading: false, error: e),
       );
     }
   }

--- a/lib/page/firewall/views/usp_firewall_view.dart
+++ b/lib/page/firewall/views/usp_firewall_view.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/firewall/models/firewall_feature_state.dart';
 import 'package:privacy_gui/page/firewall/models/firewall_ui_model.dart';
@@ -36,8 +38,8 @@ class UspFirewallView extends ConsumerWidget {
         if (status.isLoading) {
           return const Center(child: AppLoader());
         }
-        if (status.errorMessage != null) {
-          return _buildError(context, ref);
+        if (status.error != null) {
+          return _buildError(context, ref, status.error!);
         }
         return _buildContent(context, ref, state);
       },
@@ -66,7 +68,7 @@ class UspFirewallView extends ConsumerWidget {
   // Error
   // ---------------------------------------------------------------------------
 
-  Widget _buildError(BuildContext context, WidgetRef ref) {
+  Widget _buildError(BuildContext context, WidgetRef ref, ServiceError error) {
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -74,10 +76,12 @@ class UspFirewallView extends ConsumerWidget {
           AppIcon.font(Icons.error_outline,
               size: 48, color: Theme.of(context).colorScheme.error),
           AppGap.xl(),
-          AppText.titleMedium('Unable to load firewall settings'),
+          AppText.titleMedium(loc(context).failedToLoadSettings),
           AppGap.md(),
+          AppText.bodyMedium(error.toString()),
+          AppGap.xl(),
           AppButton(
-            label: 'Retry',
+            label: loc(context).retry,
             onTap: () =>
                 ref.read(uspFirewallProvider.notifier).fetch(forceRemote: true),
           ),

--- a/lib/page/internet_settings/models/internet_settings_status.dart
+++ b/lib/page/internet_settings/models/internet_settings_status.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/page/internet_settings/models/internet_settings_read_only_info.dart';
 
 /// Transient (non-editable) status for the internet settings feature page.
@@ -8,7 +9,7 @@ class InternetSettingsStatus extends Equatable {
   final bool isLoading;
   final bool isSaving;
   final bool isEditing;
-  final String? errorMessage;
+  final ServiceError? error;
 
   /// Tracks active mutation: null (idle), 'save', 'renewIpv4', 'renewIpv6'.
   final String? activeMutation;
@@ -28,7 +29,7 @@ class InternetSettingsStatus extends Equatable {
     this.isLoading = true,
     this.isSaving = false,
     this.isEditing = false,
-    this.errorMessage,
+    this.error,
     this.activeMutation,
     this.readOnlyInfo = const InternetSettingsReadOnlyInfo(),
     this.pppInstancePath,
@@ -39,7 +40,8 @@ class InternetSettingsStatus extends Equatable {
     bool? isLoading,
     bool? isSaving,
     bool? isEditing,
-    String? errorMessage,
+    ServiceError? error,
+    bool clearError = false,
     String? activeMutation,
     bool clearActiveMutation = false,
     InternetSettingsReadOnlyInfo? readOnlyInfo,
@@ -52,7 +54,7 @@ class InternetSettingsStatus extends Equatable {
       isLoading: isLoading ?? this.isLoading,
       isSaving: isSaving ?? this.isSaving,
       isEditing: isEditing ?? this.isEditing,
-      errorMessage: errorMessage,
+      error: clearError ? null : (error ?? this.error),
       activeMutation:
           clearActiveMutation ? null : (activeMutation ?? this.activeMutation),
       readOnlyInfo: readOnlyInfo ?? this.readOnlyInfo,
@@ -70,7 +72,7 @@ class InternetSettingsStatus extends Equatable {
         isLoading,
         isSaving,
         isEditing,
-        errorMessage,
+        error,
         activeMutation,
         readOnlyInfo,
         pppInstancePath,

--- a/lib/page/internet_settings/providers/usp_internet_settings_notifier.dart
+++ b/lib/page/internet_settings/providers/usp_internet_settings_notifier.dart
@@ -129,7 +129,7 @@ class UspInternetSettingsNotifier
       logger.e('[USP][Network][WAN]: Fetch failed', error: e);
       return (
         null,
-        InternetSettingsStatus(isLoading: false, errorMessage: '$e'),
+        InternetSettingsStatus(isLoading: false, error: e),
       );
     }
   }

--- a/lib/page/internet_settings/views/usp_internet_settings_view.dart
+++ b/lib/page/internet_settings/views/usp_internet_settings_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
@@ -42,24 +43,27 @@ class UspInternetSettingsView extends ConsumerWidget {
         if (state.status.isLoading) {
           return const Center(child: AppLoader());
         }
-        if (state.status.errorMessage != null) {
-          return _buildError(childContext, ref, state.status.errorMessage!);
+        if (state.status.error != null) {
+          return _buildError(childContext, ref, state.status.error!);
         }
         return _buildContent(childContext, ref, state);
       },
     );
   }
 
-  Widget _buildError(BuildContext context, WidgetRef ref, String error) {
+  Widget _buildError(BuildContext context, WidgetRef ref, ServiceError error) {
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          AppText.bodyLarge(loc(context).failedToLoadSettings),
-          AppGap.md(),
-          AppText.bodyMedium(error),
+          AppIcon.font(Icons.error_outline,
+              size: 48, color: Theme.of(context).colorScheme.error),
           AppGap.xl(),
-          AppButton.primary(
+          AppText.titleMedium(loc(context).failedToLoadSettings),
+          AppGap.md(),
+          AppText.bodyMedium(error.toString()),
+          AppGap.xl(),
+          AppButton(
             label: loc(context).retry,
             onTap: () => ref.read(uspInternetSettingsProvider.notifier).fetch(),
           ),

--- a/lib/page/ipv6_port_service/models/ipv6_port_service_status.dart
+++ b/lib/page/ipv6_port_service/models/ipv6_port_service_status.dart
@@ -1,29 +1,31 @@
 import 'package:equatable/equatable.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 
 /// Transient status for the IPv6 port service page.
 class Ipv6PortServiceStatus extends Equatable {
   final bool isLoading;
   final bool isSaving;
-  final String? errorMessage;
+  final ServiceError? error;
 
   const Ipv6PortServiceStatus({
     this.isLoading = false,
     this.isSaving = false,
-    this.errorMessage,
+    this.error,
   });
 
   Ipv6PortServiceStatus copyWith({
     bool? isLoading,
     bool? isSaving,
-    String? errorMessage,
+    ServiceError? error,
+    bool clearError = false,
   }) {
     return Ipv6PortServiceStatus(
       isLoading: isLoading ?? this.isLoading,
       isSaving: isSaving ?? this.isSaving,
-      errorMessage: errorMessage,
+      error: clearError ? null : (error ?? this.error),
     );
   }
 
   @override
-  List<Object?> get props => [isLoading, isSaving, errorMessage];
+  List<Object?> get props => [isLoading, isSaving, error];
 }

--- a/lib/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier.dart
+++ b/lib/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier.dart
@@ -68,7 +68,7 @@ class UspIpv6PortServiceNotifier
       logger.e('[USP][Firewall][IPv6Port]: Fetch failed', error: e);
       return (
         null,
-        Ipv6PortServiceStatus(errorMessage: '$e'),
+        Ipv6PortServiceStatus(error: e),
       );
     }
   }

--- a/lib/page/ipv6_port_service/views/usp_ipv6_port_service_view.dart
+++ b/lib/page/ipv6_port_service/views/usp_ipv6_port_service_view.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/ipv6_port_service/models/ipv6_port_service_feature_state.dart';
 import 'package:privacy_gui/page/ipv6_port_service/models/ipv6_port_service_ui_model.dart';
@@ -38,8 +40,8 @@ class UspIpv6PortServiceView extends ConsumerWidget {
         if (status.isLoading) {
           return const Center(child: AppLoader());
         }
-        if (status.errorMessage != null) {
-          return _buildError(context, ref);
+        if (status.error != null) {
+          return _buildError(context, ref, status.error!);
         }
         return _buildContent(context, ref, state);
       },
@@ -69,7 +71,7 @@ class UspIpv6PortServiceView extends ConsumerWidget {
   // Error
   // ---------------------------------------------------------------------------
 
-  Widget _buildError(BuildContext context, WidgetRef ref) {
+  Widget _buildError(BuildContext context, WidgetRef ref, ServiceError error) {
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -77,10 +79,12 @@ class UspIpv6PortServiceView extends ConsumerWidget {
           AppIcon.font(Icons.error_outline,
               size: 48, color: Theme.of(context).colorScheme.error),
           AppGap.xl(),
-          AppText.titleMedium('Unable to load IPv6 port service'),
+          AppText.titleMedium(loc(context).failedToLoadSettings),
           AppGap.md(),
+          AppText.bodyMedium(error.toString()),
+          AppGap.xl(),
           AppButton(
-            label: 'Retry',
+            label: loc(context).retry,
             onTap: () => ref
                 .read(uspIpv6PortServiceProvider.notifier)
                 .fetch(forceRemote: true),

--- a/lib/page/local_network/models/local_network_status.dart
+++ b/lib/page/local_network/models/local_network_status.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 
 /// Transient (non-editable) status for the local network feature page.
 ///
@@ -6,7 +7,7 @@ import 'package:equatable/equatable.dart';
 class LocalNetworkStatus extends Equatable {
   final bool isLoading;
   final bool isSaving;
-  final String? errorMessage;
+  final ServiceError? error;
 
   /// Per-field validation errors (field key → error message).
   /// null value = no error for that field.
@@ -19,7 +20,7 @@ class LocalNetworkStatus extends Equatable {
   const LocalNetworkStatus({
     this.isLoading = true,
     this.isSaving = false,
-    this.errorMessage,
+    this.error,
     this.validationErrors = const {},
     this.lockedOctetCount = 0,
   });
@@ -29,14 +30,15 @@ class LocalNetworkStatus extends Equatable {
   LocalNetworkStatus copyWith({
     bool? isLoading,
     bool? isSaving,
-    String? errorMessage,
+    ServiceError? error,
+    bool clearError = false,
     Map<String, String?>? validationErrors,
     int? lockedOctetCount,
   }) {
     return LocalNetworkStatus(
       isLoading: isLoading ?? this.isLoading,
       isSaving: isSaving ?? this.isSaving,
-      errorMessage: errorMessage,
+      error: clearError ? null : (error ?? this.error),
       validationErrors: validationErrors ?? this.validationErrors,
       lockedOctetCount: lockedOctetCount ?? this.lockedOctetCount,
     );
@@ -44,5 +46,5 @@ class LocalNetworkStatus extends Equatable {
 
   @override
   List<Object?> get props =>
-      [isLoading, isSaving, errorMessage, validationErrors, lockedOctetCount];
+      [isLoading, isSaving, error, validationErrors, lockedOctetCount];
 }

--- a/lib/page/local_network/providers/usp_local_network_notifier.dart
+++ b/lib/page/local_network/providers/usp_local_network_notifier.dart
@@ -91,7 +91,7 @@ class UspLocalNetworkNotifier
       logger.e('[USP][Network][LAN]: Fetch failed', error: e);
       return (
         null,
-        LocalNetworkStatus(isLoading: false, errorMessage: '$e'),
+        LocalNetworkStatus(isLoading: false, error: e),
       );
     }
   }

--- a/lib/page/local_network/views/usp_local_network_view.dart
+++ b/lib/page/local_network/views/usp_local_network_view.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/local_network/models/local_network_feature_state.dart';
 import 'package:privacy_gui/page/local_network/providers/usp_local_network_notifier.dart';
@@ -101,8 +103,8 @@ class _UspLocalNetworkViewState extends ConsumerState<UspLocalNetworkView> {
         if (status.isLoading) {
           return const Center(child: AppLoader());
         }
-        if (status.errorMessage != null) {
-          return _buildError(context, ref);
+        if (status.error != null) {
+          return _buildError(context, ref, status.error!);
         }
         _syncControllers(state);
         return _buildContent(context, ref, state);
@@ -133,7 +135,7 @@ class _UspLocalNetworkViewState extends ConsumerState<UspLocalNetworkView> {
   // Error
   // ---------------------------------------------------------------------------
 
-  Widget _buildError(BuildContext context, WidgetRef ref) {
+  Widget _buildError(BuildContext context, WidgetRef ref, ServiceError error) {
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -141,10 +143,12 @@ class _UspLocalNetworkViewState extends ConsumerState<UspLocalNetworkView> {
           AppIcon.font(Icons.error_outline,
               size: 48, color: Theme.of(context).colorScheme.error),
           AppGap.xl(),
-          AppText.titleMedium('Unable to load local network settings'),
+          AppText.titleMedium(loc(context).failedToLoadSettings),
           AppGap.md(),
+          AppText.bodyMedium(error.toString()),
+          AppGap.xl(),
           AppButton(
-            label: 'Retry',
+            label: loc(context).retry,
             onTap: () => ref
                 .read(uspLocalNetworkProvider.notifier)
                 .fetch(forceRemote: true),

--- a/lib/page/port_forwarding/models/port_forwarding_page_status.dart
+++ b/lib/page/port_forwarding/models/port_forwarding_page_status.dart
@@ -1,29 +1,31 @@
 import 'package:equatable/equatable.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 
 /// Transient status for the Port Forwarding detail page.
 class PortForwardingPageStatus extends Equatable {
   final bool isLoading;
   final bool isSaving;
-  final String? errorMessage;
+  final ServiceError? error;
 
   const PortForwardingPageStatus({
     this.isLoading = false,
     this.isSaving = false,
-    this.errorMessage,
+    this.error,
   });
 
   PortForwardingPageStatus copyWith({
     bool? isLoading,
     bool? isSaving,
-    String? errorMessage,
+    ServiceError? error,
+    bool clearError = false,
   }) {
     return PortForwardingPageStatus(
       isLoading: isLoading ?? this.isLoading,
       isSaving: isSaving ?? this.isSaving,
-      errorMessage: errorMessage,
+      error: clearError ? null : (error ?? this.error),
     );
   }
 
   @override
-  List<Object?> get props => [isLoading, isSaving, errorMessage];
+  List<Object?> get props => [isLoading, isSaving, error];
 }

--- a/lib/page/port_forwarding/providers/usp_port_forwarding_page_notifier.dart
+++ b/lib/page/port_forwarding/providers/usp_port_forwarding_page_notifier.dart
@@ -89,7 +89,7 @@ class UspPortForwardingPageNotifier
       logger.e('[USP][Firewall][PortForwarding]: Fetch failed', error: e);
       return (
         null,
-        PortForwardingPageStatus(errorMessage: '$e'),
+        PortForwardingPageStatus(error: e),
       );
     }
   }

--- a/lib/page/port_forwarding/views/usp_port_forwarding_detail_view.dart
+++ b/lib/page/port_forwarding/views/usp_port_forwarding_detail_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
+import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/port_forwarding/models/port_forwarding_page_feature_state.dart';
 import 'package:privacy_gui/page/port_forwarding/models/port_forwarding_page_status.dart';
@@ -123,7 +124,7 @@ class _UspPortForwardingDetailViewState
     if (status.isLoading) {
       return const Center(child: AppLoader());
     }
-    if (status.errorMessage != null) {
+    if (status.error != null) {
       return Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -131,10 +132,12 @@ class _UspPortForwardingDetailViewState
             AppIcon.font(Icons.error_outline,
                 size: 48, color: Theme.of(context).colorScheme.error),
             AppGap.xl(),
-            AppText.titleMedium('Unable to load data'),
+            AppText.titleMedium(loc(context).failedToLoadSettings),
             AppGap.md(),
+            AppText.bodyMedium(status.error.toString()),
+            AppGap.xl(),
             AppButton(
-              label: 'Retry',
+              label: loc(context).retry,
               onTap: () => ref
                   .read(uspPortForwardingPageProvider.notifier)
                   .fetch(forceRemote: true),

--- a/lib/page/static_routing/models/static_routing_status.dart
+++ b/lib/page/static_routing/models/static_routing_status.dart
@@ -1,29 +1,31 @@
 import 'package:equatable/equatable.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 
 /// Transient status for the static routing page.
 class StaticRoutingStatus extends Equatable {
   final bool isLoading;
   final bool isSaving;
-  final String? errorMessage;
+  final ServiceError? error;
 
   const StaticRoutingStatus({
     this.isLoading = false,
     this.isSaving = false,
-    this.errorMessage,
+    this.error,
   });
 
   StaticRoutingStatus copyWith({
     bool? isLoading,
     bool? isSaving,
-    String? errorMessage,
+    ServiceError? error,
+    bool clearError = false,
   }) {
     return StaticRoutingStatus(
       isLoading: isLoading ?? this.isLoading,
       isSaving: isSaving ?? this.isSaving,
-      errorMessage: errorMessage,
+      error: clearError ? null : (error ?? this.error),
     );
   }
 
   @override
-  List<Object?> get props => [isLoading, isSaving, errorMessage];
+  List<Object?> get props => [isLoading, isSaving, error];
 }

--- a/lib/page/static_routing/providers/usp_static_routing_notifier.dart
+++ b/lib/page/static_routing/providers/usp_static_routing_notifier.dart
@@ -76,7 +76,7 @@ class UspStaticRoutingNotifier
       logger.e('[USP][Network][Routing]: Fetch failed', error: e);
       return (
         null,
-        StaticRoutingStatus(errorMessage: '$e'),
+        StaticRoutingStatus(error: e),
       );
     }
   }

--- a/lib/page/static_routing/views/usp_static_routing_view.dart
+++ b/lib/page/static_routing/views/usp_static_routing_view.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/components/shortcuts/snack_bar.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/static_routing/models/static_routing_feature_state.dart';
 import 'package:privacy_gui/page/static_routing/models/static_routing_ui_model.dart';
@@ -35,8 +37,8 @@ class UspStaticRoutingView extends ConsumerWidget {
         if (status.isLoading) {
           return const Center(child: AppLoader());
         }
-        if (status.errorMessage != null) {
-          return _buildError(context, ref);
+        if (status.error != null) {
+          return _buildError(context, ref, status.error!);
         }
         return _buildContent(context, ref, state);
       },
@@ -65,7 +67,7 @@ class UspStaticRoutingView extends ConsumerWidget {
   // Error
   // ---------------------------------------------------------------------------
 
-  Widget _buildError(BuildContext context, WidgetRef ref) {
+  Widget _buildError(BuildContext context, WidgetRef ref, ServiceError error) {
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -73,10 +75,12 @@ class UspStaticRoutingView extends ConsumerWidget {
           AppIcon.font(Icons.error_outline,
               size: 48, color: Theme.of(context).colorScheme.error),
           AppGap.xl(),
-          AppText.titleMedium('Unable to load static routing'),
+          AppText.titleMedium(loc(context).failedToLoadSettings),
           AppGap.md(),
+          AppText.bodyMedium(error.toString()),
+          AppGap.xl(),
           AppButton(
-            label: 'Retry',
+            label: loc(context).retry,
             onTap: () => ref
                 .read(uspStaticRoutingProvider.notifier)
                 .fetch(forceRemote: true),

--- a/lib/page/unified_diagnostics/cards/usp_speed_test_card.dart
+++ b/lib/page/unified_diagnostics/cards/usp_speed_test_card.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/shortcuts/dialogs.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/unified_diagnostics/models/speed_test_state.dart';
 import 'package:privacy_gui/page/unified_diagnostics/providers/speed_test_notifier.dart';
 import 'package:privacy_gui/page/unified_diagnostics/views/widgets/speed_gauge.dart';
@@ -160,7 +162,9 @@ class UspSpeedTestCard extends ConsumerWidget {
         AppIcon.font(Icons.error_outline, size: 32, color: colorScheme.error),
         AppGap.sm(),
         AppText.bodySmall(
-          state.errorMessage ?? 'Test failed',
+          state.error != null
+              ? _translateError(context, state.error!)
+              : loc(context).diagnosticUnexpectedError,
           textAlign: TextAlign.center,
           color: colorScheme.onSurfaceVariant,
           maxLines: 2,
@@ -249,6 +253,18 @@ class UspSpeedTestCard extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  String _translateError(BuildContext context, ServiceError error) {
+    return switch (error) {
+      DiagnosticTimeoutError(:final operation, :final host) =>
+        loc(context).diagnosticTimeout(operation, host ?? ''),
+      SpeedTestStatusError(:final status, :final target) =>
+        loc(context).speedTestStatusError(status, target ?? ''),
+      ConnectivityError() => loc(context).diagnosticsUnavailable,
+      NetworkError() => loc(context).routerLostConnection,
+      _ => loc(context).diagnosticUnexpectedError,
+    };
   }
 }
 

--- a/lib/page/unified_diagnostics/models/diagnostic_state.dart
+++ b/lib/page/unified_diagnostics/models/diagnostic_state.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/page/unified_diagnostics/models/speed_test_state.dart';
 
 import 'diagnostic_result.dart';
@@ -159,8 +160,8 @@ class UnifiedDiagnosticsState extends Equatable {
   /// Recommendations based on diagnostic results.
   final List<RecommendationUIModel> recommendations;
 
-  /// Error message if a step failed.
-  final String? errorMessage;
+  /// Error if a step failed.
+  final ServiceError? error;
 
   /// Progress of current step (0.0–1.0).
   final double? progress;
@@ -172,7 +173,7 @@ class UnifiedDiagnosticsState extends Equatable {
     this.results = const [],
     this.speedTest,
     this.recommendations = const [],
-    this.errorMessage,
+    this.error,
     this.progress,
   });
 
@@ -199,7 +200,7 @@ class UnifiedDiagnosticsState extends Equatable {
     List<DiagnosticStepUIModel>? results,
     SpeedTestResult? speedTest,
     List<RecommendationUIModel>? recommendations,
-    String? errorMessage,
+    ServiceError? error,
     double? progress,
     bool clearError = false,
     bool clearSpeedTest = false,
@@ -219,7 +220,7 @@ class UnifiedDiagnosticsState extends Equatable {
       recommendations: clearRecommendations
           ? const []
           : (recommendations ?? this.recommendations),
-      errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
+      error: clearError ? null : (error ?? this.error),
       progress: clearProgress ? null : (progress ?? this.progress),
     );
   }
@@ -232,7 +233,7 @@ class UnifiedDiagnosticsState extends Equatable {
         results,
         speedTest,
         recommendations,
-        errorMessage,
+        error,
         progress,
       ];
 }

--- a/lib/page/unified_diagnostics/models/manual_tools_state.dart
+++ b/lib/page/unified_diagnostics/models/manual_tools_state.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/services/sse_operation_awaiter.dart';
 
 /// Which diagnostic tool is active.
@@ -21,7 +22,7 @@ class NetworkDiagnosticsState extends Equatable {
   final PingResult? pingResult;
   final TracerouteResult? tracerouteResult;
   final NsLookupResult? nsLookupResult;
-  final String? errorMessage;
+  final ServiceError? error;
 
   const NetworkDiagnosticsState({
     this.activeTab = DiagnosticType.ping,
@@ -33,7 +34,7 @@ class NetworkDiagnosticsState extends Equatable {
     this.pingResult,
     this.tracerouteResult,
     this.nsLookupResult,
-    this.errorMessage,
+    this.error,
   });
 
   NetworkDiagnosticsState copyWith({
@@ -49,7 +50,7 @@ class NetworkDiagnosticsState extends Equatable {
     bool clearTracerouteResult = false,
     NsLookupResult? nsLookupResult,
     bool clearNsLookupResult = false,
-    String? errorMessage,
+    ServiceError? error,
     bool clearError = false,
   }) {
     return NetworkDiagnosticsState(
@@ -65,7 +66,7 @@ class NetworkDiagnosticsState extends Equatable {
           : (tracerouteResult ?? this.tracerouteResult),
       nsLookupResult:
           clearNsLookupResult ? null : (nsLookupResult ?? this.nsLookupResult),
-      errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
+      error: clearError ? null : (error ?? this.error),
     );
   }
 
@@ -87,6 +88,6 @@ class NetworkDiagnosticsState extends Equatable {
         pingResult,
         tracerouteResult,
         nsLookupResult,
-        errorMessage,
+        error,
       ];
 }

--- a/lib/page/unified_diagnostics/models/speed_test_state.dart
+++ b/lib/page/unified_diagnostics/models/speed_test_state.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 
 enum SpeedTestStep {
   idle,
@@ -147,7 +148,7 @@ class SpeedTestState extends Equatable {
   final SpeedTestStep step;
   final SpeedTestServer selectedServer;
   final SpeedTestResult? result;
-  final String? errorMessage;
+  final ServiceError? error;
   final String? progressMessage;
 
   const SpeedTestState({
@@ -159,7 +160,7 @@ class SpeedTestState extends Equatable {
       sizeMb: 100,
     ),
     this.result,
-    this.errorMessage,
+    this.error,
     this.progressMessage,
   });
 
@@ -175,7 +176,7 @@ class SpeedTestState extends Equatable {
     SpeedTestServer? selectedServer,
     SpeedTestResult? result,
     bool clearResult = false,
-    String? errorMessage,
+    ServiceError? error,
     bool clearError = false,
     String? progressMessage,
     bool clearProgress = false,
@@ -184,7 +185,7 @@ class SpeedTestState extends Equatable {
       step: step ?? this.step,
       selectedServer: selectedServer ?? this.selectedServer,
       result: clearResult ? null : (result ?? this.result),
-      errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
+      error: clearError ? null : (error ?? this.error),
       progressMessage:
           clearProgress ? null : (progressMessage ?? this.progressMessage),
     );
@@ -192,5 +193,5 @@ class SpeedTestState extends Equatable {
 
   @override
   List<Object?> get props =>
-      [step, selectedServer, result, errorMessage, progressMessage];
+      [step, selectedServer, result, error, progressMessage];
 }

--- a/lib/page/unified_diagnostics/providers/manual_tools_notifier.dart
+++ b/lib/page/unified_diagnostics/providers/manual_tools_notifier.dart
@@ -128,26 +128,16 @@ class ManualToolsNotifier
       logger.w('[USP][Diagnostics]: Ping timeout: $e');
       state = AsyncData(state.requireValue.copyWith(
         status: DiagnosticStatus.error,
-        errorMessage: 'Ping timed out — no response from ${s.host}',
+        error: DiagnosticTimeoutError(operation: 'ping', host: s.host),
       ));
     } catch (e) {
       logger.w('[USP][Diagnostics]: Ping failed: $e');
       final mapped = e is ServiceError ? e : mapUspErrorToServiceError(e);
       state = AsyncData(state.requireValue.copyWith(
         status: DiagnosticStatus.error,
-        errorMessage: _pingErrorMessage(mapped, s.host),
+        error: mapped,
       ));
     }
-  }
-
-  String _pingErrorMessage(ServiceError e, String host) {
-    return switch (e) {
-      InvalidInputError(:final message) =>
-        message ?? 'Cannot ping $host — invalid host',
-      NetworkError() => 'Ping failed — router lost connection',
-      ConnectivityError() => 'Ping unavailable — diagnostics scope not ready',
-      _ => 'Ping failed — please try again',
-    };
   }
 
   // -------------------------------------------------------------------------
@@ -185,27 +175,16 @@ class ManualToolsNotifier
       logger.w('[USP][Diagnostics]: Traceroute timeout: $e');
       state = AsyncData(state.requireValue.copyWith(
         status: DiagnosticStatus.error,
-        errorMessage: 'Traceroute timed out — route to ${s.host} incomplete',
+        error: DiagnosticTimeoutError(operation: 'traceroute', host: s.host),
       ));
     } catch (e) {
       logger.w('[USP][Diagnostics]: Traceroute failed: $e');
       final mapped = e is ServiceError ? e : mapUspErrorToServiceError(e);
       state = AsyncData(state.requireValue.copyWith(
         status: DiagnosticStatus.error,
-        errorMessage: _tracerouteErrorMessage(mapped, s.host),
+        error: mapped,
       ));
     }
-  }
-
-  String _tracerouteErrorMessage(ServiceError e, String host) {
-    return switch (e) {
-      InvalidInputError(:final message) =>
-        message ?? 'Cannot trace $host — invalid host',
-      NetworkError() => 'Traceroute failed — router lost connection',
-      ConnectivityError() =>
-        'Traceroute unavailable — diagnostics scope not ready',
-      _ => 'Traceroute failed — please try again',
-    };
   }
 
   // -------------------------------------------------------------------------
@@ -245,27 +224,15 @@ class ManualToolsNotifier
       logger.w('[USP][Diagnostics]: NS Lookup timeout: $e');
       state = AsyncData(state.requireValue.copyWith(
         status: DiagnosticStatus.error,
-        errorMessage:
-            'NS Lookup timed out — no response while resolving ${s.host}',
+        error: DiagnosticTimeoutError(operation: 'nslookup', host: s.host),
       ));
     } catch (e) {
       logger.w('[USP][Diagnostics]: NS Lookup failed: $e');
       final mapped = e is ServiceError ? e : mapUspErrorToServiceError(e);
       state = AsyncData(state.requireValue.copyWith(
         status: DiagnosticStatus.error,
-        errorMessage: _nsLookupErrorMessage(mapped, s.host),
+        error: mapped,
       ));
     }
-  }
-
-  String _nsLookupErrorMessage(ServiceError e, String host) {
-    return switch (e) {
-      InvalidInputError(:final message) =>
-        message ?? 'Cannot resolve $host — invalid host',
-      NetworkError() => 'NS Lookup failed — router lost connection',
-      ConnectivityError() =>
-        'NS Lookup unavailable — diagnostics scope not ready',
-      _ => 'NS Lookup failed — please try again',
-    };
   }
 }

--- a/lib/page/unified_diagnostics/providers/speed_test_notifier.dart
+++ b/lib/page/unified_diagnostics/providers/speed_test_notifier.dart
@@ -114,7 +114,7 @@ class SpeedTestNotifier extends AutoDisposeAsyncNotifier<SpeedTestState> {
       state = AsyncData(state.requireValue.copyWith(
         step: SpeedTestStep.error,
         clearProgress: true,
-        errorMessage: _scopeErrorMessage(mapped),
+        error: mapped,
       ));
       return;
     }
@@ -165,11 +165,12 @@ class SpeedTestNotifier extends AutoDisposeAsyncNotifier<SpeedTestState> {
       if (downloadStatus != 'Complete') {
         logger.w(
             '[USP][SpeedTest]: Download failed with status: $downloadStatus');
-        final errorMsg = _getDownloadErrorMessage(downloadStatus, downloadUrl);
+        final uri = Uri.tryParse(downloadUrl);
+        final host = uri?.host ?? downloadUrl;
         state = AsyncData(state.requireValue.copyWith(
           step: SpeedTestStep.error,
           clearProgress: true,
-          errorMessage: errorMsg,
+          error: SpeedTestStatusError(status: downloadStatus, target: host),
         ));
         return;
       }
@@ -211,7 +212,8 @@ class SpeedTestNotifier extends AutoDisposeAsyncNotifier<SpeedTestState> {
       state = AsyncData(state.requireValue.copyWith(
         step: SpeedTestStep.error,
         clearProgress: true,
-        errorMessage: 'Speed test timed out',
+        error:
+            DiagnosticTimeoutError(operation: 'speedTest', host: server.host),
       ));
     } catch (e) {
       logger.w('[USP][SpeedTest]: Failed: $e');
@@ -219,7 +221,7 @@ class SpeedTestNotifier extends AutoDisposeAsyncNotifier<SpeedTestState> {
       state = AsyncData(state.requireValue.copyWith(
         step: SpeedTestStep.error,
         clearProgress: true,
-        errorMessage: _runErrorMessage(mapped),
+        error: mapped,
       ));
     } finally {
       if (identical(_activeScope, scope)) _activeScope = null;
@@ -245,55 +247,5 @@ class SpeedTestNotifier extends AutoDisposeAsyncNotifier<SpeedTestState> {
       return;
     }
     state = const AsyncData(SpeedTestState());
-  }
-
-  // -------------------------------------------------------------------------
-  // Error messages
-  // -------------------------------------------------------------------------
-
-  String _scopeErrorMessage(ServiceError e) {
-    return switch (e) {
-      ConnectivityError() =>
-        'Speed test unavailable — diagnostics scope not ready',
-      NetworkError() => 'Speed test unavailable — router lost connection',
-      _ => 'Speed test unavailable — please try again',
-    };
-  }
-
-  String _runErrorMessage(ServiceError e) {
-    return switch (e) {
-      NetworkError() => 'Speed test failed — router lost connection',
-      ConnectivityError() =>
-        'Speed test unavailable — diagnostics scope not ready',
-      InvalidInputError(:final message) =>
-        message ?? 'Speed test failed — invalid configuration',
-      _ => 'Speed test failed — please try again',
-    };
-  }
-
-  String _getDownloadErrorMessage(String status, String url) {
-    // Extract hostname from URL for display
-    final uri = Uri.tryParse(url);
-    final host = uri?.host ?? url;
-
-    return switch (status) {
-      'Error_NoResponse' =>
-        'Could not connect to test server ($host). Please check your internet connection.',
-      'Error_InitConnectionFailed' =>
-        'Failed to establish connection to test server ($host).',
-      'Error_CannotResolveHostName' =>
-        'Could not resolve test server address ($host). DNS may be unavailable.',
-      'Error_Timeout' => 'Connection to test server timed out.',
-      'Error_TransferFailed' => 'Data transfer failed during test.',
-      'Error_PasswordRequestFailed' =>
-        'Authentication failed with test server.',
-      'Error_LoginFailed' => 'Login to test server failed.',
-      'Error_NoTransferMode' =>
-        'Server does not support required transfer mode.',
-      'Error_NoPASV' => 'Server does not support passive mode.',
-      'Error_IncorrectSize' => 'Downloaded file size mismatch.',
-      'Error_Internal' => 'Internal error occurred during speed test.',
-      _ => 'Speed test failed: $status',
-    };
   }
 }

--- a/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
+++ b/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
@@ -296,7 +296,8 @@ class UnifiedDiagnosticsNotifier
     if (_cancelled) return;
     final svc = _svc;
     if (svc == null) {
-      _setError('Diagnostics service not available');
+      _setError(const ConnectivityError(
+          message: 'Diagnostics service not available'));
       return;
     }
 
@@ -450,7 +451,8 @@ class UnifiedDiagnosticsNotifier
     if (_cancelled) return;
     final svc = _svc;
     if (svc == null) {
-      _setError('Diagnostics service not available');
+      _setError(const ConnectivityError(
+          message: 'Diagnostics service not available'));
       return;
     }
 
@@ -576,7 +578,8 @@ class UnifiedDiagnosticsNotifier
     if (_cancelled) return;
     final svc = _svc;
     if (svc == null) {
-      _setError('Diagnostics service not available');
+      _setError(const ConnectivityError(
+          message: 'Diagnostics service not available'));
       return;
     }
 
@@ -628,7 +631,8 @@ class UnifiedDiagnosticsNotifier
     if (_cancelled) return;
     final svc = _svc;
     if (svc == null) {
-      _setError('Diagnostics service not available');
+      _setError(const ConnectivityError(
+          message: 'Diagnostics service not available'));
       return;
     }
 
@@ -674,7 +678,8 @@ class UnifiedDiagnosticsNotifier
     if (_cancelled) return;
     final svc = _svc;
     if (svc == null) {
-      _setError('Diagnostics service not available');
+      _setError(const ConnectivityError(
+          message: 'Diagnostics service not available'));
       return;
     }
 
@@ -750,7 +755,8 @@ class UnifiedDiagnosticsNotifier
     if (_cancelled) return;
     final svc = _svc;
     if (svc == null) {
-      _setError('Diagnostics service not available');
+      _setError(const ConnectivityError(
+          message: 'Diagnostics service not available'));
       return;
     }
 
@@ -835,7 +841,7 @@ class UnifiedDiagnosticsNotifier
         }
       } else if (speedState.step == SpeedTestStep.error) {
         if (!completer.isCompleted) {
-          logger.w('[Diagnostics] SpeedTest error: ${speedState.errorMessage}');
+          logger.w('[Diagnostics] SpeedTest error: ${speedState.error}');
           completer.complete(null);
         }
       }
@@ -1356,11 +1362,11 @@ class UnifiedDiagnosticsNotifier
     );
   }
 
-  void _setError(String message) {
-    logger.e('[Diagnostics] Error: $message');
+  void _setError(ServiceError error) {
+    logger.e('[Diagnostics] Error: $error');
     state = state.copyWith(
       step: DiagnosticStep.showingResults,
-      errorMessage: message,
+      error: error,
     );
   }
 }

--- a/lib/page/unified_diagnostics/services/diagnostic_report_service.dart
+++ b/lib/page/unified_diagnostics/services/diagnostic_report_service.dart
@@ -27,8 +27,8 @@ class DiagnosticReportService {
     buffer.writeln('Flow: ${_flowName(state)}');
     buffer.writeln();
 
-    if (state.errorMessage != null) {
-      buffer.writeln('ERROR: ${state.errorMessage}');
+    if (state.error != null) {
+      buffer.writeln('ERROR: ${state.error}');
       buffer.writeln();
     }
 

--- a/lib/page/unified_diagnostics/views/speed_test_view.dart
+++ b/lib/page/unified_diagnostics/views/speed_test_view.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/shortcuts/dialogs.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/shell/usp_top_bar.dart';
 import 'package:privacy_gui/page/unified_diagnostics/models/speed_test_state.dart';
@@ -394,9 +396,9 @@ class SpeedTestView extends ConsumerWidget {
           AppGap.xl(),
           AppText.titleMedium('Speed Test Failed'),
           AppGap.md(),
-          if (state.errorMessage != null)
+          if (state.error != null)
             AppText.bodyMedium(
-              state.errorMessage!,
+              _translateError(context, state.error!),
               textAlign: TextAlign.center,
               color: colorScheme.onSurfaceVariant,
             ),
@@ -414,6 +416,18 @@ class SpeedTestView extends ConsumerWidget {
     if (bytes < 1024) return '$bytes B';
     if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
     return '${(bytes / (1024 * 1024)).toStringAsFixed(2)} MB';
+  }
+
+  String _translateError(BuildContext context, ServiceError error) {
+    return switch (error) {
+      DiagnosticTimeoutError(:final operation, :final host) =>
+        loc(context).diagnosticTimeout(operation, host ?? ''),
+      SpeedTestStatusError(:final status, :final target) =>
+        loc(context).speedTestStatusError(status, target ?? ''),
+      ConnectivityError() => loc(context).diagnosticsUnavailable,
+      NetworkError() => loc(context).routerLostConnection,
+      _ => loc(context).diagnosticUnexpectedError,
+    };
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/page/unified_diagnostics/views/widgets/diagnostic_manual_tools_view.dart
+++ b/lib/page/unified_diagnostics/views/widgets/diagnostic_manual_tools_view.dart
@@ -328,8 +328,8 @@ class _DiagnosticManualToolsViewState
         loc(context).diagnosticTimeout(operation, host ?? ''),
       ConnectivityError() => loc(context).diagnosticsUnavailable,
       NetworkError() => loc(context).routerLostConnection,
-      InvalidInputError(:final field) =>
-        loc(context).diagnosticInvalidHost(field ?? ''),
+      InvalidInputError(:final field, :final message) =>
+        loc(context).diagnosticInvalidHost(field ?? message ?? ''),
       _ => loc(context).diagnosticUnexpectedError,
     };
   }

--- a/lib/page/unified_diagnostics/views/widgets/diagnostic_manual_tools_view.dart
+++ b/lib/page/unified_diagnostics/views/widgets/diagnostic_manual_tools_view.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/models/operate_result.dart';
+import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/unified_diagnostics/models/manual_tools_state.dart';
 import 'package:privacy_gui/page/unified_diagnostics/providers/manual_tools_notifier.dart';
 import 'package:ui_kit_library/ui_kit.dart';
@@ -128,7 +130,7 @@ class _DiagnosticManualToolsViewState
         ],
 
         // Error display
-        if (state.errorMessage != null) ...[
+        if (state.error != null) ...[
           AppCard(
             child: Row(
               children: [
@@ -137,7 +139,7 @@ class _DiagnosticManualToolsViewState
                 AppGap.md(),
                 Expanded(
                   child: AppText.bodyMedium(
-                    state.errorMessage!,
+                    _translateError(context, state.error!),
                     color: colorScheme.error,
                   ),
                 ),
@@ -317,6 +319,18 @@ class _DiagnosticManualToolsViewState
       DiagnosticType.ping => 'Pinging ${state.host}...',
       DiagnosticType.traceroute => 'Tracing route to ${state.host}...',
       DiagnosticType.nsLookup => 'Resolving ${state.host}...',
+    };
+  }
+
+  String _translateError(BuildContext context, ServiceError error) {
+    return switch (error) {
+      DiagnosticTimeoutError(:final operation, :final host) =>
+        loc(context).diagnosticTimeout(operation, host ?? ''),
+      ConnectivityError() => loc(context).diagnosticsUnavailable,
+      NetworkError() => loc(context).routerLostConnection,
+      InvalidInputError(:final field) =>
+        loc(context).diagnosticInvalidHost(field ?? ''),
+      _ => loc(context).diagnosticUnexpectedError,
     };
   }
 

--- a/test/page/dhcp/providers/usp_dhcp_reservations_notifier_test.dart
+++ b/test/page/dhcp/providers/usp_dhcp_reservations_notifier_test.dart
@@ -78,7 +78,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final state = container.read(uspDhcpReservationsProvider);
-      expect(state.status.errorMessage, contains('timeout'));
+      expect(state.status.error, isA<NetworkError>());
       expect(state.settings.current.reservations, isEmpty);
       container.dispose();
     });

--- a/test/page/dmz/providers/usp_dmz_notifier_test.dart
+++ b/test/page/dmz/providers/usp_dmz_notifier_test.dart
@@ -87,7 +87,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final state = container.read(uspDmzProvider);
-      expect(state.status.errorMessage, contains('Network error'));
+      expect(state.status.error, isA<NetworkError>());
       // Settings remain empty (initial) since performFetch returned null.
       expect(state.settings.current, const DmzSettings.empty());
       container.dispose();

--- a/test/page/firewall/providers/usp_firewall_notifier_test.dart
+++ b/test/page/firewall/providers/usp_firewall_notifier_test.dart
@@ -166,7 +166,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final state = container.read(uspFirewallProvider);
-      expect(state.status.errorMessage, contains('Network error'));
+      expect(state.status.error, isA<NetworkError>());
       container.dispose();
     });
 

--- a/test/page/internet_settings/models/internet_settings_status_test.dart
+++ b/test/page/internet_settings/models/internet_settings_status_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/page/internet_settings/models/internet_settings_read_only_info.dart';
 import 'package:privacy_gui/page/internet_settings/models/internet_settings_status.dart';
 
@@ -9,7 +10,7 @@ void main() {
       expect(status.isLoading, true);
       expect(status.isSaving, false);
       expect(status.isEditing, false);
-      expect(status.errorMessage, isNull);
+      expect(status.error, isNull);
       expect(status.activeMutation, isNull);
       expect(status.pppInstancePath, isNull);
       expect(status.vlanInstancePath, isNull);
@@ -22,7 +23,7 @@ void main() {
           isLoading: false,
           isSaving: true,
           isEditing: true,
-          errorMessage: 'error',
+          error: const NetworkError(message: 'error'),
           activeMutation: 'save',
           pppInstancePath: 'Device.PPP.Interface.1.',
           vlanInstancePath: 'Device.Ethernet.VLANTermination.1.',
@@ -31,7 +32,7 @@ void main() {
         expect(updated.isLoading, false);
         expect(updated.isSaving, true);
         expect(updated.isEditing, true);
-        expect(updated.errorMessage, 'error');
+        expect(updated.error, isA<NetworkError>());
         expect(updated.activeMutation, 'save');
         expect(updated.pppInstancePath, 'Device.PPP.Interface.1.');
         expect(updated.vlanInstancePath, 'Device.Ethernet.VLANTermination.1.');
@@ -74,11 +75,13 @@ void main() {
         expect(updated.vlanInstancePath, isNull);
       });
 
-      test('errorMessage resets to null when not provided', () {
-        const status = InternetSettingsStatus(errorMessage: 'error');
-        final updated = status.copyWith(isLoading: false);
+      test('clearError sets error to null', () {
+        final status = InternetSettingsStatus(
+          error: const NetworkError(message: 'error'),
+        );
+        final updated = status.copyWith(clearError: true);
 
-        expect(updated.errorMessage, isNull);
+        expect(updated.error, isNull);
       });
     });
 

--- a/test/page/internet_settings/providers/usp_internet_settings_notifier_test.dart
+++ b/test/page/internet_settings/providers/usp_internet_settings_notifier_test.dart
@@ -93,7 +93,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final state = container.read(uspInternetSettingsProvider);
-      expect(state.status.errorMessage, contains('bridge unreachable'));
+      expect(state.status.error, isA<NetworkError>());
       container.dispose();
     });
 
@@ -311,7 +311,7 @@ void main() {
 
       final state = container.read(uspInternetSettingsProvider);
       // Should hit the restore path which won't succeed with our mock.
-      expect(state.status.errorMessage, isNotNull);
+      expect(state.status.error, isNotNull);
       container.dispose();
     });
   });

--- a/test/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier_test.dart
+++ b/test/page/ipv6_port_service/providers/usp_ipv6_port_service_notifier_test.dart
@@ -82,7 +82,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final state = container.read(uspIpv6PortServiceProvider);
-      expect(state.status.errorMessage, contains('fetch failed'));
+      expect(state.status.error, isA<NetworkError>());
       expect(state.settings.current.rules, isEmpty);
       container.dispose();
     });

--- a/test/page/local_network/providers/usp_local_network_notifier_test.dart
+++ b/test/page/local_network/providers/usp_local_network_notifier_test.dart
@@ -191,7 +191,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final state = container.read(uspLocalNetworkProvider);
-      expect(state.status.errorMessage, contains('Network error'));
+      expect(state.status.error, isA<NetworkError>());
       container.dispose();
     });
 

--- a/test/page/port_forwarding/providers/usp_port_forwarding_page_notifier_test.dart
+++ b/test/page/port_forwarding/providers/usp_port_forwarding_page_notifier_test.dart
@@ -105,7 +105,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final state = container.read(uspPortForwardingPageProvider);
-      expect(state.status.errorMessage, contains('timeout'));
+      expect(state.status.error, isA<NetworkError>());
       container.dispose();
     });
 

--- a/test/page/static_routing/providers/usp_static_routing_notifier_test.dart
+++ b/test/page/static_routing/providers/usp_static_routing_notifier_test.dart
@@ -86,7 +86,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final state = container.read(uspStaticRoutingProvider);
-      expect(state.status.errorMessage, contains('connection lost'));
+      expect(state.status.error, isA<NetworkError>());
       expect(state.settings.current.routes, isEmpty);
       container.dispose();
     });

--- a/test/page/unified_diagnostics/models/diagnostic_state_test.dart
+++ b/test/page/unified_diagnostics/models/diagnostic_state_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/page/unified_diagnostics/models/speed_test_state.dart';
 import 'package:privacy_gui/page/unified_diagnostics/models/diagnostic_state.dart';
 
@@ -73,7 +74,7 @@ void main() {
       expect(state.results, isEmpty);
       expect(state.speedTest, isNull);
       expect(state.recommendations, isEmpty);
-      expect(state.errorMessage, isNull);
+      expect(state.error, isNull);
       expect(state.progress, isNull);
     });
 
@@ -110,24 +111,24 @@ void main() {
       final initial = UnifiedDiagnosticsState(
         step: DiagnosticStep.checkingWanStatus,
         flow: DiagnosticFlow.internet,
-        errorMessage: 'test error',
+        error: const UnexpectedError(message: 'test error'),
       );
 
       final copied = initial.copyWith(step: DiagnosticStep.pingGateway);
 
       expect(copied.step, DiagnosticStep.pingGateway);
       expect(copied.flow, DiagnosticFlow.internet);
-      expect(copied.errorMessage, 'test error');
+      expect(copied.error, isA<UnexpectedError>());
     });
 
     test('copyWith clears error when requested', () {
       final initial = UnifiedDiagnosticsState(
-        errorMessage: 'test error',
+        error: const UnexpectedError(message: 'test error'),
       );
 
       final cleared = initial.copyWith(clearError: true);
 
-      expect(cleared.errorMessage, isNull);
+      expect(cleared.error, isNull);
     });
 
     test('copyWith clears speedTest when requested', () {

--- a/test/page/unified_diagnostics/models/manual_tools_state_test.dart
+++ b/test/page/unified_diagnostics/models/manual_tools_state_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/models/operate_result.dart';
 import 'package:privacy_gui/page/unified_diagnostics/models/manual_tools_state.dart';
 
@@ -88,11 +89,12 @@ void main() {
         expect(next.dnsServer, baseline.dnsServer);
       });
 
-      test('clearError resets errorMessage to null', () {
-        final withError = baseline.copyWith(errorMessage: 'oops');
-        expect(withError.errorMessage, 'oops');
+      test('clearError resets error to null', () {
+        final withError =
+            baseline.copyWith(error: const UnexpectedError(message: 'oops'));
+        expect(withError.error, isA<UnexpectedError>());
         final cleared = withError.copyWith(clearError: true);
-        expect(cleared.errorMessage, isNull);
+        expect(cleared.error, isNull);
       });
 
       test('clearPingResult resets pingResult to null', () {

--- a/test/page/unified_diagnostics/providers/manual_tools_notifier_test.dart
+++ b/test/page/unified_diagnostics/providers/manual_tools_notifier_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/models/operate_result.dart';
 import 'package:privacy_gui/core/usp/providers/sse_providers.dart';
 import 'package:privacy_gui/core/usp/services/network_diagnostics_executor.dart';
@@ -226,7 +227,7 @@ void main() {
 
       final state = container.read(manualToolsProvider).valueOrNull;
       expect(state?.status, DiagnosticStatus.error);
-      expect(state?.errorMessage, contains('timed out'));
+      expect(state?.error, isA<DiagnosticTimeoutError>());
       container.dispose();
     });
 
@@ -245,7 +246,7 @@ void main() {
 
       final state = container.read(manualToolsProvider).valueOrNull;
       expect(state?.status, DiagnosticStatus.error);
-      expect(state?.errorMessage, contains('Ping failed'));
+      expect(state?.error, isA<UnexpectedError>());
       container.dispose();
     });
 
@@ -291,7 +292,7 @@ void main() {
 
       final state = container.read(manualToolsProvider).valueOrNull;
       expect(state?.status, DiagnosticStatus.error);
-      expect(state?.errorMessage, contains('Traceroute timed out'));
+      expect(state?.error, isA<DiagnosticTimeoutError>());
       container.dispose();
     });
 
@@ -363,7 +364,7 @@ void main() {
 
       final state = container.read(manualToolsProvider).valueOrNull;
       expect(state?.status, DiagnosticStatus.error);
-      expect(state?.errorMessage, contains('NS Lookup timed out'));
+      expect(state?.error, isA<DiagnosticTimeoutError>());
       container.dispose();
     });
 

--- a/test/page/unified_diagnostics/providers/speed_test_notifier_test.dart
+++ b/test/page/unified_diagnostics/providers/speed_test_notifier_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/models/operate_result.dart';
 import 'package:privacy_gui/core/usp/providers/sse_providers.dart';
 import 'package:privacy_gui/core/usp/services/network_diagnostics_executor.dart';
@@ -177,7 +178,7 @@ void main() {
 
       final state = container.read(speedTestProvider).valueOrNull;
       expect(state?.step, SpeedTestStep.error);
-      expect(state?.errorMessage, contains('Could not connect'));
+      expect(state?.error, isA<SpeedTestStatusError>());
       container.dispose();
     });
 

--- a/test/page/unified_diagnostics/services/diagnostic_report_service_test.dart
+++ b/test/page/unified_diagnostics/services/diagnostic_report_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/page/unified_diagnostics/models/diagnostic_result.dart';
 import 'package:privacy_gui/page/unified_diagnostics/models/diagnostic_state.dart';
 import 'package:privacy_gui/page/unified_diagnostics/models/speed_test_state.dart';
@@ -37,10 +38,11 @@ void main() {
     });
 
     test('renders error message when present', () {
-      const state =
-          UnifiedDiagnosticsState(errorMessage: 'Network unreachable');
+      const state = UnifiedDiagnosticsState(
+          error: NetworkError(message: 'Network unreachable'));
       final report = service.buildTextReport(state);
-      expect(report, contains('ERROR: Network unreachable'));
+      expect(report, contains('ERROR:'));
+      expect(report, contains('Network'));
     });
 
     test('renders ping result with severity icon and details', () {

--- a/test/usp_test/page/dmz/fixtures/dmz_test_data.dart
+++ b/test/usp_test/page/dmz/fixtures/dmz_test_data.dart
@@ -1,3 +1,4 @@
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/framework/preservable.dart';
 import 'package:privacy_gui/page/dmz/models/dmz_feature_state.dart';
 import 'package:privacy_gui/page/dmz/models/dmz_settings.dart';
@@ -66,8 +67,8 @@ DmzFeatureState get errorState => DmzFeatureState(
         original: DmzSettings.empty(),
         current: DmzSettings.empty(),
       ),
-      status: const DmzStatus(
+      status: DmzStatus(
         isLoading: false,
-        errorMessage: 'Connection failed',
+        error: const NetworkError(message: 'Connection failed'),
       ),
     );

--- a/test/usp_test/page/firewall/fixtures/firewall_test_data.dart
+++ b/test/usp_test/page/firewall/fixtures/firewall_test_data.dart
@@ -1,3 +1,4 @@
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/framework/preservable.dart';
 import 'package:privacy_gui/page/firewall/models/firewall_feature_state.dart';
 import 'package:privacy_gui/page/firewall/models/firewall_settings.dart';
@@ -69,8 +70,8 @@ FirewallFeatureState get errorState => FirewallFeatureState(
         original: FirewallSettings.empty(),
         current: FirewallSettings.empty(),
       ),
-      status: const FirewallStatus(
+      status: FirewallStatus(
         isLoading: false,
-        errorMessage: 'Connection failed',
+        error: const NetworkError(message: 'Connection failed'),
       ),
     );

--- a/test/usp_test/page/internet_settings/fixtures/internet_settings_test_data.dart
+++ b/test/usp_test/page/internet_settings/fixtures/internet_settings_test_data.dart
@@ -1,3 +1,4 @@
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/framework/preservable.dart';
 import 'package:privacy_gui/page/internet_settings/models/internet_settings_feature_state.dart';
 import 'package:privacy_gui/page/internet_settings/models/internet_settings_read_only_info.dart';
@@ -158,8 +159,8 @@ InternetSettingsFeatureState get errorState => InternetSettingsFeatureState(
         original: InternetSettingsSettings.empty(),
         current: InternetSettingsSettings.empty(),
       ),
-      status: const InternetSettingsStatus(
+      status: InternetSettingsStatus(
         isLoading: false,
-        errorMessage: 'Connection failed',
+        error: const NetworkError(message: 'Connection failed'),
       ),
     );

--- a/test/usp_test/page/local_network/fixtures/local_network_test_data.dart
+++ b/test/usp_test/page/local_network/fixtures/local_network_test_data.dart
@@ -1,3 +1,4 @@
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/framework/preservable.dart';
 import 'package:privacy_gui/page/local_network/models/local_network_feature_state.dart';
 import 'package:privacy_gui/page/local_network/models/local_network_settings.dart';
@@ -69,9 +70,9 @@ LocalNetworkFeatureState get errorState => LocalNetworkFeatureState(
         original: const LocalNetworkSettings.empty(),
         current: const LocalNetworkSettings.empty(),
       ),
-      status: const LocalNetworkStatus(
+      status: LocalNetworkStatus(
         isLoading: false,
-        errorMessage: 'Connection failed',
+        error: const NetworkError(message: 'Connection failed'),
       ),
     );
 

--- a/test/usp_test/page/port_forwarding/fixtures/port_forwarding_test_data.dart
+++ b/test/usp_test/page/port_forwarding/fixtures/port_forwarding_test_data.dart
@@ -1,3 +1,4 @@
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/framework/preservable.dart';
 import 'package:privacy_gui/page/_shared/models/port_forwarding_rule_ui_model.dart';
 import 'package:privacy_gui/page/port_forwarding/models/port_forwarding_page_feature_state.dart';
@@ -162,7 +163,7 @@ PortForwardingPageFeatureState get errorState => PortForwardingPageFeatureState(
         original: const PortForwardingPageSettings(),
         current: const PortForwardingPageSettings(),
       ),
-      status: const PortForwardingPageStatus(
-        errorMessage: 'Connection failed',
+      status: PortForwardingPageStatus(
+        error: const NetworkError(message: 'Connection failed'),
       ),
     );

--- a/test/usp_test/page/static_routing/fixtures/static_routing_test_data.dart
+++ b/test/usp_test/page/static_routing/fixtures/static_routing_test_data.dart
@@ -1,3 +1,4 @@
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/framework/preservable.dart';
 import 'package:privacy_gui/page/static_routing/models/static_route_list.dart';
 import 'package:privacy_gui/page/static_routing/models/static_routing_feature_state.dart';
@@ -77,7 +78,7 @@ StaticRoutingFeatureState get errorState => StaticRoutingFeatureState(
         original: const StaticRouteList(),
         current: const StaticRouteList(),
       ),
-      status: const StaticRoutingStatus(
-        errorMessage: 'Connection failed',
+      status: StaticRoutingStatus(
+        error: const NetworkError(message: 'Connection failed'),
       ),
     );

--- a/test/usp_test/page/unified_diagnostics/fixtures/unified_diagnostics_test_data.dart
+++ b/test/usp_test/page/unified_diagnostics/fixtures/unified_diagnostics_test_data.dart
@@ -1,3 +1,4 @@
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/models/operate_result.dart';
 import 'package:privacy_gui/page/unified_diagnostics/models/device_score.dart';
 import 'package:privacy_gui/page/unified_diagnostics/models/diagnostic_result.dart';
@@ -726,10 +727,11 @@ const completedState = UnifiedDiagnosticsState(
 // Error — diagnostic failed
 // =============================================================================
 
-const errorState = UnifiedDiagnosticsState(
+final errorState = UnifiedDiagnosticsState(
   step: DiagnosticStep.showingResults,
   flow: DiagnosticFlow.internet,
-  errorMessage: 'Connection timed out — unable to reach diagnostic service',
+  error: const ConnectivityError(
+      message: 'Connection timed out — unable to reach diagnostic service'),
 );
 
 // =============================================================================
@@ -874,10 +876,10 @@ const manualToolsPingRunningState = NetworkDiagnosticsState(
 // Manual tools — error state
 // =============================================================================
 
-const manualToolsErrorState = NetworkDiagnosticsState(
+final manualToolsErrorState = NetworkDiagnosticsState(
   activeTab: DiagnosticType.ping,
   status: DiagnosticStatus.error,
   host: '192.168.99.99',
   pingCount: 3,
-  errorMessage: 'Ping timed out — no response from 192.168.99.99',
+  error: const DiagnosticTimeoutError(operation: 'Ping', host: '192.168.99.99'),
 );


### PR DESCRIPTION
## Summary

Refactor **notifier-layer error handling pattern** — replace `errorMessage: '$e'` strings and hardcoded English error messages in catch blocks with `ServiceError` objects. This enables View layers to use `loc(context)` for proper i18n translation while preserving firmware error details.

## Scope

**Included:**
- Notifier catch blocks that stored errors as `errorMessage: '$e'` or hardcoded strings
- State models: `String? errorMessage` → `ServiceError? error`
- View error displays: use `loc(context).failedToLoadSettings` + `error.toString()`

**Not included:**
- Other hardcoded strings in View layers (labels, titles, descriptions)
- This PR only addresses the notifier error model pattern

## Changes

### unified_diagnostics (manual_tools, speed_test)
- Add `DiagnosticTimeoutError` and `SpeedTestStatusError` to `ServiceError`
- State models: `String? errorMessage` → `ServiceError? error`
- Notifiers: remove `_xxxErrorMessage()` helpers, store `ServiceError` directly
- Views: add `_translateError()` helper using `loc(context)`
- ARB: add 6 new keys (diagnosticTimeout, diagnosticsUnavailable, etc.)
- Tests: updated to verify error types instead of message strings

### CRUD notifiers (8 features)
- Status models: `String? errorMessage` → `ServiceError? error` with `clearError` flag
- Notifiers: store `ServiceError` directly instead of `'$e'` string
- Views: use `loc(context).failedToLoadSettings` and `loc(context).retry`

**Affected features:** dmz, dhcp, firewall, port_forwarding, local_network, internet_settings, ipv6_port_service, static_routing

## Test plan
- [ ] Verify error states display correctly in each affected page
- [ ] Confirm i18n keys are properly resolved
- [ ] Check that firmware error details are preserved in error display

🤖 Generated with [Claude Code](https://claude.com/claude-code)