### PR TITLE
fix(polling): start timer when dashboardDomainReadyProvider already resolved

### DIFF
--- a/lib/page/_shared/providers/usp_system_monitor_notifier.dart
+++ b/lib/page/_shared/providers/usp_system_monitor_notifier.dart
@@ -40,7 +40,7 @@ class UspSystemMonitorNotifier extends Notifier<SystemMonitorState> {
     const defaultInterval = Duration(seconds: 30);
     ref.listen(dashboardDomainReadyProvider, (_, next) {
       if (next is AsyncData) {
-        setRefreshInterval(defaultInterval);
+        _startTimerIfAuthenticated(defaultInterval);
       }
     });
 
@@ -48,15 +48,21 @@ class UspSystemMonitorNotifier extends Notifier<SystemMonitorState> {
     // already completed before this provider was first read, the listener above
     // will never fire. Check current state and start timer if ready.
     final domainReady = ref.read(dashboardDomainReadyProvider);
-    final isAuthenticated = ref.read(appConnectionStateProvider) ==
-        AppConnectionState.authenticated;
-    if (domainReady is AsyncData && isAuthenticated) {
-      Future.microtask(() => setRefreshInterval(defaultInterval));
+    if (domainReady is AsyncData) {
+      Future.microtask(() => _startTimerIfAuthenticated(defaultInterval));
     }
 
     return const SystemMonitorState(
       refreshInterval: defaultInterval,
     );
+  }
+
+  void _startTimerIfAuthenticated(Duration interval) {
+    final isAuthenticated = ref.read(appConnectionStateProvider) ==
+        AppConnectionState.authenticated;
+    if (isAuthenticated) {
+      setRefreshInterval(interval);
+    }
   }
 
   /// Push a snapshot from the dashboard notifier (avoids duplicate fetch).

--- a/lib/page/_shared/providers/usp_system_monitor_notifier.dart
+++ b/lib/page/_shared/providers/usp_system_monitor_notifier.dart
@@ -44,6 +44,16 @@ class UspSystemMonitorNotifier extends Notifier<SystemMonitorState> {
       }
     });
 
+    // ref.listen only fires on state CHANGES — if dashboardDomainReadyProvider
+    // already completed before this provider was first read, the listener above
+    // will never fire. Check current state and start timer if ready.
+    final domainReady = ref.read(dashboardDomainReadyProvider);
+    final isAuthenticated = ref.read(appConnectionStateProvider) ==
+        AppConnectionState.authenticated;
+    if (domainReady is AsyncData && isAuthenticated) {
+      Future.microtask(() => setRefreshInterval(defaultInterval));
+    }
+
     return const SystemMonitorState(
       refreshInterval: defaultInterval,
     );

--- a/lib/page/_shared/providers/usp_traffic_analysis_notifier.dart
+++ b/lib/page/_shared/providers/usp_traffic_analysis_notifier.dart
@@ -41,7 +41,7 @@ class UspTrafficAnalysisNotifier extends Notifier<TrafficAnalysisState> {
     const defaultInterval = Duration(seconds: 10);
     ref.listen(dashboardDomainReadyProvider, (_, next) {
       if (next is AsyncData) {
-        setRefreshInterval(defaultInterval);
+        _startTimerIfAuthenticated(defaultInterval);
       }
     });
 
@@ -49,15 +49,21 @@ class UspTrafficAnalysisNotifier extends Notifier<TrafficAnalysisState> {
     // already completed before this provider was first read, the listener above
     // will never fire. Check current state and start timer if ready.
     final domainReady = ref.read(dashboardDomainReadyProvider);
-    final isAuthenticated = ref.read(appConnectionStateProvider) ==
-        AppConnectionState.authenticated;
-    if (domainReady is AsyncData && isAuthenticated) {
-      Future.microtask(() => setRefreshInterval(defaultInterval));
+    if (domainReady is AsyncData) {
+      Future.microtask(() => _startTimerIfAuthenticated(defaultInterval));
     }
 
     return const TrafficAnalysisState(
       refreshInterval: defaultInterval,
     );
+  }
+
+  void _startTimerIfAuthenticated(Duration interval) {
+    final isAuthenticated = ref.read(appConnectionStateProvider) ==
+        AppConnectionState.authenticated;
+    if (isAuthenticated) {
+      setRefreshInterval(interval);
+    }
   }
 
   /// Set the auto-refresh interval. Pass null to stop.

--- a/lib/page/_shared/providers/usp_traffic_analysis_notifier.dart
+++ b/lib/page/_shared/providers/usp_traffic_analysis_notifier.dart
@@ -45,6 +45,16 @@ class UspTrafficAnalysisNotifier extends Notifier<TrafficAnalysisState> {
       }
     });
 
