### PR TITLE
fix(internet-settings): use SET for VLAN tagging and enable PPPoE ServiceName

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,10 +11,9 @@
           },
           {
             "type": "command",
-            "if": "Bash(git commit *)",
-            "command": "staged=$(git diff --cached --name-only --diff-filter=ACM -- '*.dart'); if [ -n \"$staged\" ]; then if command -v fvm >/dev/null 2>&1; then echo \"$staged\" | xargs fvm dart format 2>/dev/null; else echo \"$staged\" | xargs dart format 2>/dev/null; fi; echo \"$staged\" | xargs git add; fi",
+            "command": "staged=$(git diff --cached --name-only --diff-filter=ACM -- '*.dart'); if [ -n \"$staged\" ]; then if command -v fvm >/dev/null 2>&1; then echo \"$staged\" | xargs fvm dart format; else echo \"$staged\" | xargs dart format; fi; echo \"$staged\" | xargs git add; fi",
             "timeout": 30,
-            "statusMessage": "Running dart format on staged files..."
+            "statusMessage": "Formatting staged Dart files..."
           }
         ]
       }

--- a/.claude/skills/review-pr-readiness/SKILL.md
+++ b/.claude/skills/review-pr-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-pr-readiness
-description: Review current branch changes for PR readiness. Checks code quality (dart format, flutter analyze), UI Kit library usage in Views, and test file coverage. Use before creating a Pull Request. Trigger keywords (English) - review pr, check pr, pr ready, pre-pr check, review before pr. Trigger keywords (Chinese) - 檢查 PR, PR 檢查, 準備 PR, PR 審查, 發 PR 前檢查.
+description: Review current branch changes for PR readiness. Checks code quality (dart format, flutter analyze), UI Kit library usage in Views, runs affected tests, and verifies test coverage. Use before creating a Pull Request. Trigger keywords (English) - review pr, check pr, pr ready, pre-pr check, review before pr. Trigger keywords (Chinese) - 檢查 PR, PR 檢查, 準備 PR, PR 審查, 發 PR 前檢查.
 ---
 
 # Pre-PR Readiness Review
@@ -251,6 +251,47 @@ If a source file was changed but its existing test file was NOT changed in this 
 - Severity: **INFO**
 - Suggestion: "Source `<name>.dart` was modified but its test was not updated. Verify tests still cover the changes."
 
+**Step 4.3: Run Affected Tests (MANDATORY)**
+
+This step is **not optional** — it MUST run before the gate stamp can be issued. Static checks cannot catch logic regressions (e.g., tests that verify behavior that was removed or changed).
+
+**Collect test files to run:**
+
+1. For each changed source file in `lib/`, find its **direct** test file:
+   - `lib/page/[feature]/services/[name].dart` → `test/page/[feature]/services/[name]_test.dart`
+   - `lib/page/[feature]/providers/[name].dart` → `test/page/[feature]/providers/[name]_test.dart`
+   - `lib/page/[feature]/models/[name].dart` → `test/page/[feature]/models/[name]_test.dart`
+
+2. For each changed source file, find **dependent** test files that import it:
+   ```bash
+   # Find tests that import the changed source file
+   grep -rl "import.*<changed_file_package_path>" test/ --include="*.dart"
+   ```
+
+3. Include any test files that were directly changed in the branch.
+
+4. Deduplicate the collected list.
+
+**Run the tests:**
+
+```bash
+flutter test <collected_test_files> 2>&1
+```
+
+- If ALL tests pass:
+  - Severity: **PASS**
+  - Report: "Affected tests: <count> files, <total_tests> tests passed"
+
+- If any tests FAIL:
+  - Severity: **ERROR** (blocks gate stamp)
+  - Report each failing test name and a one-line summary of the failure
+  - Suggestion: "Fix failing tests before creating PR. These tests verify behavior affected by your changes."
+
+**Important notes:**
+- If the collected test list is empty (no test files found for changed sources), report as INFO and move on
+- If `flutter test` times out (>5 minutes), report as WARNING with suggestion to run manually
+- This step catches the exact scenario where source behavior changed but tests still assert old behavior
+
 ### Phase 4.5: Golden Test Coverage (Only If View Files Changed)
 
 **IMPORTANT**: This phase only runs if View files (`lib/page/**/views/**/*.dart`) are changed or added.
@@ -361,6 +402,7 @@ Changed Dart files: <count>
 ### Test Coverage
 - [PASS/WARN] Test files: <summary>
 - [PASS/INFO] Test freshness: <summary>
