### PR TITLE
feat: add Web Interface Guide link to FAQ page

### DIFF
--- a/lib/constants/url_links.dart
+++ b/lib/constants/url_links.dart
@@ -41,6 +41,8 @@ const linkHardwareNodeNotTureOn = '$officialSupportHost/kb/article/6807-en';
 const linkHardwareEthernetPortNotWorking =
     '$officialSupportHost/kb/article/8185-en';
 const linkCheckIfAutoFirmwareOn = '$officialSupportHost/kb/article/6810-en';
+// Web Interface Guide
+const linkWebInterfaceGuide = '$officialSupportHost/kb/article/9921-en';
 // Explanation
 const linksysCertExplanation =
     '$officialWebHost/support-article?articleNum=318835';

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "ما الذي تشير إليه المصابيح الموجودة على العقدة لديّ؟",
   "faqLookingFor": "لم تتمكن من العثور على ما تبحث عنه؟",
   "faqVisitLinksysSupport": "قم بزيارة دعم Linksys",
+  "faqWebInterfaceGuideTitle": "دليل واجهة الويب",
+  "faqWebInterfaceGuideDesc": "دليل شامل لأجهزة راوتر Linksys Pinnacle Mesh",
   "faqs": "الأسئلة الشائعة",
   "featureUnavailableInRemoteMode": "هذه الميزة غير متوفرة في وضع التحكم عن بُعد",
   "filterAnonymous": "تصفية طلبات إنترنت المجهولة",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "Hvad betyder lysene på min node?",
   "faqLookingFor": "Kan du ikke finde det, du leder efter?",
   "faqVisitLinksysSupport": "Besøg Linksys Support",
+  "faqWebInterfaceGuideTitle": "Webgrænsefladevejledning",
+  "faqWebInterfaceGuideDesc": "Komplet vejledning til Linksys Pinnacle Mesh-routere",
   "faqs": "Ofte stillede spørgsmål",
   "featureUnavailableInRemoteMode": "Denne funktion er ikke tilgængelig i fjernbetjeningsfunktionen",
   "filterAnonymous": "Filtrer anonyme internetanmodninger",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "Was bedeuten die Leuchten auf meinem Node?",
   "faqLookingFor": "Finden Sie nicht, was Sie suchen?",
   "faqVisitLinksysSupport": "Linksys Support besuchen",
+  "faqWebInterfaceGuideTitle": "Web-Interface-Handbuch",
+  "faqWebInterfaceGuideDesc": "Vollständige Anleitung für Linksys Pinnacle Mesh-Router",
   "faqs": "FAQs",
   "featureUnavailableInRemoteMode": "Diese Funktion ist im Fernzugriffsmodus nicht verfügbar",
   "filterAnonymous": "Anonyme Internetanfragen filtern",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -210,6 +210,8 @@
   "faqListWhatLightsMean": "Τι σημαίνουν οι λυχνίες στον κόμβο μου;",
   "faqLookingFor": "Δεν βρίσκετε αυτό που ψάχνετε;",
   "faqVisitLinksysSupport": "Επισκεφθείτε την Υποστήριξη Linksys",
+  "faqWebInterfaceGuideTitle": "Οδηγός διεπαφής Web",
+  "faqWebInterfaceGuideDesc": "Πλήρης οδηγός για δρομολογητές Linksys Pinnacle Mesh",
   "faqs": "Συχνές ερωτήσεις",
   "featureUnavailableInRemoteMode": "Αυτή η λειτουργία δεν είναι διαθέσιμη σε λειτουργία απομακρυσμένης πρόσβασης",
   "filterAnonymous": "Φιλτράρισμα ανώνυμων αιτημάτων Internet",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -420,6 +420,8 @@
   "faqListWhatLightsMean": "What do the lights on my node mean?",
   "faqLookingFor": "Can't find what you're looking for?",
   "faqVisitLinksysSupport": "Visit Linksys Support",
+  "faqWebInterfaceGuideTitle": "Web Interface Guide",
+  "faqWebInterfaceGuideDesc": "Complete guide for Linksys Pinnacle Mesh routers",
   "faqs": "FAQs",
   "featureUnavailableInRemoteMode": "This feature is unavailable in remote mode",
   "filterAnonymous": "Filter anonymous Internet requests",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "¿Qué indican las distintas luces de mi nodo?",
   "faqLookingFor": "¿No puede encontrar lo que busca?",
   "faqVisitLinksysSupport": "Visite el Soporte Linksys",
