### PR TITLE
fix(route): Port Forwarding detail back returns to Dashboard (#969)

### DIFF
--- a/lib/route/route_usp_dashboard.dart
+++ b/lib/route/route_usp_dashboard.dart
@@ -87,6 +87,13 @@ final uspDashboardRoute = ShellRoute(
       preservableProvider: preservableUspDhcpReservationsProvider,
     ),
     LinksysRoute(
+      name: RouteNamed.uspPortForwardingDetail,
+      path: RoutePath.uspPortForwardingDetail,
+      builder: (context, state) => const UspPortForwardingDetailView(),
+      enableDirtyCheck: true,
+      preservableProvider: preservableUspPortForwardingPageProvider,
+    ),
+    LinksysRoute(
       name: RouteNamed.uspSystemLog,
       path: RoutePath.uspSystemLog,
       builder: (context, state) => const UspSystemLogView(),
@@ -129,13 +136,6 @@ final uspDashboardRoute = ShellRoute(
           builder: (context, state) => const UspDmzView(),
           enableDirtyCheck: true,
           preservableProvider: preservableUspDmzProvider,
-        ),
-        LinksysRoute(
-          name: RouteNamed.uspPortForwardingDetail,
-          path: RouteNamed.uspPortForwardingDetail,
-          builder: (context, state) => const UspPortForwardingDetailView(),
-          enableDirtyCheck: true,
-          preservableProvider: preservableUspPortForwardingPageProvider,
         ),
         LinksysRoute(
           name: RouteNamed.uspStaticRouting,

--- a/test/route/issue969_blackbox_regression_test.dart
+++ b/test/route/issue969_blackbox_regression_test.dart
@@ -1,0 +1,95 @@
+// Independent black-box / regression coverage for issue #969.
+//
+// Authored by the INTEGRATION/E2E verification sub-agent (NOT the implementer).
+// These assertions are written against the FROZEN acceptance criteria, exercising
+// the REAL production route tree (uspDashboardRoute) — complementing the dev's
+// behavioral tests which run on a hand-built replica.
+//
+// AC1  Dashboard -> PF detail -> back -> Dashboard (incl. web canonical-URL).
+// AC2  Advanced Settings -> PF detail -> back -> Advanced Settings (no regression).
+// AC3  Dashboard has NO Instant Privacy entry (claim verification).
+// AC-原則 The advanced-settings sub-routes must NOT be collaterally damaged.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:privacy_gui/route/router_provider.dart';
+import 'package:privacy_gui/route/constants.dart';
+
+void main() {
+  List<RouteBase> shellRoutes() => uspDashboardRoute.routes;
+
+  GoRoute? directChild(String name) {
+    for (final r in shellRoutes()) {
+      if (r is GoRoute && r.name == name) return r;
+    }
+    return null;
+  }
+
+  GoRoute? childOf(GoRoute parent, String name) {
+    for (final r in parent.routes) {
+      if (r is GoRoute && r.name == name) return r;
+    }
+    return null;
+  }
+
+  group('#969 black-box: real production route structure', () {
+    test('AC1 structure: uspPortForwardingDetail is a DIRECT child of the '
+        'dashboard ShellRoute (flat canonical URL)', () {
+      final pf = directChild(RouteNamed.uspPortForwardingDetail);
+      expect(pf, isNotNull,
+          reason: 'PF detail must be a parallel direct child of the shell');
+      // Canonical URL is a single flat top-level segment.
+      expect(pf!.path, RoutePath.uspPortForwardingDetail);
+      expect(pf.path, '/uspPortForwardingDetail');
+      expect('/'.allMatches(pf.path).length, 1,
+          reason: 'flat top-level path => exactly one slash => no synthetic '
+              'Advanced Settings parent on web reload/deep-link');
+    });
+
+    test('AC2 + AC-原則: uspAdvancedSettings still exists as a direct shell '
+        'child AND retains ALL six legitimate nested sub-routes', () {
+      final adv = directChild(RouteNamed.uspAdvancedSettings);
+      expect(adv, isNotNull);
+
+      // The six sub-routes that MUST remain nested (back -> Advanced Settings).
+      const expectedNested = [
+        RouteNamed.uspInternetSettings,
+        RouteNamed.uspLocalNetwork,
+        RouteNamed.uspFirewall,
+        RouteNamed.uspDmz,
+        RouteNamed.uspStaticRouting,
+        RouteNamed.uspIpv6PortService,
+      ];
+      for (final name in expectedNested) {
+        expect(childOf(adv!, name), isNotNull,
+            reason: '$name must remain nested under uspAdvancedSettings '
+                '(must not be collaterally un-nested by the #969 fix)');
+      }
+      expect(adv!.routes.whereType<GoRoute>().length, expectedNested.length,
+          reason: 'Advanced Settings should have exactly the six known '
+              'sub-routes — no more (PF detail must be gone), no fewer.');
+    });
+
+    test('AC2 regression: uspPortForwardingDetail is NOT nested under '
+        'uspAdvancedSettings anymore', () {
+      final adv = directChild(RouteNamed.uspAdvancedSettings)!;
+      expect(childOf(adv, RouteNamed.uspPortForwardingDetail), isNull,
+          reason: 'PF detail must no longer be a child of Advanced Settings');
+    });
+
+    test('AC3: Instant Privacy is a parallel shell sibling, NOT under '
+        'Advanced Settings and NOT under Dashboard', () {
+      // It exists as its own top-level shell child (parallel route).
+      expect(directChild(RouteNamed.uspInstantPrivacy), isNotNull);
+
+      // It is NOT a child of Advanced Settings.
+      final adv = directChild(RouteNamed.uspAdvancedSettings)!;
+      expect(childOf(adv, RouteNamed.uspInstantPrivacy), isNull);
+
+      // The dashboard route itself has no nested Instant Privacy child.
+      final dash = directChild(RouteNamed.uspDashboard)!;
+      expect(childOf(dash, RouteNamed.uspInstantPrivacy), isNull);
+    });
+  });
+}

--- a/test/route/issue969_blackbox_regression_test.dart
+++ b/test/route/issue969_blackbox_regression_test.dart
@@ -34,7 +34,8 @@ void main() {
   }
 
   group('#969 black-box: real production route structure', () {
-    test('AC1 structure: uspPortForwardingDetail is a DIRECT child of the '
+    test(
+        'AC1 structure: uspPortForwardingDetail is a DIRECT child of the '
         'dashboard ShellRoute (flat canonical URL)', () {
       final pf = directChild(RouteNamed.uspPortForwardingDetail);
       expect(pf, isNotNull,
@@ -47,7 +48,8 @@ void main() {
               'Advanced Settings parent on web reload/deep-link');
     });
 
-    test('AC2 + AC-原則: uspAdvancedSettings still exists as a direct shell '
+    test(
+        'AC2 + AC-原則: uspAdvancedSettings still exists as a direct shell '
         'child AND retains ALL six legitimate nested sub-routes', () {
       final adv = directChild(RouteNamed.uspAdvancedSettings);
       expect(adv, isNotNull);
@@ -71,14 +73,16 @@ void main() {
               'sub-routes — no more (PF detail must be gone), no fewer.');
     });
 
-    test('AC2 regression: uspPortForwardingDetail is NOT nested under '
+    test(
+        'AC2 regression: uspPortForwardingDetail is NOT nested under '
         'uspAdvancedSettings anymore', () {
       final adv = directChild(RouteNamed.uspAdvancedSettings)!;
       expect(childOf(adv, RouteNamed.uspPortForwardingDetail), isNull,
           reason: 'PF detail must no longer be a child of Advanced Settings');
     });
 
-    test('AC3: Instant Privacy is a parallel shell sibling, NOT under '
+    test(
+        'AC3: Instant Privacy is a parallel shell sibling, NOT under '
         'Advanced Settings and NOT under Dashboard', () {
       // It exists as its own top-level shell child (parallel route).
       expect(directChild(RouteNamed.uspInstantPrivacy), isNotNull);

--- a/test/route/port_forwarding_back_nav_test.dart
+++ b/test/route/port_forwarding_back_nav_test.dart
@@ -36,8 +36,8 @@ void main() {
       return null;
     }
 
-    bool isNestedUnder(List<RouteBase> routes, String parentName,
-        String childName) {
+    bool isNestedUnder(
+        List<RouteBase> routes, String parentName, String childName) {
       for (final r in routes) {
         if (r is GoRoute && r.name == parentName) {
           return findRoute(r.routes, childName) != null;
@@ -47,28 +47,31 @@ void main() {
       return false;
     }
 
-    test('uspPortForwardingDetail is a parallel direct child of the shell, '
+    test(
+        'uspPortForwardingDetail is a parallel direct child of the shell, '
         'NOT nested under uspAdvancedSettings', () {
       final shellRoutes = uspDashboardRoute.routes;
 
       // It exists as a direct child of the shell.
-      final directChild = shellRoutes.whereType<GoRoute>().any(
-          (r) => r.name == RouteNamed.uspPortForwardingDetail);
+      final directChild = shellRoutes
+          .whereType<GoRoute>()
+          .any((r) => r.name == RouteNamed.uspPortForwardingDetail);
       expect(directChild, isTrue,
           reason:
               'uspPortForwardingDetail must be a parallel direct child of the dashboard shell');
 
       // It is NOT nested under uspAdvancedSettings anymore.
-      final nested = isNestedUnder(shellRoutes,
-          RouteNamed.uspAdvancedSettings, RouteNamed.uspPortForwardingDetail);
+      final nested = isNestedUnder(shellRoutes, RouteNamed.uspAdvancedSettings,
+          RouteNamed.uspPortForwardingDetail);
       expect(nested, isFalse,
           reason:
               'uspPortForwardingDetail must NOT be nested under uspAdvancedSettings (issue #969)');
     });
 
     test('canonical path is a single flat segment', () {
-      final route = uspDashboardRoute.routes.whereType<GoRoute>().firstWhere(
-          (r) => r.name == RouteNamed.uspPortForwardingDetail);
+      final route = uspDashboardRoute.routes
+          .whereType<GoRoute>()
+          .firstWhere((r) => r.name == RouteNamed.uspPortForwardingDetail);
       expect(route.path, RoutePath.uspPortForwardingDetail);
       expect(route.path, startsWith('/'));
       expect('/'.allMatches(route.path).length, 1,
@@ -120,8 +123,7 @@ void main() {
                   body: Center(
                     child: ElevatedButton(
                       key: const Key('dashToDetail'),
-                      onPressed: () =>
-                          c.pushNamed('uspPortForwardingDetail'),
+                      onPressed: () => c.pushNamed('uspPortForwardingDetail'),
                       child: const Text('Dashboard'),
                     ),
                   ),
@@ -134,8 +136,7 @@ void main() {
                   body: Center(
                     child: ElevatedButton(
                       key: const Key('advToDetail'),
-                      onPressed: () =>
-                          c.pushNamed('uspPortForwardingDetail'),
+                      onPressed: () => c.pushNamed('uspPortForwardingDetail'),
                       child: const Text('Advanced Settings'),
                     ),
                   ),
@@ -145,8 +146,7 @@ void main() {
               GoRoute(
                 name: 'uspPortForwardingDetail',
                 path: '/uspPortForwardingDetail',
-                builder: (c, s) =>
-                    detailPage(c, 'uspAdvancedSettings'),
+                builder: (c, s) => detailPage(c, 'uspAdvancedSettings'),
               ),
             ],
           ),

--- a/test/route/port_forwarding_back_nav_test.dart
+++ b/test/route/port_forwarding_back_nav_test.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:privacy_gui/route/router_provider.dart';
+import 'package:privacy_gui/route/constants.dart';
+
+/// Regression coverage for issue #969.
+///
+/// Bug: entering Port Forwarding detail and tapping the back arrow returned to
+/// Advanced Settings instead of the originating page.
+///
+/// ROOT CAUSE (empirically proven during development, see commit message):
+/// `uspPortForwardingDetail` was declared as a route NESTED under
+/// `uspAdvancedSettings`. With go_router, any canonical-URL entry (web fresh
+/// load, browser reload, deep link, or `context.go()` to the full nested path
+/// `/uspAdvancedSettings/uspPortForwardingDetail`) rebuilds the FULL ancestor
+/// chain, synthesising an `uspAdvancedSettings` page into the navigator stack
+/// beneath the detail page. `navigateBack()` then pops onto that synthetic
+/// parent regardless of the real entry point.
+///
+/// FIX (Option A): promote `uspPortForwardingDetail` to a PARALLEL direct child
+/// of the dashboard ShellRoute (mirroring the sibling `uspDhcpDetail`), so the
+/// canonical URL is a single flat segment with no synthetic parent.
+void main() {
+  // ---------------------------------------------------------------------------
+  // Part 1 — Structural assertion against the REAL production route tree.
+  // ---------------------------------------------------------------------------
+  group('#969 production route structure', () {
+    GoRoute? findRoute(List<RouteBase> routes, String name) {
+      for (final r in routes) {
+        if (r is GoRoute && r.name == name) return r;
+        final nested = findRoute(r.routes, name);
+        if (nested != null) return nested;
+      }
+      return null;
+    }
+
+    bool isNestedUnder(List<RouteBase> routes, String parentName,
+        String childName) {
+      for (final r in routes) {
+        if (r is GoRoute && r.name == parentName) {
+          return findRoute(r.routes, childName) != null;
+        }
+        if (isNestedUnder(r.routes, parentName, childName)) return true;
+      }
+      return false;
+    }
+
+    test('uspPortForwardingDetail is a parallel direct child of the shell, '
+        'NOT nested under uspAdvancedSettings', () {
+      final shellRoutes = uspDashboardRoute.routes;
+
+      // It exists as a direct child of the shell.
+      final directChild = shellRoutes.whereType<GoRoute>().any(
+          (r) => r.name == RouteNamed.uspPortForwardingDetail);
+      expect(directChild, isTrue,
+          reason:
+              'uspPortForwardingDetail must be a parallel direct child of the dashboard shell');
+
+      // It is NOT nested under uspAdvancedSettings anymore.
+      final nested = isNestedUnder(shellRoutes,
+          RouteNamed.uspAdvancedSettings, RouteNamed.uspPortForwardingDetail);
+      expect(nested, isFalse,
+          reason:
+              'uspPortForwardingDetail must NOT be nested under uspAdvancedSettings (issue #969)');
+    });
+
+    test('canonical path is a single flat segment', () {
+      final route = uspDashboardRoute.routes.whereType<GoRoute>().firstWhere(
+          (r) => r.name == RouteNamed.uspPortForwardingDetail);
+      expect(route.path, RoutePath.uspPortForwardingDetail);
+      expect(route.path, startsWith('/'));
+      expect('/'.allMatches(route.path).length, 1,
+          reason: 'flat top-level path has exactly one slash');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Part 2 — Behavioral AC1/AC2/AC3 on a faithful replica of the FIXED tree.
+  //
+  // The replica mirrors the post-fix structure: Dashboard, Advanced Settings,
+  // and PortForwardingDetail are all PARALLEL direct children of one ShellRoute.
+  // navigateBack semantics are reproduced exactly (canPop?pop():goNamed(fallback)).
+  // ---------------------------------------------------------------------------
+  group('#969 back navigation behavior (fixed parallel structure)', () {
+    late GlobalKey<NavigatorState> shellKey;
+
+    // Mirrors lib/route/navigation_extensions.dart navigateBack().
+    Widget detailPage(BuildContext context, String fallback) => Scaffold(
+          appBar: AppBar(title: const Text('Detail')),
+          body: Center(
+            child: ElevatedButton(
+              key: const Key('back'),
+              onPressed: () {
+                if (context.canPop()) {
+                  context.pop();
+                } else {
+                  context.goNamed(fallback);
+                }
+              },
+              child: const Text('back'),
+            ),
+          ),
+        );
+
+    GoRouter buildRouter(String initial) {
+      shellKey = GlobalKey<NavigatorState>();
+      return GoRouter(
+        initialLocation: initial,
+        routes: [
+          ShellRoute(
+            navigatorKey: shellKey,
+            builder: (c, s, child) => child,
+            routes: [
+              GoRoute(
+                name: 'uspDashboard',
+                path: '/uspDashboard',
+                builder: (c, s) => Scaffold(
+                  body: Center(
+                    child: ElevatedButton(
+                      key: const Key('dashToDetail'),
+                      onPressed: () =>
+                          c.pushNamed('uspPortForwardingDetail'),
+                      child: const Text('Dashboard'),
+                    ),
+                  ),
+                ),
+              ),
+              GoRoute(
+                name: 'uspAdvancedSettings',
+                path: '/uspAdvancedSettings',
+                builder: (c, s) => Scaffold(
+                  body: Center(
+                    child: ElevatedButton(
+                      key: const Key('advToDetail'),
+                      onPressed: () =>
+                          c.pushNamed('uspPortForwardingDetail'),
+                      child: const Text('Advanced Settings'),
+                    ),
+                  ),
+                ),
+              ),
+              // Parallel direct child — the fix.
+              GoRoute(
+                name: 'uspPortForwardingDetail',
+                path: '/uspPortForwardingDetail',
+                builder: (c, s) =>
+                    detailPage(c, 'uspAdvancedSettings'),
+              ),
+            ],
+          ),
+        ],
+      );
+    }
+
+    testWidgets('AC1: Dashboard -> detail -> back returns to Dashboard',
+        (tester) async {
+      final router = buildRouter('/uspDashboard');
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('dashToDetail')));
+      await tester.pumpAndSettle();
+      expect(find.text('Detail'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('back')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Dashboard'), findsOneWidget);
+      expect(find.text('Advanced Settings'), findsNothing);
+    });
+
+    testWidgets(
+        'AC2: Advanced Settings -> detail -> back returns to Advanced Settings',
+        (tester) async {
+      final router = buildRouter('/uspAdvancedSettings');
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('advToDetail')));
+      await tester.pumpAndSettle();
+      expect(find.text('Detail'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('back')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Advanced Settings'), findsOneWidget);
+    });
+
+    testWidgets(
+        'AC1 (web): fresh canonical-URL load -> back falls back, no synthetic '
+        'Advanced Settings parent in stack', (tester) async {
+      // Direct deep-link / browser reload at the flat detail URL.
+      final router = buildRouter('/uspPortForwardingDetail');
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+      expect(find.text('Detail'), findsOneWidget);
+
+      // Only the detail page is in the stack — no synthetic parent.
+      final nav = shellKey.currentState!;
+      expect(nav.widget.pages.length, 1,
+          reason:
+              'flat parallel route must not synthesise an Advanced Settings parent');
+      expect(nav.widget.pages.single.name, 'uspPortForwardingDetail');
+    });
+  });
+}


### PR DESCRIPTION
## fix(route): Port Forwarding detail back returns to Dashboard (#969)

Closes #969

### Title typo note
The issue **title** says "Instant Privacy", but this is a reporter typo. The issue **body's** reproduction steps describe the real case: **Port Forwarding**. The fix and tests therefore target Port Forwarding (verified — Instant Privacy was *not* mistakenly modified, see AC3 below).

### Reproduction (from issue body)
- Precondition: Dashboard style = Professional
- Steps: Dashboard/Home > Port Rules → tap "To Go" icon (Port Forwarding page) → tap back arrow
- **Actual**: returns to Advanced Settings (a second back returns to Menu)
- **Expected**: returns to Dashboard

### Root cause
`uspPortForwardingDetail` was declared as a route **nested under** `uspAdvancedSettings`. With go_router, any canonical-URL entry (web fresh load, browser reload, deep link, or `context.go()` to the full nested path `/uspAdvancedSettings/uspPortForwardingDetail`) rebuilds the **full ancestor chain**, synthesising an `uspAdvancedSettings` page beneath the detail page in the navigator stack. `navigateBack()` (`canPop() ? pop() : goNamed(fallback)`) then pops onto that synthetic parent regardless of the real entry point — so back always landed on Advanced Settings.

### Fix
Promote `uspPortForwardingDetail` to a **parallel direct child** of the dashboard `ShellRoute` (mirroring the sibling `uspDhcpDetail`), and change its `path` from the route-name string to the canonical `RoutePath.uspPortForwardingDetail` (`/uspPortForwardingDetail`). The canonical URL is now a single flat top-level segment, so there is no synthetic Advanced Settings parent. Back then pops onto the real entry page (Dashboard or Advanced Settings).

Changed file (production): `lib/route/route_usp_dashboard.dart` (+7/-7). The six legitimate `uspAdvancedSettings` sub-routes (InternetSettings / LocalNetwork / Firewall / Dmz / StaticRouting / Ipv6PortService) remain nested and unchanged.

### Acceptance criteria mapping
- **AC1** — Dashboard → PF detail → back → Dashboard (incl. web canonical-URL direct load/reload): covered by `port_forwarding_back_nav_test.dart` behavioral tests + the flat-path / no-synthetic-parent structural assertions in both test files. ✅
- **AC2** — Advanced Settings → PF detail → back → still Advanced Settings (no regression): covered by behavioral test + black-box "not nested anymore" assertion. ✅
- **AC3** — "Instant Privacy" is a title typo; real case is Port Forwarding: black-box test asserts Instant Privacy is an untouched parallel sibling (not under Advanced Settings, not under Dashboard) and the fix targets Port Forwarding. ✅
- **AC-principle** — No other route/navigation behavior broken; complies with 2.x constitutional three-layer architecture (pure route-structure change, no provider/service/codegen touched, no generated import added). Black-box test asserts Advanced Settings retains exactly its six nested sub-routes. ✅

### Test evidence
- Dev behavioral/structural tests: `test/route/port_forwarding_back_nav_test.dart` (5 tests) — structural assertions on the real `uspDashboardRoute` tree + AC1/AC2/web-canonical behavior on a faithful replica reproducing `navigateBack` semantics.
- Independent black-box regression: `test/route/issue969_blackbox_regression_test.dart` (4 tests) — assertions against the **real production route tree** for AC1/AC2/AC3 + AC-principle.
- **Full suite reran green: `+2882: All tests passed!`** (2878 pre-existing + 4 new black-box; the 5 dev tests were already counted). `flutter analyze` on the changed route file and `test/route/` reports **No issues found**.

### Note on branch contents
This branch also carries two pre-existing `fix(polling)` commits (53984197, 737acbb8) that landed ahead of `dev-2.5.0`; they are unrelated to #969 and were already on the branch. The #969-specific change is isolated to the route promotion above. All tests (including those polling tests) pass green.