+- [PASS/ERROR] Affected tests execution: <summary>
 
 ### Golden Test Coverage (if View files changed)
 - [PASS/WARN/SKIP] Golden test existence: <summary>
@@ -399,7 +441,7 @@ This stamp file is consumed by the `pr_gate.py` hook to allow `gh pr create` thr
 - **One-shot**: deleted after a single successful `gh pr create`
 - **Time-limited**: expires after 10 minutes
 
-Do NOT create the stamp if there are unresolved ERROR-level issues.
+Do NOT create the stamp if there are unresolved ERROR-level issues (including test failures from Step 4.3).
 
 ## Important Notes
 

--- a/lib/page/internet_settings/services/usp_internet_settings_service.dart
+++ b/lib/page/internet_settings/services/usp_internet_settings_service.dart
@@ -165,7 +165,7 @@ class UspInternetSettingsService {
         await _saveVlanSettings(original, edited, vlanInstancePath);
       }
 
-      // Step 6: IPv6 fields
+      // Step 5: IPv6 fields
       await _saveIpv6Settings(original, edited);
     } catch (e) {
       if (e is ServiceError) rethrow;
@@ -203,10 +203,6 @@ class UspInternetSettingsService {
 
     return currentInstancePath;
   }
-
-  // ---------------------------------------------------------------------------
-  // VLAN Lifecycle (DD-2: Match toggle — Add when enabling, Delete when disabling)
-  // ---------------------------------------------------------------------------
 
   // ---------------------------------------------------------------------------
   // WAN singleton save — DNS merge happens here
@@ -419,7 +415,6 @@ class UspInternetSettingsService {
     }
   }
 