+  "faqWebInterfaceGuideTitle": "Guía de interfaz web",
+  "faqWebInterfaceGuideDesc": "Guía completa para routers Linksys Pinnacle Mesh",
   "faqs": "Preguntas Frecuentes",
   "featureUnavailableInRemoteMode": "Esta función no está disponible en modo remoto",
   "filterAnonymous": "Filtrar solicitudes anónimas de Internet",

--- a/lib/l10n/app_es_ar.arb
+++ b/lib/l10n/app_es_ar.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "¿Qué indican las luces en mi nodo?",
   "faqLookingFor": "¿No puede encontrar lo que busca?",
   "faqVisitLinksysSupport": "Visite el Soporte Linksys",
+  "faqWebInterfaceGuideTitle": "Guía de interfaz web",
+  "faqWebInterfaceGuideDesc": "Guía completa para routers Linksys Pinnacle Mesh",
   "faqs": "Preguntas Frecuentes",
   "featureUnavailableInRemoteMode": "Esta función no está disponible en modo remoto",
   "filterAnonymous": "Filtrar solicitudes de Internet anónimas",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -210,6 +210,8 @@
   "faqListWhatLightsMean": "Mitä solmun valot tarkoittavat?",
   "faqLookingFor": "Etkö löydä etsimääsi?",
   "faqVisitLinksysSupport": "Käy Linksys-tuessa",
+  "faqWebInterfaceGuideTitle": "Verkkokäyttöliittymän opas",
+  "faqWebInterfaceGuideDesc": "Täydellinen opas Linksys Pinnacle Mesh -reitittimille",
   "faqs": "UKK",
   "featureUnavailableInRemoteMode": "Tämä ominaisuus ei ole käytettävissä etätilassa",
   "filterAnonymous": "Suodata anonyymit Internet-pyynnöt",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "À quoi correspondent les voyants sur ma borne ?",
   "faqLookingFor": "Vous ne trouvez pas ce que vous cherchez ?",
   "faqVisitLinksysSupport": "Visiter le support Linksys",
+  "faqWebInterfaceGuideTitle": "Guide de l'interface Web",
+  "faqWebInterfaceGuideDesc": "Guide complet pour les routeurs Linksys Pinnacle Mesh",
   "faqs": "FAQ",
   "featureUnavailableInRemoteMode": "Cette fonctionnalité n'est pas disponible en mode distant",
   "filterAnonymous": "Filtrage des requêtes Internet anonymes",

--- a/lib/l10n/app_fr_ca.arb
+++ b/lib/l10n/app_fr_ca.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "Que signifient les voyants sur mon nœud?",
   "faqLookingFor": "Vous ne trouvez pas ce que vous cherchez ?",
   "faqVisitLinksysSupport": "Visiter le support Linksys",
+  "faqWebInterfaceGuideTitle": "Guide de l'interface Web",
+  "faqWebInterfaceGuideDesc": "Guide complet pour les routeurs Linksys Pinnacle Mesh",
   "faqs": "FAQ",
   "featureUnavailableInRemoteMode": "Cette fonctionnalité n'est pas disponible en mode distant",
   "filterAnonymous": "Filtrage des requêtes Internet anonymes",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -210,6 +210,8 @@
   "faqListWhatLightsMean": "Apa arti nyala lampu pada simpul saya?",
   "faqLookingFor": "Tidak menemukan yang Anda cari?",
   "faqVisitLinksysSupport": "Kunjungi Dukungan Linksys",
+  "faqWebInterfaceGuideTitle": "Panduan Antarmuka Web",
+  "faqWebInterfaceGuideDesc": "Panduan lengkap untuk router Linksys Pinnacle Mesh",
   "faqs": "FAQ",
   "featureUnavailableInRemoteMode": "Fitur ini tidak tersedia dalam mode jarak jauh",
   "filterAnonymous": "Filter permintaan Internet anonim",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "Cosa indicano le spie luminose sul nodo?",
   "faqLookingFor": "Non riesci a trovare quello che stai cercando?",
   "faqVisitLinksysSupport": "Visitate il supporto Linksys",