+    // ref.listen only fires on state CHANGES — if dashboardDomainReadyProvider
+    // already completed before this provider was first read, the listener above
+    // will never fire. Check current state and start timer if ready.
+    final domainReady = ref.read(dashboardDomainReadyProvider);
+    final isAuthenticated = ref.read(appConnectionStateProvider) ==
+        AppConnectionState.authenticated;
+    if (domainReady is AsyncData && isAuthenticated) {
+      Future.microtask(() => setRefreshInterval(defaultInterval));
+    }
+
     return const TrafficAnalysisState(
       refreshInterval: defaultInterval,
     );

--- a/test/page/_shared/providers/usp_system_monitor_notifier_test.dart
+++ b/test/page/_shared/providers/usp_system_monitor_notifier_test.dart
@@ -7,12 +7,18 @@ import 'package:privacy_gui/core/usp/providers/usp_client_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_client.dart';
 import 'package:privacy_gui/page/_shared/models/system_monitor_state.dart';
 import 'package:privacy_gui/page/_shared/providers/usp_system_monitor_notifier.dart';
+import 'package:privacy_gui/page/dashboard/providers/dashboard_domain_ready_provider.dart';
 
 class MockUspClient extends Mock implements UspClient {}
 
 class _AlwaysAuthenticatedNotifier extends AppConnectionStateNotifier {
   @override
   AppConnectionState build() => AppConnectionState.authenticated;
+}
+
+class _LoggedOutNotifier extends AppConnectionStateNotifier {
+  @override
+  AppConnectionState build() => AppConnectionState.loggedOut;
 }
 
 void main() {
@@ -186,6 +192,59 @@ void main() {
 
       final state = container.read(uspSystemMonitorProvider);
       expect(state.isFetching, isFalse);
+      container.dispose();
+    });
+
+    test('starts timer when dashboardDomainReadyProvider already resolved',
+        () async {
+      final container = ProviderContainer(
+        overrides: [
+          uspClientProvider.overrideWithValue(mockUsp),
+          appConnectionStateProvider.overrideWith(() {
+            return _AlwaysAuthenticatedNotifier();
+          }),
+          dashboardDomainReadyProvider.overrideWith((ref) async {}),
+        ],
+      );
+      // Wait for dashboardDomainReadyProvider to resolve BEFORE reading the monitor.
+      await container.read(dashboardDomainReadyProvider.future);
+
+      // Now read the monitor provider — it should detect already-resolved state.
+      container.read(uspSystemMonitorProvider);
+      // Wait for microtask + initial fetch.
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspSystemMonitorProvider);
+      expect(state.refreshInterval, const Duration(seconds: 30));
+      // Timer started and fetched data.
+      verify(() => mockUsp.get(any())).called(greaterThan(0));
+      container.dispose();
+    });
+
+    test(
+        'does not start timer when dashboardDomainReadyProvider resolved but not authenticated',
+        () async {
+      final container = ProviderContainer(
+        overrides: [
+          uspClientProvider.overrideWithValue(mockUsp),
+          appConnectionStateProvider.overrideWith(() {
+            return _LoggedOutNotifier();
+          }),
+          dashboardDomainReadyProvider.overrideWith((ref) async {}),
+        ],
+      );
+      // Wait for dashboardDomainReadyProvider to resolve BEFORE reading the monitor.
+      await container.read(dashboardDomainReadyProvider.future);
+
+      // Now read the monitor provider.
+      container.read(uspSystemMonitorProvider);
+      // Wait for microtask.
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+
+      // Timer should not have started (no fetch calls).
+      verifyNever(() => mockUsp.get(any()));
       container.dispose();
     });
   });

