### PR TITLE
fix(ethernet): show LAN port as disconnected when no wired devices

### DIFF
--- a/lib/page/local_network/cards/usp_ethernet_ports_card.dart
+++ b/lib/page/local_network/cards/usp_ethernet_ports_card.dart
@@ -94,8 +94,7 @@ class UspEthernetPortsCard extends ConsumerWidget {
                       Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          AppText.titleSmall(
-                              '$lanConnected / ${lanPorts.length}'),
+                          AppText.titleSmall('$lanConnected'),
                           AppText.bodySmall(
                             'LAN Connected',
                             color: colorScheme.onSurfaceVariant,

--- a/lib/page/local_network/services/usp_ethernet_data_service.dart
+++ b/lib/page/local_network/services/usp_ethernet_data_service.dart
@@ -178,14 +178,16 @@ class UspEthernetDataService {
       }
 
       final lanBitRate = lanAggregate.currentBitRate;
-      final lanIsUp = lanAggregate.status.toLowerCase() == 'up';
 
       if (wiredConnections.isEmpty) {
+        // No wired devices → show single LAN port as disconnected.
+        // Note: lanAggregate.status reflects switch-chip link state, not
+        // whether a device is plugged in, so we use isUp=false here.
         result.add(EthernetPortUIModel(
           name: lanAggregate.name,
           label: 'LAN',
           isWan: false,
-          isUp: lanIsUp,
+          isUp: false,
           instancePath: lanAggregate.instancePath,
           currentBitRate: lanBitRate,
         ));

--- a/test/page/local_network/services/usp_ethernet_data_service_test.dart
+++ b/test/page/local_network/services/usp_ethernet_data_service_test.dart
@@ -182,11 +182,11 @@ void main() {
   // LAN port entries
   // ---------------------------------------------------------------------------
   group('LAN port entries', () {
-    test('no wired devices — single LAN entry', () async {
+    test('no wired devices — single LAN entry with isUp=false', () async {
       stubResponses(
         ethernet: {
           'Device.Ethernet.Interface.1.Name': 'eth1',
-          'Device.Ethernet.Interface.1.Status': 'Up',
+          'Device.Ethernet.Interface.1.Status': 'Up', // interface reports Up
           'Device.Ethernet.Interface.1.Upstream': false,
           'Device.Ethernet.Interface.1.CurrentBitRate': '1000',
         },
@@ -199,6 +199,8 @@ void main() {
       expect(result.portModels.first.label, 'LAN');
       expect(result.portModels.first.isWan, isFalse);
       expect(result.portModels.first.connectedDevices, isEmpty);
+      // No wired devices = disconnected, regardless of interface status
+      expect(result.portModels.first.isUp, isFalse);
     });
 
     test('one wired device — LAN 1 with device info', () async {
@@ -291,6 +293,7 @@ void main() {
       expect(result.portModels.length, 1);
       expect(result.portModels.first.label, 'LAN');
       expect(result.portModels.first.connectedDevices, isEmpty);
+      expect(result.portModels.first.isUp, isFalse);
     });
   });
 


### PR DESCRIPTION
## Summary

- LAN port `isUp` now reflects actual wired device connections, not interface status (which is always "Up" for aggregated switch)
- Remove inaccurate LAN port count denominator from display since physical port count is unavailable via TR-181

Closes #983

## Test plan

- [ ] Verify LAN port shows gray when no devices connected via Ethernet
- [ ] Verify LAN port shows green when a device is connected via Ethernet
- [ ] Verify LAN Connected displays "0" instead of "0/1" when no devices connected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)