+  "faqWebInterfaceGuideTitle": "Guida all'interfaccia Web",
+  "faqWebInterfaceGuideDesc": "Guida completa per i router Linksys Pinnacle Mesh",
   "faqs": "Domande frequenti",
   "featureUnavailableInRemoteMode": "Questa funzione non è disponibile in modalità remota",
   "filterAnonymous": "Filtro richieste Internet anonime",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "ノードのライトは何を意味しますか？",
   "faqLookingFor": "探しているものが見つかりませんか？",
   "faqVisitLinksysSupport": "Linksysサポートへ",
+  "faqWebInterfaceGuideTitle": "Webインターフェースガイド",
+  "faqWebInterfaceGuideDesc": "Linksys Pinnacle Meshルーターの完全ガイド",
   "faqs": "よくある質問",
   "featureUnavailableInRemoteMode": "この機能はリモートモードでは利用できません",
   "filterAnonymous": "匿名インターネットリクエストをフィルター処理します",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -210,6 +210,8 @@
   "faqListWhatLightsMean": "제 노드의 표시등은 무엇을 의미합니까?",
   "faqLookingFor": "찾고 계신 것이 없습니까?",
   "faqVisitLinksysSupport": "Linksys 지원 방문",
+  "faqWebInterfaceGuideTitle": "웹 인터페이스 가이드",
+  "faqWebInterfaceGuideDesc": "Linksys Pinnacle Mesh 라우터 전체 가이드",
   "faqs": "FAQ",
   "featureUnavailableInRemoteMode": "이 기능은 원격 모드에서 사용할 수 없습니다",
   "filterAnonymous": "익명의 인터넷 요청 필터링",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "Hva betyr lampene på noden min?",
   "faqLookingFor": "Finner du ikke det du leter etter?",
   "faqVisitLinksysSupport": "Besøk Linksys Support",
+  "faqWebInterfaceGuideTitle": "Webgrensesnittveiledning",
+  "faqWebInterfaceGuideDesc": "Komplett veiledning for Linksys Pinnacle Mesh-rutere",
   "faqs": "Vanlige spørsmål",
   "featureUnavailableInRemoteMode": "Denne funksjonen er ikke tilgjengelig i fjernmodus",
   "filterAnonymous": "Filtrer anonyme Internett-adresser",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "Wat betekenen de lampjes op mijn node?",
   "faqLookingFor": "Kunt u niet vinden wat u zoekt?",
   "faqVisitLinksysSupport": "Ga naar Linksys-ondersteuning",
+  "faqWebInterfaceGuideTitle": "Webinterfacegids",
+  "faqWebInterfaceGuideDesc": "Volledige gids voor Linksys Pinnacle Mesh-routers",
   "faqs": "Veelgestelde vragen",
   "featureUnavailableInRemoteMode": "Deze functie is niet beschikbaar in de externe modus",
   "filterAnonymous": "Anonieme internetverzoeken filteren",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -210,6 +210,8 @@
   "faqListWhatLightsMean": "Co oznaczają wskaźniki na moim węźle?",
   "faqLookingFor": "Nie możesz znaleźć tego, czego szukasz?",
   "faqVisitLinksysSupport": "Odwiedź pomoc techniczną Linksys",
+  "faqWebInterfaceGuideTitle": "Przewodnik po interfejsie internetowym",
+  "faqWebInterfaceGuideDesc": "Kompletny przewodnik po routerach Linksys Pinnacle Mesh",
   "faqs": "Często zadawane pytania",
   "featureUnavailableInRemoteMode": "Ta funkcja nie jest dostępna w trybie zdalnym",
   "filterAnonymous": "Filtruj anonimowe żądania dotyczące Internetu",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "O que as luzes no meu nó significam?",
   "faqLookingFor": "Não consegue encontrar o que está procurando?",
   "faqVisitLinksysSupport": "Acesse o Suporte Linksys",
+  "faqWebInterfaceGuideTitle": "Guia da Interface Web",
+  "faqWebInterfaceGuideDesc": "Guia completo para roteadores Linksys Pinnacle Mesh",
   "faqs": "Perguntas Frequentes",
   "featureUnavailableInRemoteMode": "Este recurso não está disponível no modo remoto",
   "filterAnonymous": "Filtrar solicitações de Internet anônimas",