--- a/test/page/_shared/providers/usp_traffic_analysis_notifier_test.dart
+++ b/test/page/_shared/providers/usp_traffic_analysis_notifier_test.dart
@@ -7,12 +7,18 @@ import 'package:privacy_gui/core/usp/providers/usp_client_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_client.dart';
 import 'package:privacy_gui/page/_shared/models/traffic_analysis_state.dart';
 import 'package:privacy_gui/page/_shared/providers/usp_traffic_analysis_notifier.dart';
+import 'package:privacy_gui/page/dashboard/providers/dashboard_domain_ready_provider.dart';
 
 class MockUspClient extends Mock implements UspClient {}
 
 class _AlwaysAuthenticatedNotifier extends AppConnectionStateNotifier {
   @override
   AppConnectionState build() => AppConnectionState.authenticated;
+}
+
+class _LoggedOutNotifier extends AppConnectionStateNotifier {
+  @override
+  AppConnectionState build() => AppConnectionState.loggedOut;
 }
 
 void main() {
@@ -213,6 +219,61 @@ void main() {
 
       final state = container.read(uspTrafficAnalysisProvider);
       expect(state.isFetching, isFalse);
+      container.dispose();
+    });
+
+    test('starts timer when dashboardDomainReadyProvider already resolved',
+        () async {
+      when(() => mockUsp.get(any()))
+          .thenAnswer((_) async => makeTrafficResponse());
+      final container = ProviderContainer(
+        overrides: [
+          uspClientProvider.overrideWithValue(mockUsp),
+          appConnectionStateProvider.overrideWith(() {
+            return _AlwaysAuthenticatedNotifier();
+          }),
+          dashboardDomainReadyProvider.overrideWith((ref) async {}),
+        ],
+      );
+      // Wait for dashboardDomainReadyProvider to resolve BEFORE reading the provider.
+      await container.read(dashboardDomainReadyProvider.future);
+
+      // Now read the traffic provider — it should detect already-resolved state.
+      container.read(uspTrafficAnalysisProvider);
+      // Wait for microtask + initial fetch.
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspTrafficAnalysisProvider);
+      expect(state.refreshInterval, const Duration(seconds: 10));
+      // Timer started and fetched data.
+      verify(() => mockUsp.get(any())).called(greaterThan(0));
+      container.dispose();
+    });
+
+    test(
+        'does not start timer when dashboardDomainReadyProvider resolved but not authenticated',
+        () async {
+      final container = ProviderContainer(
+        overrides: [
+          uspClientProvider.overrideWithValue(mockUsp),
+          appConnectionStateProvider.overrideWith(() {
+            return _LoggedOutNotifier();
+          }),
+          dashboardDomainReadyProvider.overrideWith((ref) async {}),
+        ],
+      );
+      // Wait for dashboardDomainReadyProvider to resolve BEFORE reading the provider.
+      await container.read(dashboardDomainReadyProvider.future);
+
+      // Now read the traffic provider.
+      container.read(uspTrafficAnalysisProvider);
+      // Wait for microtask.
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+
+      // Timer should not have started (no fetch calls).
+      verifyNever(() => mockUsp.get(any()));
       container.dispose();
     });
   });


### PR DESCRIPTION
## Summary
- Fix polling providers (traffic analysis, system monitor) not starting their timers when `dashboardDomainReadyProvider` has already completed
- `ref.listen()` only fires on state changes — if the provider was first read after domain ready resolved, the listener never fires
- Add immediate state check in `build()` to start timer if conditions are already met

## Test plan
- [x] All 2869 functional tests pass
- [x] Affected provider tests pass (16 tests)
- [x] Verified Dashboard traffic card displays data after login
- [x] Verified Statistics page displays traffic data when navigating from Dashboard

🤖 Generated with [Claude Code](https://claude.ai/claude-code)