### PR TITLE
chore: bump version to 1.2.14

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.2.13+100000
+version: 1.2.14+100000
 
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Bump app version `1.2.13+100000` → `1.2.14+100000` in preparation for the 1.2.14 release.

## Notes
Version-only change. Prepares `dev-1.2.14` for the release branch / tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)