--- a/lib/l10n/app_pt_pt.arb
+++ b/lib/l10n/app_pt_pt.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "O que significam as luzes no meu nó?",
   "faqLookingFor": "Não consegue encontrar o que está procurando?",
   "faqVisitLinksysSupport": "Acesse o Suporte Linksys",
+  "faqWebInterfaceGuideTitle": "Guia da Interface Web",
+  "faqWebInterfaceGuideDesc": "Guia completo para routers Linksys Pinnacle Mesh",
   "faqs": "Perguntas Frequentes",
   "featureUnavailableInRemoteMode": "Esta funcionalidade não está disponível no modo remoto",
   "filterAnonymous": "Filtrar pedidos de Internet anónimos",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -210,6 +210,8 @@
   "faqListWhatLightsMean": "Что означают индикаторы на моем узле?",
   "faqLookingFor": "Не нашли то, что искали?",
   "faqVisitLinksysSupport": "Посетить службу поддержки Linksys",
+  "faqWebInterfaceGuideTitle": "Руководство по веб-интерфейсу",
+  "faqWebInterfaceGuideDesc": "Полное руководство по маршрутизаторам Linksys Pinnacle Mesh",
   "faqs": "Часто задаваемые вопросы",
   "featureUnavailableInRemoteMode": "Эта функция недоступна в удаленном режиме",
   "filterAnonymous": "Фильтрация анонимных интернет-запросов",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "Vad betyder lamporna på min nod?",
   "faqLookingFor": "Hittar du inte vad du letar efter?",
   "faqVisitLinksysSupport": "Besök Linksys Support",
+  "faqWebInterfaceGuideTitle": "Webbgränssnittsguide",
+  "faqWebInterfaceGuideDesc": "Komplett guide för Linksys Pinnacle Mesh-routrar",
   "faqs": "Vanliga frågor",
   "featureUnavailableInRemoteMode": "Den här funktionen är inte tillgänglig i fjärrläge",
   "filterAnonymous": "Filtrera anonyma internetbegäran",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -210,6 +210,8 @@
   "faqListWhatLightsMean": "ไฟบนโหนดของฉันหมายความว่าอย่างไร",
   "faqLookingFor": "หาสิ่งที่ต้องการไม่พบ?",
   "faqVisitLinksysSupport": "เยี่ยมชมฝ่ายสนับสนุน Linksys",
+  "faqWebInterfaceGuideTitle": "คู่มือเว็บอินเทอร์เฟซ",
+  "faqWebInterfaceGuideDesc": "คู่มือฉบับสมบูรณ์สำหรับเราเตอร์ Linksys Pinnacle Mesh",
   "faqs": "คำถามที่พบบ่อย",
   "featureUnavailableInRemoteMode": "คุณลักษณะนี้ไม่พร้อมใช้งานในโหมดระยะไกล",
   "filterAnonymous": "กรองการร้องขออินเทอร์เน็ตที่ไม่มีชื่อ",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -210,6 +210,8 @@
   "faqListWhatLightsMean": "Düğümümdeki ışıklar ne anlama geliyor?",
   "faqLookingFor": "Aradığınızı bulamıyor musunuz?",
   "faqVisitLinksysSupport": "Linksys Desteği'ni ziyaret edin",
+  "faqWebInterfaceGuideTitle": "Web Arayüzü Kılavuzu",
+  "faqWebInterfaceGuideDesc": "Linksys Pinnacle Mesh yönlendiricileri için eksiksiz kılavuz",
   "faqs": "SSS",
   "featureUnavailableInRemoteMode": "Bu özellik uzak modda kullanılamaz",
   "filterAnonymous": "Anonim İnternet isteklerini engelle",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -210,6 +210,8 @@
   "faqListWhatLightsMean": "Đèn trên điểm nút của tôi có ý nghĩa gì?",
   "faqLookingFor": "Không tìm thấy thông tin bạn cần?",
   "faqVisitLinksysSupport": "Truy cập Hỗ trợ Linksys",
+  "faqWebInterfaceGuideTitle": "Hướng dẫn giao diện Web",
+  "faqWebInterfaceGuideDesc": "Hướng dẫn đầy đủ cho bộ định tuyến Linksys Pinnacle Mesh",
   "faqs": "FAQ",
   "featureUnavailableInRemoteMode": "Tính năng này không khả dụng trong chế độ từ xa",
   "filterAnonymous": "Lọc các yêu cầu Internet ẩn danh",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "节点上的指示灯代表什么意思？",
   "faqLookingFor": "找不到您要找的内容？",
   "faqVisitLinksysSupport": "访问Linksys支持网站",
