### PR TITLE
fix: extract inline scripts to external JS for CSP compliance

### DIFF
--- a/web/early-bootstrap.js
+++ b/web/early-bootstrap.js
@@ -1,0 +1,46 @@
+// early-bootstrap.js
+// Extracted inline scripts for CSP compliance (removes need for 'unsafe-inline' in script-src)
+// These scripts must run synchronously before body renders.
+
+(function () {
+  'use strict';
+
+  // 1. PWA install prompt early capture
+  window.deferredBeforeInstallPromptEvent = null;
+  window.addEventListener('beforeinstallprompt', function (e) {
+    e.preventDefault();
+    window.deferredBeforeInstallPromptEvent = e;
+    console.log('PWA: Early capture of beforeinstallprompt');
+  });
+
+  // 2. Theme detection and application
+  var appSettingsString = window.localStorage.getItem('flutter.AppSettings');
+
+  if (appSettingsString) {
+    try {
+      var settings = JSON.parse(JSON.parse(appSettingsString));
+      var themeMode = settings.themeMode;
+      if (themeMode === 'system') {
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+      } else {
+        document.documentElement.setAttribute('data-theme', themeMode);
+      }
+    } catch (error) {
+      console.error('app settings parse error: ', error);
+    }
+  } else {
+    console.log('app settings not found, by system');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+  }
+
+  // 3. Splash screen removal utility
+  window.removeSplashFromWeb = function () {
+    var splash = document.getElementById('splash');
+    var branding = document.getElementById('splash-branding');
+    if (splash) splash.remove();
+    if (branding) branding.remove();
+    document.body.style.background = 'transparent';
+  };
+})();

--- a/web/index.html
+++ b/web/index.html
@@ -26,15 +26,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Linksys Now">
 
-  <script>
-    // Capture PWA install prompt event early prevents missing it due to Flutter loading time.
-    window.deferredBeforeInstallPromptEvent = null;
-    window.addEventListener('beforeinstallprompt', (e) => {
-      e.preventDefault();
-      window.deferredBeforeInstallPromptEvent = e;
-      console.log('PWA: Early capture of beforeinstallprompt');
-    });
-  </script>
+  <script src="early-bootstrap.js"></script>
   <link rel="apple-touch-icon" sizes="180x180" href="logo_icons/logo-icon-180.png">
 
   <!-- Favicon -->
@@ -112,38 +104,6 @@
       right: 0;
     }
   </style>
-  <script>
-    (function () {
-      const appSettingsString = window.localStorage.getItem('flutter.AppSettings');
-
-      if (appSettingsString) {
-        try {
-          // Parse twice since it stores as string with double quotes
-          const settings = JSON.parse(JSON.parse(appSettingsString));
-          const themeMode = settings.themeMode;
-          if (themeMode === 'system') {
-            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-            document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
-          } else {
-            document.documentElement.setAttribute('data-theme', themeMode);
-          }
-        } catch (error) {
-          console.error("app settings parse error: ", error);
-        }
-      } else {
-        console.log("app settings not found, by system");
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
-      }
-    })();
-  </script>
-  <script id="splash-screen-script">
-    function removeSplashFromWeb() {
-      document.getElementById("splash")?.remove();
-      document.getElementById("splash-branding")?.remove();
-      document.body.style.background = "transparent";
-    }
-  </script>
   <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport">
 </head>
 


### PR DESCRIPTION
## Summary

- Extract inline `<script>` blocks from `index.html` to external `early-bootstrap.js`
- Enables removal of `'unsafe-inline'` from `script-src` CSP directive on router

## Related Issue

- Closes #926
- Ref: linksys/LinksysWRT#352 (F-116: CSP permits `'unsafe-inline'` for script)

## Test plan

- [x] Splash screen displays and removes correctly after Flutter loads
- [x] Dark/Light theme applies on page load without flicker
- [ ] PWA install prompt capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)