### PR TITLE
feat(mascot): health dashboard with problem-first display

### DIFF
--- a/doc/mascot/mascot-health-system.md
+++ b/doc/mascot/mascot-health-system.md
@@ -1,0 +1,194 @@
+# Mascot Health System
+
+## Overview
+
+The Mascot Health System provides a visual dashboard showing the overall health of the router system. It consists of:
+
+1. **Word Cloud UI** — Visual representation of system health dimensions
+2. **Toolbar** — Quick access to utilities (print, theme, FAQ, AI Assistant)
+3. **Health Evaluation** — Extensible dimension scoring with 6 built-in dimensions
+4. **Event Triggers** — SSE-driven proactive notifications
+
+## Architecture
+
+```
+lib/page/dashboard/mascot/
+├── mascot_config.dart           # Centralized configuration
+├── mascot_providers.dart        # Coordinator + trigger integration
+├── health_dialog_provider.dart  # Word cloud dialog UI
+│
+├── health/
+│   ├── health_dimension.dart         # Abstract interface + models
+│   ├── health_score.dart             # Score model + HealthTier
+│   ├── health_dimension_registry.dart # Registry for all dimensions
+│   ├── system_health_provider.dart   # Aggregated health state
+│   └── dimensions/                   # 6 built-in dimensions
+│       ├── internet_dimension.dart
+│       ├── wifi_dimension.dart
+│       ├── devices_dimension.dart
+│       ├── security_dimension.dart
+│       ├── system_dimension.dart
+│       └── firmware_dimension.dart
+│
+├── triggers/
+│   ├── mascot_trigger.dart           # Trigger model + cooldown
+│   ├── trigger_definitions.dart      # 9 predefined triggers
+│   └── mascot_trigger_provider.dart  # SSE listener + state detection
+│
+└── widgets/
+    ├── health_word_cloud.dart         # Word cloud widget
+    ├── dimension_tooltip_content.dart # Tooltip summary
+    ├── dimension_actions_builder.dart # Action list builder
+    └── mascot_toolbar.dart            # Utility toolbar
+```
+
+## Health Dimensions
+
+| Dimension | What it evaluates | Score mapping |
+|-----------|------------------|---------------|
+| Internet | WAN up/down | 100 (up) / 0 (down) |
+| WiFi | Radio enable status | 100 (all on) / 80 (some off) / 0 (all off) |
+| Devices | Online device ratio | 100 (all) / 80 (>80%) / 60 (>50%) / 40 (>20%) / 20 |
+| Security | Firewall + DMZ | 100 (FW on, no DMZ) / 80 (FW on, DMZ) / 20 (FW off) |
+| System | CPU/Memory usage | 100 (<50%) / 80 (<70%) / 60 (<85%) / 40 (<95%) / 20 |
+| Firmware | Update availability | 100 (none) / 60 (available) |
+
+### Adding a New Dimension
+
+1. Create `lib/page/dashboard/mascot/health/dimensions/my_dimension.dart`:
+
+```dart
+class MyHealthDimension extends HealthDimension {
+  @override
+  HealthDimensionType get type => HealthDimensionType.myDimension;
+
+  @override
+  String get displayName => 'My Dimension';
+
+  @override
+  IconData get icon => Icons.my_icon;
+
+  @override
+  Set<InvalidationDomain> get watchedDomains => {
+    InvalidationDomain.myDomain,
+  };
+
+  @override
+  int evaluate(HealthEvaluationContext context) {
+    // Return 0-100 score
+    return 100;
+  }
+
+  @override
+  DimensionSummary getSummary(HealthEvaluationContext context) {
+    return DimensionSummary(
+      status: 'Healthy',
+      items: [SummaryItem('Key', 'Value')],
+      hint: 'Tap for actions',
+    );
+  }
+
+  @override
+  List<HealthAction> getActions(BuildContext context) {
+    return [
+      HealthAction(
+        id: 'my_action',
+        label: 'My Action',
+        icon: Icons.settings,
+        routeName: RouteNamed.myRoute,
+      ),
+    ];
+  }
+}
+```
+
+2. Add enum value to `HealthDimensionType` in `health_dimension.dart`
+3. Add data to `HealthEvaluationContext` if needed
+4. Register in `HealthDimensionRegistry`
+
+## Event Triggers
+
+### Predefined Triggers
+
+| Trigger | Priority | Cooldown | Interrupt |
+|---------|----------|----------|-----------|
+| WAN Down | Critical | 5 min | Yes |
+| WAN Restored | High | 1 min | No |
+| New Device | Medium | 30 sec | No |
+| CPU High | High | 10 min | No |
+| Memory High | High | 10 min | No |
+| Firmware Available | Low | 24 hr | No |
+| WiFi Disabled | Medium | 5 min | No |
+| Firewall Disabled | High | 30 min | Yes |
+| DMZ Enabled | Medium | 1 hr | No |
+
+### Adding a New Trigger
+
+1. Add factory method in `trigger_definitions.dart`:
+
+```dart
+static MascotTrigger myTrigger() => const MascotTrigger(
+  id: 'my_trigger',
+  message: 'Something happened!',
+  priority: TriggerPriority.medium,
+  cooldown: Duration(minutes: 5),
+  animation: MascotAnimationKey.think,
+);
+```
+
+2. Add cooldown constant in `mascot_config.dart`:
+
+```dart
+abstract final class TriggerCooldowns {
+  // ...existing...
+  static const Duration myTrigger = Duration(minutes: 5);
+}
+```
+
+3. Add evaluation logic in `mascot_trigger_provider.dart`
+
+## Configuration
+
+All timing constants are centralized in `mascot_config.dart`:
+
+```dart
+// Health evaluation
+const kHealthEvaluationInterval = Duration(minutes: 5);
+const kHealthDebounceDelay = Duration(milliseconds: 500);
+
+// Dimension thresholds
+abstract final class SystemThresholds { ... }
+abstract final class DevicesThresholds { ... }
+
+// Trigger cooldowns
+abstract final class TriggerCooldowns { ... }
+
+// Random speech timing
+const kRandomSpeechMinInterval = Duration(seconds: 10);
+const kRandomSpeechMaxInterval = Duration(seconds: 30);
+```
+
+## Testing
+
+```bash
+# Run all mascot tests
+flutter test test/page/dashboard/mascot/
+
+# Run specific test groups
+flutter test test/page/dashboard/mascot/health/
+flutter test test/page/dashboard/mascot/triggers/
+flutter test test/page/dashboard/mascot/widgets/
+```
+
+## SSE Integration
+
+Health dimensions declare which `InvalidationDomain` they watch. When SSE events arrive:
+
+1. `system_health_provider` checks if domain matches any dimension's `watchedDomains`
+2. If match, debounced re-evaluation is triggered (500ms delay)
+3. Word cloud UI updates automatically via Riverpod
+
+Trigger system:
+1. `mascot_trigger_provider` listens to `sseInvalidationProvider`
+2. On matching domain, evaluates state changes (WAN up→down, device count change, etc.)
+3. If change detected and not in cooldown, fires notification via `MascotController`

--- a/doc/mascot/mascot-health-system.md
+++ b/doc/mascot/mascot-health-system.md
@@ -4,7 +4,7 @@
 
 The Mascot Health System provides a visual dashboard showing the overall health of the router system. It consists of:
 
-1. **Word Cloud UI** — Visual representation of system health dimensions
+1. **Health Status View** — Problem-first display highlighting issues at top, healthy items as chips
 2. **Toolbar** — Quick access to utilities (print, theme, FAQ, AI Assistant)
 3. **Health Evaluation** — Extensible dimension scoring with 6 built-in dimensions
 4. **Event Triggers** — SSE-driven proactive notifications
@@ -15,12 +15,12 @@ The Mascot Health System provides a visual dashboard showing the overall health 
 lib/page/dashboard/mascot/
 ├── mascot_config.dart           # Centralized configuration
 ├── mascot_providers.dart        # Coordinator + trigger integration
-├── health_dialog_provider.dart  # Word cloud dialog UI
+├── health_dialog_provider.dart  # Health dashboard dialog UI
 │
 ├── health/
 │   ├── health_dimension.dart         # Abstract interface + models
 │   ├── health_score.dart             # Score model + HealthTier
-│   ├── health_dimension_registry.dart # Registry for all dimensions
+│   ├── health_dimension_registry.dart # Static registry (HealthDimensions)
 │   ├── system_health_provider.dart   # Aggregated health state
 │   └── dimensions/                   # 6 built-in dimensions
 │       ├── internet_dimension.dart
@@ -36,7 +36,8 @@ lib/page/dashboard/mascot/
 │   └── mascot_trigger_provider.dart  # SSE listener + state detection
 │
 └── widgets/
-    ├── health_word_cloud.dart         # Word cloud widget
+    ├── health_status_view.dart        # Problem-first health display
+    ├── dimension_detail_view.dart     # Dimension detail with actions
     ├── dimension_tooltip_content.dart # Tooltip summary
     ├── dimension_actions_builder.dart # Action list builder
     └── mascot_toolbar.dart            # Utility toolbar