+  "faqWebInterfaceGuideTitle": "Web界面指南",
+  "faqWebInterfaceGuideDesc": "Linksys Pinnacle Mesh路由器完整指南",
   "faqs": "常见问题解答",
   "featureUnavailableInRemoteMode": "此功能在远程模式下不可用",
   "filterAnonymous": "过滤匿名Internet请求",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -228,6 +228,8 @@
   "faqListWhatLightsMean": "節點上的燈號代表什麼意思？",
   "faqLookingFor": "找不到您要找的內容？",
   "faqVisitLinksysSupport": "瀏覽Linksys支援網站",
+  "faqWebInterfaceGuideTitle": "Web介面指南",
+  "faqWebInterfaceGuideDesc": "Linksys Pinnacle Mesh路由器完整指南",
   "faqs": "常見問題解答",
   "featureUnavailableInRemoteMode": "此功能在遠端模式下無法使用",
   "filterAnonymous": "篩選匿名網際網路請求",

--- a/lib/page/support/faq_list_view.dart
+++ b/lib/page/support/faq_list_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/page/components/widgets/brand_asset_widget.dart';
 import 'package:privacy_gui/providers/global_model_number_provider.dart';
 import 'package:privacy_gui/constants/url_links.dart';
+import 'package:privacygui_widgets/widgets/card/card.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/components/styled/consts.dart';
 import 'package:privacy_gui/page/components/styled/menus/menu_consts.dart';
@@ -98,6 +99,8 @@ class _FaqListViewState extends ConsumerState<FaqListView> {
             children: [
               // LinksysSearchComponent(),
               // const AppGap.medium(),
+              _buildWebInterfaceGuideCard(context),
+              const AppGap.medium(),
               ...categories.map((category) => Column(
                     children: [
                       _buildExpansionCard(
@@ -126,6 +129,34 @@ class _FaqListViewState extends ConsumerState<FaqListView> {
           ),
         );
       },
+    );
+  }
+
+  Widget _buildWebInterfaceGuideCard(BuildContext context) {
+    return AppCard(
+      onTap: () {
+        gotoOfficialWebUrl(linkWebInterfaceGuide,
+            locale: ref.read(appSettingsProvider).locale);
+      },
+      child: Row(
+        children: [
+          Icon(LinksysIcons.infoCircle,
+              color: Theme.of(context).colorScheme.primary),
+          const AppGap.medium(),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                AppText.labelLarge(loc(context).faqWebInterfaceGuideTitle),
+                const AppGap.small3(),
+                AppText.bodySmall(loc(context).faqWebInterfaceGuideDesc),
+              ],
+            ),
+          ),
+          Icon(LinksysIcons.openInNew,
+              color: Theme.of(context).colorScheme.primary),
+        ],
+      ),
     );
   }
 

--- a/lib/page/support/faq_list_view.dart
+++ b/lib/page/support/faq_list_view.dart
@@ -134,6 +134,7 @@ class _FaqListViewState extends ConsumerState<FaqListView> {
 
   Widget _buildWebInterfaceGuideCard(BuildContext context) {
     return AppCard(
+      identifier: 'now-faq-web-interface-guide',
       onTap: () {
         gotoOfficialWebUrl(linkWebInterfaceGuide,
             locale: ref.read(appSettingsProvider).locale);


### PR DESCRIPTION
## Summary
- Add a prominent "Web Interface Guide" card at the top of the FAQ list
- Links to the generic Pinnacle router support article (KB #9921)
- Card includes info and external link icons in primary color
- Added translations for all 26 supported languages

## Screenshot
![FAQ with Web Interface Guide](https://github.com/user-attachments/assets/placeholder)

## Test plan
- [ ] Open FAQ page from Support menu
- [ ] Verify the Web Interface Guide card appears at the top
- [ ] Click the card and verify it opens https://support.linksys.com/kb/article/9921-en/
- [ ] Verify icons are displayed in primary color (blue)

Closes #985

🤖 Generated with [Claude Code](https://claude.ai/claude-code)