-  /// Parse and validate DELETE result using standard UspResultParser (Strict mode).
   /// Parse and validate OPERATE result using standard UspResultParser (Strict mode).
   void _handleOperateResult(Map<String, dynamic> result) {
     final parsed = UspResultParser.parseOperateResult(result);

--- a/lib/page/internet_settings/services/usp_internet_settings_service.dart
+++ b/lib/page/internet_settings/services/usp_internet_settings_service.dart
@@ -146,20 +146,13 @@ class UspInternetSettingsService {
         currentInstancePath: pppInstancePath,
       );
 
-      // Step 2: VLAN lifecycle
-      final vlanPath = await _handleVlanLifecycle(
-        original,
-        edited,
-        currentInstancePath: vlanInstancePath,
-      );
-
-      // Step 3: WAN mode switch or field edit (per-mode dispatch)
+      // Step 2: WAN mode switch or field edit (per-mode dispatch)
       final typeChanged = original.connectionType != edited.connectionType;
       final switchingToPppoe =
           typeChanged && edited.connectionType == UspWanConnectionType.pppoe;
       await _saveWanSettings(original, edited);
 
-      // Step 4: PPP instance fields (skip username/password if already sent
+      // Step 3: PPP instance fields (skip username/password if already sent
       // in the ordered Set above)
       if (pppPath != null &&
           edited.connectionType == UspWanConnectionType.pppoe) {
@@ -167,9 +160,9 @@ class UspInternetSettingsService {
             skipCredentials: switchingToPppoe);
       }
 
-      // Step 5: VLAN instance fields
-      if (vlanPath != null && edited.vlanEnabled) {
-        await _saveVlanSettings(original, edited, vlanPath);
+      // Step 4: VLAN settings (always use SET on existing instance)
+      if (vlanInstancePath != null) {
+        await _saveVlanSettings(original, edited, vlanInstancePath);
       }
 
       // Step 6: IPv6 fields
@@ -214,43 +207,6 @@ class UspInternetSettingsService {
   // ---------------------------------------------------------------------------
   // VLAN Lifecycle (DD-2: Match toggle — Add when enabling, Delete when disabling)
   // ---------------------------------------------------------------------------
-
-  /// Returns the VLAN instance path to use for subsequent Set operations,
-  /// or null if no VLAN instance exists after this step.
-  Future<String?> _handleVlanLifecycle(
-    UspInternetSettingsForm original,
-    UspInternetSettingsForm edited, {
-    String? currentInstancePath,
-  }) async {
-    final wasEnabled = original.vlanEnabled;
-    final isEnabled = edited.vlanEnabled;
-
-    if (!wasEnabled && isEnabled && currentInstancePath == null) {
-      // Enabling VLAN and no instance exists — Add
-      logger.d('[USP][WAN]: Adding VLANTermination instance');
-      final result = await VlanTermination.add(_usp, [{}]);
-      // Extract instance path from structured response
-      final parsedResult = UspResultParser.parseAddResult(result);
-      if (parsedResult is UspSuccess<List<String>>) {
-        final createdInstances = parsedResult.allCreatedInstances;
-        if (createdInstances.isNotEmpty) {
-          return createdInstances.first.affectedPath;
-        }
-      }
-      return null;
-    } else if (wasEnabled && !isEnabled && currentInstancePath != null) {
-      // Disabling VLAN — Delete
-      logger.d(
-          '[USP][WAN]: Deleting VLANTermination instance $currentInstancePath');
-      final deleteResult =
-          await VlanTermination.delete(_usp, [currentInstancePath]);
-      _handleDeleteResult(deleteResult);
-      return null;
-    }
-
-    // No lifecycle change — return current path
-    return currentInstancePath;
-  }
 
   // ---------------------------------------------------------------------------
   // WAN singleton save — DNS merge happens here
@@ -347,9 +303,8 @@ class UspInternetSettingsService {
           password: skipCredentials
               ? null
               : _diff(original.pppPassword, edited.pppPassword),
-          // pppoeServiceName — disabled: bbfdm rejects SET (fault 9001)
-          // pppoeServiceName:
-          //     _diff(original.pppoeServiceName, edited.pppoeServiceName),
+          pppoeServiceName:
+              _diff(original.pppoeServiceName, edited.pppoeServiceName),
           connectionTrigger:
               _diff(original.connectionTrigger, edited.connectionTrigger),
           idleDisconnectTime:
@@ -465,29 +420,6 @@ class UspInternetSettingsService {
   }
 
   /// Parse and validate DELETE result using standard UspResultParser (Strict mode).
-  void _handleDeleteResult(Map<String, dynamic> result) {
-    final parsed = UspResultParser.parseDeleteResult(result);
-    switch (parsed) {
-      case UspSuccess():
-        break;
-      case UspPartialSuccess(
-          :final errorSummary,
-          :final successes,
-          :final failures
-        ):
-        throw UspPartialFailureError(
-          summary: 'WAN delete partial failure: $errorSummary',
-          successPaths: successes.map((s) => s.requestedPath).toList(),
-          failedPaths: failures.map((f) => f.requestedPath).toList(),
-        );
-      case UspFailure(:final errorSummary, :final errors):
-        throw UspCompleteFailureError(
-          summary: 'WAN delete failed: $errorSummary',
-          failedPaths: errors.map((e) => e.requestedPath).toList(),
-        );
-    }
-  }
-
   /// Parse and validate OPERATE result using standard UspResultParser (Strict mode).
   void _handleOperateResult(Map<String, dynamic> result) {
     final parsed = UspResultParser.parseOperateResult(result);

--- a/lib/page/internet_settings/views/sections/usp_ipv4_section.dart
+++ b/lib/page/internet_settings/views/sections/usp_ipv4_section.dart
@@ -39,7 +39,7 @@ class _UspIpv4SectionState extends ConsumerState<UspIpv4Section> {
   late TextEditingController _dns3Controller;
   late TextEditingController _pppUsernameController;
   late TextEditingController _pppPasswordController;
-  // late TextEditingController _pppServiceNameController;
+  late TextEditingController _pppServiceNameController;
   late TextEditingController _vlanIdController;
   late TextEditingController _idleTimeController;
 
@@ -59,8 +59,8 @@ class _UspIpv4SectionState extends ConsumerState<UspIpv4Section> {
     _dns3Controller = TextEditingController(text: form.dnsServer3);
     _pppUsernameController = TextEditingController(text: form.pppUsername);
     _pppPasswordController = TextEditingController(text: form.pppPassword);
-    // _pppServiceNameController =
-    //     TextEditingController(text: form.pppoeServiceName);
+    _pppServiceNameController =
+        TextEditingController(text: form.pppoeServiceName);
     _vlanIdController = TextEditingController(text: form.vlanId.toString());
     _idleTimeController =
         TextEditingController(text: form.idleDisconnectTime.toString());
@@ -84,7 +84,7 @@ class _UspIpv4SectionState extends ConsumerState<UspIpv4Section> {
     _syncIfDifferent(_dns3Controller, form.dnsServer3);
     _syncIfDifferent(_pppUsernameController, form.pppUsername);
     _syncIfDifferent(_pppPasswordController, form.pppPassword);
-    // _syncIfDifferent(_pppServiceNameController, form.pppoeServiceName);
+    _syncIfDifferent(_pppServiceNameController, form.pppoeServiceName);
     _syncIfDifferent(_vlanIdController, form.vlanId.toString());
     _syncIfDifferent(_idleTimeController, form.idleDisconnectTime.toString());
   }
@@ -105,7 +105,7 @@ class _UspIpv4SectionState extends ConsumerState<UspIpv4Section> {
     _dns3Controller.dispose();
     _pppUsernameController.dispose();
     _pppPasswordController.dispose();
-    // _pppServiceNameController.dispose();
+    _pppServiceNameController.dispose();
     _vlanIdController.dispose();
     _idleTimeController.dispose();
     super.dispose();
@@ -230,8 +230,7 @@ class _UspIpv4SectionState extends ConsumerState<UspIpv4Section> {
     if (!isEditing) {
       return [
         UspInfoRow(label: l.username, value: form.pppUsername),
-        // ServiceName — disabled: bbfdm rejects SET (fault 9001)
-        // UspInfoRow(label: l.serviceName, value: form.pppoeServiceName),
+        UspInfoRow(label: l.serviceName, value: form.pppoeServiceName),
         UspInfoRow(label: l.connectionMode, value: form.connectionTrigger),
         UspInfoRow(label: l.pppStatus, value: widget.state.pppConnectionStatus),
         if (form.vlanEnabled)
@@ -251,13 +250,12 @@ class _UspIpv4SectionState extends ConsumerState<UspIpv4Section> {
         obscureText: true,
         onChanged: (v) => _updateField((f) => f.copyWith(pppPassword: v)),
       ),
-      // ServiceName — disabled: bbfdm rejects SET (fault 9001)
-      // AppGap.md(),
-      // AppTextFormField(
-      //   controller: _pppServiceNameController,
-      //   label: l.serviceNameOptional,
-      //   onChanged: (v) => _updateField((f) => f.copyWith(pppoeServiceName: v)),
-      // ),
+      AppGap.md(),
+      AppTextFormField(
+        controller: _pppServiceNameController,
+        label: l.serviceNameOptional,
+        onChanged: (v) => _updateField((f) => f.copyWith(pppoeServiceName: v)),
+      ),
       AppGap.lg(),
       // Connection mode
       AppText.labelLarge(l.connectionMode),

--- a/test/page/instant_setup/services/pnp_service_test.dart
+++ b/test/page/instant_setup/services/pnp_service_test.dart
@@ -131,13 +131,6 @@ void main() {
         });
   }
 
-  void setupDeleteMock() {
-    when(() => mockUsp.delete(any())).thenAnswer((_) async => {
-          'success': true,
-          'result': {'data': <String, dynamic>{}},
-        });
-  }
-
   void setupOperateMock() {
     when(() => mockUsp.operate(any())).thenAnswer((_) async => {
           'success': true,
@@ -270,7 +263,7 @@ void main() {
     });
 
     test(
-        'PPPoE+VLAN → PPPoE: calls VlanTermination.delete to remove VLAN instance',
+        'PPPoE+VLAN → PPPoE: disables VLAN via SET Enable=false on existing instance',
         () async {
       // Start with PPPoE+VLAN enabled
       final wanPppoeResponse = Map<String, dynamic>.from(wanResponse);
@@ -300,9 +293,7 @@ void main() {
         return {};
       });
       setupSetMocks();
-      setupDeleteMock();
 
-      // PnpIspConfig with PPPoE (no VLAN) — this should trigger VLAN delete
       const config = PnpIspConfig(
         type: IspConnectionType.pppoe,
         pppUsername: 'existinguser',
@@ -313,22 +304,32 @@ void main() {
 
       await service.saveIspSettings(config);
 
-      // Verify fetchSettings was called
-      verify(() => mockUsp.get(any())).called(7);
+      // Verify SET was called with VLANTermination.Enable = false
+      final setCaptures = verify(() => mockUsp.set(captureAny())).captured;
+      final vlanSet = setCaptures.whereType<Map<String, dynamic>>().where(
+          (params) => params.keys.any((k) => k.contains('VLANTermination')));
+      expect(vlanSet, isNotEmpty);
+      expect(
+          vlanSet.first['Device.Ethernet.VLANTermination.1.Enable'], isFalse);
 
-      // Verify VlanTermination.delete was called
-      final deleteCaptures =
-          verify(() => mockUsp.delete(captureAny())).captured;
-      expect(deleteCaptures, isNotEmpty);
-      final deletePaths = deleteCaptures.first as List<String>;
-      expect(deletePaths, contains('Device.Ethernet.VLANTermination.1.'));
+      // Verify no DELETE was called
+      verifyNever(() => mockUsp.delete(any()));
     });
 
-    test('PPPoE+VLAN: creates VLAN instance when enabling VLAN', () async {
-      // Start with PPPoE (no VLAN)
+    test('PPPoE+VLAN: enables VLAN via SET on existing instance', () async {
+      // Start with PPPoE, VLAN instance exists but disabled
       final wanPppoeResponse = Map<String, dynamic>.from(wanResponse);
       wanPppoeResponse['Device.IP.Interface.2.IPv4Address.1.AddressingType'] =
           'IPCP';
+
+      // VLAN instance exists but is disabled — fetchSettings will find it
+      // and pass vlanInstancePath to saveAll.
+      // Note: codegen skips instances where ALL fields are zero/false/empty,
+      // so VLANID must be non-zero for the instance to be recognized.
+      const vlanDisabledResponse = <String, dynamic>{
+        'Device.Ethernet.VLANTermination.1.Enable': false,
+        'Device.Ethernet.VLANTermination.1.VLANID': '50',
+      };
 
       when(() => mockUsp.get(any())).thenAnswer((invocation) async {
         final paths = invocation.positionalArguments[0] as List<String>;
@@ -348,12 +349,11 @@ void main() {
           return pppExistingResponse;
         }
         if (paths.any((p) => p.contains('VLANTermination'))) {
-          return vlanEmptyResponse; // No existing VLAN
+          return vlanDisabledResponse;
         }
         return {};
       });
       setupSetMocks();
-      setupAddMock(createdPath: 'Device.Ethernet.VLANTermination.1.');
 
       const config = PnpIspConfig(
         type: IspConnectionType.pppoeVlan,
@@ -365,9 +365,17 @@ void main() {
 
       await service.saveIspSettings(config);
 
-      // Verify VlanTermination.add was called
-      final addCaptures = verify(() => mockUsp.add(captureAny())).captured;
-      expect(addCaptures, isNotEmpty);
+      // Verify SET was called with VLANTermination.Enable = true
+      final setCaptures = verify(() => mockUsp.set(captureAny())).captured;
+      final vlanSet = setCaptures.whereType<Map<String, dynamic>>().where(
+          (params) => params.keys.any((k) => k.contains('VLANTermination')));
+      expect(vlanSet, isNotEmpty);
+      expect(vlanSet.first['Device.Ethernet.VLANTermination.1.Enable'], isTrue);
+      expect(vlanSet.first['Device.Ethernet.VLANTermination.1.VLANID'],
+          equals(100));
+
+      // Verify no ADD was called
+      verifyNever(() => mockUsp.add(any()));
     });
   });
 }

--- a/test/page/internet_settings/services/usp_internet_settings_service_test.dart
+++ b/test/page/internet_settings/services/usp_internet_settings_service_test.dart
@@ -290,26 +290,7 @@ void main() {
       verify(() => mockUsp.add(any())).called(1);
     });
 
-    test('adds VLAN instance when enabling VLAN without existing instance',
-        () async {
-      when(() => mockUsp.add(any())).thenAnswer((_) async => {
-            'overallSuccess': true,
-            'hasAnySuccess': true,
-            'hasErrors': false,
-            'results': [
-              {
-                'requestedPath': 'Device.Ethernet.VLANTermination.',
-                'success': true,
-                'createdInstances': [
-                  {
-                    'affectedPath': 'Device.Ethernet.VLANTermination.1.',
-                    'initialParams': {}
-                  }
-                ]
-              }
-            ]
-          });
-
+    test('enables VLAN via SET on existing instance', () async {
       final original = UspInternetSettingsForm(
         connectionType: UspWanConnectionType.pppoe,
         pppUsername: 'user',
@@ -322,18 +303,19 @@ void main() {
         original,
         edited,
         pppInstancePath: 'Device.PPP.Interface.1.',
+        vlanInstancePath: 'Device.Ethernet.VLANTermination.1.',
       );
 
-      verify(() => mockUsp.add(any())).called(1);
+      final captured = verify(() => mockUsp.set(captureAny())).captured;
+      final vlanSet = captured.lastWhere((params) => (params
+              as Map<String, dynamic>)
+          .keys
+          .any((k) => k.contains('VLANTermination'))) as Map<String, dynamic>;
+      expect(vlanSet['Device.Ethernet.VLANTermination.1.Enable'], isTrue);
+      expect(vlanSet['Device.Ethernet.VLANTermination.1.VLANID'], equals(100));
     });
 
-    test('deletes VLAN instance when disabling VLAN', () async {
-      // WASM v0.11.0 format for DELETE success
-      when(() => mockUsp.delete(any())).thenAnswer((_) async => {
-            'success': true,
-            'result': {'data': <String, dynamic>{}},
-          });
-
+    test('disables VLAN via SET on existing instance', () async {
       final original = UspInternetSettingsForm(
         connectionType: UspWanConnectionType.pppoe,
         pppUsername: 'user',
@@ -350,7 +332,37 @@ void main() {
         vlanInstancePath: 'Device.Ethernet.VLANTermination.1.',
       );
 
-      verify(() => mockUsp.delete(any())).called(1);
+      final captured = verify(() => mockUsp.set(captureAny())).captured;
+      final vlanSet = captured.lastWhere((params) => (params
+              as Map<String, dynamic>)
+          .keys
+          .any((k) => k.contains('VLANTermination'))) as Map<String, dynamic>;
+      expect(vlanSet['Device.Ethernet.VLANTermination.1.Enable'], isFalse);
+    });
+
+    test('skips VLAN SET when no vlanInstancePath provided', () async {
+      final original = UspInternetSettingsForm(
+        connectionType: UspWanConnectionType.pppoe,
+        pppUsername: 'user',
+        pppPassword: 'pass',
+        vlanEnabled: false,
+        mtu: 1492,
+      );
+      final edited =
+          original.copyWith(vlanEnabled: true, vlanId: 100, mtu: 1400);
+
+      await service.saveAll(
+        original,
+        edited,
+        pppInstancePath: 'Device.PPP.Interface.1.',
+      );
+
+      // MTU change triggers a set() call, but VLAN keys should not appear
+      final setInvocations = verify(() => mockUsp.set(captureAny())).captured;
+      for (final params in setInvocations) {
+        final map = params as Map<String, dynamic>;
+        expect(map.keys.any((k) => k.contains('VLANTermination')), isFalse);
+      }
     });
 
     test('switching to DHCP sends only AddressingType', () async {
@@ -690,42 +702,6 @@ void main() {
       expect(
         () => service.saveAll(original, edited),
         throwsA(isA<UspPartialFailureError>()),
-      );
-    });
-
-    test('delete VLAN throws UspCompleteFailureError on DELETE failure',
-        () async {
-      // WASM v0.11.0 format: success=false for DELETE
-      when(() => mockUsp.delete(any())).thenAnswer((_) async => {
-            'success': false,
-            'result': {
-              'data': <String, dynamic>{},
-              'error': {
-                'Device.Ethernet.VLANTermination.1.': {
-                  'errorCode': 7003,
-                  'errorMessage': 'Invalid path',
-                },
-              },
-            },
-          });
-
-      final original = UspInternetSettingsForm(
-        connectionType: UspWanConnectionType.pppoe,
-        pppUsername: 'user',
-        pppPassword: 'pass',
-        vlanEnabled: true,
-        vlanId: 100,
-      );
-      final edited = original.copyWith(vlanEnabled: false);
-
-      expect(
-        () => service.saveAll(
-          original,
-          edited,
-          pppInstancePath: 'Device.PPP.Interface.1.',
-          vlanInstancePath: 'Device.Ethernet.VLANTermination.1.',
-        ),
-        throwsA(isA<UspCompleteFailureError>()),
       );
     });
 


### PR DESCRIPTION
## Summary
- Replace VLAN lifecycle (ADD/DELETE) with SET Enable on the existing VLANTermination.1 instance, fixing the bug where disabling VLAN still showed as enabled due to a system-default instance that cannot be deleted.
- Uncomment PPPoE ServiceName field in UI and service layer now that bbfdm supports SET on PPPoE.ServiceName.
- Clean up stale comments and fix step numbering after VLAN lifecycle removal.
- Fix dart format pre-commit hook that never triggered due to glob mismatch with heredoc commands.

## Test plan
- [x] Verify VLAN tagging toggle on/off persists correctly on router
- [x] Verify PPPoE ServiceName field saves without fault 9001
- [x] Verify dart format hook triggers on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)