--- a/lib/components/styled/menus/widgets/menu_holder.dart
+++ b/lib/components/styled/menus/widgets/menu_holder.dart
@@ -59,11 +59,12 @@ class MenuHolderState extends ConsumerState<MenuHolder> {
 
   @override
   Widget build(BuildContext context) {
-    final pageRoute = GoRouter.maybeOf(context)
+    final lastRoute = GoRouter.maybeOf(context)
         ?.routerDelegate
         .currentConfiguration
         .routes
-        .last as LinksysRoute?;
+        .last;
+    final pageRoute = lastRoute is LinksysRoute ? lastRoute : null;
 
     const autoHide = false; //LinksysRoute.autoHideNaviRail(context);
     final showNavi = LinksysRoute.isShowNaviRail(context, pageRoute?.config);

--- a/lib/demo/pages/pnp_demo_launcher.dart
+++ b/lib/demo/pages/pnp_demo_launcher.dart
@@ -38,6 +38,7 @@ class PnpDemoLauncher extends ConsumerWidget {
         padding: const EdgeInsets.all(AppSpacing.lg),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
           children: [
             AppText.headlineSmall('PnP Demo Launcher'),
             AppGap.sm(),
@@ -45,25 +46,25 @@ class PnpDemoLauncher extends ConsumerWidget {
               'Select a PnP path to demo. Each card jumps directly to that stage.',
             ),
             AppGap.lg(),
-            Expanded(
-              child: GridView.builder(
-                gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
-                  maxCrossAxisExtent: 280,
-                  mainAxisExtent: 160,
-                  crossAxisSpacing: AppSpacing.md,
-                  mainAxisSpacing: AppSpacing.md,
-                ),
-                itemCount: entries.length,
-                itemBuilder: (context, index) {
-                  final e = entries[index];
-                  return _DemoCard(
-                    icon: e.icon,
-                    title: e.title,
-                    subtitle: e.subtitle,
-                    onTap: e.onTap,
-                  );
-                },
+            GridView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                maxCrossAxisExtent: 280,
+                mainAxisExtent: 160,
+                crossAxisSpacing: AppSpacing.md,
+                mainAxisSpacing: AppSpacing.md,
               ),
+              itemCount: entries.length,
+              itemBuilder: (context, index) {
+                final e = entries[index];
+                return _DemoCard(
+                  icon: e.icon,
+                  title: e.title,
+                  subtitle: e.subtitle,
+                  onTap: e.onTap,
+                );
+              },
             ),
           ],
         ),
@@ -73,6 +74,14 @@ class PnpDemoLauncher extends ConsumerWidget {
 
   List<_DemoEntry> _buildEntries(BuildContext context, WidgetRef ref) {
     return [
+      _DemoEntry(
+        icon: Icons.dashboard,
+        title: 'USP Dashboard',
+        subtitle: 'Skip PnP, go directly to dashboard (Mascot)',
+        onTap: () {
+          context.go(RoutePath.uspDashboard);
+        },
+      ),
       _DemoEntry(
         icon: Icons.play_arrow_rounded,
         title: 'Full Flow',

--- a/lib/demo/providers/demo_router_provider.dart
+++ b/lib/demo/providers/demo_router_provider.dart
@@ -10,6 +10,7 @@ import 'package:privacy_gui/demo/theme_studio/theme_studio_panel.dart';
 import 'package:privacy_gui/demo/providers/demo_ui_provider.dart';
 
 /// Route path for the PnP demo launcher (demo-only).
+/// Access via /demoPnpLauncher to test PnP flows.
 const _demoPnpLauncher = '/demoPnpLauncher';
 
 /// Overrides the main routerProvider for the Demo Application.
@@ -79,8 +80,9 @@ final demoRouterProvider = Provider<GoRouter>((ref) {
     ],
     redirect: (context, state) {
       if (state.matchedLocation == '/') {
-        // Demo mode: go to PnP launcher instead of auto-configuration.
-        return _demoPnpLauncher;
+        // Demo mode: go directly to USP Dashboard for UI verification.
+        // Access PnP flows via /demoPnpLauncher if needed.
+        return RoutePath.uspDashboard;
       } else if (state.matchedLocation == _demoPnpLauncher) {
         return state.uri.toString();
       } else if (state.matchedLocation == RoutePath.localLoginPassword) {

--- a/lib/page/_shared/components/layout_blocks/row_blocks.dart
+++ b/lib/page/_shared/components/layout_blocks/row_blocks.dart
@@ -121,6 +121,7 @@ class NetworkBadgeWidget extends StatelessWidget {
     return AppBadge(
       label: badge.label,
       color: badge.color,
+      icon: badge.icon != null ? Icon(badge.icon, size: 12) : null,
     );
   }
 }

--- a/lib/page/dashboard/mascot/health/dimensions/devices_dimension.dart
+++ b/lib/page/dashboard/mascot/health/dimensions/devices_dimension.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
+import 'package:privacy_gui/route/constants.dart';
+
+import '../../mascot_config.dart';
+import '../health_dimension.dart';
+
+/// Health dimension for connected devices.
+///
+/// Evaluates:
+/// - Ratio of online devices to total devices
+/// - Presence of mesh nodes (bonus)
+///
+/// Score mapping:
+/// - 100: All devices online or no devices
+/// - 80: > 80% online
+/// - 60: > 50% online
+/// - 40: > 20% online
+/// - 20: <= 20% online
+class DevicesHealthDimension extends HealthDimension {
+  @override
+  HealthDimensionType get type => HealthDimensionType.devices;
+
+  @override
+  String get displayName => 'Devices';
+
+  @override
+  IconData get icon => Icons.devices;
+
+  @override
+  Set<InvalidationDomain> get watchedDomains => {
+        InvalidationDomain.connectedDevices,
+        InvalidationDomain.wifiClients,
+      };
+
+  @override
+  int evaluate(HealthEvaluationContext context) {
+    final devices = context.devices;
+    if (devices == null) return 100;
+
+    final total = devices.totalClientCount;
+    if (total == 0) return 100;
+
+    final online = devices.onlineClientCount;
+    final ratio = online / total;
+
+    if (ratio >= DevicesThresholds.excellent) return 100;
+    if (ratio >= DevicesThresholds.good) return 80;
+    if (ratio >= DevicesThresholds.fair) return 60;
+    if (ratio >= 0.2) return 40;
+    return 20;
+  }
+
+  @override
+  DimensionSummary getSummary(HealthEvaluationContext context) {
+    final devices = context.devices;
+    if (devices == null) {
+      return const DimensionSummary(
+        status: 'Loading...',
+        hint: 'Tap for actions',
+      );
+    }
+
+    final online = devices.onlineClientCount;
+    final total = devices.totalClientCount;
+    final meshNodes = devices.nodeModels.where((n) => !n.isMaster).length;
+
+    String status;
+    if (total == 0) {
+      status = 'No devices';
+    } else if (online == total) {
+      status = 'All Online';
+    } else {
+      status = '$online Online';
+    }
+
+    final items = <SummaryItem>[
+      SummaryItem('Connected', '$online/$total'),
+    ];
+
+    if (meshNodes > 0) {
+      items.add(SummaryItem('Mesh Nodes', '$meshNodes'));
+    }
+
+    return DimensionSummary(
+      status: status,
+      items: items,
+      hint: 'Tap for actions',
+    );
+  }
+
+  @override
+  List<HealthAction> getActions(BuildContext context) {
+    return [
+      HealthAction(
+        id: 'view_devices',
+        label: 'View Devices',
+        icon: Icons.devices,
+        routeName: RouteNamed.uspDeviceList,
+      ),
+      HealthAction(
+        id: 'network_topology',
+        label: 'Network Topology',
+        icon: Icons.hub,
+        routeName: RouteNamed.uspTopology,
+      ),
+    ];
+  }
+}

--- a/lib/page/dashboard/mascot/health/dimensions/firmware_dimension.dart
+++ b/lib/page/dashboard/mascot/health/dimensions/firmware_dimension.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
+import 'package:privacy_gui/route/constants.dart';
+
+import '../health_dimension.dart';
+
+/// Health dimension for firmware status.
+///
+/// Evaluates:
+/// - Whether firmware is up to date
+/// - Whether there's an available update bank
+///
+/// Score mapping:
+/// - 100: Running latest or no update info available
+/// - 60: Update available (not critical but recommended)
+class FirmwareHealthDimension extends HealthDimension {
+  @override
+  HealthDimensionType get type => HealthDimensionType.firmware;
+
+  @override
+  String get displayName => 'Firmware';
+
+  @override
+  IconData get icon => Icons.system_update;
+
+  @override
+  Set<InvalidationDomain> get watchedDomains => const {};
+
+  @override
+  int evaluate(HealthEvaluationContext context) {
+    final firmware = context.firmware;
+    if (firmware == null) return 100;
+
+    final available = firmware.availableBank;
+    if (available != null) {
+      return 60; // Update available
+    }
+
+    return 100; // Up to date
+  }
+
+  @override
+  DimensionSummary getSummary(HealthEvaluationContext context) {
+    final firmware = context.firmware;
+    if (firmware == null) {
+      return const DimensionSummary(
+        status: 'Loading...',
+        hint: 'Tap for actions',
+      );
+    }
+
+    final active = firmware.activeBank;
+    final available = firmware.availableBank;
+
+    String status;
+    if (available != null) {
+      status = 'Update Available';
+    } else {
+      status = 'Up to Date';
+    }
+
+    final items = <SummaryItem>[];
+
+    if (active != null) {
+      items.add(SummaryItem('Current', active.version));
+    }
+
+    if (available != null) {
+      items.add(SummaryItem('Available', available.version));
+    }
+
+    return DimensionSummary(
+      status: status,
+      items: items,
+      hint: 'Tap for actions',
+    );
+  }
+
+  @override
+  List<HealthAction> getActions(BuildContext context) {
+    return [
+      HealthAction(
+        id: 'firmware_update',
+        label: 'Firmware Update',
+        icon: Icons.system_update,
+        routeName: RouteNamed.uspFirmwareUpdate,
+      ),
+    ];
+  }
+}

--- a/lib/page/dashboard/mascot/health/dimensions/internet_dimension.dart
+++ b/lib/page/dashboard/mascot/health/dimensions/internet_dimension.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
+import 'package:privacy_gui/route/constants.dart';
+
+import '../health_dimension.dart';
+
+/// Health dimension for Internet/WAN connectivity.
+///
+/// Evaluates:
+/// - WAN link status (up/down)
+/// - Connection stability
+///
+/// Score mapping:
+/// - 100: WAN up and stable
+/// - 50: WAN up but unstable (if detectable)
+/// - 0: WAN down
+class InternetHealthDimension extends HealthDimension {
+  @override
+  HealthDimensionType get type => HealthDimensionType.internet;
+
+  @override
+  String get displayName => 'Internet';
+
+  @override
+  IconData get icon => Icons.public;
+
+  @override
+  Set<InvalidationDomain> get watchedDomains => {
+        InvalidationDomain.wanStatus,
+      };
+
+  @override
+  int evaluate(HealthEvaluationContext context) {
+    final wan = context.wan;
+    if (wan == null) return 100; // No data = assume healthy
+
+    final isUp = wan.model.isUp;
+    if (!isUp) return 0;
+
+    // TODO: Add stability detection if available
+    return 100;
+  }
+
+  @override
+  DimensionSummary getSummary(HealthEvaluationContext context) {
+    final wan = context.wan;
+    if (wan == null) {
+      return const DimensionSummary(
+        status: 'Loading...',
+        hint: 'Tap for actions',
+      );
+    }
+
+    final model = wan.model;
+    final isUp = model.isUp;
+    final items = <SummaryItem>[];
+
+    if (model.ipAddress.isNotEmpty) {
+      items.add(SummaryItem('IP', model.ipAddress));
+    }
+    if (model.gateway.isNotEmpty) {
+      items.add(SummaryItem('Gateway', model.gateway));
+    }
+    if (model.addressingType.isNotEmpty) {
+      items.add(SummaryItem('Type', model.addressingType));
+    }
+
+    return DimensionSummary(
+      status: isUp ? 'Connected' : 'Disconnected',
+      items: items,
+      hint: 'Tap for actions',
+    );
+  }
+
+  @override
+  List<HealthAction> getActions(BuildContext context) {
+    return [
+      HealthAction(
+        id: 'diagnose_internet',
+        label: 'Run Diagnostics',
+        icon: Icons.network_check,
+        routeName: RouteNamed.uspUnifiedDiagnostics,
+      ),
+      HealthAction(
+        id: 'internet_settings',
+        label: 'Internet Settings',
+        icon: Icons.settings,
+        routeName: RouteNamed.uspInternetSettings,
+      ),
+    ];
+  }
+}

--- a/lib/page/dashboard/mascot/health/dimensions/security_dimension.dart
+++ b/lib/page/dashboard/mascot/health/dimensions/security_dimension.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
+import 'package:privacy_gui/route/constants.dart';
+
+import '../health_dimension.dart';
+
+/// Health dimension for security settings.
+///
+/// Evaluates:
+/// - IPv4 firewall enabled (required)
+/// - IPv6 firewall enabled (bonus)
+/// - DMZ disabled (security risk if enabled)
+///
+/// Score mapping:
+/// - 100: IPv4 + IPv6 firewall on, DMZ off
+/// - 80: IPv4 firewall on, DMZ off
+/// - 50: IPv4 firewall on, DMZ on (security risk)
+/// - 30: IPv4 firewall off
+class SecurityHealthDimension extends HealthDimension {
+  @override
+  HealthDimensionType get type => HealthDimensionType.security;
+
+  @override
+  String get displayName => 'Security';
+
+  @override
+  IconData get icon => Icons.security;
+
+  @override
+  Set<InvalidationDomain> get watchedDomains => {
+        InvalidationDomain.firewallRules,
+        InvalidationDomain.dmz,
+      };
+
+  @override
+  int evaluate(HealthEvaluationContext context) {
+    final firewall = context.firewall;
+    if (firewall == null) return 100;
+
+    final ipv4On = firewall.firewallModel.isIPv4FirewallEnabled;
+    final ipv6On = firewall.firewallModel.isIPv6FirewallEnabled;
+    final dmzOn = firewall.dmzModel.isEnabled;
+
+    if (!ipv4On) return 30; // Critical: no firewall
+
+    if (dmzOn) return 50; // Warning: DMZ exposes device
+
+    if (ipv4On && ipv6On) return 100;
+    return 80; // IPv4 only
+  }
+
+  @override
+  DimensionSummary getSummary(HealthEvaluationContext context) {
+    final firewall = context.firewall;
+    if (firewall == null) {
+      return const DimensionSummary(
+        status: 'Loading...',
+        hint: 'Tap for actions',
+      );
+    }
+
+    final ipv4On = firewall.firewallModel.isIPv4FirewallEnabled;
+    final ipv6On = firewall.firewallModel.isIPv6FirewallEnabled;
+    final dmzOn = firewall.dmzModel.isEnabled;
+
+    String status;
+    if (!ipv4On) {
+      status = 'At Risk';
+    } else if (dmzOn) {
+      status = 'DMZ Active';
+    } else if (ipv4On && ipv6On) {
+      status = 'Protected';
+    } else {
+      status = 'Basic';
+    }
+
+    final items = <SummaryItem>[
+      SummaryItem('IPv4 Firewall', ipv4On ? 'On' : 'Off'),
+      SummaryItem('IPv6 Firewall', ipv6On ? 'On' : 'Off'),
+      SummaryItem('DMZ', dmzOn ? 'Enabled' : 'Disabled'),
+    ];
+
+    return DimensionSummary(
+      status: status,
+      items: items,
+      hint: 'Tap for actions',
+    );
+  }
+
+  @override
+  List<HealthAction> getActions(BuildContext context) {
+    return [
+      HealthAction(
+        id: 'firewall_settings',
+        label: 'Firewall Settings',
+        icon: Icons.shield,
+        routeName: RouteNamed.uspFirewall,
+      ),
+      HealthAction(
+        id: 'dmz_settings',
+        label: 'DMZ Settings',
+        icon: Icons.public_off,
+        routeName: RouteNamed.uspDmz,
+      ),
+    ];
+  }
+}

--- a/lib/page/dashboard/mascot/health/dimensions/system_dimension.dart
+++ b/lib/page/dashboard/mascot/health/dimensions/system_dimension.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
+import 'package:privacy_gui/route/constants.dart';
+
+import '../../mascot_config.dart';
+import '../health_dimension.dart';
+
+/// Health dimension for system resources (CPU, Memory).
+///
+/// Evaluates:
+/// - CPU usage percentage
+/// - Memory usage percentage
+///
+/// Score mapping (uses the worse of CPU/Memory):
+/// - 100: Both < 50%
+/// - 80: Both < 70%
+/// - 60: Both < 85%
+/// - 40: Either >= 85%
+/// - 20: Either >= 95%
+class SystemHealthDimension extends HealthDimension {
+  @override
+  HealthDimensionType get type => HealthDimensionType.system;
+
+  @override
+  String get displayName => 'System';
+
+  @override
+  IconData get icon => Icons.memory;
+
+  @override
+  Set<InvalidationDomain> get watchedDomains => const {};
+
+  @override
+  int evaluate(HealthEvaluationContext context) {
+    final info = context.systemInfo;
+    if (info == null) return 100;
+
+    final cpu = info.model.cpuPercent;
+    final memory = info.model.memoryPercent;
+    final maxUsage = cpu > memory ? cpu : memory;
+
+    if (maxUsage < SystemThresholds.excellent) return 100;
+    if (maxUsage < SystemThresholds.good) return 80;
+    if (maxUsage < SystemThresholds.fair) return 60;
+    if (maxUsage < SystemThresholds.poor) return 40;
+    return 20;
+  }
+
+  @override
+  DimensionSummary getSummary(HealthEvaluationContext context) {
+    final info = context.systemInfo;
+    if (info == null) {
+      return const DimensionSummary(
+        status: 'Loading...',
+        hint: 'Tap for actions',
+      );
+    }
+
+    final model = info.model;
+    final cpu = model.cpuPercent;
+    final memory = model.memoryPercent;
+    final maxUsage = cpu > memory ? cpu : memory;
+
+    String status;
+    if (maxUsage < SystemThresholds.excellent) {
+      status = 'Healthy';
+    } else if (maxUsage < SystemThresholds.good) {
+      status = 'Normal';
+    } else if (maxUsage < SystemThresholds.fair) {
+      status = 'Moderate Load';
+    } else {
+      status = 'High Load';
+    }
+
+    final items = <SummaryItem>[
+      SummaryItem('CPU', '$cpu%'),
+      SummaryItem('Memory', '$memory%'),
+    ];
+
+    if (model.formattedUptime.isNotEmpty) {
+      items.add(SummaryItem('Uptime', model.formattedUptime));
+    }
+
+    return DimensionSummary(
+      status: status,
+      items: items,
+      hint: 'Tap for actions',
+    );
+  }
+
+  @override
+  List<HealthAction> getActions(BuildContext context) {
+    return [
+      HealthAction(
+        id: 'reboot_router',
+        label: 'Reboot Router',
+        icon: Icons.restart_alt,
+        routeName: RouteNamed.uspAdmin,
+      ),
+      HealthAction(
+        id: 'system_info',
+        label: 'System Information',
+        icon: Icons.info_outline,
+        routeName: RouteNamed.uspAdmin,
+      ),
+    ];
+  }
+}

--- a/lib/page/dashboard/mascot/health/dimensions/wifi_dimension.dart
+++ b/lib/page/dashboard/mascot/health/dimensions/wifi_dimension.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
+import 'package:privacy_gui/route/constants.dart';
+
+import '../health_dimension.dart';
+
+/// Health dimension for WiFi status.
+///
+/// Evaluates:
+/// - Number of enabled radios vs total radios
+/// - Radio health (all enabled = healthy)
+///
+/// Score mapping:
+/// - 100: All radios enabled
+/// - 70: Some radios enabled
+/// - 30: All radios disabled
+class WifiHealthDimension extends HealthDimension {
+  @override
+  HealthDimensionType get type => HealthDimensionType.wifi;
+
+  @override
+  String get displayName => 'WiFi';
+
+  @override
+  IconData get icon => Icons.wifi;
+
+  @override
+  Set<InvalidationDomain> get watchedDomains => {
+        InvalidationDomain.wifiRadios,
+        InvalidationDomain.wifiSsids,
+        InvalidationDomain.wifiAccessPoints,
+      };
+
+  @override
+  int evaluate(HealthEvaluationContext context) {
+    final wifi = context.wifi;
+    if (wifi == null) return 100;
+
+    final radios = wifi.radioModels;
+    if (radios.isEmpty) return 100;
+
+    final enabledCount = radios.where((r) => r.enable).length;
+    final totalCount = radios.length;
+
+    if (enabledCount == totalCount) return 100;
+    if (enabledCount == 0) return 30;
+    return 70; // Partial
+  }
+
+  @override
+  DimensionSummary getSummary(HealthEvaluationContext context) {
+    final wifi = context.wifi;
+    if (wifi == null) {
+      return const DimensionSummary(
+        status: 'Loading...',
+        hint: 'Tap for actions',
+      );
+    }
+
+    final radios = wifi.radioModels;
+    if (radios.isEmpty) {
+      return const DimensionSummary(
+        status: 'No radios',
+        hint: 'Tap for actions',
+      );
+    }
+
+    final enabledCount = radios.where((r) => r.enable).length;
+    final totalCount = radios.length;
+
+    String status;
+    if (enabledCount == totalCount) {
+      status = 'All Active';
+    } else if (enabledCount == 0) {
+      status = 'All Disabled';
+    } else {
+      status = 'Partial';
+    }
+
+    final items = <SummaryItem>[
+      SummaryItem('Radios', '$enabledCount/$totalCount enabled'),
+    ];
+
+    for (final radio in radios) {
+      final state = radio.enable ? 'On' : 'Off';
+      items.add(SummaryItem(radio.band, state));
+    }
+
+    return DimensionSummary(
+      status: status,
+      items: items,
+      hint: 'Tap for actions',
+    );
+  }
+
+  @override
+  List<HealthAction> getActions(BuildContext context) {
+    return [
+      HealthAction(
+        id: 'wifi_settings',
+        label: 'WiFi Settings',
+        icon: Icons.wifi,
+        routeName: RouteNamed.uspWifiSettings,
+      ),
+      HealthAction(
+        id: 'wifi_guest',
+        label: 'Guest Network',
+        icon: Icons.people,
+        routeName: RouteNamed.uspWifiSettings,
+      ),
+    ];
+  }
+}

--- a/lib/page/dashboard/mascot/health/health_dimension.dart
+++ b/lib/page/dashboard/mascot/health/health_dimension.dart
@@ -1,0 +1,175 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
+import 'package:privacy_gui/page/admin/providers/system_info_data_provider.dart';
+import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
+import 'package:privacy_gui/page/firewall/providers/firewall_data_provider.dart';
+import 'package:privacy_gui/page/firmware_update/providers/firmware_banks_data_provider.dart';
+import 'package:privacy_gui/page/internet_settings/providers/wan_data_provider.dart';
+import 'package:privacy_gui/page/wifi_settings/providers/wifi_data_provider.dart';
+
+/// Health dimension types for system evaluation.
+///
+/// Each dimension represents a distinct area of router health
+/// that can be independently evaluated and displayed.
+enum HealthDimensionType {
+  internet,
+  wifi,
+  devices,
+  security,
+  system,
+  firmware,
+}
+
+/// Read-only context containing all data needed for health evaluation.
+///
+/// This is a snapshot of the current system state, populated from
+/// L1 dashboard providers. All fields are nullable to handle cases
+/// where data hasn't loaded yet.
+class HealthEvaluationContext extends Equatable {
+  final WanData? wan;
+  final WifiData? wifi;
+  final DevicesData? devices;
+  final FirewallData? firewall;
+  final SystemInfoData? systemInfo;
+  final FirmwareBanksData? firmware;
+
+  const HealthEvaluationContext({
+    this.wan,
+    this.wifi,
+    this.devices,
+    this.firewall,
+    this.systemInfo,
+    this.firmware,
+  });
+
+  const HealthEvaluationContext.empty() : this();
+
+  bool get hasAnyData =>
+      wan != null ||
+      wifi != null ||
+      devices != null ||
+      firewall != null ||
+      systemInfo != null ||
+      firmware != null;
+
+  @override
+  List<Object?> get props =>
+      [wan, wifi, devices, firewall, systemInfo, firmware];
+}
+
+/// A single item in the dimension summary tooltip.
+class SummaryItem extends Equatable {
+  final String label;
+  final String value;
+
+  const SummaryItem(this.label, this.value);
+
+  @override
+  List<Object?> get props => [label, value];
+}
+
+/// Summary information displayed in the tooltip on long-press.
+class DimensionSummary extends Equatable {
+  final String status;
+  final List<SummaryItem> items;
+  final String? hint;
+
+  const DimensionSummary({
+    required this.status,
+    this.items = const [],
+    this.hint,
+  });
+
+  @override
+  List<Object?> get props => [status, items, hint];
+}
+
+/// An action the user can take for a dimension.
+class HealthAction extends Equatable {
+  final String id;
+  final String label;
+  final IconData icon;
+  final String? routeName;
+  final VoidCallback? onTap;
+
+  const HealthAction({
+    required this.id,
+    required this.label,
+    required this.icon,
+    this.routeName,
+    this.onTap,
+  });
+
+  @override
+  List<Object?> get props => [id, label, icon, routeName];
+}
+
+/// Configurable thresholds for health tier calculation.
+///
+/// Scores are mapped to tiers as follows:
+/// - >= excellent: Excellent
+/// - >= good: Good
+/// - >= fair: Fair
+/// - >= poor: Poor
+/// - < poor: Critical
+class HealthThresholds extends Equatable {
+  final int excellent;
+  final int good;
+  final int fair;
+  final int poor;
+
+  const HealthThresholds({
+    this.excellent = 90,
+    this.good = 70,
+    this.fair = 50,
+    this.poor = 30,
+  });
+
+  @override
+  List<Object?> get props => [excellent, good, fair, poor];
+}
+
+/// Abstract interface for a health dimension.
+///
+/// Each dimension is responsible for:
+/// 1. Evaluating its health score (0-100)
+/// 2. Providing a tooltip summary
+/// 3. Defining available actions
+/// 4. Specifying which SSE domains trigger re-evaluation
+///
+/// To add a new dimension:
+/// 1. Create a class extending [HealthDimension]
+/// 2. Register it in [HealthDimensionRegistry]
+abstract class HealthDimension {
+  /// The type identifier for this dimension.
+  HealthDimensionType get type;
+
+  /// Display name shown in the word cloud.
+  String get displayName;
+
+  /// Icon representing this dimension.
+  IconData get icon;
+
+  /// Optional custom thresholds for this dimension.
+  HealthThresholds get thresholds => const HealthThresholds();
+
+  /// Evaluate the health score for this dimension.
+  ///
+  /// Returns a value from 0 (critical) to 100 (excellent).
+  /// Should return 100 if data is unavailable (assume healthy).
+  int evaluate(HealthEvaluationContext context);
+
+  /// Get summary information for the tooltip.
+  DimensionSummary getSummary(HealthEvaluationContext context);
+
+  /// Get available actions for this dimension.
+  ///
+  /// The [context] parameter provides build context for navigation.
+  List<HealthAction> getActions(BuildContext context);
+
+  /// SSE invalidation domains that should trigger re-evaluation.
+  ///
+  /// When any of these domains emit, the health score will be recalculated.
+  Set<InvalidationDomain> get watchedDomains;
+}

--- a/lib/page/dashboard/mascot/health/health_dimension_registry.dart
+++ b/lib/page/dashboard/mascot/health/health_dimension_registry.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
+
+import 'health_dimension.dart';
+import 'dimensions/devices_dimension.dart';
+import 'dimensions/firmware_dimension.dart';
+import 'dimensions/internet_dimension.dart';
+import 'dimensions/security_dimension.dart';
+import 'dimensions/system_dimension.dart';
+import 'dimensions/wifi_dimension.dart';
+
+/// Registry of all available health dimensions.
+///
+/// This is the single source of truth for which dimensions are evaluated.
+/// To add a new dimension:
+/// 1. Create a class extending [HealthDimension]
+/// 2. Add an instance to [_defaultDimensions]
+final healthDimensionRegistryProvider =
+    Provider<HealthDimensionRegistry>((ref) {
+  return HealthDimensionRegistry();
+});
+
+class HealthDimensionRegistry {
+  final List<HealthDimension> _dimensions = [];
+
+  HealthDimensionRegistry() {
+    _registerDefaults();
+  }
+
+  void _registerDefaults() {
+    register(InternetHealthDimension());
+    register(WifiHealthDimension());
+    register(DevicesHealthDimension());
+    register(SecurityHealthDimension());
+    register(SystemHealthDimension());
+    register(FirmwareHealthDimension());
+  }
+
+  /// Register a new dimension.
+  void register(HealthDimension dimension) {
+    final existing = _dimensions.indexWhere((d) => d.type == dimension.type);
+    if (existing >= 0) {
+      _dimensions[existing] = dimension;
+    } else {
+      _dimensions.add(dimension);
+    }
+  }
+
+  /// Unregister a dimension by type.
+  void unregister(HealthDimensionType type) {
+    _dimensions.removeWhere((d) => d.type == type);
+  }
+
+  /// All registered dimensions.
+  List<HealthDimension> get dimensions => List.unmodifiable(_dimensions);
+
+  /// Get dimension by type.
+  HealthDimension? getDimension(HealthDimensionType type) {
+    try {
+      return _dimensions.firstWhere((d) => d.type == type);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// All SSE domains that any dimension watches.
+  Set<InvalidationDomain> get allWatchedDomains {
+    final domains = <InvalidationDomain>{};
+    for (final dim in _dimensions) {
+      domains.addAll(dim.watchedDomains);
+    }
+    return domains;
+  }
+
+  /// Get dimensions that watch a specific SSE domain.
+  List<HealthDimension> getDimensionsWatching(InvalidationDomain domain) {
+    return _dimensions.where((d) => d.watchedDomains.contains(domain)).toList();
+  }
+}

--- a/lib/page/dashboard/mascot/health/health_dimension_registry.dart
+++ b/lib/page/dashboard/mascot/health/health_dimension_registry.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
 
 import 'health_dimension.dart';
@@ -9,71 +8,42 @@ import 'dimensions/security_dimension.dart';
 import 'dimensions/system_dimension.dart';
 import 'dimensions/wifi_dimension.dart';
 
-/// Registry of all available health dimensions.
+/// Static registry of all available health dimensions.
 ///
-/// This is the single source of truth for which dimensions are evaluated.
-/// To add a new dimension:
-/// 1. Create a class extending [HealthDimension]
-/// 2. Add an instance to [_defaultDimensions]
-final healthDimensionRegistryProvider =
-    Provider<HealthDimensionRegistry>((ref) {
-  return HealthDimensionRegistry();
-});
-
-class HealthDimensionRegistry {
-  final List<HealthDimension> _dimensions = [];
-
-  HealthDimensionRegistry() {
-    _registerDefaults();
-  }
-
-  void _registerDefaults() {
-    register(InternetHealthDimension());
-    register(WifiHealthDimension());
-    register(DevicesHealthDimension());
-    register(SecurityHealthDimension());
-    register(SystemHealthDimension());
-    register(FirmwareHealthDimension());
-  }
-
-  /// Register a new dimension.
-  void register(HealthDimension dimension) {
-    final existing = _dimensions.indexWhere((d) => d.type == dimension.type);
-    if (existing >= 0) {
-      _dimensions[existing] = dimension;
-    } else {
-      _dimensions.add(dimension);
-    }
-  }
-
-  /// Unregister a dimension by type.
-  void unregister(HealthDimensionType type) {
-    _dimensions.removeWhere((d) => d.type == type);
-  }
-
+/// Provides access to dimension instances without the overhead of
+/// Provider/singleton patterns — dimensions are stateless and can
+/// be instantiated on demand.
+abstract final class HealthDimensions {
   /// All registered dimensions.
-  List<HealthDimension> get dimensions => List.unmodifiable(_dimensions);
+  static List<HealthDimension> get all => [
+        InternetHealthDimension(),
+        WifiHealthDimension(),
+        DevicesHealthDimension(),
+        SecurityHealthDimension(),
+        SystemHealthDimension(),
+        FirmwareHealthDimension(),
+      ];
 
   /// Get dimension by type.
-  HealthDimension? getDimension(HealthDimensionType type) {
-    try {
-      return _dimensions.firstWhere((d) => d.type == type);
-    } catch (_) {
-      return null;
+  static HealthDimension? byType(HealthDimensionType type) {
+    for (final dim in all) {
+      if (dim.type == type) return dim;
     }
+    return null;
   }
 
   /// All SSE domains that any dimension watches.
-  Set<InvalidationDomain> get allWatchedDomains {
+  static Set<InvalidationDomain> get allWatchedDomains {
     final domains = <InvalidationDomain>{};
-    for (final dim in _dimensions) {
+    for (final dim in all) {
       domains.addAll(dim.watchedDomains);
     }
     return domains;
   }
 
   /// Get dimensions that watch a specific SSE domain.
-  List<HealthDimension> getDimensionsWatching(InvalidationDomain domain) {
-    return _dimensions.where((d) => d.watchedDomains.contains(domain)).toList();
+  static List<HealthDimension> getDimensionsWatching(
+      InvalidationDomain domain) {
+    return all.where((d) => d.watchedDomains.contains(domain)).toList();
   }
 }

--- a/lib/page/dashboard/mascot/health/health_score.dart
+++ b/lib/page/dashboard/mascot/health/health_score.dart
@@ -53,18 +53,18 @@ class HealthScore extends Equatable {
 /// Aggregated health state for all dimensions.
 class SystemHealthState extends Equatable {
   final Map<HealthDimensionType, HealthScore> scores;
-  final DateTime lastEvaluated;
+  final DateTime? lastEvaluated;
   final bool isEvaluating;
 
   const SystemHealthState({
     required this.scores,
-    required this.lastEvaluated,
+    this.lastEvaluated,
     this.isEvaluating = false,
   });
 
   const SystemHealthState.initial()
       : scores = const {},
-        lastEvaluated = const _Epoch(),
+        lastEvaluated = null,
         isEvaluating = true;
 
   /// Get score for a specific dimension, or null if not evaluated.
@@ -107,12 +107,4 @@ class SystemHealthState extends Equatable {
 
   @override
   List<Object?> get props => [scores, lastEvaluated, isEvaluating];
-}
-
-class _Epoch implements DateTime {
-  const _Epoch();
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      DateTime.fromMillisecondsSinceEpoch(0);
 }

--- a/lib/page/dashboard/mascot/health/health_score.dart
+++ b/lib/page/dashboard/mascot/health/health_score.dart
@@ -1,0 +1,118 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'package:privacy_gui/page/_shared/models/network_health_helpers.dart';
+
+import 'health_dimension.dart';
+
+/// Health score for a single dimension.
+class HealthScore extends Equatable {
+  final HealthDimensionType dimension;
+  final int score;
+  final DateTime evaluatedAt;
+  final String? issueMessage;
+
+  const HealthScore({
+    required this.dimension,
+    required this.score,
+    required this.evaluatedAt,
+    this.issueMessage,
+  });
+
+  /// Map score to health tier using default thresholds.
+  HealthTier get tier => tierFromScore(score);
+
+  /// Map score to health tier using custom thresholds.
+  HealthTier tierWithThresholds(HealthThresholds t) {
+    if (score >= t.excellent) return HealthTier.excellent;
+    if (score >= t.good) return HealthTier.good;
+    if (score >= t.fair) return HealthTier.fair;
+    if (score >= t.poor) return HealthTier.poor;
+    return HealthTier.critical;
+  }
+
+  /// Default tier calculation (reuses NetworkHealthHelpers thresholds).
+  static HealthTier tierFromScore(int score) {
+    return NetworkHealthHelpers.tierFromScore(score);
+  }
+
+  /// Font size multiplier for word cloud (lower score = bigger).
+  ///
+  /// Returns a value between 1.0 (score=100) and 2.0 (score=0).
+  double get fontSizeMultiplier => 1.0 + (100 - score.clamp(0, 100)) / 100;
+
+  /// Get tier-appropriate color from color scheme.
+  Color getColor(ColorScheme cs) => NetworkHealthHelpers.tierColor(tier, cs);
+
+  /// Human-readable tier label.
+  String get tierLabel => NetworkHealthHelpers.tierLabel(tier);
+
+  @override
+  List<Object?> get props => [dimension, score, evaluatedAt, issueMessage];
+}
+
+/// Aggregated health state for all dimensions.
+class SystemHealthState extends Equatable {
+  final Map<HealthDimensionType, HealthScore> scores;
+  final DateTime lastEvaluated;
+  final bool isEvaluating;
+
+  const SystemHealthState({
+    required this.scores,
+    required this.lastEvaluated,
+    this.isEvaluating = false,
+  });
+
+  const SystemHealthState.initial()
+      : scores = const {},
+        lastEvaluated = const _Epoch(),
+        isEvaluating = true;
+
+  /// Get score for a specific dimension, or null if not evaluated.
+  HealthScore? operator [](HealthDimensionType type) => scores[type];
+
+  /// Overall system health (average of all dimensions).
+  int get overallScore {
+    if (scores.isEmpty) return 100;
+    final total = scores.values.map((s) => s.score).reduce((a, b) => a + b);
+    return total ~/ scores.length;
+  }
+
+  /// Overall health tier.
+  HealthTier get overallTier => HealthScore.tierFromScore(overallScore);
+
+  /// Dimensions that need attention (score < 70).
+  List<HealthDimensionType> get attentionNeeded =>
+      scores.entries.where((e) => e.value.score < 70).map((e) => e.key).toList()
+        ..sort((a, b) => scores[a]!.score.compareTo(scores[b]!.score));
+
+  /// Whether any dimension is in critical state.
+  bool get hasCritical =>
+      scores.values.any((s) => s.tier == HealthTier.critical);
+
+  /// Whether any dimension needs attention.
+  bool get hasIssues => attentionNeeded.isNotEmpty;
+
+  /// Create a copy with updated values.
+  SystemHealthState copyWith({
+    Map<HealthDimensionType, HealthScore>? scores,
+    DateTime? lastEvaluated,
+    bool? isEvaluating,
+  }) {
+    return SystemHealthState(
+      scores: scores ?? this.scores,
+      lastEvaluated: lastEvaluated ?? this.lastEvaluated,
+      isEvaluating: isEvaluating ?? this.isEvaluating,
+    );
+  }
+
+  @override
+  List<Object?> get props => [scores, lastEvaluated, isEvaluating];
+}
+
+class _Epoch implements DateTime {
+  const _Epoch();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      DateTime.fromMillisecondsSinceEpoch(0);
+}

--- a/lib/page/dashboard/mascot/health/system_health_provider.dart
+++ b/lib/page/dashboard/mascot/health/system_health_provider.dart
@@ -97,8 +97,7 @@ class SystemHealthNotifier extends AsyncNotifier<SystemHealthState> {
   }
 
   bool _shouldReEvaluate(InvalidationDomain domain) {
-    final registry = ref.read(healthDimensionRegistryProvider);
-    return registry.allWatchedDomains.contains(domain);
+    return HealthDimensions.allWatchedDomains.contains(domain);
   }
 
   void _debouncedReEvaluate() {
@@ -124,13 +123,12 @@ class SystemHealthNotifier extends AsyncNotifier<SystemHealthState> {
   }
 
   Future<SystemHealthState> _evaluate() async {
-    final registry = ref.read(healthDimensionRegistryProvider);
     final context = _buildContext();
     final now = DateTime.now();
 
     final scores = <HealthDimensionType, HealthScore>{};
 
-    for (final dimension in registry.dimensions) {
+    for (final dimension in HealthDimensions.all) {
       final score = dimension.evaluate(context);
       scores[dimension.type] = HealthScore(
         dimension: dimension.type,

--- a/lib/page/dashboard/mascot/health/system_health_provider.dart
+++ b/lib/page/dashboard/mascot/health/system_health_provider.dart
@@ -1,0 +1,168 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
+import 'package:privacy_gui/page/admin/providers/system_info_data_provider.dart';
+import 'package:privacy_gui/page/dashboard/providers/dashboard_domain_ready_provider.dart';
+import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
+import 'package:privacy_gui/page/firewall/providers/firewall_data_provider.dart';
+import 'package:privacy_gui/page/firmware_update/providers/firmware_banks_data_provider.dart';
+import 'package:privacy_gui/page/internet_settings/providers/wan_data_provider.dart';
+import 'package:privacy_gui/page/wifi_settings/providers/wifi_data_provider.dart';
+
+import '../mascot_config.dart';
+import 'health_dimension.dart';
+import 'health_dimension_registry.dart';
+import 'health_score.dart';
+
+/// Configuration for the health evaluation system.
+class SystemHealthConfig {
+  /// Interval between periodic evaluations.
+  final Duration evaluationInterval;
+
+  /// Debounce delay for SSE-triggered evaluations.
+  final Duration debounceDelay;
+
+  const SystemHealthConfig({
+    this.evaluationInterval = kHealthEvaluationInterval,
+    this.debounceDelay = kHealthDebounceDelay,
+  });
+}
+
+/// Provider for system health configuration.
+final systemHealthConfigProvider = Provider<SystemHealthConfig>((ref) {
+  return const SystemHealthConfig();
+});
+
+/// Provider for health evaluation context.
+///
+/// Aggregates all L1 data providers into a single snapshot for dimension
+/// evaluation and summary display. This eliminates duplication across
+/// widgets and notifiers.
+final healthEvaluationContextProvider =
+    Provider<HealthEvaluationContext>((ref) {
+  return HealthEvaluationContext(
+    wan: ref.watch(wanDataProvider).valueOrNull,
+    wifi: ref.watch(wifiDataProvider).valueOrNull,
+    devices: ref.watch(devicesDataProvider).valueOrNull,
+    firewall: ref.watch(firewallDataProvider).valueOrNull,
+    systemInfo: ref.watch(systemInfoDataProvider).valueOrNull,
+    firmware: ref.watch(firmwareBanksDataProvider).valueOrNull,
+  );
+});
+
+/// Aggregated system health state provider.
+///
+/// Evaluates all registered health dimensions and provides:
+/// 1. Initial evaluation when dashboard is ready
+/// 2. Periodic re-evaluation (default: every 5 minutes)
+/// 3. SSE-triggered re-evaluation (debounced)
+final systemHealthProvider =
+    AsyncNotifierProvider<SystemHealthNotifier, SystemHealthState>(
+  SystemHealthNotifier.new,
+);
+
+class SystemHealthNotifier extends AsyncNotifier<SystemHealthState> {
+  Timer? _periodicTimer;
+  Timer? _debounceTimer;
+
+  @override
+  Future<SystemHealthState> build() async {
+    final config = ref.watch(systemHealthConfigProvider);
+
+    _listenToSseEvents();
+    _startPeriodicEvaluation(config.evaluationInterval);
+
+    ref.onDispose(() {
+      _periodicTimer?.cancel();
+      _debounceTimer?.cancel();
+    });
+
+    final isDashboardReady = ref.watch(dashboardDomainReadyProvider).hasValue;
+    if (!isDashboardReady) {
+      return const SystemHealthState.initial();
+    }
+
+    return _evaluate();
+  }
+
+  void _listenToSseEvents() {
+    ref.listen(sseInvalidationProvider, (prev, next) {
+      final domain = next.valueOrNull;
+      if (domain != null && _shouldReEvaluate(domain)) {
+        _debouncedReEvaluate();
+      }
+    });
+  }
+
+  bool _shouldReEvaluate(InvalidationDomain domain) {
+    final registry = ref.read(healthDimensionRegistryProvider);
+    return registry.allWatchedDomains.contains(domain);
+  }
+
+  void _debouncedReEvaluate() {
+    final config = ref.read(systemHealthConfigProvider);
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(config.debounceDelay, () {
+      _reEvaluate();
+    });
+  }
+
+  void _startPeriodicEvaluation(Duration interval) {
+    _periodicTimer?.cancel();
+    _periodicTimer = Timer.periodic(interval, (_) {
+      _reEvaluate();
+    });
+  }
+
+  Future<void> _reEvaluate() async {
+    if (!state.hasValue) return;
+
+    final newState = await _evaluate();
+    state = AsyncData(newState);
+  }
+
+  Future<SystemHealthState> _evaluate() async {
+    final registry = ref.read(healthDimensionRegistryProvider);
+    final context = _buildContext();
+    final now = DateTime.now();
+
+    final scores = <HealthDimensionType, HealthScore>{};
+
+    for (final dimension in registry.dimensions) {
+      final score = dimension.evaluate(context);
+      scores[dimension.type] = HealthScore(
+        dimension: dimension.type,
+        score: score,
+        evaluatedAt: now,
+      );
+    }
+
+    debugPrint('[Mascot][Health]: Evaluated ${scores.length} dimensions — '
+        'overall=${_calculateOverall(scores)}');
+
+    return SystemHealthState(
+      scores: scores,
+      lastEvaluated: now,
+      isEvaluating: false,
+    );
+  }
+
+  int _calculateOverall(Map<HealthDimensionType, HealthScore> scores) {
+    if (scores.isEmpty) return 100;
+    final total = scores.values.map((s) => s.score).reduce((a, b) => a + b);
+    return total ~/ scores.length;
+  }
+
+  HealthEvaluationContext _buildContext() {
+    return ref.read(healthEvaluationContextProvider);
+  }
+
+  /// Force immediate re-evaluation.
+  Future<void> refresh() async {
+    state = AsyncData(state.valueOrNull?.copyWith(isEvaluating: true) ??
+        const SystemHealthState.initial());
+    await _reEvaluate();
+  }
+}

--- a/lib/page/dashboard/mascot/health_dialog_provider.dart
+++ b/lib/page/dashboard/mascot/health_dialog_provider.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/constants/url_links.dart';
 import 'package:privacy_gui/page/support/faq_data.dart';
 import 'package:privacy_gui/page/unified_diagnostics/models/diagnostic_state.dart';
@@ -24,13 +23,13 @@ import 'widgets/mascot_toolbar.dart';
 class HealthDialogProvider extends MascotDialogProvider {
   HealthDialogProvider({
     required this.ref,
-    required this.context,
     required this.controller,
     required this.onRunFullDiagnostics,
     required this.onRunFlowDiagnostics,
     required this.onPrintReport,
     required this.onOpenThemeStudio,
     required this.onOpenAiAssistant,
+    required this.onNavigate,
     required this.getLocale,
     required this.getFaqCategoryTitle,
     required this.getFaqItemTitle,
@@ -39,7 +38,6 @@ class HealthDialogProvider extends MascotDialogProvider {
   });
 
   final WidgetRef ref;
-  final BuildContext context;
   final MascotController controller;
   final Future<DiagnosticsResult> Function() onRunFullDiagnostics;
   final Future<DiagnosticsResult> Function(DiagnosticFlow flow)
@@ -47,6 +45,7 @@ class HealthDialogProvider extends MascotDialogProvider {
   final Future<void> Function() onPrintReport;
   final VoidCallback onOpenThemeStudio;
   final VoidCallback onOpenAiAssistant;
+  final void Function(String routeName) onNavigate;
   final Locale? Function() getLocale;
   final bool isThemeStudioEnabled;
   final String Function(FaqCategory category) getFaqCategoryTitle;
@@ -77,13 +76,9 @@ class HealthDialogProvider extends MascotDialogProvider {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
+        AppText.bodyMedium(
           greeting,
-          style: TextStyle(
-            color: textColor,
-            fontSize: 14,
-            fontWeight: FontWeight.w500,
-          ),
+          color: textColor,
         ),
         const SizedBox(height: 12),
         HealthStatusView(
@@ -159,8 +154,7 @@ class HealthDialogProvider extends MascotDialogProvider {
   ];
 
   void _handleDimensionTap(HealthDimensionType dimensionType) {
-    final registry = ref.read(healthDimensionRegistryProvider);
-    final dimension = registry.getDimension(dimensionType);
+    final dimension = HealthDimensions.byType(dimensionType);
     if (dimension == null) return;
 
     final healthState = ref.read(systemHealthProvider).valueOrNull;
@@ -188,7 +182,7 @@ class HealthDialogProvider extends MascotDialogProvider {
 
   void _handleHealthAction(HealthAction action) {
     if (action.routeName != null) {
-      context.push(action.routeName!);
+      onNavigate(action.routeName!);
       controller.dismissDialog();
     }
   }

--- a/lib/page/dashboard/mascot/health_dialog_provider.dart
+++ b/lib/page/dashboard/mascot/health_dialog_provider.dart
@@ -1,0 +1,424 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/constants/url_links.dart';
+import 'package:privacy_gui/page/support/faq_data.dart';
+import 'package:privacy_gui/page/unified_diagnostics/models/diagnostic_state.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import 'dashboard_dialog_provider.dart' show DiagnosticsResult;
+
+import 'health/health_dimension.dart';
+import 'health/health_dimension_registry.dart';
+import 'health/system_health_provider.dart';
+import 'widgets/dimension_detail_view.dart';
+import 'widgets/health_status_view.dart';
+import 'widgets/mascot_toolbar.dart';
+
+/// Dialog provider for the health-based mascot UI.
+///
+/// Replaces the old fixed-option dialog with:
+/// 1. Word cloud showing system health dimensions
+/// 2. Toolbar for utility functions (print, FAQ, AI)
+/// 3. Dimension expansion for detailed actions
+class HealthDialogProvider extends MascotDialogProvider {
+  HealthDialogProvider({
+    required this.ref,
+    required this.context,
+    required this.controller,
+    required this.onRunFullDiagnostics,
+    required this.onRunFlowDiagnostics,
+    required this.onPrintReport,
+    required this.onOpenThemeStudio,
+    required this.onOpenAiAssistant,
+    required this.getLocale,
+    required this.getFaqCategoryTitle,
+    required this.getFaqItemTitle,
+    required this.isThemeStudioEnabled,
+    required this.getRouterTime,
+  });
+
+  final WidgetRef ref;
+  final BuildContext context;
+  final MascotController controller;
+  final Future<DiagnosticsResult> Function() onRunFullDiagnostics;
+  final Future<DiagnosticsResult> Function(DiagnosticFlow flow)
+      onRunFlowDiagnostics;
+  final Future<void> Function() onPrintReport;
+  final VoidCallback onOpenThemeStudio;
+  final VoidCallback onOpenAiAssistant;
+  final Locale? Function() getLocale;
+  final bool isThemeStudioEnabled;
+  final String Function(FaqCategory category) getFaqCategoryTitle;
+  final String Function(FaqItem item) getFaqItemTitle;
+  final DateTime? Function() getRouterTime;
+
+  static final List<FaqCategory> _faqCategories = [
+    FaqSetupCategory(),
+    FaqConnectivityCategory(),
+    FaqSpeedCategory(),
+    FaqPasswordCategory(),
+    FaqHardwareCategory(),
+  ];
+
+  @override
+  Future<MascotDialogNode> getInitialDialog() async {
+    final greeting = _buildGreeting();
+    return MascotDialogNode.custom(
+      id: 'health_dashboard',
+      text: greeting,
+      contentBuilder: (ctx, textColor) =>
+          _buildHealthDashboard(textColor, greeting),
+    );
+  }
+
+  Widget _buildHealthDashboard(Color textColor, String greeting) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          greeting,
+          style: TextStyle(
+            color: textColor,
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        const SizedBox(height: 12),
+        HealthStatusView(
+          textColor: textColor,
+          onDimensionTap: _handleDimensionTap,
+        ),
+        const SizedBox(height: 12),
+        MascotToolbar(
+          iconColor: textColor,
+          showThemeStudio: isThemeStudioEnabled,
+          onAction: _handleToolbarAction,
+        ),
+      ],
+    );
+  }
+
+  String _buildGreeting() {
+    final routerTime = getRouterTime();
+    if (routerTime == null) {
+      return _randomPick(_generalGreetings);
+    }
+
+    final hour = routerTime.hour;
+    if (hour >= 5 && hour < 12) {
+      return _randomPick(_morningGreetings);
+    } else if (hour >= 12 && hour < 17) {
+      return _randomPick(_afternoonGreetings);
+    } else if (hour >= 17 && hour < 21) {
+      return _randomPick(_eveningGreetings);
+    } else {
+      return _randomPick(_nightGreetings);
+    }
+  }
+
+  String _randomPick(List<String> options) {
+    final index = DateTime.now().millisecondsSinceEpoch % options.length;
+    return options[index];
+  }
+
+  static const _generalGreetings = [
+    'Hi there! How can I help?',
+    'Hello! Everything running smoothly?',
+    'Hey! Need any help?',
+    'Welcome back!',
+  ];
+
+  static const _morningGreetings = [
+    'Good morning! Ready to check your network?',
+    'Rise and shine! How\'s the network?',
+    'Morning! Everything connected?',
+    'Good morning! Need any help?',
+  ];
+
+  static const _afternoonGreetings = [
+    'Good afternoon! Everything running smoothly?',
+    'Hey there! How\'s your day?',
+    'Afternoon! Need any help?',
+    'Good afternoon! Network check?',
+  ];
+
+  static const _eveningGreetings = [
+    'Good evening! Winding down?',
+    'Evening! Quick network check?',
+    'Good evening! How was your day?',
+    'Hey! Checking in before bed?',
+  ];
+
+  static const _nightGreetings = [
+    'Hello, night owl!',
+    'Burning the midnight oil?',
+    'Late night check-in?',
+    'Can\'t sleep? Let\'s check the network!',
+  ];
+
+  void _handleDimensionTap(HealthDimensionType dimensionType) {
+    final registry = ref.read(healthDimensionRegistryProvider);
+    final dimension = registry.getDimension(dimensionType);
+    if (dimension == null) return;
+
+    final healthState = ref.read(systemHealthProvider).valueOrNull;
+    final score = healthState?[dimensionType];
+
+    // Build evaluation context for summary
+    final evalContext = ref.read(healthEvaluationContextProvider);
+    final summary = dimension.getSummary(evalContext);
+
+    controller.showDialog(MascotDialogNode.custom(
+      id: 'dimension_${dimensionType.name}',
+      text: dimension.displayName,
+      contentBuilder: (ctx, textColor) => DimensionDetailView(
+        dimension: dimension,
+        score: score,
+        summary: summary,
+        textColor: textColor,
+        onBack: () async {
+          controller.showDialog(await getInitialDialog());
+        },
+        onAction: (action) => _handleHealthAction(action),
+      ),
+    ));
+  }
+
+  void _handleHealthAction(HealthAction action) {
+    if (action.routeName != null) {
+      context.push(action.routeName!);
+      controller.dismissDialog();
+    }
+  }
+
+  void _handleToolbarAction(MascotToolbarAction action) {
+    switch (action) {
+      case MascotToolbarAction.print:
+        _handlePrint();
+        break;
+      case MascotToolbarAction.themeStudio:
+        onOpenThemeStudio();
+        break;
+      case MascotToolbarAction.faq:
+        controller.showDialog(_faqCategoriesMenu());
+        break;
+      case MascotToolbarAction.aiAssistant:
+        onOpenAiAssistant();
+        break;
+    }
+  }
+
+  @override
+  Future<MascotDialogNode?> handleSelection(
+    String nodeId,
+    String optionId,
+  ) async {
+    // FAQ categories
+    if (nodeId == 'faq_categories') {
+      if (optionId == 'back') return getInitialDialog();
+      final categoryIndex = int.tryParse(optionId.replaceFirst('cat_', ''));
+      if (categoryIndex != null && categoryIndex < _faqCategories.length) {
+        return _faqItemsMenu(_faqCategories[categoryIndex]);
+      }
+    }
+
+    // FAQ items
+    if (nodeId.startsWith('faq_items_')) {
+      if (optionId == 'back') return _faqCategoriesMenu();
+      if (optionId.startsWith('item_')) {
+        final parts = optionId.split('_');
+        if (parts.length >= 3) {
+          final catIndex = int.tryParse(parts[1]);
+          final itemIndex = int.tryParse(parts[2]);
+          if (catIndex != null && itemIndex != null) {
+            final category = _faqCategories[catIndex];
+            final item = category.items[itemIndex];
+            gotoOfficialWebUrl(item.url, locale: getLocale());
+            return null;
+          }
+        }
+      }
+    }
+
+    // Diagnostics result
+    if (nodeId == 'diagnostics_result') {
+      if (optionId == 'back') return _diagnosticsMenu();
+      if (optionId == 'main') return getInitialDialog();
+    }
+
+    // Diagnostics menu
+    if (nodeId == 'diagnostics_menu') {
+      if (optionId == 'back') return getInitialDialog();
+      if (optionId == 'full') return _runFullDiagnostics();
+      final flow = _flowFromOptionId(optionId);
+      if (flow != null) return _runFlowDiagnostics(flow);
+    }
+
+    return null;
+  }
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // Diagnostics
+  // ══════════════════════════════════════════════════════════════════════════
+
+  MascotDialogNode _diagnosticsMenu() {
+    return const MascotDialogNode(
+      id: 'diagnostics_menu',
+      text: 'What would you like to check?',
+      options: [
+        MascotDialogOption(
+          id: 'full',
+          label: 'Full diagnostic',
+          icon: Icons.checklist,
+        ),
+        MascotDialogOption(
+          id: 'internet',
+          label: 'Internet connection',
+          icon: Icons.public,
+        ),
+        MascotDialogOption(
+          id: 'wifi',
+          label: 'WiFi coverage',
+          icon: Icons.wifi,
+        ),
+        MascotDialogOption(
+          id: 'back',
+          label: 'Back',
+          icon: Icons.arrow_back,
+        ),
+      ],
+    );
+  }
+
+  DiagnosticFlow? _flowFromOptionId(String optionId) {
+    return switch (optionId) {
+      'internet' => DiagnosticFlow.internet,
+      'wifi' => DiagnosticFlow.wifiCoverage,
+      _ => null,
+    };
+  }
+
+  Future<MascotDialogNode> _runFullDiagnostics() async {
+    _showLoading('Running full diagnostic...');
+    final result = await onRunFullDiagnostics();
+    return _buildDiagnosticsResult(result);
+  }
+
+  Future<MascotDialogNode> _runFlowDiagnostics(DiagnosticFlow flow) async {
+    final flowName = _flowDisplayName(flow);
+    _showLoading('Checking $flowName...');
+    final result = await onRunFlowDiagnostics(flow);
+    return _buildDiagnosticsResult(result);
+  }
+
+  void _showLoading(String message) {
+    controller.showDialog(MascotDialogNode(
+      id: 'diagnostics_loading',
+      text: message,
+      type: MascotDialogType.loading,
+      suggestedAnimation: MascotAnimationKey.think,
+    ));
+  }
+
+  String _flowDisplayName(DiagnosticFlow flow) {
+    return switch (flow) {
+      DiagnosticFlow.internet => 'internet connection',
+      DiagnosticFlow.wifiCoverage => 'WiFi coverage',
+      DiagnosticFlow.meshBackhaul => 'mesh backhaul',
+      DiagnosticFlow.deviceIssues => 'device issues',
+      DiagnosticFlow.intermittent => 'intermittent issues',
+    };
+  }
+
+  MascotDialogNode _buildDiagnosticsResult(DiagnosticsResult result) {
+    final type =
+        result.hasIssues ? MascotDialogType.error : MascotDialogType.success;
+    final animation = result.hasIssues
+        ? MascotAnimationKey.sad
+        : MascotAnimationKey.celebrate;
+
+    return MascotDialogNode(
+      id: 'diagnostics_result',
+      text: result.message,
+      type: type,
+      suggestedAnimation: animation,
+      options: const [
+        MascotDialogOption(
+          id: 'back',
+          label: 'Run another test',
+          icon: Icons.refresh,
+        ),
+        MascotDialogOption(
+          id: 'main',
+          label: 'Main menu',
+          icon: Icons.home,
+        ),
+      ],
+    );
+  }
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // Print Report
+  // ══════════════════════════════════════════════════════════════════════════
+
+  Future<void> _handlePrint() async {
+    _showLoading('Generating report...');
+    await onPrintReport();
+    controller.dismissDialog();
+  }
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // FAQ
+  // ══════════════════════════════════════════════════════════════════════════
+
+  MascotDialogNode _faqCategoriesMenu() {
+    return MascotDialogNode(
+      id: 'faq_categories',
+      text: 'What do you need help with?',
+      options: [
+        ..._faqCategories.asMap().entries.map((entry) => MascotDialogOption(
+              id: 'cat_${entry.key}',
+              label: getFaqCategoryTitle(entry.value),
+              icon: _iconForCategory(entry.value),
+            )),
+        const MascotDialogOption(
+          id: 'back',
+          label: 'Back',
+          icon: Icons.arrow_back,
+        ),
+      ],
+    );
+  }
+
+  MascotDialogNode _faqItemsMenu(FaqCategory category) {
+    final catIndex = _faqCategories.indexOf(category);
+    return MascotDialogNode(
+      id: 'faq_items_$catIndex',
+      text: getFaqCategoryTitle(category),
+      options: [
+        ...category.items.asMap().entries.map((entry) => MascotDialogOption(
+              id: 'item_${catIndex}_${entry.key}',
+              label: getFaqItemTitle(entry.value),
+              icon: Icons.open_in_new,
+            )),
+        const MascotDialogOption(
+          id: 'back',
+          label: 'Back',
+          icon: Icons.arrow_back,
+        ),
+      ],
+    );
+  }
+
+  IconData _iconForCategory(FaqCategory category) {
+    return switch (category) {
+      FaqSetupCategory() => Icons.settings_suggest,
+      FaqConnectivityCategory() => Icons.wifi,
+      FaqSpeedCategory() => Icons.speed,
+      FaqPasswordCategory() => Icons.lock,
+      FaqHardwareCategory() => Icons.router,
+    };
+  }
+}

--- a/lib/page/dashboard/mascot/linksys_mascot_renderer.dart
+++ b/lib/page/dashboard/mascot/linksys_mascot_renderer.dart
@@ -127,7 +127,8 @@ class _PixelBuddyPainter extends CustomPainter {
   final bool isWalking;
   final bool isGreeting;
 
-  // Colors
+  // Mascot brand colors - intentionally hardcoded for character consistency
+  // These represent the physical router device and should not change with theme
   static const _bodyColor = Color(0xFFFAFAFA);
   static const _borderColor = Color(0xFF333333);
   static const _ledBlue = Color(0xFF00A3E0);

--- a/lib/page/dashboard/mascot/mascot_config.dart
+++ b/lib/page/dashboard/mascot/mascot_config.dart
@@ -1,0 +1,94 @@
+/// Centralized configuration for the Mascot system.
+///
+/// All magic numbers and timing constants are collected here for easy
+/// adjustment. Future: these could be loaded from user preferences or
+/// remote config.
+library;
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Health Evaluation Config
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// Interval between periodic health evaluations.
+const kHealthEvaluationInterval = Duration(minutes: 5);
+
+/// Debounce delay for SSE-triggered health re-evaluation.
+const kHealthDebounceDelay = Duration(milliseconds: 500);
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Health Dimension Thresholds
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// System dimension: CPU/Memory usage thresholds.
+abstract final class SystemThresholds {
+  static const int excellent = 50; // < 50% = score 100
+  static const int good = 70; // 50-70% = score 80
+  static const int fair = 85; // 70-85% = score 60
+  static const int poor = 95; // 85-95% = score 40
+  // >= 95% = score 20
+}
+
+/// Devices dimension: Online ratio thresholds.
+abstract final class DevicesThresholds {
+  static const double excellent = 1.0; // 100% online = score 100
+  static const double good = 0.8; // > 80% = score 80
+  static const double fair = 0.5; // > 50% = score 60
+  // <= 50% = score 40
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Trigger Cooldowns
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// Default cooldowns for each trigger type.
+///
+/// Adjust these to control notification frequency.
+abstract final class TriggerCooldowns {
+  static const Duration wanDown = Duration(minutes: 5);
+  static const Duration wanRestored = Duration(minutes: 1);
+  static const Duration newDevice = Duration(seconds: 30);
+  static const Duration cpuHigh = Duration(minutes: 10);
+  static const Duration memoryHigh = Duration(minutes: 10);
+  static const Duration firmwareAvailable = Duration(hours: 24);
+  static const Duration wifiRadioDisabled = Duration(minutes: 5);
+  static const Duration firewallDisabled = Duration(minutes: 30);
+  static const Duration dmzEnabled = Duration(hours: 1);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Trigger Auto-Hide Durations
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// How long trigger notifications stay visible before auto-hiding.
+abstract final class TriggerAutoHide {
+  static const Duration critical = Duration(seconds: 8);
+  static const Duration high = Duration(seconds: 6);
+  static const Duration medium = Duration(seconds: 5);
+  static const Duration low = Duration(seconds: 5);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Random Speech Config
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// Minimum interval between random mascot speeches.
+const kRandomSpeechMinInterval = Duration(seconds: 10);
+
+/// Maximum interval between random mascot speeches.
+const kRandomSpeechMaxInterval = Duration(seconds: 30);
+
+/// How long random speech bubbles stay visible.
+const kRandomSpeechAutoHide = Duration(seconds: 5);
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Word Cloud Config
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// Font size range for word cloud dimensions.
+abstract final class WordCloudFontSize {
+  static const double min = 12.0;
+  static const double max = 24.0;
+}
+
+/// Base spacing between word cloud items.
+const kWordCloudSpacing = 8.0;

--- a/lib/page/dashboard/mascot/mascot_hero_widget.dart
+++ b/lib/page/dashboard/mascot/mascot_hero_widget.dart
@@ -34,7 +34,8 @@ class MascotHeroWidget extends StatelessWidget {
 class _StaticMascotPainter extends CustomPainter {
   final MascotAnimationKey animation;
 
-  // Colors (same as LinksysMascotRenderer)
+  // Mascot brand colors - intentionally hardcoded for character consistency
+  // These represent the physical router device and should not change with theme
   static const _bodyColor = Color(0xFFFAFAFA);
   static const _borderColor = Color(0xFF333333);
   static const _ledBlue = Color(0xFF00A3E0);

--- a/lib/page/dashboard/mascot/mascot_providers.dart
+++ b/lib/page/dashboard/mascot/mascot_providers.dart
@@ -18,8 +18,12 @@ import 'package:ui_kit_library/ui_kit.dart';
 import 'package:privacy_gui/page/ai_assistant/views/router_assistant_view.dart';
 
 import 'dashboard_dialog_provider.dart';
+import 'health_dialog_provider.dart';
+import 'mascot_config.dart';
 import 'mascot_hero_widget.dart';
 import 'mascot_message_provider.dart';
+import 'triggers/mascot_trigger.dart';
+import 'triggers/mascot_trigger_provider.dart';
 
 /// Provider for the mascot controller.
 final mascotControllerProvider = Provider.autoDispose<MascotController>((ref) {
@@ -38,6 +42,34 @@ final mascotDialogProvider =
     final controller = ref.watch(mascotControllerProvider);
 
     return DashboardDialogProvider(
+      controller: controller,
+      onRunFullDiagnostics: () => _runFullDiagnostics(ref),
+      onRunFlowDiagnostics: (flow) => _runFlowDiagnostics(ref, flow),
+      onPrintReport: () => _printReport(ref),
+      onOpenThemeStudio: () => _openThemeStudio(ref),
+      onOpenAiAssistant: () => _openAiAssistant(context),
+      getLocale: () => locale,
+      getFaqCategoryTitle: (category) => category.displayString(context),
+      getFaqItemTitle: (item) => item.displayString(context),
+      isThemeStudioEnabled: BuildConfig.enableThemeStudio,
+      getRouterTime: () => _getRouterTime(ref),
+    );
+  },
+);
+
+/// Provider for the health-based mascot dialog UI.
+///
+/// Uses word cloud + toolbar layout instead of fixed options.
+final mascotHealthDialogProvider = Provider.autoDispose
+    .family<HealthDialogProvider, (BuildContext, WidgetRef)>(
+  (ref, args) {
+    final (context, widgetRef) = args;
+    final locale = ref.watch(appSettingsProvider.select((s) => s.locale));
+    final controller = ref.watch(mascotControllerProvider);
+
+    return HealthDialogProvider(
+      ref: widgetRef,
+      context: context,
       controller: controller,
       onRunFullDiagnostics: () => _runFullDiagnostics(ref),
       onRunFlowDiagnostics: (flow) => _runFlowDiagnostics(ref, flow),
@@ -230,9 +262,9 @@ class MascotCoordinatorNotifier extends AutoDisposeNotifier<void> {
   final _random = Random();
   VoidCallback? _controllerListener;
 
-  static const _minInterval = Duration(seconds: 10);
-  static const _maxInterval = Duration(seconds: 30);
-  static const _autoHideDuration = Duration(seconds: 5);
+  static const _minInterval = kRandomSpeechMinInterval;
+  static const _maxInterval = kRandomSpeechMaxInterval;
+  static const _autoHideDuration = kRandomSpeechAutoHide;
 
   @override
   void build() {
@@ -245,7 +277,31 @@ class MascotCoordinatorNotifier extends AutoDisposeNotifier<void> {
 
     if (showMascot && isDashboardReady) {
       _startRandomSpeech(controller);
+      _startTriggerListener(controller);
     }
+  }
+
+  void _startTriggerListener(MascotController controller) {
+    final triggerNotifier = ref.read(mascotTriggerProvider.notifier);
+    triggerNotifier.onTrigger =
+        (trigger) => _handleTrigger(controller, trigger);
+  }
+
+  void _handleTrigger(MascotController controller, MascotTrigger trigger) {
+    if (!controller.isVisible) return;
+
+    // For critical triggers, interrupt current dialog
+    if (trigger.interruptCurrent && controller.isDialogVisible) {
+      controller.dismissDialog();
+    }
+
+    // Don't interrupt user interaction for non-critical triggers
+    if (!trigger.interruptCurrent &&
+        controller.state == MascotState.interacting) {
+      return;
+    }
+
+    controller.showDialog(trigger.toDialogNode());
   }
 
   void _startRandomSpeech(MascotController controller) {

--- a/lib/page/dashboard/mascot/mascot_providers.dart
+++ b/lib/page/dashboard/mascot/mascot_providers.dart
@@ -11,6 +11,7 @@ import 'package:privacy_gui/page/dashboard/providers/pdf_report_data_provider.da
 import 'package:privacy_gui/page/unified_diagnostics/models/diagnostic_state.dart';
 import 'package:privacy_gui/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart';
 import 'package:privacy_gui/page/dashboard/providers/dashboard_domain_ready_provider.dart';
+import 'package:privacy_gui/page/support/faq_data.dart';
 import 'package:privacy_gui/providers/app_settings/app_settings_provider.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:ui_kit_library/ui_kit.dart';
@@ -47,7 +48,7 @@ final mascotDialogProvider =
       onRunFlowDiagnostics: (flow) => _runFlowDiagnostics(ref, flow),
       onPrintReport: () => _printReport(ref),
       onOpenThemeStudio: () => _openThemeStudio(ref),
-      onOpenAiAssistant: () => _openAiAssistant(context),
+      onOpenAiAssistant: () => openAiAssistantWithTransition(context),
       getLocale: () => locale,
       getFaqCategoryTitle: (category) => category.displayString(context),
       getFaqItemTitle: (item) => item.displayString(context),
@@ -57,28 +58,48 @@ final mascotDialogProvider =
   },
 );
 
+/// Arguments for creating [HealthDialogProvider].
+///
+/// Contains callbacks that require [BuildContext], allowing the widget layer
+/// to handle navigation and localization while keeping the provider context-free.
+class HealthDialogProviderArgs {
+  final WidgetRef widgetRef;
+  final void Function(String routeName) onNavigate;
+  final VoidCallback onOpenAiAssistant;
+  final String Function(FaqCategory category) getFaqCategoryTitle;
+  final String Function(FaqItem item) getFaqItemTitle;
+
+  const HealthDialogProviderArgs({
+    required this.widgetRef,
+    required this.onNavigate,
+    required this.onOpenAiAssistant,
+    required this.getFaqCategoryTitle,
+    required this.getFaqItemTitle,
+  });
+}
+
 /// Provider for the health-based mascot dialog UI.
 ///
 /// Uses word cloud + toolbar layout instead of fixed options.
-final mascotHealthDialogProvider = Provider.autoDispose
-    .family<HealthDialogProvider, (BuildContext, WidgetRef)>(
+/// Widget layer provides context-dependent callbacks via [HealthDialogProviderArgs].
+final mascotHealthDialogProvider =
+    Provider.autoDispose.family<HealthDialogProvider, HealthDialogProviderArgs>(
   (ref, args) {
-    final (context, widgetRef) = args;
     final locale = ref.watch(appSettingsProvider.select((s) => s.locale));
     final controller = ref.watch(mascotControllerProvider);
 
     return HealthDialogProvider(
-      ref: widgetRef,
-      context: context,
+      ref: args.widgetRef,
       controller: controller,
       onRunFullDiagnostics: () => _runFullDiagnostics(ref),
       onRunFlowDiagnostics: (flow) => _runFlowDiagnostics(ref, flow),
       onPrintReport: () => _printReport(ref),
       onOpenThemeStudio: () => _openThemeStudio(ref),
-      onOpenAiAssistant: () => _openAiAssistant(context),
+      onNavigate: args.onNavigate,
+      onOpenAiAssistant: args.onOpenAiAssistant,
       getLocale: () => locale,
-      getFaqCategoryTitle: (category) => category.displayString(context),
-      getFaqItemTitle: (item) => item.displayString(context),
+      getFaqCategoryTitle: args.getFaqCategoryTitle,
+      getFaqItemTitle: args.getFaqItemTitle,
       isThemeStudioEnabled: BuildConfig.enableThemeStudio,
       getRouterTime: () => _getRouterTime(ref),
     );
@@ -173,7 +194,7 @@ void _openThemeStudio(Ref ref) {
 /// The custom PageRouteBuilder enables the mascot fly-in transition
 /// which requires dynamic position calculation from MediaQuery.
 /// go_router's CustomTransitionPage doesn't easily support this pattern.
-void _openAiAssistant(BuildContext context) {
+void openAiAssistantWithTransition(BuildContext context) {
   final screenSize = MediaQuery.of(context).size;
 
   // Mascot's starting position (bottom-right, where the overlay typically is)

--- a/lib/page/dashboard/mascot/triggers/mascot_trigger.dart
+++ b/lib/page/dashboard/mascot/triggers/mascot_trigger.dart
@@ -1,0 +1,77 @@
+import 'package:equatable/equatable.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+/// Priority levels for mascot triggers.
+///
+/// Lower value = higher priority.
+abstract class TriggerPriority {
+  static const critical = 1; // WAN down
+  static const high = 2; // WAN restored, CPU critical
+  static const medium = 3; // New device joined
+  static const low = 4; // Informational
+}
+
+/// A trigger condition that can activate a mascot notification.
+class MascotTrigger extends Equatable {
+  /// Unique identifier for this trigger.
+  final String id;
+
+  /// Message to display when triggered.
+  final String message;
+
+  /// Priority level (lower = more important).
+  final int priority;
+
+  /// Minimum time between consecutive triggers of this type.
+  final Duration cooldown;
+
+  /// Suggested animation to play.
+  final MascotAnimationKey? animation;
+
+  /// Whether this trigger should interrupt the current dialog.
+  final bool interruptCurrent;
+
+  /// Auto-hide duration for the notification.
+  final Duration autoHideDuration;
+
+  const MascotTrigger({
+    required this.id,
+    required this.message,
+    this.priority = TriggerPriority.medium,
+    this.cooldown = const Duration(minutes: 5),
+    this.animation,
+    this.interruptCurrent = false,
+    this.autoHideDuration = const Duration(seconds: 5),
+  });
+
+  @override
+  List<Object?> get props =>
+      [id, message, priority, cooldown, animation, interruptCurrent];
+}
+
+/// State tracking for trigger cooldowns.
+class TriggerCooldownState {
+  final Map<String, DateTime> _lastTriggered = {};
+
+  /// Check if a trigger is currently in cooldown.
+  bool isInCooldown(MascotTrigger trigger) {
+    final lastTime = _lastTriggered[trigger.id];
+    if (lastTime == null) return false;
+    return DateTime.now().difference(lastTime) < trigger.cooldown;
+  }
+
+  /// Record that a trigger was fired.
+  void recordTrigger(MascotTrigger trigger) {
+    _lastTriggered[trigger.id] = DateTime.now();
+  }
+
+  /// Clear cooldown for a specific trigger.
+  void clearCooldown(String triggerId) {
+    _lastTriggered.remove(triggerId);
+  }
+
+  /// Clear all cooldowns.
+  void clearAll() {
+    _lastTriggered.clear();
+  }
+}

--- a/lib/page/dashboard/mascot/triggers/mascot_trigger_provider.dart
+++ b/lib/page/dashboard/mascot/triggers/mascot_trigger_provider.dart
@@ -1,0 +1,286 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
+import 'package:privacy_gui/page/dashboard/providers/dashboard_domain_ready_provider.dart';
+import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
+import 'package:privacy_gui/page/firewall/providers/firewall_data_provider.dart';
+import 'package:privacy_gui/page/internet_settings/providers/wan_data_provider.dart';
+import 'package:privacy_gui/page/wifi_settings/providers/wifi_data_provider.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import 'mascot_trigger.dart';
+import 'trigger_definitions.dart';
+
+/// Provider for the mascot trigger system.
+///
+/// Listens to SSE events and fires mascot notifications based on
+/// predefined trigger conditions. Features:
+/// - Cooldown management (prevents spam)
+/// - Priority ordering (critical events interrupt)
+/// - State change detection (only triggers on actual changes)
+final mascotTriggerProvider =
+    NotifierProvider.autoDispose<MascotTriggerNotifier, MascotTriggerState>(
+  MascotTriggerNotifier.new,
+);
+
+/// State for the trigger system.
+class MascotTriggerState {
+  /// The most recently triggered event (for external consumption).
+  final MascotTrigger? lastTrigger;
+
+  /// Timestamp of the last trigger.
+  final DateTime? lastTriggerTime;
+
+  /// Previous WAN status for change detection.
+  final bool? previousWanUp;
+
+  /// Previous device count for change detection.
+  final int? previousDeviceCount;
+
+  /// Previous firewall status for change detection.
+  final bool? previousFirewallEnabled;
+
+  const MascotTriggerState({
+    this.lastTrigger,
+    this.lastTriggerTime,
+    this.previousWanUp,
+    this.previousDeviceCount,
+    this.previousFirewallEnabled,
+  });
+
+  MascotTriggerState copyWith({
+    MascotTrigger? lastTrigger,
+    DateTime? lastTriggerTime,
+    bool? previousWanUp,
+    int? previousDeviceCount,
+    bool? previousFirewallEnabled,
+  }) {
+    return MascotTriggerState(
+      lastTrigger: lastTrigger ?? this.lastTrigger,
+      lastTriggerTime: lastTriggerTime ?? this.lastTriggerTime,
+      previousWanUp: previousWanUp ?? this.previousWanUp,
+      previousDeviceCount: previousDeviceCount ?? this.previousDeviceCount,
+      previousFirewallEnabled:
+          previousFirewallEnabled ?? this.previousFirewallEnabled,
+    );
+  }
+}
+
+class MascotTriggerNotifier extends AutoDisposeNotifier<MascotTriggerState> {
+  final _cooldownState = TriggerCooldownState();
+  Timer? _debounceTimer;
+
+  /// External callback for firing triggers.
+  ///
+  /// Set by [MascotCoordinatorNotifier] to wire into the mascot controller.
+  void Function(MascotTrigger)? onTrigger;
+
+  @override
+  MascotTriggerState build() {
+    _listenToSseEvents();
+    _initializeState();
+
+    ref.onDispose(() {
+      _debounceTimer?.cancel();
+      _cooldownState.clearAll();
+    });
+
+    return const MascotTriggerState();
+  }
+
+  void _initializeState() {
+    final isDashboardReady = ref.read(dashboardDomainReadyProvider).hasValue;
+    if (!isDashboardReady) return;
+
+    // Capture initial state for change detection
+    final wan = ref.read(wanDataProvider).valueOrNull;
+    final devices = ref.read(devicesDataProvider).valueOrNull;
+    final firewall = ref.read(firewallDataProvider).valueOrNull;
+
+    state = MascotTriggerState(
+      previousWanUp: wan?.model.isUp,
+      previousDeviceCount: devices?.deviceModels.length,
+      previousFirewallEnabled: firewall?.firewallModel.isIPv4FirewallEnabled,
+    );
+  }
+
+  void _listenToSseEvents() {
+    ref.listen(sseInvalidationProvider, (prev, next) {
+      final domain = next.valueOrNull;
+      if (domain != null &&
+          TriggerDomainMapping.canTriggerNotification(domain)) {
+        _debouncedEvaluate(domain);
+      }
+    });
+  }
+
+  void _debouncedEvaluate(InvalidationDomain domain) {
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(const Duration(milliseconds: 500), () {
+      _evaluateTriggers(domain);
+    });
+  }
+
+  void _evaluateTriggers(InvalidationDomain domain) {
+    final triggers = <MascotTrigger>[];
+
+    switch (domain) {
+      case InvalidationDomain.wanStatus:
+        final wanTrigger = _evaluateWanStatus();
+        if (wanTrigger != null) triggers.add(wanTrigger);
+        break;
+
+      case InvalidationDomain.connectedDevices:
+        final deviceTrigger = _evaluateDeviceChanges();
+        if (deviceTrigger != null) triggers.add(deviceTrigger);
+        break;
+
+      case InvalidationDomain.firewallRules:
+      case InvalidationDomain.dmz:
+        final firewallTrigger = _evaluateFirewallChanges();
+        if (firewallTrigger != null) triggers.add(firewallTrigger);
+        break;
+
+      case InvalidationDomain.wifiRadios:
+        final wifiTrigger = _evaluateWifiChanges();
+        if (wifiTrigger != null) triggers.add(wifiTrigger);
+        break;
+
+      default:
+        break;
+    }
+
+    // Sort by priority (lower = higher priority)
+    triggers.sort((a, b) => a.priority.compareTo(b.priority));
+
+    // Fire highest priority trigger that isn't in cooldown
+    for (final trigger in triggers) {
+      if (!_cooldownState.isInCooldown(trigger)) {
+        _fireTrigger(trigger);
+        break;
+      }
+    }
+  }
+
+  MascotTrigger? _evaluateWanStatus() {
+    final wan = ref.read(wanDataProvider).valueOrNull;
+    if (wan == null) return null;
+
+    final currentUp = wan.model.isUp;
+    final previousUp = state.previousWanUp;
+
+    // Update state for next comparison
+    state = state.copyWith(previousWanUp: currentUp);
+
+    // Only trigger on actual state change
+    if (previousUp == null) return null;
+    if (currentUp == previousUp) return null;
+
+    if (!currentUp) {
+      debugPrint('[Mascot][Trigger]: WAN went down');
+      return TriggerDefinitions.wanDown();
+    } else {
+      debugPrint('[Mascot][Trigger]: WAN restored');
+      return TriggerDefinitions.wanRestored();
+    }
+  }
+
+  MascotTrigger? _evaluateDeviceChanges() {
+    final devices = ref.read(devicesDataProvider).valueOrNull;
+    if (devices == null) return null;
+
+    final currentCount = devices.deviceModels.length;
+    final previousCount = state.previousDeviceCount;
+
+    // Update state for next comparison
+    state = state.copyWith(previousDeviceCount: currentCount);
+
+    // Only trigger when new device joins (count increases)
+    if (previousCount == null) return null;
+    if (currentCount <= previousCount) return null;
+
+    // Find the newest device (last in list by convention)
+    final newDevice = devices.deviceModels.isNotEmpty
+        ? (devices.deviceModels.last.hostName.isNotEmpty
+            ? devices.deviceModels.last.hostName
+            : devices.deviceModels.last.mac)
+        : 'Unknown device';
+
+    debugPrint('[Mascot][Trigger]: New device joined — $newDevice');
+    return TriggerDefinitions.newDeviceJoined(newDevice);
+  }
+
+  MascotTrigger? _evaluateFirewallChanges() {
+    final firewall = ref.read(firewallDataProvider).valueOrNull;
+    if (firewall == null) return null;
+
+    final currentEnabled = firewall.firewallModel.isIPv4FirewallEnabled;
+    final previousEnabled = state.previousFirewallEnabled;
+
+    // Update state for next comparison
+    state = state.copyWith(previousFirewallEnabled: currentEnabled);
+
+    // Only trigger when firewall becomes disabled
+    if (previousEnabled == null) return null;
+    if (currentEnabled || !previousEnabled) return null;
+
+    debugPrint('[Mascot][Trigger]: Firewall disabled');
+    return TriggerDefinitions.firewallDisabled();
+  }
+
+  MascotTrigger? _evaluateWifiChanges() {
+    final wifi = ref.read(wifiDataProvider).valueOrNull;
+    if (wifi == null) return null;
+
+    // Check if any radio is disabled
+    // Note: This is a simplified check; a full implementation would
+    // track previous state per radio
+    final disabledRadios = wifi.radioModels.where((r) => !r.enable).toList();
+    if (disabledRadios.isEmpty) return null;
+
+    final band = disabledRadios.first.band;
+    debugPrint('[Mascot][Trigger]: WiFi radio disabled — $band');
+    return TriggerDefinitions.wifiRadioDisabled(band);
+  }
+
+  void _fireTrigger(MascotTrigger trigger) {
+    _cooldownState.recordTrigger(trigger);
+
+    state = state.copyWith(
+      lastTrigger: trigger,
+      lastTriggerTime: DateTime.now(),
+    );
+
+    debugPrint('[Mascot][Trigger]: Firing trigger — ${trigger.id}');
+
+    onTrigger?.call(trigger);
+  }
+
+  /// Manually fire a trigger (for testing or external use).
+  void manualTrigger(MascotTrigger trigger) {
+    if (!_cooldownState.isInCooldown(trigger)) {
+      _fireTrigger(trigger);
+    }
+  }
+
+  /// Clear all cooldowns (for testing).
+  void clearCooldowns() {
+    _cooldownState.clearAll();
+  }
+}
+
+/// Extension to convert [MascotTrigger] to [MascotDialogNode].
+extension TriggerToDialogNode on MascotTrigger {
+  MascotDialogNode toDialogNode() {
+    return MascotDialogNode(
+      id: 'trigger_$id',
+      text: message,
+      autoHide: true,
+      autoHideDuration: autoHideDuration,
+      showDismissButton: priority <= TriggerPriority.high,
+      suggestedAnimation: animation,
+    );
+  }
+}

--- a/lib/page/dashboard/mascot/triggers/mascot_trigger_provider.dart
+++ b/lib/page/dashboard/mascot/triggers/mascot_trigger_provider.dart
@@ -42,12 +42,16 @@ class MascotTriggerState {
   /// Previous firewall status for change detection.
   final bool? previousFirewallEnabled;
 
+  /// Previous disabled WiFi radios for change detection.
+  final Set<String>? previousDisabledRadios;
+
   const MascotTriggerState({
     this.lastTrigger,
     this.lastTriggerTime,
     this.previousWanUp,
     this.previousDeviceCount,
     this.previousFirewallEnabled,
+    this.previousDisabledRadios,
   });
 
   MascotTriggerState copyWith({
@@ -56,6 +60,7 @@ class MascotTriggerState {
     bool? previousWanUp,
     int? previousDeviceCount,
     bool? previousFirewallEnabled,
+    Set<String>? previousDisabledRadios,
   }) {
     return MascotTriggerState(
       lastTrigger: lastTrigger ?? this.lastTrigger,
@@ -64,6 +69,8 @@ class MascotTriggerState {
       previousDeviceCount: previousDeviceCount ?? this.previousDeviceCount,
       previousFirewallEnabled:
           previousFirewallEnabled ?? this.previousFirewallEnabled,
+      previousDisabledRadios:
+          previousDisabledRadios ?? this.previousDisabledRadios,
     );
   }
 }
@@ -98,11 +105,16 @@ class MascotTriggerNotifier extends AutoDisposeNotifier<MascotTriggerState> {
     final wan = ref.read(wanDataProvider).valueOrNull;
     final devices = ref.read(devicesDataProvider).valueOrNull;
     final firewall = ref.read(firewallDataProvider).valueOrNull;
+    final wifi = ref.read(wifiDataProvider).valueOrNull;
+
+    final disabledRadios =
+        wifi?.radioModels.where((r) => !r.enable).map((r) => r.band).toSet();
 
     state = MascotTriggerState(
       previousWanUp: wan?.model.isUp,
       previousDeviceCount: devices?.deviceModels.length,
       previousFirewallEnabled: firewall?.firewallModel.isIPv4FirewallEnabled,
+      previousDisabledRadios: disabledRadios,
     );
   }
 
@@ -234,13 +246,20 @@ class MascotTriggerNotifier extends AutoDisposeNotifier<MascotTriggerState> {
     final wifi = ref.read(wifiDataProvider).valueOrNull;
     if (wifi == null) return null;
 
-    // Check if any radio is disabled
-    // Note: This is a simplified check; a full implementation would
-    // track previous state per radio
-    final disabledRadios = wifi.radioModels.where((r) => !r.enable).toList();
-    if (disabledRadios.isEmpty) return null;
+    final currentDisabled =
+        wifi.radioModels.where((r) => !r.enable).map((r) => r.band).toSet();
+    final previousDisabled = state.previousDisabledRadios;
 
-    final band = disabledRadios.first.band;
+    // Update state for next comparison
+    state = state.copyWith(previousDisabledRadios: currentDisabled);
+
+    // Only trigger on actual state change (newly disabled radios)
+    if (previousDisabled == null) return null;
+
+    final newlyDisabled = currentDisabled.difference(previousDisabled);
+    if (newlyDisabled.isEmpty) return null;
+
+    final band = newlyDisabled.first;
     debugPrint('[Mascot][Trigger]: WiFi radio disabled — $band');
     return TriggerDefinitions.wifiRadioDisabled(band);
   }

--- a/lib/page/dashboard/mascot/triggers/trigger_definitions.dart
+++ b/lib/page/dashboard/mascot/triggers/trigger_definitions.dart
@@ -1,0 +1,143 @@
+import 'package:ui_kit_library/ui_kit.dart';
+import 'package:privacy_gui/core/usp/models/invalidation_domain.dart';
+import '../mascot_config.dart';
+import 'mascot_trigger.dart';
+
+/// Factory for creating predefined mascot triggers.
+///
+/// Extensible: add new triggers by creating factory methods.
+abstract final class TriggerDefinitions {
+  /// WAN connection lost — critical priority.
+  static MascotTrigger wanDown() => const MascotTrigger(
+        id: 'wan_down',
+        message:
+            'Internet connection lost. Check your WAN cable or contact your ISP.',
+        priority: TriggerPriority.critical,
+        cooldown: TriggerCooldowns.wanDown,
+        animation: MascotAnimationKey.sad,
+        interruptCurrent: true,
+        autoHideDuration: TriggerAutoHide.critical,
+      );
+
+  /// WAN connection restored.
+  static MascotTrigger wanRestored() => const MascotTrigger(
+        id: 'wan_restored',
+        message: 'Internet connection restored!',
+        priority: TriggerPriority.high,
+        cooldown: TriggerCooldowns.wanRestored,
+        animation: MascotAnimationKey.celebrate,
+        interruptCurrent: false,
+        autoHideDuration: TriggerAutoHide.medium,
+      );
+
+  /// New device joined the network.
+  static MascotTrigger newDeviceJoined(String deviceName) => MascotTrigger(
+        id: 'new_device_joined',
+        message: 'New device "$deviceName" joined the network.',
+        priority: TriggerPriority.medium,
+        cooldown: TriggerCooldowns.newDevice,
+        animation: MascotAnimationKey.greet,
+        interruptCurrent: false,
+        autoHideDuration: TriggerAutoHide.medium,
+      );
+
+  /// CPU usage exceeded threshold.
+  static MascotTrigger cpuHigh(int percentage) => MascotTrigger(
+        id: 'cpu_high',
+        message:
+            'CPU usage is at $percentage%. System performance may be affected.',
+        priority: TriggerPriority.high,
+        cooldown: TriggerCooldowns.cpuHigh,
+        animation: MascotAnimationKey.think,
+        interruptCurrent: false,
+        autoHideDuration: TriggerAutoHide.high,
+      );
+
+  /// Memory usage exceeded threshold.
+  static MascotTrigger memoryHigh(int percentage) => MascotTrigger(
+        id: 'memory_high',
+        message:
+            'Memory usage is at $percentage%. Consider restarting the router.',
+        priority: TriggerPriority.high,
+        cooldown: TriggerCooldowns.memoryHigh,
+        animation: MascotAnimationKey.think,
+        interruptCurrent: false,
+        autoHideDuration: TriggerAutoHide.high,
+      );
+
+  /// Firmware update available.
+  static MascotTrigger firmwareAvailable(String version) => MascotTrigger(
+        id: 'firmware_available',
+        message: 'Firmware update $version is available.',
+        priority: TriggerPriority.low,
+        cooldown: TriggerCooldowns.firmwareAvailable,
+        animation: MascotAnimationKey.idle,
+        interruptCurrent: false,
+        autoHideDuration: TriggerAutoHide.low,
+      );
+
+  /// WiFi radio disabled.
+  static MascotTrigger wifiRadioDisabled(String band) => MascotTrigger(
+        id: 'wifi_radio_disabled_$band',
+        message: '$band WiFi radio has been disabled.',
+        priority: TriggerPriority.medium,
+        cooldown: TriggerCooldowns.wifiRadioDisabled,
+        animation: MascotAnimationKey.sad,
+        interruptCurrent: false,
+        autoHideDuration: TriggerAutoHide.medium,
+      );
+
+  /// Firewall disabled.
+  static MascotTrigger firewallDisabled() => const MascotTrigger(
+        id: 'firewall_disabled',
+        message: 'Firewall has been disabled. Your network may be vulnerable.',
+        priority: TriggerPriority.high,
+        cooldown: TriggerCooldowns.firewallDisabled,
+        animation: MascotAnimationKey.sad,
+        interruptCurrent: true,
+        autoHideDuration: TriggerAutoHide.critical,
+      );
+
+  /// DMZ enabled warning.
+  static MascotTrigger dmzEnabled(String deviceName) => MascotTrigger(
+        id: 'dmz_enabled',
+        message:
+            'DMZ is enabled for "$deviceName". This device is exposed to the internet.',
+        priority: TriggerPriority.medium,
+        cooldown: TriggerCooldowns.dmzEnabled,
+        animation: MascotAnimationKey.think,
+        interruptCurrent: false,
+        autoHideDuration: TriggerAutoHide.high,
+      );
+}
+
+/// Mapping from InvalidationDomain to trigger evaluation.
+///
+/// Determines which domains should trigger immediate health re-evaluation.
+abstract final class TriggerDomainMapping {
+  /// Domains that require immediate health re-evaluation when invalidated.
+  static const Set<InvalidationDomain> healthCriticalDomains = {
+    InvalidationDomain.wanStatus,
+    InvalidationDomain.connectedDevices,
+    InvalidationDomain.wifiRadios,
+    InvalidationDomain.firewallRules,
+    InvalidationDomain.dmz,
+  };
+
+  /// Domains that may trigger proactive notifications.
+  static const Set<InvalidationDomain> notificationDomains = {
+    InvalidationDomain.wanStatus,
+    InvalidationDomain.connectedDevices,
+    InvalidationDomain.wifiRadios,
+    InvalidationDomain.firewallRules,
+    InvalidationDomain.dmz,
+  };
+
+  /// Check if a domain should trigger health re-evaluation.
+  static bool isHealthCritical(InvalidationDomain domain) =>
+      healthCriticalDomains.contains(domain);
+
+  /// Check if a domain may trigger a notification.
+  static bool canTriggerNotification(InvalidationDomain domain) =>
+      notificationDomains.contains(domain);
+}

--- a/lib/page/dashboard/mascot/widgets/dimension_actions_builder.dart
+++ b/lib/page/dashboard/mascot/widgets/dimension_actions_builder.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import '../health/health_dimension.dart';
+import '../health/health_score.dart';
+
+/// Builds MascotDialogNode for a dimension's action list.
+class DimensionActionsBuilder {
+  /// Build a dialog node showing dimension details and actions.
+  static MascotDialogNode buildActionsNode({
+    required HealthDimension dimension,
+    required HealthScore? score,
+    required BuildContext context,
+  }) {
+    final actions = dimension.getActions(context);
+    final tierLabel = score?.tierLabel ?? 'Unknown';
+    final scoreValue = score?.score ?? 100;
+
+    return MascotDialogNode(
+      id: 'dimension_${dimension.type.name}',
+      text: '${dimension.displayName}\nScore: $scoreValue ($tierLabel)',
+      options: [
+        ...actions.map((action) => MascotDialogOption(
+              id: action.id,
+              label: action.label,
+              icon: action.icon,
+            )),
+        const MascotDialogOption(
+          id: 'back_to_cloud',
+          label: 'Back',
+          icon: Icons.arrow_back,
+        ),
+      ],
+    );
+  }
+
+  /// Get the route name for an action ID.
+  static String? getRouteForAction(
+    HealthDimension dimension,
+    String actionId,
+    BuildContext context,
+  ) {
+    final actions = dimension.getActions(context);
+    try {
+      final action = actions.firstWhere((a) => a.id == actionId);
+      return action.routeName;
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/page/dashboard/mascot/widgets/dimension_detail_view.dart
+++ b/lib/page/dashboard/mascot/widgets/dimension_detail_view.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:privacy_gui/page/_shared/models/network_health_helpers.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import '../health/health_dimension.dart';
+import '../health/health_score.dart';
+
+/// Detail view for a single health dimension.
+///
+/// Shows:
+/// - Dimension name with back button
+/// - Status and summary items
+/// - Action buttons (navigate, reboot, etc.)
+class DimensionDetailView extends StatelessWidget {
+  final HealthDimension dimension;
+  final HealthScore? score;
+  final DimensionSummary summary;
+  final Color textColor;
+  final VoidCallback onBack;
+  final void Function(HealthAction action) onAction;
+
+  const DimensionDetailView({
+    super.key,
+    required this.dimension,
+    required this.score,
+    required this.summary,
+    required this.textColor,
+    required this.onBack,
+    required this.onAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tier = score?.tier ?? HealthTier.excellent;
+    final tierColor = NetworkHealthHelpers.tierColor(tier, cs);
+    final tierLabel = NetworkHealthHelpers.tierLabel(tier);
+    final actions = dimension.getActions(context);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Header with back button
+        Row(
+          children: [
+            InkWell(
+              onTap: onBack,
+              borderRadius: BorderRadius.circular(16),
+              child: Padding(
+                padding: const EdgeInsets.all(4),
+                child: Icon(
+                  Icons.arrow_back,
+                  size: 20,
+                  color: textColor,
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Icon(dimension.icon, size: 20, color: tierColor),
+            const SizedBox(width: 6),
+            Expanded(
+              child: AppText.titleMedium(
+                dimension.displayName,
+                color: textColor,
+              ),
+            ),
+          ],
+        ),
+
+        const SizedBox(height: 12),
+
+        // Status
+        Row(
+          children: [
+            Container(
+              width: 8,
+              height: 8,
+              decoration: BoxDecoration(
+                color: tierColor,
+                shape: BoxShape.circle,
+              ),
+            ),
+            const SizedBox(width: 8),
+            AppText.bodyMedium(
+              '${summary.status} ($tierLabel)',
+              color: textColor,
+            ),
+          ],
+        ),
+
+        // Summary items
+        if (summary.items.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          ...summary.items.map((item) => Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Row(
+                  children: [
+                    SizedBox(
+                      width: 80,
+                      child: AppText.bodySmall(
+                        item.label,
+                        color: textColor.withValues(alpha: 0.6),
+                      ),
+                    ),
+                    Expanded(
+                      child: AppText.bodySmall(
+                        item.value,
+                        color: textColor,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              )),
+        ],
+
+        const SizedBox(height: 16),
+
+        // Action buttons
+        if (actions.isNotEmpty)
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: actions
+                .map((action) => _ActionButton(
+                      action: action,
+                      textColor: textColor,
+                      onTap: () => onAction(action),
+                    ))
+                .toList(),
+          ),
+      ],
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  final HealthAction action;
+  final Color textColor;
+  final VoidCallback onTap;
+
+  const _ActionButton({
+    required this.action,
+    required this.textColor,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+
+    return Material(
+      color: cs.primaryContainer,
+      borderRadius: BorderRadius.circular(8),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                action.icon,
+                size: 16,
+                color: cs.onPrimaryContainer,
+              ),
+              const SizedBox(width: 6),
+              AppText.labelMedium(
+                action.label,
+                color: cs.onPrimaryContainer,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/page/dashboard/mascot/widgets/dimension_tooltip_content.dart
+++ b/lib/page/dashboard/mascot/widgets/dimension_tooltip_content.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:privacy_gui/page/_shared/models/network_health_helpers.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import '../health/health_dimension.dart';
+import '../health/health_score.dart';
+
+/// Tooltip content showing dimension summary.
+class DimensionTooltipContent extends StatelessWidget {
+  final HealthDimension dimension;
+  final HealthScore? score;
+  final DimensionSummary? summary;
+
+  const DimensionTooltipContent({
+    super.key,
+    required this.dimension,
+    this.score,
+    this.summary,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveSummary = summary ??
+        const DimensionSummary(status: 'Unknown', hint: 'Tap for actions');
+    final tier = score?.tier ?? HealthTier.excellent;
+    final tierLabel = NetworkHealthHelpers.tierLabel(tier);
+    final cs = Theme.of(context).colorScheme;
+    final tierColor = NetworkHealthHelpers.tierColor(tier, cs);
+
+    // Theme-aware text colors for tooltip
+    final textColor = cs.onSurface;
+    final subtitleColor = cs.onSurfaceVariant;
+    final hintColor = cs.outline;
+
+    return Container(
+      constraints: const BoxConstraints(maxWidth: 200),
+      padding: const EdgeInsets.all(8),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(dimension.icon, size: 16, color: tierColor),
+              const SizedBox(width: 6),
+              AppText.labelLarge(
+                dimension.displayName,
+                color: textColor,
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          AppText.bodySmall(
+            '${effectiveSummary.status} ($tierLabel)',
+            color: subtitleColor,
+          ),
+          if (effectiveSummary.items.isNotEmpty) ...[
+            const SizedBox(height: 6),
+            ...effectiveSummary.items.map((item) => Padding(
+                  padding: const EdgeInsets.only(bottom: 2),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      AppText.labelSmall(
+                        '${item.label}: ',
+                        color: subtitleColor,
+                      ),
+                      Flexible(
+                        child: AppText.labelSmall(
+                          item.value,
+                          color: textColor,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                )),
+          ],
+          const SizedBox(height: 4),
+          AppText.labelSmall(
+            effectiveSummary.hint ?? 'Tap for actions',
+            color: hintColor,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/page/dashboard/mascot/widgets/health_status_view.dart
+++ b/lib/page/dashboard/mascot/widgets/health_status_view.dart
@@ -29,10 +29,9 @@ class HealthStatusView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final healthState = ref.watch(systemHealthProvider);
-    final registry = ref.watch(healthDimensionRegistryProvider);
 
     return healthState.when(
-      data: (state) => _buildStatusView(context, ref, state, registry),
+      data: (state) => _buildStatusView(context, ref, state),
       loading: () => _buildLoading(),
       error: (_, __) => AppText.bodyMedium(
         'Unable to load health data',
@@ -55,11 +54,10 @@ class HealthStatusView extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     SystemHealthState state,
-    HealthDimensionRegistry registry,
   ) {
     final evalContext = ref.read(healthEvaluationContextProvider);
 
-    final dimensions = registry.dimensions;
+    final dimensions = HealthDimensions.all;
     if (dimensions.isEmpty) {
       return AppText.bodyMedium('No dimensions', color: textColor);
     }

--- a/lib/page/dashboard/mascot/widgets/health_status_view.dart
+++ b/lib/page/dashboard/mascot/widgets/health_status_view.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/page/_shared/models/network_health_helpers.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import '../health/health_dimension.dart';
+import '../health/health_dimension_registry.dart';
+import '../health/health_score.dart';
+import '../health/system_health_provider.dart';
+
+/// Callback when a dimension is tapped.
+typedef OnDimensionTap = void Function(HealthDimensionType dimension);
+
+/// Health status view with problem-first display.
+///
+/// - When all healthy: Shows "All systems healthy" with summary
+/// - When issues exist: Highlights problems, collapses healthy items
+/// - Tap dimension to expand details
+class HealthStatusView extends ConsumerWidget {
+  final OnDimensionTap? onDimensionTap;
+  final Color textColor;
+
+  const HealthStatusView({
+    super.key,
+    this.onDimensionTap,
+    required this.textColor,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final healthState = ref.watch(systemHealthProvider);
+    final registry = ref.watch(healthDimensionRegistryProvider);
+
+    return healthState.when(
+      data: (state) => _buildStatusView(context, ref, state, registry),
+      loading: () => _buildLoading(),
+      error: (_, __) => AppText.bodyMedium(
+        'Unable to load health data',
+        color: textColor,
+      ),
+    );
+  }
+
+  Widget _buildLoading() {
+    return const Center(
+      child: SizedBox(
+        width: 24,
+        height: 24,
+        child: CircularProgressIndicator(strokeWidth: 2),
+      ),
+    );
+  }
+
+  Widget _buildStatusView(
+    BuildContext context,
+    WidgetRef ref,
+    SystemHealthState state,
+    HealthDimensionRegistry registry,
+  ) {
+    final evalContext = ref.read(healthEvaluationContextProvider);
+
+    final dimensions = registry.dimensions;
+    if (dimensions.isEmpty) {
+      return AppText.bodyMedium('No dimensions', color: textColor);
+    }
+
+    // Separate healthy from problematic
+    final problematic = <HealthDimension>[];
+    final healthy = <HealthDimension>[];
+
+    for (final dim in dimensions) {
+      final score = state[dim.type]?.score ?? 100;
+      if (score < 80) {
+        problematic.add(dim);
+      } else {
+        healthy.add(dim);
+      }
+    }
+
+    // Sort problematic by score (worst first)
+    problematic.sort((a, b) {
+      final scoreA = state[a.type]?.score ?? 100;
+      final scoreB = state[b.type]?.score ?? 100;
+      return scoreA.compareTo(scoreB);
+    });
+
+    if (problematic.isEmpty) {
+      return _buildAllHealthy(context, ref, healthy, state, evalContext);
+    }
+
+    return _buildWithIssues(
+        context, ref, problematic, healthy, state, evalContext);
+  }
+
+  Widget _buildAllHealthy(
+    BuildContext context,
+    WidgetRef ref,
+    List<HealthDimension> dimensions,
+    SystemHealthState state,
+    HealthEvaluationContext evalContext,
+  ) {
+    final cs = Theme.of(context).colorScheme;
+
+    // Build summary text
+    final summaryParts = <String>[];
+    for (final dim in dimensions) {
+      final summary = dim.getSummary(evalContext);
+      if (summary.items.isNotEmpty) {
+        final firstItem = summary.items.first;
+        summaryParts.add(firstItem.value);
+      }
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.check_circle, color: cs.primary, size: 20),
+            const SizedBox(width: 8),
+            Expanded(
+              child: AppText.titleSmall(
+                'All systems healthy',
+                color: textColor,
+              ),
+            ),
+          ],
+        ),
+        if (summaryParts.isNotEmpty) ...[
+          const SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.only(left: 28),
+            child: AppText.bodySmall(
+              summaryParts.take(3).join(' · '),
+              color: textColor.withValues(alpha: 0.7),
+            ),
+          ),
+        ],
+        const SizedBox(height: 8),
+        _buildHealthyChips(context, dimensions, state),
+      ],
+    );
+  }
+
+  Widget _buildWithIssues(
+    BuildContext context,
+    WidgetRef ref,
+    List<HealthDimension> problematic,
+    List<HealthDimension> healthy,
+    SystemHealthState state,
+    HealthEvaluationContext evalContext,
+  ) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Problematic items (expanded)
+        ...problematic.map((dim) => _buildProblemItem(
+              context,
+              dim,
+              state[dim.type],
+              dim.getSummary(evalContext),
+            )),
+
+        if (healthy.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          Divider(color: textColor.withValues(alpha: 0.2), height: 1),
+          const SizedBox(height: 8),
+          _buildHealthyChips(context, healthy, state),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildProblemItem(
+    BuildContext context,
+    HealthDimension dimension,
+    HealthScore? score,
+    DimensionSummary summary,
+  ) {
+    final cs = Theme.of(context).colorScheme;
+    final tier = score?.tier ?? HealthTier.excellent;
+    final tierColor = NetworkHealthHelpers.tierColor(tier, cs);
+    final icon = tier == HealthTier.critical || tier == HealthTier.poor
+        ? Icons.error
+        : Icons.warning;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: InkWell(
+        onTap: () => onDimensionTap?.call(dimension.type),
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+          child: Row(
+            children: [
+              Icon(icon, color: tierColor, size: 18),
+              const SizedBox(width: 8),
+              AppText.labelLarge(
+                dimension.displayName,
+                color: tierColor,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: AppText.bodySmall(
+                  summary.status,
+                  color: textColor.withValues(alpha: 0.8),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              Icon(
+                Icons.chevron_right,
+                color: textColor.withValues(alpha: 0.5),
+                size: 18,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHealthyChips(
+    BuildContext context,
+    List<HealthDimension> dimensions,
+    SystemHealthState state,
+  ) {
+    final cs = Theme.of(context).colorScheme;
+
+    return Wrap(
+      spacing: 6,
+      runSpacing: 4,
+      children: dimensions.map((dim) {
+        return InkWell(
+          onTap: () => onDimensionTap?.call(dim.type),
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: cs.primary.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.check_circle,
+                  size: 12,
+                  color: cs.primary,
+                ),
+                const SizedBox(width: 4),
+                AppText.labelSmall(
+                  dim.displayName,
+                  color: textColor.withValues(alpha: 0.8),
+                ),
+              ],
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/page/dashboard/mascot/widgets/mascot_toolbar.dart
+++ b/lib/page/dashboard/mascot/widgets/mascot_toolbar.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+/// Toolbar action types.
+enum MascotToolbarAction {
+  print,
+  themeStudio,
+  faq,
+  aiAssistant,
+}
+
+/// Callback when a toolbar action is tapped.
+typedef OnToolbarAction = void Function(MascotToolbarAction action);
+
+/// Compact toolbar for utility functions.
+///
+/// Displays icons for: Print, Theme Studio (optional), FAQ, AI Assistant
+class MascotToolbar extends StatelessWidget {
+  final OnToolbarAction? onAction;
+  final bool showThemeStudio;
+  final Color iconColor;
+
+  const MascotToolbar({
+    super.key,
+    this.onAction,
+    this.showThemeStudio = false,
+    required this.iconColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      decoration: BoxDecoration(
+        border: Border(
+          top: BorderSide(
+            color: iconColor.withValues(alpha: 0.2),
+            width: 1,
+          ),
+        ),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          _ToolbarButton(
+            icon: Icons.print,
+            tooltip: 'Print Report',
+            color: iconColor,
+            onTap: () => onAction?.call(MascotToolbarAction.print),
+          ),
+          if (showThemeStudio)
+            _ToolbarButton(
+              icon: Icons.palette,
+              tooltip: 'Theme Studio',
+              color: iconColor,
+              onTap: () => onAction?.call(MascotToolbarAction.themeStudio),
+            ),
+          _ToolbarButton(
+            icon: Icons.help_outline,
+            tooltip: 'FAQ',
+            color: iconColor,
+            onTap: () => onAction?.call(MascotToolbarAction.faq),
+          ),
+          _ToolbarButton(
+            icon: Icons.auto_awesome,
+            tooltip: 'AI Assistant',
+            color: iconColor,
+            onTap: () => onAction?.call(MascotToolbarAction.aiAssistant),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ToolbarButton extends StatelessWidget {
+  final IconData icon;
+  final String tooltip;
+  final Color color;
+  final VoidCallback? onTap;
+
+  const _ToolbarButton({
+    required this.icon,
+    required this.tooltip,
+    required this.color,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: Icon(
+            icon,
+            size: 24,
+            color: color,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/page/shell/usp_dashboard_shell.dart
+++ b/lib/page/shell/usp_dashboard_shell.dart
@@ -22,7 +22,7 @@ import 'package:privacy_gui/page/dashboard/mascot/mascot_providers.dart'
     show
         mascotControllerProvider,
         mascotCoordinatorProvider,
-        mascotDialogProvider;
+        mascotHealthDialogProvider;
 import 'package:privacy_gui/page/dashboard/providers/dashboard_domain_ready_provider.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
@@ -118,7 +118,8 @@ class _UspDashboardShellState extends ConsumerState<UspDashboardShell> {
         ref.watch(appSettingsProvider.select((s) => s.showMascot));
     final isDashboardReady = ref.watch(dashboardDomainReadyProvider).hasValue;
     final mascotController = ref.watch(mascotControllerProvider);
-    final dialogProvider = ref.watch(mascotDialogProvider(context));
+    final dialogProvider =
+        ref.watch(mascotHealthDialogProvider((context, ref)));
 
     // Activate mascot coordinator (manages random speech timer internally)
     ref.watch(mascotCoordinatorProvider);

--- a/lib/page/shell/usp_dashboard_shell.dart
+++ b/lib/page/shell/usp_dashboard_shell.dart
@@ -18,11 +18,14 @@ import 'package:privacy_gui/core/usp/providers/sse_providers.dart';
 import 'package:privacy_gui/page/_shared/components/sse_connection_banner.dart';
 import 'package:privacy_gui/page/_shared/providers/usp_bars_visible_provider.dart';
 import 'package:privacy_gui/page/dashboard/mascot/linksys_mascot_renderer.dart';
+import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/page/dashboard/mascot/mascot_providers.dart'
     show
+        HealthDialogProviderArgs,
         mascotControllerProvider,
         mascotCoordinatorProvider,
-        mascotHealthDialogProvider;
+        mascotHealthDialogProvider,
+        openAiAssistantWithTransition;
 import 'package:privacy_gui/page/dashboard/providers/dashboard_domain_ready_provider.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
@@ -118,8 +121,17 @@ class _UspDashboardShellState extends ConsumerState<UspDashboardShell> {
         ref.watch(appSettingsProvider.select((s) => s.showMascot));
     final isDashboardReady = ref.watch(dashboardDomainReadyProvider).hasValue;
     final mascotController = ref.watch(mascotControllerProvider);
-    final dialogProvider =
-        ref.watch(mascotHealthDialogProvider((context, ref)));
+    final dialogProvider = ref.watch(mascotHealthDialogProvider(
+      HealthDialogProviderArgs(
+        widgetRef: ref,
+        onNavigate: (routeName) {
+          if (context.mounted) context.push(routeName);
+        },
+        onOpenAiAssistant: () => openAiAssistantWithTransition(context),
+        getFaqCategoryTitle: (category) => category.displayString(context),
+        getFaqItemTitle: (item) => item.displayString(context),
+      ),
+    ));
 
     // Activate mascot coordinator (manages random speech timer internally)
     ref.watch(mascotCoordinatorProvider);

--- a/test/page/dashboard/mascot/health/dimensions/devices_dimension_test.dart
+++ b/test/page/dashboard/mascot/health/dimensions/devices_dimension_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
+import 'package:privacy_gui/page/_shared/models/device_ui_model.dart';
+import 'package:privacy_gui/page/dashboard/mascot/health/dimensions/devices_dimension.dart';
+import 'package:privacy_gui/page/dashboard/mascot/health/health_dimension.dart';
+import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
+
+void main() {
+  group('DevicesHealthDimension', () {
+    late DevicesHealthDimension dimension;
+
+    setUp(() {
+      dimension = DevicesHealthDimension();
+    });
+
+    DeviceUIModel createDevice({
+      required String mac,
+      required bool isActive,
+      String? deviceRole,
+    }) {
+      return DeviceUIModel(
+        mac: mac,
+        ip: '192.168.1.10',
+        hostName: 'device-$mac',
+        isActive: isActive,
+        isWifi: true,
+        deviceRole: deviceRole,
+      );
+    }
+
+    group('evaluate', () {
+      test('returns 100 when devices data is null', () {
+        const context = HealthEvaluationContext();
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 100);
+      });
+
+      test('returns 100 when no devices', () {
+        final context = HealthEvaluationContext(
+          devices: const DevicesData(deviceModels: []),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 100);
+      });
+
+      test('returns 100 when all devices online', () {
+        final context = HealthEvaluationContext(
+          devices: DevicesData(
+            deviceModels: [
+              createDevice(mac: 'AA:BB:CC:DD:EE:01', isActive: true),
+              createDevice(mac: 'AA:BB:CC:DD:EE:02', isActive: true),
+            ],
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 100);
+      });
+
+      test('returns 80 when > 80% online', () {
+        final context = HealthEvaluationContext(
+          devices: DevicesData(
+            deviceModels: [
+              createDevice(mac: 'AA:BB:CC:DD:EE:01', isActive: true),
+              createDevice(mac: 'AA:BB:CC:DD:EE:02', isActive: true),
+              createDevice(mac: 'AA:BB:CC:DD:EE:03', isActive: true),
+              createDevice(mac: 'AA:BB:CC:DD:EE:04', isActive: true),
+              createDevice(mac: 'AA:BB:CC:DD:EE:05', isActive: false), // 80%
+            ],
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 80);
+      });
+
+      test('returns 60 when > 50% online', () {
+        final context = HealthEvaluationContext(
+          devices: DevicesData(
+            deviceModels: [
+              createDevice(mac: 'AA:BB:CC:DD:EE:01', isActive: true),
+              createDevice(mac: 'AA:BB:CC:DD:EE:02', isActive: true),
+              createDevice(mac: 'AA:BB:CC:DD:EE:03', isActive: false),
+              createDevice(mac: 'AA:BB:CC:DD:EE:04', isActive: false), // 50%
+            ],
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 60);
+      });
+
+      test('excludes mesh nodes from client count', () {
+        final context = HealthEvaluationContext(
+          devices: DevicesData(
+            deviceModels: [
+              createDevice(mac: 'AA:BB:CC:DD:EE:01', isActive: true),
+              createDevice(
+                  mac: 'AA:BB:CC:DD:EE:02',
+                  isActive: true,
+                  deviceRole: 'master'),
+              createDevice(
+                  mac: 'AA:BB:CC:DD:EE:03',
+                  isActive: true,
+                  deviceRole: 'slave'),
+            ],
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 100); // Only 1 client device, 100% online
+      });
+    });
+
+    group('getSummary', () {
+      test('returns All Online when all devices active', () {
+        final context = HealthEvaluationContext(
+          devices: DevicesData(
+            deviceModels: [
+              createDevice(mac: 'AA:BB:CC:DD:EE:01', isActive: true),
+              createDevice(mac: 'AA:BB:CC:DD:EE:02', isActive: true),
+            ],
+          ),
+        );
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'All Online');
+        expect(summary.items.any((i) => i.label == 'Connected'), true);
+      });
+
+      test('returns No devices when empty', () {
+        final context = HealthEvaluationContext(
+          devices: const DevicesData(deviceModels: []),
+        );
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'No devices');
+      });
+    });
+
+    group('watchedDomains', () {
+      test('watches device-related domains', () {
+        expect(dimension.watchedDomains,
+            contains(InvalidationDomain.connectedDevices));
+        expect(
+            dimension.watchedDomains, contains(InvalidationDomain.wifiClients));
+      });
+    });
+
+    group('getActions', () {
+      testWidgets('returns view devices action', (tester) async {
+        await tester.pumpWidget(const SizedBox());
+        final context = tester.element(find.byType(SizedBox));
+
+        final actions = dimension.getActions(context);
+
+        expect(actions.any((a) => a.id == 'view_devices'), true);
+      });
+    });
+  });
+}

--- a/test/page/dashboard/mascot/health/dimensions/firmware_dimension_test.dart
+++ b/test/page/dashboard/mascot/health/dimensions/firmware_dimension_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/firmware_update/models/firmware_image_ui_model.dart';
+import 'package:privacy_gui/page/dashboard/mascot/health/dimensions/firmware_dimension.dart';
+import 'package:privacy_gui/page/dashboard/mascot/health/health_dimension.dart';
+import 'package:privacy_gui/page/firmware_update/providers/firmware_banks_data_provider.dart';
+
+void main() {
+  group('FirmwareHealthDimension', () {
+    late FirmwareHealthDimension dimension;
+
+    setUp(() {
+      dimension = FirmwareHealthDimension();
+    });
+
+    FirmwareImageUIModel createBank({
+      required String version,
+      required bool isActive,
+      required bool available,
+    }) {
+      return FirmwareImageUIModel(
+        instance: 1,
+        instancePath: 'Device.DeviceInfo.FirmwareImage.1',
+        name: 'Bank 1',
+        version: version,
+        status: isActive ? 'Active' : 'Valid',
+        available: available,
+        isBootTarget: isActive,
+      );
+    }
+
+    group('evaluate', () {
+      test('returns 100 when firmware data is null', () {
+        const context = HealthEvaluationContext();
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 100);
+      });
+
+      test('returns 100 when no update available', () {
+        final context = HealthEvaluationContext(
+          firmware: FirmwareBanksData(
+            banks: [
+              createBank(version: '1.0.0', isActive: true, available: true),
+            ],
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 100);
+      });
+
+      test('returns 60 when update available', () {
+        final context = HealthEvaluationContext(
+          firmware: FirmwareBanksData(
+            banks: [
+              createBank(version: '1.0.0', isActive: true, available: true),
+              createBank(version: '1.1.0', isActive: false, available: true),
+            ],
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 60);
+      });
+    });
+
+    group('getSummary', () {
+      test('returns Up to Date when no update available', () {
+        final context = HealthEvaluationContext(
+          firmware: FirmwareBanksData(
+            banks: [
+              createBank(version: '1.0.0', isActive: true, available: true),
+            ],
+          ),
+        );
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'Up to Date');
+        expect(summary.items.any((i) => i.label == 'Current'), true);
+      });
+
+      test('returns Update Available when update exists', () {
+        final context = HealthEvaluationContext(
+          firmware: FirmwareBanksData(
+            banks: [
+              createBank(version: '1.0.0', isActive: true, available: true),
+              createBank(version: '1.1.0', isActive: false, available: true),
+            ],
+          ),
+        );
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'Update Available');
+        expect(summary.items.any((i) => i.label == 'Available'), true);
+      });
+    });
+
+    group('watchedDomains', () {
+      test('has no SSE domains (polls only)', () {
+        expect(dimension.watchedDomains, isEmpty);
+      });
+    });
+
+    group('getActions', () {
+      testWidgets('returns firmware update action', (tester) async {
+        await tester.pumpWidget(const SizedBox());
+        final context = tester.element(find.byType(SizedBox));
+
+        final actions = dimension.getActions(context);
+
+        expect(actions.any((a) => a.id == 'firmware_update'), true);
+      });
+    });
+  });
+}

--- a/test/page/dashboard/mascot/health/dimensions/internet_dimension_test.dart
+++ b/test/page/dashboard/mascot/health/dimensions/internet_dimension_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
+import 'package:privacy_gui/page/_shared/models/wan_status_ui_model.dart';
+import 'package:privacy_gui/page/dashboard/mascot/health/dimensions/internet_dimension.dart';
+import 'package:privacy_gui/page/dashboard/mascot/health/health_dimension.dart';
+import 'package:privacy_gui/page/internet_settings/providers/wan_data_provider.dart';
+
+void main() {
+  group('InternetHealthDimension', () {
+    late InternetHealthDimension dimension;
+
+    setUp(() {
+      dimension = InternetHealthDimension();
+    });
+
+    group('evaluate', () {
+      test('returns 100 when wan data is null (assume healthy)', () {
+        const context = HealthEvaluationContext();
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 100);
+      });
+
+      test('returns 100 when WAN is up', () {
+        final context = HealthEvaluationContext(
+          wan: WanData(
+            model: const WanStatusUIModel(
+              isUp: true,
+              ipAddress: '192.168.1.100',
+              subnetMask: '255.255.255.0',
+              addressingType: 'DHCP',
+              mtu: 1500,
+              gateway: '192.168.1.1',
+            ),
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 100);
+      });
+
+      test('returns 0 when WAN is down', () {
+        final context = HealthEvaluationContext(
+          wan: WanData(
+            model: const WanStatusUIModel(
+              isUp: false,
+              ipAddress: '',
+              subnetMask: '',
+              addressingType: '',
+              mtu: 0,
+            ),
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 0);
+      });
+    });
+
+    group('getSummary', () {
+      test('returns loading state when wan data is null', () {
+        const context = HealthEvaluationContext();
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'Loading...');
+        expect(summary.hint, 'Tap for actions');
+      });
+
+      test('returns Connected status when WAN is up', () {
+        final context = HealthEvaluationContext(
+          wan: WanData(
+            model: const WanStatusUIModel(
+              isUp: true,
+              ipAddress: '192.168.1.100',
+              subnetMask: '255.255.255.0',
+              addressingType: 'DHCP',
+              mtu: 1500,
+              gateway: '192.168.1.1',
+            ),
+          ),
+        );
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'Connected');
+        expect(summary.items.any((i) => i.label == 'IP'), true);
+        expect(summary.items.firstWhere((i) => i.label == 'IP').value,
+            '192.168.1.100');
+      });
+
+      test('returns Disconnected status when WAN is down', () {
+        final context = HealthEvaluationContext(
+          wan: WanData(
+            model: const WanStatusUIModel(
+              isUp: false,
+              ipAddress: '',
+              subnetMask: '',
+              addressingType: '',
+              mtu: 0,
+            ),
+          ),
+        );
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'Disconnected');
+      });
+    });
+
+    group('watchedDomains', () {
+      test('watches wanStatus domain', () {
+        expect(
+            dimension.watchedDomains, contains(InvalidationDomain.wanStatus));
+      });
+    });
+
+    group('getActions', () {
+      testWidgets('returns diagnose and settings actions', (tester) async {
+        await tester.pumpWidget(const SizedBox());
+        final context = tester.element(find.byType(SizedBox));
+
+        final actions = dimension.getActions(context);
+
+        expect(actions.length, 2);
+        expect(actions.any((a) => a.id == 'diagnose_internet'), true);
+        expect(actions.any((a) => a.id == 'internet_settings'), true);
+      });
+    });
+  });
+}

--- a/test/page/dashboard/mascot/health/dimensions/security_dimension_test.dart
+++ b/test/page/dashboard/mascot/health/dimensions/security_dimension_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
+import 'package:privacy_gui/page/dashboard/mascot/health/dimensions/security_dimension.dart';
+import 'package:privacy_gui/page/dashboard/mascot/health/health_dimension.dart';
+import 'package:privacy_gui/page/dmz/models/dmz_ui_model.dart';
+import 'package:privacy_gui/page/firewall/models/firewall_ui_model.dart';
+import 'package:privacy_gui/page/firewall/providers/firewall_data_provider.dart';
+import 'package:privacy_gui/page/firewall/services/usp_firewall_service.dart';
+
+void main() {
+  group('SecurityHealthDimension', () {
+    late SecurityHealthDimension dimension;
+
+    setUp(() {
+      dimension = SecurityHealthDimension();
+    });
+
+    FirewallData createFirewallData({
+      bool ipv4 = true,
+      bool ipv6 = true,
+      bool dmzEnabled = false,
+    }) {
+      return FirewallData(
+        firewallModel: FirewallUIModel(
+          isIPv4FirewallEnabled: ipv4,
+          isIPv6FirewallEnabled: ipv6,
+        ),
+        ruleContext: FirewallRuleContext.empty,
+        ruleSummaries: const [],
+        dmzModel: DmzUIModel(
+          isEnabled: dmzEnabled,
+          destIp: '',
+          sourceType: DmzSourceType.any,
+          sourcePrefix: '',
+        ),
+        dmzSummaries: const [],
+      );
+    }
+
+    group('evaluate', () {
+      test('returns 100 when firewall data is null', () {
+        const context = HealthEvaluationContext();
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 100);
+      });
+
+      test('returns 100 when both firewalls on and DMZ off', () {
+        final context = HealthEvaluationContext(
+          firewall:
+              createFirewallData(ipv4: true, ipv6: true, dmzEnabled: false),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 100);
+      });
+
+      test('returns 80 when IPv4 only and DMZ off', () {
+        final context = HealthEvaluationContext(
+          firewall:
+              createFirewallData(ipv4: true, ipv6: false, dmzEnabled: false),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 80);
+      });
+
+      test('returns 50 when firewall on but DMZ enabled', () {
+        final context = HealthEvaluationContext(
+          firewall:
+              createFirewallData(ipv4: true, ipv6: true, dmzEnabled: true),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 50);
+      });
+
+      test('returns 30 when IPv4 firewall off', () {
+        final context = HealthEvaluationContext(
+          firewall:
+              createFirewallData(ipv4: false, ipv6: true, dmzEnabled: false),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 30);
+      });
+    });
+
+    group('getSummary', () {
+      test('returns Protected when fully secured', () {
+        final context = HealthEvaluationContext(
+          firewall:
+              createFirewallData(ipv4: true, ipv6: true, dmzEnabled: false),
+        );
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'Protected');
+      });
+
+      test('returns At Risk when firewall off', () {
+        final context = HealthEvaluationContext(
+          firewall: createFirewallData(ipv4: false),
+        );
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'At Risk');
+      });
+
+      test('returns DMZ Active when DMZ enabled', () {
+        final context = HealthEvaluationContext(
+          firewall: createFirewallData(ipv4: true, dmzEnabled: true),
+        );
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'DMZ Active');
+      });
+    });
+
+    group('watchedDomains', () {
+      test('watches firewall and DMZ domains', () {
+        expect(dimension.watchedDomains,
+            contains(InvalidationDomain.firewallRules));
+        expect(dimension.watchedDomains, contains(InvalidationDomain.dmz));
+      });
+    });
+
+    group('getActions', () {
+      testWidgets('returns firewall and DMZ actions', (tester) async {
+        await tester.pumpWidget(const SizedBox());
+        final context = tester.element(find.byType(SizedBox));
+
+        final actions = dimension.getActions(context);
+
+        expect(actions.any((a) => a.id == 'firewall_settings'), true);
+        expect(actions.any((a) => a.id == 'dmz_settings'), true);
+      });
+    });
+  });
+}

--- a/test/page/dashboard/mascot/health/dimensions/system_dimension_test.dart
+++ b/test/page/dashboard/mascot/health/dimensions/system_dimension_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/_shared/models/system_info_ui_model.dart';
+import 'package:privacy_gui/page/admin/providers/system_info_data_provider.dart';
+import 'package:privacy_gui/page/dashboard/mascot/health/dimensions/system_dimension.dart';
+import 'package:privacy_gui/page/dashboard/mascot/health/health_dimension.dart';
+
+void main() {
+  group('SystemHealthDimension', () {
+    late SystemHealthDimension dimension;
+
+    setUp(() {
+      dimension = SystemHealthDimension();
+    });
+
+    SystemInfoData createSystemInfo({
+      int cpuUsage = 30,
+      int totalMemory = 512000,
+      int freeMemory = 256000,
+    }) {
+      return SystemInfoData(
+        model: SystemInfoUIModel(
+          manufacturer: 'Linksys',
+          modelName: 'MR7350',
+          serialNumber: '123456',
+          hardwareVersion: '1.0',
+          softwareVersion: '1.0.0',
+          uptime: 86400,
+          totalMemory: totalMemory,
+          freeMemory: freeMemory,
+          cpuUsage: cpuUsage,
+        ),
+      );
+    }
+
+    group('evaluate', () {
+      test('returns 100 when systemInfo is null (assume healthy)', () {
+        const context = HealthEvaluationContext();
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 100);
+      });
+
+      test('returns 100 when CPU and memory are low (< 50%)', () {
+        final context = HealthEvaluationContext(
+          systemInfo: createSystemInfo(
+            cpuUsage: 30,
+            totalMemory: 512000,
+            freeMemory: 307200, // 40% used
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 100);
+      });
+
+      test('returns 80 when max usage is between 50-70%', () {
+        final context = HealthEvaluationContext(
+          systemInfo: createSystemInfo(
+            cpuUsage: 65,
+            totalMemory: 512000,
+            freeMemory: 256000, // 50% used
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 80);
+      });
+
+      test('returns 60 when max usage is between 70-85%', () {
+        final context = HealthEvaluationContext(
+          systemInfo: createSystemInfo(
+            cpuUsage: 80,
+            totalMemory: 512000,
+            freeMemory: 256000,
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 60);
+      });
+
+      test('returns 40 when max usage is between 85-95%', () {
+        final context = HealthEvaluationContext(
+          systemInfo: createSystemInfo(
+            cpuUsage: 90,
+            totalMemory: 512000,
+            freeMemory: 256000,
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 40);
+      });
+
+      test('returns 20 when max usage is >= 95%', () {
+        final context = HealthEvaluationContext(
+          systemInfo: createSystemInfo(
+            cpuUsage: 98,
+            totalMemory: 512000,
+            freeMemory: 256000,
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 20);
+      });
+
+      test('uses memory percent when higher than CPU', () {
+        final context = HealthEvaluationContext(
+          systemInfo: createSystemInfo(
+            cpuUsage: 30,
+            totalMemory: 512000,
+            freeMemory: 25600, // 95% used
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 20); // Based on memory, not CPU
+      });
+    });
+
+    group('getSummary', () {
+      test('returns loading state when systemInfo is null', () {
+        const context = HealthEvaluationContext();
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'Loading...');
+      });
+
+      test('returns Healthy status when usage is low', () {
+        final context = HealthEvaluationContext(
+          systemInfo: createSystemInfo(
+            cpuUsage: 30,
+            totalMemory: 512000,
+            freeMemory: 307200, // 40% used, max(30, 40) = 40 < 50
+          ),
+        );
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'Healthy');
+        expect(summary.items.any((i) => i.label == 'CPU'), true);
+        expect(summary.items.any((i) => i.label == 'Memory'), true);
+      });
+
+      test('returns High Load status when usage is high', () {
+        final context = HealthEvaluationContext(
+          systemInfo: createSystemInfo(cpuUsage: 90),
+        );
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'High Load');
+      });
+    });
+
+    group('watchedDomains', () {
+      test('has no SSE domains (polls only)', () {
+        expect(dimension.watchedDomains, isEmpty);
+      });
+    });
+
+    group('getActions', () {
+      testWidgets('returns reboot and system info actions', (tester) async {
+        await tester.pumpWidget(const SizedBox());
+        final context = tester.element(find.byType(SizedBox));
+
+        final actions = dimension.getActions(context);
+
+        expect(actions.length, 2);
+        expect(actions.any((a) => a.id == 'reboot_router'), true);
+        expect(actions.any((a) => a.id == 'system_info'), true);
+      });
+    });
+  });
+}

--- a/test/page/dashboard/mascot/health/dimensions/wifi_dimension_test.dart
+++ b/test/page/dashboard/mascot/health/dimensions/wifi_dimension_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
+import 'package:privacy_gui/page/_shared/models/wifi_radio_ui_model.dart';
+import 'package:privacy_gui/page/dashboard/mascot/health/dimensions/wifi_dimension.dart';
+import 'package:privacy_gui/page/dashboard/mascot/health/health_dimension.dart';
+import 'package:privacy_gui/page/wifi_settings/providers/wifi_data_provider.dart';
+
+void main() {
+  group('WifiHealthDimension', () {
+    late WifiHealthDimension dimension;
+
+    setUp(() {
+      dimension = WifiHealthDimension();
+    });
+
+    WifiRadioUIModel createRadio({
+      required String band,
+      required bool enable,
+    }) {
+      return WifiRadioUIModel(
+        instancePath: 'Device.WiFi.Radio.1',
+        band: band,
+        enable: enable,
+        transmitPower: 100,
+        maxBitRate: 1200,
+        channel: 6,
+        autoChannelEnable: true,
+        channelBandwidth: '20MHz',
+        supportedStandards: '802.11ax',
+      );
+    }
+
+    group('evaluate', () {
+      test('returns 100 when wifi data is null', () {
+        const context = HealthEvaluationContext();
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 100);
+      });
+
+      test('returns 100 when all radios are enabled', () {
+        final context = HealthEvaluationContext(
+          wifi: WifiData(
+            codegenContext: WifiCodegenContext.empty,
+            radioModels: [
+              createRadio(band: '2.4GHz', enable: true),
+              createRadio(band: '5GHz', enable: true),
+            ],
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 100);
+      });
+
+      test('returns 70 when some radios are disabled', () {
+        final context = HealthEvaluationContext(
+          wifi: WifiData(
+            codegenContext: WifiCodegenContext.empty,
+            radioModels: [
+              createRadio(band: '2.4GHz', enable: true),
+              createRadio(band: '5GHz', enable: false),
+            ],
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 70);
+      });
+
+      test('returns 30 when all radios are disabled', () {
+        final context = HealthEvaluationContext(
+          wifi: WifiData(
+            codegenContext: WifiCodegenContext.empty,
+            radioModels: [
+              createRadio(band: '2.4GHz', enable: false),
+              createRadio(band: '5GHz', enable: false),
+            ],
+          ),
+        );
+
+        final score = dimension.evaluate(context);
+
+        expect(score, 30);
+      });
+    });
+
+    group('getSummary', () {
+      test('returns All Active when all radios enabled', () {
+        final context = HealthEvaluationContext(
+          wifi: WifiData(
+            codegenContext: WifiCodegenContext.empty,
+            radioModels: [
+              createRadio(band: '2.4GHz', enable: true),
+              createRadio(band: '5GHz', enable: true),
+            ],
+          ),
+        );
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'All Active');
+        expect(summary.items.any((i) => i.label == 'Radios'), true);
+      });
+
+      test('returns All Disabled when no radios enabled', () {
+        final context = HealthEvaluationContext(
+          wifi: WifiData(
+            codegenContext: WifiCodegenContext.empty,
+            radioModels: [
+              createRadio(band: '2.4GHz', enable: false),
+            ],
+          ),
+        );
+
+        final summary = dimension.getSummary(context);
+
+        expect(summary.status, 'All Disabled');
+      });
+    });
+
+    group('watchedDomains', () {
+      test('watches wifi-related domains', () {
+        expect(
+            dimension.watchedDomains, contains(InvalidationDomain.wifiRadios));
+        expect(
+            dimension.watchedDomains, contains(InvalidationDomain.wifiSsids));
+      });
+    });
+
+    group('getActions', () {
+      testWidgets('returns wifi settings action', (tester) async {
+        await tester.pumpWidget(const SizedBox());
+        final context = tester.element(find.byType(SizedBox));
+
+        final actions = dimension.getActions(context);
+
+        expect(actions.any((a) => a.id == 'wifi_settings'), true);
+      });
+    });
+  });
+}

--- a/test/page/dashboard/mascot/triggers/mascot_trigger_test.dart
+++ b/test/page/dashboard/mascot/triggers/mascot_trigger_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/dashboard/mascot/triggers/mascot_trigger.dart';
+
+void main() {
+  group('MascotTrigger', () {
+    test('creates with required fields', () {
+      const trigger = MascotTrigger(
+        id: 'test_trigger',
+        message: 'Test message',
+      );
+
+      expect(trigger.id, 'test_trigger');
+      expect(trigger.message, 'Test message');
+      expect(trigger.priority, TriggerPriority.medium);
+      expect(trigger.cooldown, const Duration(minutes: 5));
+      expect(trigger.interruptCurrent, false);
+    });
+
+    test('creates with custom priority', () {
+      const trigger = MascotTrigger(
+        id: 'critical_trigger',
+        message: 'Critical!',
+        priority: TriggerPriority.critical,
+        interruptCurrent: true,
+      );
+
+      expect(trigger.priority, TriggerPriority.critical);
+      expect(trigger.interruptCurrent, true);
+    });
+
+    test('equality based on props', () {
+      const trigger1 = MascotTrigger(id: 'test', message: 'Hello');
+      const trigger2 = MascotTrigger(id: 'test', message: 'Hello');
+      const trigger3 = MascotTrigger(id: 'other', message: 'Hello');
+
+      expect(trigger1, trigger2);
+      expect(trigger1, isNot(trigger3));
+    });
+  });
+
+  group('TriggerCooldownState', () {
+    test('initially not in cooldown', () {
+      final cooldown = TriggerCooldownState();
+      const trigger = MascotTrigger(id: 'test', message: 'Test');
+
+      expect(cooldown.isInCooldown(trigger), false);
+    });
+
+    test('enters cooldown after recording', () {
+      final cooldown = TriggerCooldownState();
+      const trigger = MascotTrigger(
+        id: 'test',
+        message: 'Test',
+        cooldown: Duration(minutes: 5),
+      );
+
+      cooldown.recordTrigger(trigger);
+      expect(cooldown.isInCooldown(trigger), true);
+    });
+
+    test('different triggers have independent cooldowns', () {
+      final cooldown = TriggerCooldownState();
+      const trigger1 = MascotTrigger(id: 'test1', message: 'Test 1');
+      const trigger2 = MascotTrigger(id: 'test2', message: 'Test 2');
+
+      cooldown.recordTrigger(trigger1);
+
+      expect(cooldown.isInCooldown(trigger1), true);
+      expect(cooldown.isInCooldown(trigger2), false);
+    });
+
+    test('clearCooldown removes specific trigger', () {
+      final cooldown = TriggerCooldownState();
+      const trigger = MascotTrigger(id: 'test', message: 'Test');
+
+      cooldown.recordTrigger(trigger);
+      expect(cooldown.isInCooldown(trigger), true);
+
+      cooldown.clearCooldown('test');
+      expect(cooldown.isInCooldown(trigger), false);
+    });
+
+    test('clearAll removes all cooldowns', () {
+      final cooldown = TriggerCooldownState();
+      const trigger1 = MascotTrigger(id: 'test1', message: 'Test 1');
+      const trigger2 = MascotTrigger(id: 'test2', message: 'Test 2');
+
+      cooldown.recordTrigger(trigger1);
+      cooldown.recordTrigger(trigger2);
+
+      cooldown.clearAll();
+
+      expect(cooldown.isInCooldown(trigger1), false);
+      expect(cooldown.isInCooldown(trigger2), false);
+    });
+
+    test('cooldown expires after duration', () async {
+      final cooldown = TriggerCooldownState();
+      const trigger = MascotTrigger(
+        id: 'test',
+        message: 'Test',
+        cooldown: Duration(milliseconds: 50),
+      );
+
+      cooldown.recordTrigger(trigger);
+      expect(cooldown.isInCooldown(trigger), true);
+
+      await Future.delayed(const Duration(milliseconds: 60));
+      expect(cooldown.isInCooldown(trigger), false);
+    });
+  });
+
+  group('TriggerPriority', () {
+    test('priority ordering', () {
+      expect(TriggerPriority.critical, lessThan(TriggerPriority.high));
+      expect(TriggerPriority.high, lessThan(TriggerPriority.medium));
+      expect(TriggerPriority.medium, lessThan(TriggerPriority.low));
+    });
+  });
+}

--- a/test/page/dashboard/mascot/triggers/trigger_definitions_test.dart
+++ b/test/page/dashboard/mascot/triggers/trigger_definitions_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/core/usp/models/invalidation_domain.dart';
+import 'package:privacy_gui/page/dashboard/mascot/triggers/mascot_trigger.dart';
+import 'package:privacy_gui/page/dashboard/mascot/triggers/trigger_definitions.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+void main() {
+  group('TriggerDefinitions', () {
+    test('wanDown creates critical priority trigger', () {
+      final trigger = TriggerDefinitions.wanDown();
+
+      expect(trigger.id, 'wan_down');
+      expect(trigger.priority, TriggerPriority.critical);
+      expect(trigger.interruptCurrent, true);
+      expect(trigger.animation, MascotAnimationKey.sad);
+    });
+
+    test('wanRestored creates high priority trigger', () {
+      final trigger = TriggerDefinitions.wanRestored();
+
+      expect(trigger.id, 'wan_restored');
+      expect(trigger.priority, TriggerPriority.high);
+      expect(trigger.interruptCurrent, false);
+      expect(trigger.animation, MascotAnimationKey.celebrate);
+    });
+
+    test('newDeviceJoined includes device name', () {
+      final trigger = TriggerDefinitions.newDeviceJoined('iPhone');
+
+      expect(trigger.id, 'new_device_joined');
+      expect(trigger.message, contains('iPhone'));
+      expect(trigger.priority, TriggerPriority.medium);
+    });
+
+    test('cpuHigh includes percentage', () {
+      final trigger = TriggerDefinitions.cpuHigh(95);
+
+      expect(trigger.id, 'cpu_high');
+      expect(trigger.message, contains('95%'));
+      expect(trigger.priority, TriggerPriority.high);
+    });
+
+    test('memoryHigh includes percentage', () {
+      final trigger = TriggerDefinitions.memoryHigh(90);
+
+      expect(trigger.id, 'memory_high');
+      expect(trigger.message, contains('90%'));
+    });
+
+    test('firmwareAvailable includes version', () {
+      final trigger = TriggerDefinitions.firmwareAvailable('1.0.17');
+
+      expect(trigger.id, 'firmware_available');
+      expect(trigger.message, contains('1.0.17'));
+      expect(trigger.priority, TriggerPriority.low);
+    });
+
+    test('wifiRadioDisabled includes band', () {
+      final trigger = TriggerDefinitions.wifiRadioDisabled('5GHz');
+
+      expect(trigger.id, 'wifi_radio_disabled_5GHz');
+      expect(trigger.message, contains('5GHz'));
+    });
+
+    test('firewallDisabled is high priority', () {
+      final trigger = TriggerDefinitions.firewallDisabled();
+
+      expect(trigger.id, 'firewall_disabled');
+      expect(trigger.priority, TriggerPriority.high);
+      expect(trigger.interruptCurrent, true);
+    });
+
+    test('dmzEnabled includes device name', () {
+      final trigger = TriggerDefinitions.dmzEnabled('Gaming PC');
+
+      expect(trigger.id, 'dmz_enabled');
+      expect(trigger.message, contains('Gaming PC'));
+      expect(trigger.priority, TriggerPriority.medium);
+    });
+  });
+
+  group('TriggerDomainMapping', () {
+    test('healthCriticalDomains contains expected domains', () {
+      expect(
+        TriggerDomainMapping.healthCriticalDomains,
+        contains(InvalidationDomain.wanStatus),
+      );
+      expect(
+        TriggerDomainMapping.healthCriticalDomains,
+        contains(InvalidationDomain.connectedDevices),
+      );
+      expect(
+        TriggerDomainMapping.healthCriticalDomains,
+        contains(InvalidationDomain.wifiRadios),
+      );
+    });
+
+    test('isHealthCritical returns true for critical domains', () {
+      expect(
+        TriggerDomainMapping.isHealthCritical(InvalidationDomain.wanStatus),
+        true,
+      );
+      expect(
+        TriggerDomainMapping.isHealthCritical(InvalidationDomain.dhcpClients),
+        false,
+      );
+    });
+
+    test('canTriggerNotification returns true for notification domains', () {
+      expect(
+        TriggerDomainMapping.canTriggerNotification(
+            InvalidationDomain.wanStatus),
+        true,
+      );
+      expect(
+        TriggerDomainMapping.canTriggerNotification(
+            InvalidationDomain.connectedDevices),
+        true,
+      );
+    });
+  });
+}

--- a/test/page/dashboard/mascot/widgets/mascot_toolbar_test.dart
+++ b/test/page/dashboard/mascot/widgets/mascot_toolbar_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/dashboard/mascot/widgets/mascot_toolbar.dart';
+
+void main() {
+  group('MascotToolbar', () {
+    testWidgets('renders all default buttons', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MascotToolbar(iconColor: Colors.black),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.print), findsOneWidget);
+      expect(find.byIcon(Icons.help_outline), findsOneWidget);
+      expect(find.byIcon(Icons.auto_awesome), findsOneWidget);
+      // Theme studio hidden by default
+      expect(find.byIcon(Icons.palette), findsNothing);
+    });
+
+    testWidgets('shows theme studio when enabled', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MascotToolbar(
+              iconColor: Colors.black,
+              showThemeStudio: true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.palette), findsOneWidget);
+    });
+
+    testWidgets('calls onAction when print tapped', (tester) async {
+      MascotToolbarAction? tappedAction;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MascotToolbar(
+              iconColor: Colors.black,
+              onAction: (action) => tappedAction = action,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.print));
+      await tester.pump();
+
+      expect(tappedAction, MascotToolbarAction.print);
+    });
+
+    testWidgets('calls onAction when FAQ tapped', (tester) async {
+      MascotToolbarAction? tappedAction;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MascotToolbar(
+              iconColor: Colors.black,
+              onAction: (action) => tappedAction = action,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.help_outline));
+      await tester.pump();
+
+      expect(tappedAction, MascotToolbarAction.faq);
+    });
+
+    testWidgets('calls onAction when AI Assistant tapped', (tester) async {
+      MascotToolbarAction? tappedAction;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MascotToolbar(
+              iconColor: Colors.black,
+              onAction: (action) => tappedAction = action,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.auto_awesome));
+      await tester.pump();
+
+      expect(tappedAction, MascotToolbarAction.aiAssistant);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add health dashboard UI with problem-first display replacing word cloud
- Enable icon support in NetworkBadgeWidget (closes #916)
- Fix demo mode to directly enter Dashboard for UI verification

## Changes

### Mascot Health System
- **HealthStatusView**: Problem-first display - issues highlighted at top, healthy items collapsed as chips
- **DimensionDetailView**: Expanded dimension details with actionable buttons (navigate, reboot)
- **healthEvaluationContextProvider**: DRY refactor eliminating 4x duplicate HealthEvaluationContext construction
- **MascotToolbar**: Compact toolbar for utility functions (print, FAQ, AI assistant)

### UI Kit Compliance
- Migrate all `Text` to `AppText` per constitution Article XV
- Add brand color comments for mascot hardcoded colors
- Enable `AppBadge.icon` parameter in `NetworkBadgeWidget`

### Code Quality
- Delete unused `health_word_cloud.dart`
- 2842 unit tests passing (99 mascot-specific tests)

## Test plan

- [ ] Run demo mode (`main_demo.dart`) and verify mascot dialog shows health status
- [ ] Click dimension to see detail view with action buttons
- [ ] Verify toolbar actions (print, FAQ, AI) work correctly
- [ ] Run `./run_tests.sh` - all 2842 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)