### PR TITLE
feat(remote): SSE & subscription support for Remote Assistance mode

### DIFF
--- a/lib/core/usp/providers/remote_assistance_provider.dart
+++ b/lib/core/usp/providers/remote_assistance_provider.dart
@@ -89,7 +89,8 @@ class RemoteAssistanceNotifier extends Notifier<RemoteAssistanceState> {
     }
 
     final jsClient = builder.build();
-    final raClient = UspClient.fromBuilder(jsClient);
+    final guardianUrl = 'https://${config.guardianBaseUrl}';
+    final raClient = UspClient.fromBuilder(jsClient, baseUrl: guardianUrl);
 
     // Swap UspClient atomically with mutation lock to prevent races
     await ref.read(uspMutationLockProvider).withLock(() async {

--- a/lib/core/usp/providers/sse_providers.dart
+++ b/lib/core/usp/providers/sse_providers.dart
@@ -9,14 +9,28 @@ import 'package:privacy_gui/core/usp/services/network_diagnostics_executor.dart'
 import 'package:privacy_gui/core/usp/services/sse_connection_manager.dart';
 import 'package:privacy_gui/core/usp/services/sse_manager.dart';
 import 'package:privacy_gui/core/usp/services/sse_operation_awaiter.dart';
+import 'package:privacy_gui/core/usp/providers/remote_assistance_provider.dart';
+import 'package:privacy_gui/core/usp/services/bridge_endpoints.dart';
 import 'package:privacy_gui/core/usp/services/usp_bridge_client.dart';
 import 'package:privacy_gui/config/global_config.dart';
 import 'package:privacy_gui/providers/auth/auth_provider.dart';
 
 /// Provides [UspBridgeClient] instance — depends on [UspClient].
+///
+/// In Remote Assistance mode, uses Guardian proxy endpoints.
+/// In local mode, uses on-router usp-bridge endpoints.
 final uspBridgeClientProvider = Provider<UspBridgeClient?>((ref) {
   final usp = ref.watch(uspClientProvider);
   if (usp == null) return null;
+
+  if (GlobalConfig.remote.isActive) {
+    final raState = ref.watch(remoteAssistanceProvider);
+    final config = raState.config;
+    if (config == null) return null;
+    final endpoints = BridgeEndpoints.remote(config.sessionId);
+    return UspBridgeClient(usp, endpoints: endpoints);
+  }
+
   return UspBridgeClient(usp);
 });
 
@@ -112,12 +126,6 @@ final networkDiagnosticsExecutorProvider =
 /// Watch this from the app shell to trigger SSE connection after login.
 /// Core subscriptions are "always-on" while the app is connected.
 final sseBootstrapProvider = FutureProvider<void>((ref) async {
-  // Skip SSE in Remote Assistance mode — Guardian proxy does not support SSE
-  if (GlobalConfig.remote.isActive) {
-    logger.d('[USP][SSE][Bootstrap]: Skipping in Remote Assistance mode');
-    return;
-  }
-
   final manager = ref.watch(sseManagerProvider);
   if (manager == null) return;
 
@@ -127,15 +135,18 @@ final sseBootstrapProvider = FutureProvider<void>((ref) async {
   final bridge = ref.watch(uspBridgeClientProvider);
   if (bridge == null) return;
 
-  // Step 0: Health check — best-effort, non-fatal.
+  // Step 0: Health check — best-effort, non-fatal (local mode only).
   // If the bridge is busy (504) or slow, we still attempt SSE connection
   // because SseConnectionManager has its own retry/backoff logic.
-  try {
-    await bridge.health().timeout(const Duration(seconds: 5));
-    logger.d('[USP][SSE][Bootstrap]: Bridge health check passed');
-  } catch (e) {
-    logger.w(
-        '[USP][SSE][Bootstrap]: Bridge health check failed: $e — continuing');
+  // Skip in Remote mode — Guardian proxy has no health endpoint.
+  if (!GlobalConfig.remote.isActive) {
+    try {
+      await bridge.health().timeout(const Duration(seconds: 5));
+      logger.d('[USP][SSE][Bootstrap]: Bridge health check passed');
+    } catch (e) {
+      logger.w(
+          '[USP][SSE][Bootstrap]: Bridge health check failed: $e — continuing');
+    }
   }
 
   // Connect SSE only — core subscriptions are registered by the dashboard

--- a/lib/core/usp/providers/sse_providers.dart
+++ b/lib/core/usp/providers/sse_providers.dart
@@ -7,8 +7,11 @@ import 'package:privacy_gui/core/usp/providers/usp_auth_coordinator.dart';
 import 'package:privacy_gui/core/usp/providers/usp_client_provider.dart';
 import 'package:privacy_gui/core/usp/services/network_diagnostics_executor.dart';
 import 'package:privacy_gui/core/usp/services/sse_connection_manager.dart';
+import 'package:privacy_gui/core/usp/services/sse_local_strategy.dart';
 import 'package:privacy_gui/core/usp/services/sse_manager.dart';
 import 'package:privacy_gui/core/usp/services/sse_operation_awaiter.dart';
+import 'package:privacy_gui/core/usp/services/sse_operation_strategy.dart';
+import 'package:privacy_gui/core/usp/services/sse_remote_strategy.dart';
 import 'package:privacy_gui/core/usp/providers/remote_assistance_provider.dart';
 import 'package:privacy_gui/core/usp/services/bridge_endpoints.dart';
 import 'package:privacy_gui/core/usp/services/usp_bridge_client.dart';
@@ -28,7 +31,12 @@ final uspBridgeClientProvider = Provider<UspBridgeClient?>((ref) {
     final config = raState.config;
     if (config == null) return null;
     final endpoints = BridgeEndpoints.remote(config.sessionId);
-    return UspBridgeClient(usp, endpoints: endpoints);
+    return UspBridgeClient(
+      usp,
+      endpoints: endpoints,
+      authToken: config.temporaryAccessToken,
+      clientTypeId: config.clientTypeId,
+    );
   }
 
   return UspBridgeClient(usp);
@@ -40,14 +48,22 @@ final uspBridgeClientProvider = Provider<UspBridgeClient?>((ref) {
 /// - [SseConnectionManager] — SSE stream lifecycle
 /// - [SseSubscriptionRegistry] — OBUSPA + bridge subscription tracking
 /// - [SseEventRouter] — event demux by subscription_id
+///
+/// Uses [LocalSseStrategy] or [RemoteSseStrategy] based on mode.
 final sseManagerProvider = Provider<SseManager?>((ref) {
   final usp = ref.watch(uspClientProvider);
   final bridge = ref.watch(uspBridgeClientProvider);
   if (usp == null || bridge == null) return null;
 
-  final manager = SseManager(usp: usp, bridge: bridge);
+  // Select strategy based on mode
+  final SseOperationStrategy strategy = GlobalConfig.remote.isActive
+      ? RemoteSseStrategy(bridge)
+      : LocalSseStrategy(bridge);
 
-  // Wire proactive token refresh on SSE heartbeat
+  final manager = SseManager(usp: usp, bridge: bridge, strategy: strategy);
+
+  // Wire proactive token refresh on SSE heartbeat (Local mode only)
+  // Strategy's heartbeatConfig.authCheckEnabled controls whether this runs
   final authCoordinator = ref.read(uspAuthCoordinatorProvider);
   manager.onHeartbeatAuth = () => authCoordinator.ensureAuth();
 

--- a/lib/core/usp/providers/sse_providers.dart
+++ b/lib/core/usp/providers/sse_providers.dart
@@ -26,20 +26,36 @@ final uspBridgeClientProvider = Provider<UspBridgeClient?>((ref) {
   final usp = ref.watch(uspClientProvider);
   if (usp == null) return null;
 
+  final UspBridgeClient bridge;
+
   if (GlobalConfig.remote.isActive) {
-    final raState = ref.watch(remoteAssistanceProvider);
-    final config = raState.config;
+    // W-4 fix: use select to avoid rebuilds on unrelated state changes
+    final config = ref.watch(
+      remoteAssistanceProvider.select((s) => s.config),
+    );
     if (config == null) return null;
-    final endpoints = BridgeEndpoints.remote(config.sessionId);
-    return UspBridgeClient(
+
+    bridge = UspBridgeClient(
       usp,
-      endpoints: endpoints,
+      endpoints: BridgeEndpoints.remote(config.sessionId),
       authToken: config.temporaryAccessToken,
       clientTypeId: config.clientTypeId,
+      authBehavior: AuthBehavior.remote,
+    );
+  } else {
+    bridge = UspBridgeClient(
+      usp,
+      authBehavior: AuthBehavior.local,
     );
   }
 
-  return UspBridgeClient(usp);
+  // W-1 fix: wire auth failure to logout (both modes)
+  bridge.onAuthFailed = () {
+    logger.w('[USP][Auth]: Session expired — triggering logout');
+    ref.read(authProvider.notifier).logout();
+  };
+
+  return bridge;
 });
 
 /// Singleton [SseManager] provider — NOT autoDispose.

--- a/lib/core/usp/services/bridge_endpoints.dart
+++ b/lib/core/usp/services/bridge_endpoints.dart
@@ -1,0 +1,35 @@
+/// Endpoint configuration for [UspBridgeClient].
+///
+/// Allows switching between local usp-bridge and remote Guardian proxy
+/// endpoints without changing the client implementation.
+class BridgeEndpoints {
+  final String notifications;
+  final String subscription;
+  final String health;
+  final String turboPrefix;
+
+  const BridgeEndpoints({
+    required this.notifications,
+    required this.subscription,
+    required this.health,
+    required this.turboPrefix,
+  });
+
+  /// Local usp-bridge endpoints (on-router).
+  static const local = BridgeEndpoints(
+    notifications: '/api/v1/notifications',
+    subscription: '/api/v1/subscription',
+    health: '/api/v1/health',
+    turboPrefix: '/api/v1/turbo',
+  );
+
+  /// Remote Guardian proxy endpoints.
+  static BridgeEndpoints remote(String sessionId) => BridgeEndpoints(
+        notifications:
+            '/remote-assistances/sessions/$sessionId/usp/notifications',
+        subscription:
+            '/remote-assistances/sessions/$sessionId/usp/subscriptions',
+        health: '/remote-assistances/sessions/$sessionId/usp/health',
+        turboPrefix: '/remote-assistances/sessions/$sessionId/usp/turbo',
+      );
+}

--- a/lib/core/usp/services/bridge_endpoints.dart
+++ b/lib/core/usp/services/bridge_endpoints.dart
@@ -26,10 +26,12 @@ class BridgeEndpoints {
   /// Remote Guardian proxy endpoints.
   static BridgeEndpoints remote(String sessionId) => BridgeEndpoints(
         notifications:
-            '/remote-assistances/sessions/$sessionId/usp/notifications',
+            '/v1/guardians/remote-assistances/sessions/$sessionId/usp/notifications',
         subscription:
-            '/remote-assistances/sessions/$sessionId/usp/subscriptions',
-        health: '/remote-assistances/sessions/$sessionId/usp/health',
-        turboPrefix: '/remote-assistances/sessions/$sessionId/usp/turbo',
+            '/v1/guardians/remote-assistances/sessions/$sessionId/usp/subscriptions',
+        health:
+            '/v1/guardians/remote-assistances/sessions/$sessionId/usp/health',
+        turboPrefix:
+            '/v1/guardians/remote-assistances/sessions/$sessionId/usp/turbo',
       );
 }

--- a/lib/core/usp/services/sse_connection_manager.dart
+++ b/lib/core/usp/services/sse_connection_manager.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 
+import 'sse_operation_strategy.dart';
 import 'usp_bridge_client.dart';
 
 /// SSE connection lifecycle states.
@@ -31,13 +32,16 @@ enum SseConnectionState {
 /// [SseSubscriptionRegistry] and [SseEventRouter] respectively.
 class SseConnectionManager {
   final UspBridgeClient _bridge;
+  final HeartbeatConfig _heartbeatConfig;
 
   SseConnectionManager(
     this._bridge, {
+    HeartbeatConfig? heartbeatConfig,
     Duration? initialBackoff,
     Duration? maxBackoff,
     int? maxRetries,
-  })  : _initialBackoff = initialBackoff ?? _defaultInitialBackoff,
+  })  : _heartbeatConfig = heartbeatConfig ?? HeartbeatConfig.local,
+        _initialBackoff = initialBackoff ?? _defaultInitialBackoff,
         _maxBackoff = maxBackoff ?? _defaultMaxBackoff,
         _maxRetries = maxRetries ?? _defaultMaxRetries {
     assert(!_initialBackoff.isNegative, 'initialBackoff must not be negative');
@@ -48,8 +52,6 @@ class SseConnectionManager {
   // ══════════════════════════════════════════════════════════════════════════
   // Configuration
   // ══════════════════════════════════════════════════════════════════════════
-
-  static const Duration _heartbeatTimeout = Duration(seconds: 45);
   static const Duration _defaultInitialBackoff = Duration(seconds: 1);
   static const Duration _defaultMaxBackoff = Duration(seconds: 60);
   static const int _defaultMaxRetries = 5;
@@ -257,10 +259,14 @@ class SseConnectionManager {
 
   void _resetHeartbeatWatchdog() {
     _heartbeatWatchdog?.cancel();
-    _heartbeatWatchdog = Timer(_heartbeatTimeout, () {
-      logger
-          .w('[USP][SSE]: Heartbeat timeout (${_heartbeatTimeout.inSeconds}s) '
-              '— connection may be stale');
+
+    // Skip watchdog if heartbeat monitoring is disabled (e.g., Remote mode)
+    if (!_heartbeatConfig.enabled) return;
+
+    final timeout = _heartbeatConfig.timeout;
+    _heartbeatWatchdog = Timer(timeout, () {
+      logger.w('[USP][SSE]: Heartbeat timeout (${timeout.inSeconds}s) '
+          '— connection may be stale');
       _sseSubscription?.cancel();
       _handleStreamEnd();
     });

--- a/lib/core/usp/services/sse_local_strategy.dart
+++ b/lib/core/usp/services/sse_local_strategy.dart
@@ -1,0 +1,118 @@
+import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/core/usp/models/sse_subscription_record.dart';
+
+import 'sse_operation_strategy.dart';
+import 'usp_bridge_client.dart';
+
+/// Local SSE strategy for usp-bridge (on-router).
+///
+/// Characteristics:
+/// - Bridge is idempotent: re-registering same ID is safe
+/// - Direct register without unregister
+/// - Auto resubscribe on reconnect
+/// - Heartbeat watchdog enabled (45s timeout)
+/// - Proactive auth check on heartbeat
+class LocalSseStrategy implements SseOperationStrategy {
+  final UspBridgeClient _bridge;
+
+  LocalSseStrategy(this._bridge);
+
+  @override
+  HeartbeatConfig get heartbeatConfig => HeartbeatConfig.local;
+
+  @override
+  Future<List<SseSubscriptionRecord>> registerSubscriptions(
+    List<SubscriptionDef> subscriptions,
+  ) async {
+    final records = <SseSubscriptionRecord>[];
+
+    for (final sub in subscriptions) {
+      try {
+        logger.d('[SSE][Local]: Registering ${sub.subscriptionId}');
+
+        await _bridge.subscribe(
+          subscriptionId: sub.subscriptionId,
+          path: sub.referenceList,
+          notifType: _notifTypeToInt(sub.notifType),
+        );
+
+        records.add(SseSubscriptionRecord(
+          subscriptionId: sub.subscriptionId,
+          notifType: sub.notifType,
+          referenceList: sub.referenceList,
+          createdAt: DateTime.now(),
+        ));
+
+        // Small breathing room for embedded router between requests
+        await Future.delayed(const Duration(milliseconds: 50));
+      } catch (e) {
+        logger.w('[SSE][Local]: Failed to register ${sub.subscriptionId}: $e');
+      }
+    }
+
+    logger.d(
+        '[SSE][Local]: Registered ${records.length}/${subscriptions.length} subscriptions');
+    return records;
+  }
+
+  @override
+  Future<void> unregisterSubscriptions(List<String> subscriptionIds) async {
+    for (final id in subscriptionIds) {
+      try {
+        await _bridge.unsubscribe(subscriptionId: id);
+        logger.d('[SSE][Local]: Unregistered $id');
+      } catch (e) {
+        logger.w('[SSE][Local]: Failed to unregister $id: $e');
+      }
+    }
+  }
+
+  @override
+  Future<void> onSseConnected(
+      List<SseSubscriptionRecord> existingRecords) async {
+    if (existingRecords.isEmpty) {
+      logger.d(
+          '[SSE][Local]: onConnected — no existing subscriptions to resubscribe');
+      return;
+    }
+
+    logger.d(
+        '[SSE][Local]: onConnected — resubscribing ${existingRecords.length} subscriptions');
+
+    // Bridge is idempotent, safe to re-register directly
+    for (final record in existingRecords) {
+      try {
+        await _bridge.subscribe(
+          subscriptionId: record.subscriptionId,
+          path: record.referenceList,
+          notifType: _notifTypeToInt(record.notifType),
+        );
+      } catch (e) {
+        logger.w(
+            '[SSE][Local]: Failed to resubscribe ${record.subscriptionId}: $e');
+      }
+    }
+  }
+
+  @override
+  Future<void> onSseDisconnected({required bool intentional}) async {
+    // Local: Bridge handles cleanup, no action needed
+    logger.d('[SSE][Local]: onDisconnected (intentional=$intentional)');
+  }
+
+  @override
+  void dispose() {
+    // No resources to dispose
+  }
+
+  int _notifTypeToInt(String notifType) {
+    const mapping = {
+      'ValueChange': 1,
+      'ObjectCreation': 2,
+      'ObjectDeletion': 3,
+      'OperationComplete': 4,
+      'Event': 5,
+    };
+    return mapping[notifType] ?? 1;
+  }
+}

--- a/lib/core/usp/services/sse_local_strategy.dart
+++ b/lib/core/usp/services/sse_local_strategy.dart
@@ -21,6 +21,9 @@ class LocalSseStrategy implements SseOperationStrategy {
   HeartbeatConfig get heartbeatConfig => HeartbeatConfig.local;
 
   @override
+  AuthBehavior get authBehavior => AuthBehavior.local;
+
+  @override
   Future<List<SseSubscriptionRecord>> registerSubscriptions(
     List<SubscriptionDef> subscriptions,
   ) async {

--- a/lib/core/usp/services/sse_manager.dart
+++ b/lib/core/usp/services/sse_manager.dart
@@ -5,6 +5,7 @@ import 'package:privacy_gui/core/utils/logger.dart';
 
 import 'sse_connection_manager.dart';
 import 'sse_event_router.dart';
+import 'sse_operation_strategy.dart';
 import 'sse_subscription_registry.dart';
 import 'sse_unload_handler.dart';
 import 'usp_bridge_client.dart';
@@ -17,7 +18,7 @@ import 'usp_client.dart';
 ///
 /// Usage:
 /// ```dart
-/// final manager = SseManager(usp: usp, bridge: bridge);
+/// final manager = SseManager(usp: usp, bridge: bridge, strategy: strategy);
 /// await manager.connect();
 ///
 /// // Register a subscription with handler
@@ -37,13 +38,14 @@ import 'usp_client.dart';
 class SseManager {
   final UspClient _usp;
   final UspBridgeClient _bridge;
+  final SseOperationStrategy _strategy;
   final SseConnectionManager connection;
   final SseSubscriptionRegistry registry;
   final SseEventRouter router;
   final SseUnloadHandler _unloadHandler = SseUnloadHandler();
-  List<(String id, String notifType, String referenceList)> _coreSubscriptions =
-      [];
-  bool _coreSubsDeferred = false;
+
+  List<SubscriptionDef> _coreSubscriptions = [];
+  bool _registrationInProgress = false;
 
   /// Delegate for proactive auth check on heartbeat. Set by provider layer
   /// to wire [UspAuthCoordinator.ensureAuth].
@@ -58,33 +60,39 @@ class SseManager {
   SseManager({
     required UspClient usp,
     required UspBridgeClient bridge,
+    required SseOperationStrategy strategy,
   })  : _usp = usp,
         _bridge = bridge,
-        connection = SseConnectionManager(bridge),
-        registry = SseSubscriptionRegistry(bridge),
+        _strategy = strategy,
+        connection = SseConnectionManager(
+          bridge,
+          heartbeatConfig: strategy.heartbeatConfig,
+        ),
+        registry = SseSubscriptionRegistry(strategy),
         router = SseEventRouter() {
     // Wire connection events to router
     connection.onEvent = router.routeEvent;
 
     // Wire heartbeat → proactive auth check (fire-and-forget)
-    router.onHeartbeat = () {
-      final authCheck = onHeartbeatAuth;
-      if (authCheck != null) {
-        authCheck().catchError((e) {
-          logger.w('[USP][SSE]: Heartbeat auth check error: $e');
-        });
-      }
-    };
+    // Only if enabled by strategy (disabled in Remote mode)
+    if (strategy.heartbeatConfig.authCheckEnabled) {
+      router.onHeartbeat = () {
+        final authCheck = onHeartbeatAuth;
+        if (authCheck != null) {
+          authCheck().catchError((e) {
+            logger.w('[USP][SSE]: Heartbeat auth check error: $e');
+          });
+        }
+      };
+    }
 
-    // On connect (first or reconnect): register/re-register subscriptions.
-    // First connect: registers core subscriptions set via setCoreSubscriptions().
-    // Reconnect: re-registers existing subscriptions on the bridge.
+    // On connect: delegate to registry which uses strategy
     connection.onConnected = () {
-      logger.d('[USP][SSE]: Connected — registering/re-registering '
-          'subscriptions on bridge');
-      _registerOrResubscribe();
+      logger.d('[USP][SSE]: Connected');
+      _onSseConnected();
     };
 
+    // On disconnect: delegate to registry which uses strategy
     connection.onDisconnected = () {
       logger.d('[USP][SSE]: Disconnected');
     };
@@ -94,11 +102,14 @@ class SseManager {
 
     // Force SSE reconnect after full re-login to ensure the new session's
     // subscription routing is active (prevents silent notification failure).
-    _usp.onTokenRefreshed = () {
-      logger.d('[USP][SSE]: Token refreshed (full re-login) '
-          '— forcing SSE reconnect');
-      connection.disconnect().then((_) => connection.connect());
-    };
+    // Skip in Remote mode where token cannot refresh.
+    if (strategy.heartbeatConfig.authCheckEnabled) {
+      _usp.onTokenRefreshed = () {
+        logger.d('[USP][SSE]: Token refreshed (full re-login) '
+            '— forcing SSE reconnect');
+        connection.disconnect().then((_) => connection.connect());
+      };
+    }
 
     // Register browser unload handler to abort SSE on page refresh/close.
     // abortSse() is synchronous — critical because `beforeunload` does NOT
@@ -124,12 +135,14 @@ class SseManager {
     required String referenceList,
     required SseNotificationHandler onNotification,
   }) async {
-    // Register on both OBUSPA + bridge layers
-    await registry.register(
-      subscriptionId: subscriptionId,
-      notifType: notifType,
-      referenceList: referenceList,
-    );
+    // Register via strategy
+    await registry.registerAll([
+      SubscriptionDef(
+        subscriptionId: subscriptionId,
+        notifType: notifType,
+        referenceList: referenceList,
+      ),
+    ]);
 
     // Add handler to event router
     final removeHandler = router.addHandler(subscriptionId, onNotification);
@@ -161,12 +174,14 @@ class SseManager {
     required String referenceList,
     required void Function() onNotification,
   }) async {
-    // Register OBUSPA + bridge subscription
-    await registry.register(
-      subscriptionId: subscriptionId,
-      notifType: notifType,
-      referenceList: referenceList,
-    );
+    // Register via strategy
+    await registry.registerAll([
+      SubscriptionDef(
+        subscriptionId: subscriptionId,
+        notifType: notifType,
+        referenceList: referenceList,
+      ),
+    ]);
 
     // Wildcard handler: match by type + path prefix
     final removeHandler = router.addWildcardHandler((notification) {
@@ -201,65 +216,61 @@ class SseManager {
     }
   }
 
-  /// Sets the core subscriptions to register when SSE first connects.
+  /// Sets the core subscriptions to register.
   ///
-  /// Called once from [sseBootstrapProvider]. Subscriptions are registered
-  /// from the [onConnected] callback after the first heartbeat, rather than
-  /// during bootstrap, to reduce the HTTP request burst on the bridge.
+  /// Called by orchestrator. In Local mode, subscriptions may be auto-registered
+  /// on SSE connect. In Remote mode, orchestrator explicitly calls
+  /// [registerCoreSubscriptions].
   void setCoreSubscriptions(List<(String, String, String)> subscriptions) {
-    _coreSubscriptions = subscriptions;
+    _coreSubscriptions = subscriptions
+        .map((s) => SubscriptionDef(
+              subscriptionId: s.$1,
+              notifType: s.$2,
+              referenceList: s.$3,
+            ))
+        .toList();
   }
 
-  /// Handles subscription registration on SSE connect/reconnect.
-  ///
-  /// - Reconnect (registry has entries): re-registers immediately via bridge
-  /// - First connect (registry empty): registers core subscriptions directly.
-  ///   [onConnected] fires on the first real heartbeat (~30s after stream
-  ///   opens), by which time dashboard HTTP requests have already completed —
-  ///   no HTTP/1.1 connection pool contention.
-  Future<void> _registerOrResubscribe() async {
-    if (registry.activeIds.isNotEmpty) {
-      // Reconnect path: re-register existing subscriptions on bridge
-      await registry.resubscribeAll();
-    } else if (_coreSubscriptions.isNotEmpty) {
-      // First connect: register directly (no contention at heartbeat time)
-      await registerDeferredSubscriptions(force: true);
-    }
+  /// Called when SSE connects. Strategy decides behavior:
+  /// - Local: auto resubscribe existing records
+  /// - Remote: no-op (orchestrator controls)
+  Future<void> _onSseConnected() async {
+    await registry.onSseConnected();
   }
 
-  /// Registers core subscriptions on the bridge.
+  /// Registers core subscriptions.
   ///
-  /// In normal flow, called from [_registerOrResubscribe] when SSE first
-  /// connects (on heartbeat). In the post-reload path, the orchestrator
-  /// calls this with [force] = true to register before onConnected fires.
-  ///
-  /// Pass [force] = true to skip the deferral check and register immediately.
-  Future<void> registerDeferredSubscriptions({bool force = false}) async {
-    if (!force && !_coreSubsDeferred) return;
-    _coreSubsDeferred = false;
-
-    for (final (id, notifType, referenceList) in _coreSubscriptions) {
-      try {
-        await registry.register(
-          subscriptionId: id,
-          notifType: notifType,
-          referenceList: referenceList,
-        );
-        // Small breathing room for embedded router between requests
-        await Future.delayed(const Duration(milliseconds: 50));
-      } catch (e) {
-        logger.w('[USP][SSE]: Failed to register core sub $id: $e');
-      }
+  /// Called by orchestrator after domain providers are ready.
+  /// Strategy handles the actual registration logic.
+  Future<void> registerCoreSubscriptions() async {
+    if (_coreSubscriptions.isEmpty) {
+      logger.d('[USP][SSE]: No core subscriptions to register');
+      return;
     }
-    logger.d('[USP][SSE]: Registered ${registry.activeIds.length} '
-        'core subscriptions (deferred)');
+
+    if (_registrationInProgress) {
+      logger.d('[USP][SSE]: Registration already in progress, skipping');
+      return;
+    }
+    _registrationInProgress = true;
+
+    try {
+      await registry.registerAll(_coreSubscriptions);
+      logger.d('[USP][SSE]: Registered ${registry.activeIds.length} '
+          'core subscriptions');
+    } finally {
+      _registrationInProgress = false;
+    }
   }
 
   /// Starts the SSE connection.
   Future<void> connect() => connection.connect();
 
   /// Disconnects SSE (intentional, stops reconnection).
-  Future<void> disconnect() => connection.disconnect();
+  Future<void> disconnect() async {
+    await connection.disconnect();
+    await registry.onSseDisconnected(intentional: true);
+  }
 
   /// Attempts to reconnect from suspended/disconnected state.
   /// Returns `true` if a reconnect attempt was started.
@@ -280,6 +291,7 @@ class SseManager {
     _bridge.abortSse();
     await connection.disconnect();
     await registry.unregisterAll();
+    _strategy.dispose();
     router.dispose();
     connection.dispose();
   }

--- a/lib/core/usp/services/sse_operation_strategy.dart
+++ b/lib/core/usp/services/sse_operation_strategy.dart
@@ -1,0 +1,74 @@
+import 'package:privacy_gui/core/usp/models/sse_subscription_record.dart';
+
+/// Configuration for SSE heartbeat monitoring.
+class HeartbeatConfig {
+  final bool enabled;
+  final Duration timeout;
+  final bool authCheckEnabled;
+
+  const HeartbeatConfig({
+    required this.enabled,
+    required this.timeout,
+    required this.authCheckEnabled,
+  });
+
+  static const local = HeartbeatConfig(
+    enabled: true,
+    timeout: Duration(seconds: 45), // 30s bridge interval + 15s grace
+    authCheckEnabled: true,
+  );
+
+  static const remote = HeartbeatConfig(
+    enabled: false,
+    timeout: Duration.zero,
+    authCheckEnabled: false,
+  );
+}
+
+/// Subscription definition for registration.
+class SubscriptionDef {
+  final String subscriptionId;
+  final String notifType;
+  final String referenceList;
+
+  const SubscriptionDef({
+    required this.subscriptionId,
+    required this.notifType,
+    required this.referenceList,
+  });
+}
+
+/// Strategy interface for SSE operations.
+///
+/// Abstracts the differences between local (usp-bridge) and remote (Guardian)
+/// SSE subscription management.
+abstract class SseOperationStrategy {
+  /// Configuration for heartbeat monitoring.
+  HeartbeatConfig get heartbeatConfig;
+
+  /// Registers subscriptions on the backend.
+  ///
+  /// Local: Direct register (bridge is idempotent).
+  /// Remote: Unregister first → delay → register (to avoid ID conflicts).
+  Future<List<SseSubscriptionRecord>> registerSubscriptions(
+    List<SubscriptionDef> subscriptions,
+  );
+
+  /// Unregisters subscriptions from the backend.
+  Future<void> unregisterSubscriptions(List<String> subscriptionIds);
+
+  /// Called when SSE connection is established.
+  ///
+  /// Local: Auto resubscribe existing subscriptions (idempotent).
+  /// Remote: No-op (orchestrator controls registration).
+  Future<void> onSseConnected(List<SseSubscriptionRecord> existingRecords);
+
+  /// Called when SSE disconnects (intentional or not).
+  ///
+  /// Local: No-op (bridge handles cleanup).
+  /// Remote: Fire-and-forget cleanup if intentional disconnect.
+  Future<void> onSseDisconnected({required bool intentional});
+
+  /// Disposes resources.
+  void dispose();
+}

--- a/lib/core/usp/services/sse_operation_strategy.dart
+++ b/lib/core/usp/services/sse_operation_strategy.dart
@@ -1,5 +1,19 @@
 import 'package:privacy_gui/core/usp/models/sse_subscription_record.dart';
 
+/// Configuration for auth failure handling on 401 responses.
+class AuthBehavior {
+  /// Whether to attempt reauth and retry on 401.
+  final bool shouldRetryOnFailure;
+
+  const AuthBehavior._({required this.shouldRetryOnFailure});
+
+  /// Local mode: attempt WASM reauth and retry once.
+  static const local = AuthBehavior._(shouldRetryOnFailure: true);
+
+  /// Remote mode: no retry (temporaryAccessToken cannot refresh).
+  static const remote = AuthBehavior._(shouldRetryOnFailure: false);
+}
+
 /// Configuration for SSE heartbeat monitoring.
 class HeartbeatConfig {
   final bool enabled;
@@ -45,6 +59,9 @@ class SubscriptionDef {
 abstract class SseOperationStrategy {
   /// Configuration for heartbeat monitoring.
   HeartbeatConfig get heartbeatConfig;
+
+  /// Configuration for auth failure handling.
+  AuthBehavior get authBehavior;
 
   /// Registers subscriptions on the backend.
   ///

--- a/lib/core/usp/services/sse_remote_strategy.dart
+++ b/lib/core/usp/services/sse_remote_strategy.dart
@@ -1,0 +1,128 @@
+import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/core/usp/models/sse_subscription_record.dart';
+
+import 'sse_operation_strategy.dart';
+import 'usp_bridge_client.dart';
+
+/// Remote SSE strategy for Guardian proxy.
+///
+/// Characteristics:
+/// - Guardian does NOT allow duplicate subscription IDs (causes conflict)
+/// - Must unregister → delay → register
+/// - No auto resubscribe on reconnect (orchestrator controls)
+/// - Heartbeat watchdog disabled (Guardian doesn't send heartbeats)
+/// - No auth check (temporaryAccessToken cannot refresh)
+class RemoteSseStrategy implements SseOperationStrategy {
+  final UspBridgeClient _bridge;
+
+  /// Delay between unregister and register to allow Guardian to process.
+  static const _unregisterDelay = Duration(milliseconds: 100);
+
+  RemoteSseStrategy(this._bridge);
+
+  @override
+  HeartbeatConfig get heartbeatConfig => HeartbeatConfig.remote;
+
+  @override
+  Future<List<SseSubscriptionRecord>> registerSubscriptions(
+    List<SubscriptionDef> subscriptions,
+  ) async {
+    final records = <SseSubscriptionRecord>[];
+
+    for (final sub in subscriptions) {
+      try {
+        logger.d('[SSE][Remote]: Registering ${sub.subscriptionId}');
+
+        // Unregister first to avoid ID conflict
+        try {
+          await _bridge.unsubscribe(subscriptionId: sub.subscriptionId);
+          await Future.delayed(_unregisterDelay);
+        } catch (_) {
+          // Ignore — subscription may not exist
+        }
+
+        await _bridge.subscribe(
+          subscriptionId: sub.subscriptionId,
+          path: sub.referenceList,
+          notifType: _notifTypeToInt(sub.notifType),
+        );
+
+        records.add(SseSubscriptionRecord(
+          subscriptionId: sub.subscriptionId,
+          notifType: sub.notifType,
+          referenceList: sub.referenceList,
+          createdAt: DateTime.now(),
+        ));
+
+        // Breathing room for Guardian between requests
+        await Future.delayed(const Duration(milliseconds: 50));
+      } catch (e) {
+        logger.w('[SSE][Remote]: Failed to register ${sub.subscriptionId}: $e');
+      }
+    }
+
+    logger.d(
+        '[SSE][Remote]: Registered ${records.length}/${subscriptions.length} subscriptions');
+    return records;
+  }
+
+  @override
+  Future<void> unregisterSubscriptions(List<String> subscriptionIds) async {
+    for (final id in subscriptionIds) {
+      try {
+        await _bridge.unsubscribe(subscriptionId: id);
+        logger.d('[SSE][Remote]: Unregistered $id');
+      } catch (e) {
+        logger.w('[SSE][Remote]: Failed to unregister $id: $e');
+      }
+    }
+  }
+
+  @override
+  Future<void> onSseConnected(
+      List<SseSubscriptionRecord> existingRecords) async {
+    // Remote: Do NOT auto resubscribe — orchestrator controls registration
+    // This avoids duplicate registration when orchestrator has already registered
+    logger.d('[SSE][Remote]: onConnected — skipping auto resubscribe '
+        '(orchestrator controls registration)');
+  }
+
+  @override
+  Future<void> onSseDisconnected({required bool intentional}) async {
+    if (intentional) {
+      // Fire-and-forget cleanup: unregister all subscriptions on Guardian
+      // Don't await — let it complete in background
+      logger.d('[SSE][Remote]: onDisconnected (intentional) — '
+          'fire-and-forget cleanup');
+      _fireAndForgetCleanup();
+    } else {
+      logger.d('[SSE][Remote]: onDisconnected (unintentional) — '
+          'will resubscribe on reconnect via orchestrator');
+    }
+  }
+
+  void _fireAndForgetCleanup() {
+    // Query existing subscriptions and unregister all (best-effort)
+    _bridge.listSubscriptions().then((ids) {
+      for (final id in ids) {
+        _bridge.unsubscribe(subscriptionId: id).ignore();
+      }
+    }).ignore();
+  }
+
+  @override
+  void dispose() {
+    // No resources to dispose
+  }
+
+  int _notifTypeToInt(String notifType) {
+    const mapping = {
+      'ValueChange': 1,
+      'ObjectCreation': 2,
+      'ObjectDeletion': 3,
+      'OperationComplete': 4,
+      'Event': 5,
+    };
+    return mapping[notifType] ?? 1;
+  }
+}

--- a/lib/core/usp/services/sse_remote_strategy.dart
+++ b/lib/core/usp/services/sse_remote_strategy.dart
@@ -24,6 +24,9 @@ class RemoteSseStrategy implements SseOperationStrategy {
   HeartbeatConfig get heartbeatConfig => HeartbeatConfig.remote;
 
   @override
+  AuthBehavior get authBehavior => AuthBehavior.remote;
+
+  @override
   Future<List<SseSubscriptionRecord>> registerSubscriptions(
     List<SubscriptionDef> subscriptions,
   ) async {

--- a/lib/core/usp/services/sse_subscription_registry.dart
+++ b/lib/core/usp/services/sse_subscription_registry.dart
@@ -1,25 +1,21 @@
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/models/sse_subscription_record.dart';
 
-import 'usp_bridge_client.dart';
+import 'sse_operation_strategy.dart';
 
 export 'package:privacy_gui/core/usp/models/sse_subscription_record.dart';
 
-/// Tracks active SSE subscriptions via the bridge API.
+/// Tracks active SSE subscriptions in memory and delegates
+/// registration to [SseOperationStrategy].
 ///
-/// The bridge handles the full OBUSPA `Device.LocalAgent.Subscription.{i}`
-/// lifecycle automatically:
-/// - **register** → bridge creates OBUSPA subscription + SSE session mapping
-/// - **unregister** → bridge deletes OBUSPA subscription + SSE session mapping
-/// - **re-register** (same ID) → bridge is idempotent, reuses existing OBUSPA
-///
-/// On SSE reconnect, [resubscribeAll] re-registers all tracked subscriptions
-/// on the bridge. Since bridge is idempotent by subscription_id, this is safe
-/// even if the OBUSPA subscriptions persist from the previous session.
+/// This class is responsible for:
+/// - In-memory tracking of active subscriptions
+/// - Delegating actual register/unregister to the strategy
+/// - Preventing duplicate registration (in-memory check)
 class SseSubscriptionRegistry {
-  final UspBridgeClient _bridge;
+  final SseOperationStrategy _strategy;
 
-  SseSubscriptionRegistry(this._bridge);
+  SseSubscriptionRegistry(this._strategy);
 
   final Map<String, SseSubscriptionRecord> _subscriptions = {};
 
@@ -27,122 +23,78 @@ class SseSubscriptionRegistry {
   Set<String> get activeIds => _subscriptions.keys.toSet();
 
   /// All current subscription records.
-  Iterable<SseSubscriptionRecord> get records => _subscriptions.values;
+  List<SseSubscriptionRecord> get records => _subscriptions.values.toList();
 
-  /// Registers a subscription via the bridge API.
+  /// Registers subscriptions via the strategy.
   ///
-  /// The bridge creates the OBUSPA subscription and SSE routing in one call.
-  /// Throws on failure.
-  Future<SseSubscriptionRecord> register({
-    required String subscriptionId,
-    required String notifType,
-    required String referenceList,
-  }) async {
-    // Check for duplicate
-    if (_subscriptions.containsKey(subscriptionId)) {
-      logger.d(
-          '[USP][SSE][Registry]: Subscription $subscriptionId already exists, '
-          'skipping duplicate registration');
-      return _subscriptions[subscriptionId]!;
+  /// Filters out already-registered subscriptions (in-memory check)
+  /// and delegates actual registration to the strategy.
+  Future<void> registerAll(List<SubscriptionDef> subscriptions) async {
+    // Filter out already registered (in-memory)
+    final toRegister = subscriptions
+        .where((s) => !_subscriptions.containsKey(s.subscriptionId))
+        .toList();
+
+    if (toRegister.isEmpty) {
+      logger.d('[SSE][Registry]: All ${subscriptions.length} subscriptions '
+          'already registered, skipping');
+      return;
     }
 
-    logger.d('[USP][SSE][Registry]: Registering $subscriptionId '
-        '(type=$notifType, ref=$referenceList)');
+    if (toRegister.length < subscriptions.length) {
+      logger.d(
+          '[SSE][Registry]: Skipping ${subscriptions.length - toRegister.length} '
+          'already registered subscriptions');
+    }
 
-    await _bridge.subscribe(
-      subscriptionId: subscriptionId,
-      path: referenceList,
-      notifType: _notifTypeToInt(notifType),
-    );
+    final records = await _strategy.registerSubscriptions(toRegister);
 
-    final record = SseSubscriptionRecord(
-      subscriptionId: subscriptionId,
-      notifType: notifType,
-      referenceList: referenceList,
-      createdAt: DateTime.now(),
-    );
-    _subscriptions[subscriptionId] = record;
+    for (final record in records) {
+      _subscriptions[record.subscriptionId] = record;
+    }
 
-    logger.d('[USP][SSE][Registry]: Registered $subscriptionId');
-    return record;
+    logger.d('[SSE][Registry]: Registered ${records.length} subscriptions, '
+        'total active: ${_subscriptions.length}');
   }
 
-  /// Unregisters a subscription via the bridge API.
-  ///
-  /// The bridge deletes the OBUSPA subscription and SSE routing.
+  /// Unregisters a subscription.
   Future<void> unregister(String subscriptionId) async {
     final record = _subscriptions.remove(subscriptionId);
     if (record == null) {
       logger.d(
-          '[USP][SSE][Registry]: Unregister $subscriptionId: not found, skipping');
+          '[SSE][Registry]: Unregister $subscriptionId: not found, skipping');
       return;
     }
 
-    logger.d('[USP][SSE][Registry]: Unregistering $subscriptionId');
-
-    try {
-      await _bridge.unsubscribe(subscriptionId: subscriptionId);
-    } catch (e) {
-      logger.w('[USP][SSE][Registry]: Bridge unsubscribe failed for '
-          '$subscriptionId: $e');
-    }
+    await _strategy.unregisterSubscriptions([subscriptionId]);
   }
 
-  /// Re-registers ALL tracked subscriptions on the bridge.
-  ///
-  /// Called after SSE reconnect. Bridge is idempotent by subscription_id,
-  /// so this safely reuses any OBUSPA subscriptions that persist from the
-  /// previous session.
-  Future<void> resubscribeAll() async {
-    if (_subscriptions.isEmpty) {
-      logger.d(
-          '[USP][SSE][Registry]: resubscribeAll: no subscriptions to re-register');
-      return;
-    }
-
-    logger.d('[USP][SSE][Registry]: Re-registering ${_subscriptions.length} '
-        'subscriptions on bridge');
-
-    for (final record in _subscriptions.values) {
-      try {
-        await _bridge.subscribe(
-          subscriptionId: record.subscriptionId,
-          path: record.referenceList,
-          notifType: _notifTypeToInt(record.notifType),
-        );
-        logger
-            .d('[USP][SSE][Registry]: Re-registered ${record.subscriptionId}');
-      } catch (e) {
-        logger.w('[USP][SSE][Registry]: Failed to re-register '
-            '${record.subscriptionId}: $e');
-      }
-    }
-  }
-
-  /// Removes all subscriptions (bridge unregister for each).
-  /// Used during logout / dispose.
+  /// Unregisters all subscriptions.
   Future<void> unregisterAll() async {
+    if (_subscriptions.isEmpty) return;
+
     final ids = _subscriptions.keys.toList();
-    for (final id in ids) {
-      await unregister(id);
+    _subscriptions.clear();
+
+    await _strategy.unregisterSubscriptions(ids);
+    logger.d('[SSE][Registry]: Unregistered all ${ids.length} subscriptions');
+  }
+
+  /// Called when SSE connects. Delegates to strategy for reconnect handling.
+  Future<void> onSseConnected() async {
+    await _strategy.onSseConnected(records);
+  }
+
+  /// Called when SSE disconnects.
+  Future<void> onSseDisconnected({required bool intentional}) async {
+    await _strategy.onSseDisconnected(intentional: intentional);
+    if (intentional) {
+      _subscriptions.clear();
     }
   }
 
-  /// Converts a notification type string to the bridge API integer.
-  static int _notifTypeToInt(String notifType) {
-    switch (notifType) {
-      case 'ValueChange':
-        return 1;
-      case 'ObjectCreation':
-        return 2;
-      case 'ObjectDeletion':
-        return 3;
-      case 'OperationComplete':
-        return 4;
-      case 'Event':
-        return 5;
-      default:
-        return 1;
-    }
+  /// Clears in-memory state without unregistering on backend.
+  void clearLocal() {
+    _subscriptions.clear();
   }
 }

--- a/lib/core/usp/services/usp_bridge_client_base.dart
+++ b/lib/core/usp/services/usp_bridge_client_base.dart
@@ -7,7 +7,12 @@ import 'usp_client.dart';
 /// All methods throw [UnsupportedError] since SSE/bridge functionality
 /// requires the browser Fetch API.
 class UspBridgeClient {
-  UspBridgeClient(UspClient usp, {BridgeEndpoints? endpoints});
+  UspBridgeClient(
+    UspClient usp, {
+    BridgeEndpoints? endpoints,
+    String? authToken,
+    String? clientTypeId,
+  });
 
   Future<Map<String, dynamic>> health() =>
       throw UnsupportedError('UspBridgeClient is only available on Web');
@@ -28,6 +33,9 @@ class UspBridgeClient {
   Future<Map<String, dynamic>> unsubscribe({
     required String subscriptionId,
   }) =>
+      throw UnsupportedError('UspBridgeClient is only available on Web');
+
+  Future<List<String>> listSubscriptions() =>
       throw UnsupportedError('UspBridgeClient is only available on Web');
 
   Future<Map<String, dynamic>> turboStart() =>

--- a/lib/core/usp/services/usp_bridge_client_base.dart
+++ b/lib/core/usp/services/usp_bridge_client_base.dart
@@ -1,5 +1,17 @@
 import 'bridge_endpoints.dart';
+import 'sse_operation_strategy.dart';
 import 'usp_client.dart';
+
+export 'sse_operation_strategy.dart' show AuthBehavior;
+
+/// Exception thrown when session expires and cannot be recovered.
+class SessionExpiredException implements Exception {
+  final String message;
+  SessionExpiredException(this.message);
+
+  @override
+  String toString() => 'SessionExpiredException: $message';
+}
 
 /// Stub implementation of [UspBridgeClient] for non-Web platforms (Dart VM / tests).
 ///
@@ -7,11 +19,15 @@ import 'usp_client.dart';
 /// All methods throw [UnsupportedError] since SSE/bridge functionality
 /// requires the browser Fetch API.
 class UspBridgeClient {
+  /// Called when auth fails and cannot be recovered (session expired).
+  void Function()? onAuthFailed;
+
   UspBridgeClient(
     UspClient usp, {
     BridgeEndpoints? endpoints,
     String? authToken,
     String? clientTypeId,
+    AuthBehavior authBehavior = AuthBehavior.local,
   });
 
   Future<Map<String, dynamic>> health() =>

--- a/lib/core/usp/services/usp_bridge_client_base.dart
+++ b/lib/core/usp/services/usp_bridge_client_base.dart
@@ -1,3 +1,4 @@
+import 'bridge_endpoints.dart';
 import 'usp_client.dart';
 
 /// Stub implementation of [UspBridgeClient] for non-Web platforms (Dart VM / tests).
@@ -6,7 +7,7 @@ import 'usp_client.dart';
 /// All methods throw [UnsupportedError] since SSE/bridge functionality
 /// requires the browser Fetch API.
 class UspBridgeClient {
-  UspBridgeClient(UspClient usp);
+  UspBridgeClient(UspClient usp, {BridgeEndpoints? endpoints});
 
   Future<Map<String, dynamic>> health() =>
       throw UnsupportedError('UspBridgeClient is only available on Web');

--- a/lib/core/usp/services/usp_bridge_client_web.dart
+++ b/lib/core/usp/services/usp_bridge_client_web.dart
@@ -7,7 +7,19 @@ import 'package:http/http.dart' as http;
 import 'package:web/web.dart' as web;
 
 import 'bridge_endpoints.dart';
+import 'sse_operation_strategy.dart';
 import 'usp_client.dart';
+
+export 'sse_operation_strategy.dart' show AuthBehavior;
+
+/// Exception thrown when session expires and cannot be recovered.
+class SessionExpiredException implements Exception {
+  final String message;
+  SessionExpiredException(this.message);
+
+  @override
+  String toString() => 'SessionExpiredException: $message';
+}
 
 /// Global JS property to persist SSE AbortController across hot restarts.
 @JS('_sseAbort')
@@ -28,15 +40,21 @@ class UspBridgeClient {
   final BridgeEndpoints _endpoints;
   final String? _overrideToken;
   final String? _clientTypeId;
+  final AuthBehavior _authBehavior;
+
+  /// Called when auth fails and cannot be recovered (session expired).
+  void Function()? onAuthFailed;
 
   UspBridgeClient(
     this._usp, {
     BridgeEndpoints? endpoints,
     String? authToken,
     String? clientTypeId,
+    AuthBehavior authBehavior = AuthBehavior.local,
   })  : _endpoints = endpoints ?? BridgeEndpoints.local,
         _overrideToken = authToken,
-        _clientTypeId = clientTypeId;
+        _clientTypeId = clientTypeId,
+        _authBehavior = authBehavior;
 
   /// Active SSE AbortController — stored so [abortSse] can cancel
   /// synchronously from a `beforeunload` handler.
@@ -67,17 +85,33 @@ class UspBridgeClient {
   // 401 Auth Retry (REST path)
   // ══════════════════════════════════════════════════════════════════════════
 
-  /// Wraps a REST request with 401 retry. On 401, delegates to
-  /// [UspClient.reauth] (shared Completer lock) then retries once.
+  /// Wraps a REST request with 401 handling based on [AuthBehavior].
+  ///
+  /// Local mode: delegates to [UspClient.reauth] then retries once.
+  /// Remote mode: no retry (temporaryAccessToken cannot refresh), triggers
+  /// [onAuthFailed] and throws [SessionExpiredException].
   Future<T> _withAuthRetry<T>(
     Future<http.Response> Function() request,
     T Function(http.Response) parser,
   ) async {
     var response = await request();
     if (response.statusCode == 401) {
-      debugPrint('[UspBridgeClient] 401 detected, triggering reauth...');
-      await _usp.reauth();
-      response = await request();
+      if (_authBehavior.shouldRetryOnFailure) {
+        // Local mode: reauth + retry
+        debugPrint('[UspBridgeClient] 401 detected, attempting reauth...');
+        await _usp.reauth();
+        response = await request();
+        if (response.statusCode == 401) {
+          debugPrint('[UspBridgeClient] 401 after reauth — session expired');
+          onAuthFailed?.call();
+          throw SessionExpiredException('Local session expired after reauth');
+        }
+      } else {
+        // Remote mode: no retry, session is over
+        debugPrint('[UspBridgeClient] 401 in Remote mode — session expired');
+        onAuthFailed?.call();
+        throw SessionExpiredException('Remote session expired');
+      }
     }
     return parser(response);
   }
@@ -205,21 +239,35 @@ class UspBridgeClient {
 
       if (!response.ok) {
         if (response.status == 401) {
-          if (authRetryCount >= 1) {
-            debug('401 retry limit reached (max 1 retry)');
-            controller.addError('SSE 401 after reauth retry');
-            await controller.close();
-            return;
-          }
-          debug('401 detected, attempting reauth and reconnect...');
-          try {
-            await _usp.reauth();
-            debug('Reauth succeeded, reconnecting SSE...');
-            await _startSseStream(controller, abortController,
-                authRetryCount: authRetryCount + 1);
-          } catch (e) {
-            debug('Reauth failed: $e');
-            controller.addError('SSE 401 reauth failed: $e');
+          if (_authBehavior.shouldRetryOnFailure) {
+            // Local mode: attempt reauth and retry
+            if (authRetryCount >= 1) {
+              debug('401 retry limit reached (max 1 retry)');
+              onAuthFailed?.call();
+              controller.addError(SessionExpiredException(
+                  'Local session expired after reauth'));
+              await controller.close();
+              return;
+            }
+            debug('401 detected, attempting reauth and reconnect...');
+            try {
+              await _usp.reauth();
+              debug('Reauth succeeded, reconnecting SSE...');
+              await _startSseStream(controller, abortController,
+                  authRetryCount: authRetryCount + 1);
+            } catch (e) {
+              debug('Reauth failed: $e');
+              onAuthFailed?.call();
+              controller.addError(
+                  SessionExpiredException('SSE 401 reauth failed: $e'));
+              await controller.close();
+            }
+          } else {
+            // Remote mode: no retry, session is over
+            debug('401 in Remote mode — session expired, closing SSE');
+            onAuthFailed?.call();
+            controller
+                .addError(SessionExpiredException('Remote session expired'));
             await controller.close();
           }
           return;

--- a/lib/core/usp/services/usp_bridge_client_web.dart
+++ b/lib/core/usp/services/usp_bridge_client_web.dart
@@ -26,9 +26,17 @@ external set _jsSseAbort(JSAny? value);
 class UspBridgeClient {
   final UspClient _usp;
   final BridgeEndpoints _endpoints;
+  final String? _overrideToken;
+  final String? _clientTypeId;
 
-  UspBridgeClient(this._usp, {BridgeEndpoints? endpoints})
-      : _endpoints = endpoints ?? BridgeEndpoints.local;
+  UspBridgeClient(
+    this._usp, {
+    BridgeEndpoints? endpoints,
+    String? authToken,
+    String? clientTypeId,
+  })  : _endpoints = endpoints ?? BridgeEndpoints.local,
+        _overrideToken = authToken,
+        _clientTypeId = clientTypeId;
 
   /// Active SSE AbortController — stored so [abortSse] can cancel
   /// synchronously from a `beforeunload` handler.
@@ -37,6 +45,10 @@ class UspBridgeClient {
   String get _baseUrl => _usp.baseUrl;
 
   String get _token {
+    // Remote mode: use override token (temporaryAccessToken from Guardian)
+    if (_overrideToken != null) return _overrideToken;
+
+    // Local mode: use session token from WASM client
     final token = _usp.sessionToken;
     if (token == null) {
       throw StateError('Session token not available. '
@@ -48,6 +60,7 @@ class UspBridgeClient {
   Map<String, String> get _authHeaders => {
         'Authorization': 'Bearer $_token',
         'Content-Type': 'application/json',
+        if (_clientTypeId != null) 'X-Linksys-Client-Type-Id': _clientTypeId,
       };
 
   // ══════════════════════════════════════════════════════════════════════════
@@ -175,12 +188,9 @@ class UspBridgeClient {
       final url = '$_baseUrl${_endpoints.notifications}';
       debug('Fetching $url ...');
 
-      final token = _token;
-      debug('Token: ${token.substring(0, 20)}...(${token.length} chars)');
-
       final headers = web.Headers();
-      headers.append('Authorization', 'Bearer $token');
-      headers.append('Accept', 'text/event-stream');
+      _authHeaders.forEach((k, v) => headers.append(k, v));
+      headers.set('Accept', 'text/event-stream'); // override Content-Type
 
       final init = web.RequestInit(
         method: 'GET',
@@ -368,6 +378,26 @@ class UspBridgeClient {
       ),
       (r) => jsonDecode(r.body) as Map<String, dynamic>,
     );
+  }
+
+  /// Lists all active subscriptions (Remote mode only).
+  Future<List<String>> listSubscriptions() async {
+    final response = await _withAuthRetry(
+      () => http.get(
+        Uri.parse('$_baseUrl${_endpoints.subscription}'),
+        headers: _authHeaders,
+      ),
+      (r) => jsonDecode(r.body),
+    );
+    // Format: { "subscriptions": [{"subscription_id": "...", ...}, ...] }
+    if (response is Map && response['subscriptions'] is List) {
+      final subs = response['subscriptions'] as List;
+      return subs
+          .map((s) => s is Map ? s['subscription_id'] as String? : null)
+          .whereType<String>()
+          .toList();
+    }
+    return [];
   }
 
   // ══════════════════════════════════════════════════════════════════════════

--- a/lib/core/usp/services/usp_bridge_client_web.dart
+++ b/lib/core/usp/services/usp_bridge_client_web.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:web/web.dart' as web;
 
+import 'bridge_endpoints.dart';
 import 'usp_client.dart';
 
 /// Global JS property to persist SSE AbortController across hot restarts.
@@ -24,8 +25,10 @@ external set _jsSseAbort(JSAny? value);
 /// re-authentication to [UspClient.reauth].
 class UspBridgeClient {
   final UspClient _usp;
+  final BridgeEndpoints _endpoints;
 
-  UspBridgeClient(this._usp);
+  UspBridgeClient(this._usp, {BridgeEndpoints? endpoints})
+      : _endpoints = endpoints ?? BridgeEndpoints.local;
 
   /// Active SSE AbortController — stored so [abortSse] can cancel
   /// synchronously from a `beforeunload` handler.
@@ -70,11 +73,11 @@ class UspBridgeClient {
   // Health
   // ══════════════════════════════════════════════════════════════════════════
 
-  /// Calls GET /api/v1/health.
+  /// Calls GET health endpoint.
   Future<Map<String, dynamic>> health() async {
     return _withAuthRetry(
-      () =>
-          http.get(Uri.parse('$_baseUrl/api/v1/health'), headers: _authHeaders),
+      () => http.get(Uri.parse('$_baseUrl${_endpoints.health}'),
+          headers: _authHeaders),
       (r) => jsonDecode(r.body) as Map<String, dynamic>,
     );
   }
@@ -141,7 +144,7 @@ class UspBridgeClient {
   Future<Map<String, String>> notificationsProbe() async {
     final response = await http
         .get(
-      Uri.parse('$_baseUrl/api/v1/notifications'),
+      Uri.parse('$_baseUrl${_endpoints.notifications}'),
       headers: _authHeaders,
     )
         .timeout(const Duration(seconds: 5), onTimeout: () {
@@ -169,7 +172,7 @@ class UspBridgeClient {
     }
 
     try {
-      final url = '$_baseUrl/api/v1/notifications';
+      final url = '$_baseUrl${_endpoints.notifications}';
       debug('Fetching $url ...');
 
       final token = _token;
@@ -337,7 +340,7 @@ class UspBridgeClient {
     };
     return _withAuthRetry(
       () => http.post(
-        Uri.parse('$_baseUrl/api/v1/subscription'),
+        Uri.parse('$_baseUrl${_endpoints.subscription}'),
         headers: _authHeaders,
         body: jsonEncode({
           'action': 'register',
@@ -356,7 +359,7 @@ class UspBridgeClient {
   }) async {
     return _withAuthRetry(
       () => http.post(
-        Uri.parse('$_baseUrl/api/v1/subscription'),
+        Uri.parse('$_baseUrl${_endpoints.subscription}'),
         headers: _authHeaders,
         body: jsonEncode({
           'action': 'unregister',
@@ -384,7 +387,7 @@ class UspBridgeClient {
   /// Gets the current turbo channel status.
   Future<Map<String, dynamic>> turboStatus() async {
     return _withAuthRetry(
-      () => http.get(Uri.parse('$_baseUrl/api/v1/turbo/status'),
+      () => http.get(Uri.parse('$_baseUrl${_endpoints.turboPrefix}/status'),
           headers: _authHeaders),
       (r) => jsonDecode(r.body) as Map<String, dynamic>,
     );
@@ -401,7 +404,7 @@ class UspBridgeClient {
         sessionId != null ? jsonEncode({'session_id': sessionId}) : null;
     return _withAuthRetry(
       () => http.post(
-        Uri.parse('$_baseUrl/api/v1/turbo/$action'),
+        Uri.parse('$_baseUrl${_endpoints.turboPrefix}/$action'),
         headers: {
           ..._authHeaders,
           'Content-Type': 'application/json',

--- a/lib/core/usp/services/usp_client.dart
+++ b/lib/core/usp/services/usp_client.dart
@@ -83,7 +83,8 @@ class UspClient {
   /// Creates a UspClient from a pre-built WASM client (via UspClientBuilder).
   /// Used for Remote Assistance mode where the client is configured with
   /// custom endpoint, auth token, and extra headers.
-  UspClient.fromBuilder(dynamic jsClient) : _baseUrl = '' {
+  UspClient.fromBuilder(dynamic jsClient, {required String baseUrl})
+      : _baseUrl = baseUrl {
     if (!kIsWeb) {
       throw UnsupportedError('This POC only supports Web platforms currently.');
     }

--- a/lib/page/dashboard/orchestrator/dashboard_orchestrator.dart
+++ b/lib/page/dashboard/orchestrator/dashboard_orchestrator.dart
@@ -196,14 +196,10 @@ class DashboardOrchestrator extends AsyncNotifier<DashboardOrchestratorState> {
   /// competing with data GET requests on the bridge, which causes 503
   /// errors due to the single-threaded OBUSPA backend.
   ///
-  /// Skipped for Remote Assistance mode — Guardian proxy does not support SSE.
+  /// Strategy handles the registration logic:
+  /// - Local: direct register (bridge is idempotent)
+  /// - Remote: unregister → delay → register (to avoid ID conflicts)
   Future<void> _registerSSEAfterDomainReady() async {
-    final loginType = ref.read(authProvider).value?.loginType;
-    if (loginType == LoginType.remote) {
-      logger.d('[USP][Orchestrator]: Skipping SSE in Remote Assistance mode');
-      return;
-    }
-
     await ref.read(dashboardDomainReadyProvider.future);
 
     // Wait for throttler to fully drain (WAN, LAN, DHCP, firewall, etc.)
@@ -221,7 +217,7 @@ class DashboardOrchestrator extends AsyncNotifier<DashboardOrchestratorState> {
     }
 
     manager.setCoreSubscriptions(coreSubscriptions);
-    await manager.registerDeferredSubscriptions(force: true);
+    await manager.registerCoreSubscriptions();
     logger.d(
         '[USP][Orchestrator]: SSE subscriptions registered after domain ready');
   }

--- a/test/core/usp/mocks.dart
+++ b/test/core/usp/mocks.dart
@@ -1,4 +1,6 @@
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/models/sse_subscription_record.dart';
+import 'package:privacy_gui/core/usp/services/sse_operation_strategy.dart';
 import 'package:privacy_gui/core/usp/services/usp_bridge_client.dart';
 import 'package:privacy_gui/core/usp/services/usp_client.dart';
 import 'package:privacy_gui/core/usp/services/sse_manager.dart';
@@ -8,3 +10,76 @@ class MockUspBridgeClient extends Mock implements UspBridgeClient {}
 class MockUspClient extends Mock implements UspClient {}
 
 class MockSseManager extends Mock implements SseManager {}
+
+class MockSseOperationStrategy extends Mock implements SseOperationStrategy {}
+
+/// Fake strategy for testing that behaves like LocalSseStrategy.
+class FakeSseOperationStrategy implements SseOperationStrategy {
+  final UspBridgeClient bridge;
+
+  FakeSseOperationStrategy(this.bridge);
+
+  @override
+  HeartbeatConfig get heartbeatConfig => HeartbeatConfig.local;
+
+  @override
+  Future<List<SseSubscriptionRecord>> registerSubscriptions(
+    List<SubscriptionDef> subscriptions,
+  ) async {
+    final records = <SseSubscriptionRecord>[];
+    for (final sub in subscriptions) {
+      try {
+        await bridge.subscribe(
+          subscriptionId: sub.subscriptionId,
+          path: sub.referenceList,
+          notifType: _notifTypeToInt(sub.notifType),
+        );
+        records.add(SseSubscriptionRecord(
+          subscriptionId: sub.subscriptionId,
+          notifType: sub.notifType,
+          referenceList: sub.referenceList,
+          createdAt: DateTime.now(),
+        ));
+      } catch (_) {
+        // Log and continue (matches real strategy behavior)
+      }
+    }
+    return records;
+  }
+
+  @override
+  Future<void> unregisterSubscriptions(List<String> subscriptionIds) async {
+    for (final id in subscriptionIds) {
+      await bridge.unsubscribe(subscriptionId: id);
+    }
+  }
+
+  @override
+  Future<void> onSseConnected(
+      List<SseSubscriptionRecord> existingRecords) async {
+    for (final record in existingRecords) {
+      await bridge.subscribe(
+        subscriptionId: record.subscriptionId,
+        path: record.referenceList,
+        notifType: _notifTypeToInt(record.notifType),
+      );
+    }
+  }
+
+  @override
+  Future<void> onSseDisconnected({required bool intentional}) async {}
+
+  @override
+  void dispose() {}
+
+  int _notifTypeToInt(String notifType) {
+    const mapping = {
+      'ValueChange': 1,
+      'ObjectCreation': 2,
+      'ObjectDeletion': 3,
+      'OperationComplete': 4,
+      'Event': 5,
+    };
+    return mapping[notifType] ?? 1;
+  }
+}

--- a/test/core/usp/mocks.dart
+++ b/test/core/usp/mocks.dart
@@ -23,6 +23,9 @@ class FakeSseOperationStrategy implements SseOperationStrategy {
   HeartbeatConfig get heartbeatConfig => HeartbeatConfig.local;
 
   @override
+  AuthBehavior get authBehavior => AuthBehavior.local;
+
+  @override
   Future<List<SseSubscriptionRecord>> registerSubscriptions(
     List<SubscriptionDef> subscriptions,
   ) async {

--- a/test/core/usp/services/sse_local_strategy_test.dart
+++ b/test/core/usp/services/sse_local_strategy_test.dart
@@ -32,6 +32,12 @@ void main() {
     });
   });
 
+  group('authBehavior', () {
+    test('returns local config with shouldRetryOnFailure=true', () {
+      expect(strategy.authBehavior.shouldRetryOnFailure, isTrue);
+    });
+  });
+
   group('registerSubscriptions', () {
     test('calls bridge.subscribe for each subscription', () async {
       await strategy.registerSubscriptions([

--- a/test/core/usp/services/sse_local_strategy_test.dart
+++ b/test/core/usp/services/sse_local_strategy_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/services/sse_local_strategy.dart';
+import 'package:privacy_gui/core/usp/services/sse_operation_strategy.dart';
+import 'package:privacy_gui/core/usp/models/sse_subscription_record.dart';
+
+import '../mocks.dart';
+
+void main() {
+  late MockUspBridgeClient mockBridge;
+  late LocalSseStrategy strategy;
+
+  setUp(() {
+    mockBridge = MockUspBridgeClient();
+    strategy = LocalSseStrategy(mockBridge);
+
+    when(() => mockBridge.subscribe(
+          subscriptionId: any(named: 'subscriptionId'),
+          path: any(named: 'path'),
+          notifType: any(named: 'notifType'),
+        )).thenAnswer((_) async => {});
+    when(() => mockBridge.unsubscribe(
+          subscriptionId: any(named: 'subscriptionId'),
+        )).thenAnswer((_) async => {});
+  });
+
+  group('heartbeatConfig', () {
+    test('returns local config with enabled=true', () {
+      expect(strategy.heartbeatConfig.enabled, isTrue);
+      expect(strategy.heartbeatConfig.authCheckEnabled, isTrue);
+      expect(strategy.heartbeatConfig.timeout, const Duration(seconds: 45));
+    });
+  });
+
+  group('registerSubscriptions', () {
+    test('calls bridge.subscribe for each subscription', () async {
+      await strategy.registerSubscriptions([
+        SubscriptionDef(
+          subscriptionId: 'sub-1',
+          notifType: 'ValueChange',
+          referenceList: 'Device.WiFi.',
+        ),
+        SubscriptionDef(
+          subscriptionId: 'sub-2',
+          notifType: 'ObjectCreation',
+          referenceList: 'Device.Hosts.',
+        ),
+      ]);
+
+      verify(() => mockBridge.subscribe(
+            subscriptionId: 'sub-1',
+            path: 'Device.WiFi.',
+            notifType: 1,
+          )).called(1);
+      verify(() => mockBridge.subscribe(
+            subscriptionId: 'sub-2',
+            path: 'Device.Hosts.',
+            notifType: 2,
+          )).called(1);
+    });
+
+    test('returns records for successful registrations', () async {
+      final records = await strategy.registerSubscriptions([
+        SubscriptionDef(
+          subscriptionId: 'sub-1',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Test.',
+        ),
+      ]);
+
+      expect(records.length, 1);
+      expect(records.first.subscriptionId, 'sub-1');
+      expect(records.first.notifType, 'ValueChange');
+    });
+
+    test('continues on failure and excludes failed from results', () async {
+      when(() => mockBridge.subscribe(
+            subscriptionId: 'fail-sub',
+            path: any(named: 'path'),
+            notifType: any(named: 'notifType'),
+          )).thenThrow(Exception('bridge error'));
+
+      final records = await strategy.registerSubscriptions([
+        SubscriptionDef(
+          subscriptionId: 'fail-sub',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Fail.',
+        ),
+        SubscriptionDef(
+          subscriptionId: 'ok-sub',
+          notifType: 'ValueChange',
+          referenceList: 'Device.OK.',
+        ),
+      ]);
+
+      expect(records.length, 1);
+      expect(records.first.subscriptionId, 'ok-sub');
+    });
+
+    test('converts notifType correctly', () async {
+      await strategy.registerSubscriptions([
+        SubscriptionDef(
+            subscriptionId: 'vc',
+            notifType: 'ValueChange',
+            referenceList: 'D.'),
+        SubscriptionDef(
+            subscriptionId: 'oc',
+            notifType: 'ObjectCreation',
+            referenceList: 'D.'),
+        SubscriptionDef(
+            subscriptionId: 'od',
+            notifType: 'ObjectDeletion',
+            referenceList: 'D.'),
+        SubscriptionDef(
+            subscriptionId: 'op',
+            notifType: 'OperationComplete',
+            referenceList: 'D.'),
+        SubscriptionDef(
+            subscriptionId: 'ev', notifType: 'Event', referenceList: 'D.'),
+      ]);
+
+      verify(() => mockBridge.subscribe(
+          subscriptionId: 'vc', path: any(named: 'path'), notifType: 1));
+      verify(() => mockBridge.subscribe(
+          subscriptionId: 'oc', path: any(named: 'path'), notifType: 2));
+      verify(() => mockBridge.subscribe(
+          subscriptionId: 'od', path: any(named: 'path'), notifType: 3));
+      verify(() => mockBridge.subscribe(
+          subscriptionId: 'op', path: any(named: 'path'), notifType: 4));
+      verify(() => mockBridge.subscribe(
+          subscriptionId: 'ev', path: any(named: 'path'), notifType: 5));
+    });
+  });
+
+  group('unregisterSubscriptions', () {
+    test('calls bridge.unsubscribe for each id', () async {
+      await strategy.unregisterSubscriptions(['sub-1', 'sub-2']);
+
+      verify(() => mockBridge.unsubscribe(subscriptionId: 'sub-1')).called(1);
+      verify(() => mockBridge.unsubscribe(subscriptionId: 'sub-2')).called(1);
+    });
+
+    test('continues on failure', () async {
+      when(() => mockBridge.unsubscribe(subscriptionId: 'fail'))
+          .thenThrow(Exception('error'));
+
+      await strategy.unregisterSubscriptions(['fail', 'ok']);
+
+      verify(() => mockBridge.unsubscribe(subscriptionId: 'fail')).called(1);
+      verify(() => mockBridge.unsubscribe(subscriptionId: 'ok')).called(1);
+    });
+  });
+
+  group('onSseConnected', () {
+    test('resubscribes all existing records', () async {
+      final records = [
+        SseSubscriptionRecord(
+          subscriptionId: 'sub-1',
+          notifType: 'ValueChange',
+          referenceList: 'Device.WiFi.',
+          createdAt: DateTime.now(),
+        ),
+        SseSubscriptionRecord(
+          subscriptionId: 'sub-2',
+          notifType: 'ObjectCreation',
+          referenceList: 'Device.Hosts.',
+          createdAt: DateTime.now(),
+        ),
+      ];
+
+      await strategy.onSseConnected(records);
+
+      verify(() => mockBridge.subscribe(
+            subscriptionId: 'sub-1',
+            path: 'Device.WiFi.',
+            notifType: 1,
+          )).called(1);
+      verify(() => mockBridge.subscribe(
+            subscriptionId: 'sub-2',
+            path: 'Device.Hosts.',
+            notifType: 2,
+          )).called(1);
+    });
+
+    test('does nothing with empty records', () async {
+      await strategy.onSseConnected([]);
+
+      verifyNever(() => mockBridge.subscribe(
+            subscriptionId: any(named: 'subscriptionId'),
+            path: any(named: 'path'),
+            notifType: any(named: 'notifType'),
+          ));
+    });
+  });
+
+  group('onSseDisconnected', () {
+    test('does nothing (bridge handles cleanup)', () async {
+      await strategy.onSseDisconnected(intentional: true);
+      await strategy.onSseDisconnected(intentional: false);
+
+      verifyNever(() => mockBridge.unsubscribe(
+            subscriptionId: any(named: 'subscriptionId'),
+          ));
+    });
+  });
+}

--- a/test/core/usp/services/sse_manager_test.dart
+++ b/test/core/usp/services/sse_manager_test.dart
@@ -67,7 +67,11 @@ void main() {
     }
   });
 
-  SseManager createManager() => SseManager(usp: mockUsp, bridge: mockBridge);
+  SseManager createManager() => SseManager(
+        usp: mockUsp,
+        bridge: mockBridge,
+        strategy: FakeSseOperationStrategy(mockBridge),
+      );
 
   // ---------------------------------------------------------------------------
   // Construction / wiring
@@ -105,20 +109,42 @@ void main() {
       await manager.dispose();
     });
 
-    test('connection.onConnected triggers subscription registration', () async {
+    test('connection.onConnected triggers resubscribe of existing records',
+        () async {
       final manager = createManager();
 
-      // Set core subscriptions
+      // First register subscriptions via registerCoreSubscriptions
       manager.setCoreSubscriptions([
         ('wifi-vc', 'ValueChange', 'Device.WiFi.SSID.'),
       ]);
+      await manager.registerCoreSubscriptions();
+      expect(manager.registry.activeIds, contains('wifi-vc'));
 
+      // Reset mock to track resubscribe calls
+      reset(mockBridge);
+      when(() => mockBridge.notifications())
+          .thenAnswer((_) => streamController.stream);
+      when(() => mockBridge.subscribe(
+            subscriptionId: any(named: 'subscriptionId'),
+            path: any(named: 'path'),
+            notifType: any(named: 'notifType'),
+          )).thenAnswer((_) async => {});
+      when(() => mockBridge.unsubscribe(
+            subscriptionId: any(named: 'subscriptionId'),
+          )).thenAnswer((_) async => {});
+      when(() => mockBridge.abortSse()).thenReturn(null);
+
+      // Connect triggers onSseConnected which resubscribes existing records
       await manager.connect();
       streamController.add(heartbeatEvent());
       await Future.delayed(const Duration(milliseconds: 100));
 
-      // Core subscription should have been registered
-      expect(manager.registry.activeIds, contains('wifi-vc'));
+      // Should have resubscribed
+      verify(() => mockBridge.subscribe(
+            subscriptionId: 'wifi-vc',
+            path: 'Device.WiFi.SSID.',
+            notifType: 1,
+          )).called(1);
 
       await manager.dispose();
     });
@@ -276,7 +302,7 @@ void main() {
       manager.dispose();
     });
 
-    test('first connect registers core subs', () async {
+    test('registerCoreSubscriptions registers core subs', () async {
       final manager = createManager();
 
       manager.setCoreSubscriptions([
@@ -284,9 +310,8 @@ void main() {
         ('sub-2', 'ObjectCreation', 'Device.Hosts.Host.'),
       ]);
 
-      await manager.connect();
-      streamController.add(heartbeatEvent());
-      await Future.delayed(const Duration(milliseconds: 200));
+      // In new architecture, orchestrator calls registerCoreSubscriptions
+      await manager.registerCoreSubscriptions();
 
       expect(manager.registry.activeIds, containsAll(['sub-1', 'sub-2']));
 
@@ -334,19 +359,16 @@ void main() {
       await manager.dispose();
     });
 
-    test(
-        'registerDeferredSubscriptions with force=false and not deferred is no-op',
-        () async {
+    test('registerCoreSubscriptions registers all subscriptions', () async {
       final manager = createManager();
 
       manager.setCoreSubscriptions([
         ('sub-1', 'ValueChange', 'Device.Test.'),
       ]);
 
-      // force=false and _coreSubsDeferred=false → should not register
-      await manager.registerDeferredSubscriptions();
+      await manager.registerCoreSubscriptions();
 
-      expect(manager.registry.activeIds, isEmpty);
+      expect(manager.registry.activeIds, contains('sub-1'));
 
       manager.dispose();
     });
@@ -441,7 +463,11 @@ void main() {
 
     setUp(() {
       capturingUsp = _CapturingUspClient();
-      manager = SseManager(usp: capturingUsp, bridge: mockBridge);
+      manager = SseManager(
+        usp: capturingUsp,
+        bridge: mockBridge,
+        strategy: FakeSseOperationStrategy(mockBridge),
+      );
     });
 
     tearDown(() async {
@@ -655,7 +681,11 @@ void main() {
   group('onTokenRefreshed callback', () {
     test('forces disconnect then reconnect', () async {
       final capturingUsp = _CapturingUspClient();
-      final manager = SseManager(usp: capturingUsp, bridge: mockBridge);
+      final manager = SseManager(
+        usp: capturingUsp,
+        bridge: mockBridge,
+        strategy: FakeSseOperationStrategy(mockBridge),
+      );
 
       await manager.connect();
       streamController.add(heartbeatEvent());
@@ -681,9 +711,9 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // registerDeferredSubscriptions error handling
+  // registerCoreSubscriptions error handling
   // ---------------------------------------------------------------------------
-  group('registerDeferredSubscriptions error handling', () {
+  group('registerCoreSubscriptions error handling', () {
     test('logs and continues when registration fails', () async {
       // Make bridge.subscribe throw for specific subscription
       when(() => mockBridge.subscribe(
@@ -699,9 +729,8 @@ void main() {
         ('ok-sub', 'ValueChange', 'Device.OK.'),
       ]);
 
-      await manager.connect();
-      streamController.add(heartbeatEvent());
-      await Future.delayed(const Duration(milliseconds: 300));
+      // In new architecture, orchestrator calls registerCoreSubscriptions
+      await manager.registerCoreSubscriptions();
 
       // ok-sub should still be registered despite fail-sub throwing
       expect(manager.registry.activeIds, contains('ok-sub'));

--- a/test/core/usp/services/sse_operation_awaiter_test.dart
+++ b/test/core/usp/services/sse_operation_awaiter_test.dart
@@ -38,7 +38,11 @@ void main() {
     when(() => mockUsp.operate(any(), args: any(named: 'args')))
         .thenAnswer((_) async => {'commandKey': 'test-key-123'});
 
-    manager = SseManager(usp: mockUsp, bridge: mockBridge);
+    manager = SseManager(
+      usp: mockUsp,
+      bridge: mockBridge,
+      strategy: FakeSseOperationStrategy(mockBridge),
+    );
     awaiter = SseOperationAwaiter(manager, mockUsp);
   });
 

--- a/test/core/usp/services/sse_remote_strategy_test.dart
+++ b/test/core/usp/services/sse_remote_strategy_test.dart
@@ -33,6 +33,12 @@ void main() {
     });
   });
 
+  group('authBehavior', () {
+    test('returns remote config with shouldRetryOnFailure=false', () {
+      expect(strategy.authBehavior.shouldRetryOnFailure, isFalse);
+    });
+  });
+
   group('registerSubscriptions', () {
     test('calls unsubscribe before subscribe for each subscription', () async {
       await strategy.registerSubscriptions([

--- a/test/core/usp/services/sse_remote_strategy_test.dart
+++ b/test/core/usp/services/sse_remote_strategy_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/services/sse_remote_strategy.dart';
+import 'package:privacy_gui/core/usp/services/sse_operation_strategy.dart';
+import 'package:privacy_gui/core/usp/models/sse_subscription_record.dart';
+
+import '../mocks.dart';
+
+void main() {
+  late MockUspBridgeClient mockBridge;
+  late RemoteSseStrategy strategy;
+
+  setUp(() {
+    mockBridge = MockUspBridgeClient();
+    strategy = RemoteSseStrategy(mockBridge);
+
+    when(() => mockBridge.subscribe(
+          subscriptionId: any(named: 'subscriptionId'),
+          path: any(named: 'path'),
+          notifType: any(named: 'notifType'),
+        )).thenAnswer((_) async => {});
+    when(() => mockBridge.unsubscribe(
+          subscriptionId: any(named: 'subscriptionId'),
+        )).thenAnswer((_) async => {});
+    when(() => mockBridge.listSubscriptions())
+        .thenAnswer((_) async => <String>[]);
+  });
+
+  group('heartbeatConfig', () {
+    test('returns remote config with enabled=false', () {
+      expect(strategy.heartbeatConfig.enabled, isFalse);
+      expect(strategy.heartbeatConfig.authCheckEnabled, isFalse);
+    });
+  });
+
+  group('registerSubscriptions', () {
+    test('calls unsubscribe before subscribe for each subscription', () async {
+      await strategy.registerSubscriptions([
+        SubscriptionDef(
+          subscriptionId: 'sub-1',
+          notifType: 'ValueChange',
+          referenceList: 'Device.WiFi.',
+        ),
+      ]);
+
+      verifyInOrder([
+        () => mockBridge.unsubscribe(subscriptionId: 'sub-1'),
+        () => mockBridge.subscribe(
+              subscriptionId: 'sub-1',
+              path: 'Device.WiFi.',
+              notifType: 1,
+            ),
+      ]);
+    });
+
+    test('ignores unsubscribe error and continues to subscribe', () async {
+      when(() => mockBridge.unsubscribe(
+              subscriptionId: any(named: 'subscriptionId')))
+          .thenThrow(Exception('not found'));
+
+      final records = await strategy.registerSubscriptions([
+        SubscriptionDef(
+          subscriptionId: 'sub-1',
+          notifType: 'ValueChange',
+          referenceList: 'Device.WiFi.',
+        ),
+      ]);
+
+      expect(records.length, 1);
+      verify(() => mockBridge.subscribe(
+            subscriptionId: 'sub-1',
+            path: 'Device.WiFi.',
+            notifType: 1,
+          )).called(1);
+    });
+
+    test('returns records for successful registrations', () async {
+      final records = await strategy.registerSubscriptions([
+        SubscriptionDef(
+          subscriptionId: 'sub-1',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Test.',
+        ),
+      ]);
+
+      expect(records.length, 1);
+      expect(records.first.subscriptionId, 'sub-1');
+    });
+
+    test('continues on subscribe failure', () async {
+      when(() => mockBridge.subscribe(
+            subscriptionId: 'fail-sub',
+            path: any(named: 'path'),
+            notifType: any(named: 'notifType'),
+          )).thenThrow(Exception('guardian error'));
+
+      final records = await strategy.registerSubscriptions([
+        SubscriptionDef(
+          subscriptionId: 'fail-sub',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Fail.',
+        ),
+        SubscriptionDef(
+          subscriptionId: 'ok-sub',
+          notifType: 'ValueChange',
+          referenceList: 'Device.OK.',
+        ),
+      ]);
+
+      expect(records.length, 1);
+      expect(records.first.subscriptionId, 'ok-sub');
+    });
+  });
+
+  group('unregisterSubscriptions', () {
+    test('calls bridge.unsubscribe for each id', () async {
+      await strategy.unregisterSubscriptions(['sub-1', 'sub-2']);
+
+      verify(() => mockBridge.unsubscribe(subscriptionId: 'sub-1')).called(1);
+      verify(() => mockBridge.unsubscribe(subscriptionId: 'sub-2')).called(1);
+    });
+
+    test('continues on failure', () async {
+      when(() => mockBridge.unsubscribe(subscriptionId: 'fail'))
+          .thenThrow(Exception('error'));
+
+      await strategy.unregisterSubscriptions(['fail', 'ok']);
+
+      verify(() => mockBridge.unsubscribe(subscriptionId: 'ok')).called(1);
+    });
+  });
+
+  group('onSseConnected', () {
+    test('does NOT auto resubscribe (orchestrator controls)', () async {
+      final records = [
+        SseSubscriptionRecord(
+          subscriptionId: 'sub-1',
+          notifType: 'ValueChange',
+          referenceList: 'Device.WiFi.',
+          createdAt: DateTime.now(),
+        ),
+      ];
+
+      await strategy.onSseConnected(records);
+
+      // Remote strategy does NOT auto resubscribe on connect
+      verifyNever(() => mockBridge.subscribe(
+            subscriptionId: any(named: 'subscriptionId'),
+            path: any(named: 'path'),
+            notifType: any(named: 'notifType'),
+          ));
+    });
+  });
+
+  group('onSseDisconnected', () {
+    test('intentional disconnect triggers fire-and-forget cleanup', () async {
+      when(() => mockBridge.listSubscriptions())
+          .thenAnswer((_) async => ['sub-1', 'sub-2']);
+
+      await strategy.onSseDisconnected(intentional: true);
+
+      // Fire-and-forget, so we just verify it was called
+      // The actual cleanup happens asynchronously
+      await Future.delayed(const Duration(milliseconds: 50));
+      verify(() => mockBridge.listSubscriptions()).called(1);
+    });
+
+    test('unintentional disconnect does not trigger cleanup', () async {
+      await strategy.onSseDisconnected(intentional: false);
+
+      verifyNever(() => mockBridge.listSubscriptions());
+    });
+  });
+}

--- a/test/core/usp/services/sse_subscription_registry_test.dart
+++ b/test/core/usp/services/sse_subscription_registry_test.dart
@@ -1,16 +1,19 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/usp/services/sse_operation_strategy.dart';
 import 'package:privacy_gui/core/usp/services/sse_subscription_registry.dart';
 
 import '../mocks.dart';
 
 void main() {
   late MockUspBridgeClient mockBridge;
+  late FakeSseOperationStrategy strategy;
   late SseSubscriptionRegistry registry;
 
   setUp(() {
     mockBridge = MockUspBridgeClient();
-    registry = SseSubscriptionRegistry(mockBridge);
+    strategy = FakeSseOperationStrategy(mockBridge);
+    registry = SseSubscriptionRegistry(strategy);
 
     // Default stubs
     when(() => mockBridge.subscribe(
@@ -24,15 +27,17 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // register
+  // registerAll
   // ---------------------------------------------------------------------------
-  group('register', () {
-    test('calls bridge.subscribe with correct params', () async {
-      await registry.register(
-        subscriptionId: 'wifi-vc',
-        notifType: 'ValueChange',
-        referenceList: 'Device.WiFi.SSID.',
-      );
+  group('registerAll', () {
+    test('calls strategy.registerSubscriptions with correct params', () async {
+      await registry.registerAll([
+        SubscriptionDef(
+          subscriptionId: 'wifi-vc',
+          notifType: 'ValueChange',
+          referenceList: 'Device.WiFi.SSID.',
+        ),
+      ]);
 
       verify(() => mockBridge.subscribe(
             subscriptionId: 'wifi-vc',
@@ -41,40 +46,33 @@ void main() {
           )).called(1);
     });
 
-    test('returns SseSubscriptionRecord with correct fields', () async {
-      final record = await registry.register(
-        subscriptionId: 'hosts-oc',
-        notifType: 'ObjectCreation',
-        referenceList: 'Device.Hosts.Host.',
-      );
-
-      expect(record.subscriptionId, 'hosts-oc');
-      expect(record.notifType, 'ObjectCreation');
-      expect(record.referenceList, 'Device.Hosts.Host.');
-      expect(record.createdAt, isNotNull);
-    });
-
     test('adds to activeIds', () async {
-      await registry.register(
-        subscriptionId: 'test-sub',
-        notifType: 'ValueChange',
-        referenceList: 'Device.Test.',
-      );
+      await registry.registerAll([
+        SubscriptionDef(
+          subscriptionId: 'test-sub',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Test.',
+        ),
+      ]);
 
       expect(registry.activeIds, contains('test-sub'));
     });
 
-    test('duplicate subscriptionId skips bridge call', () async {
-      await registry.register(
-        subscriptionId: 'dup-sub',
-        notifType: 'ValueChange',
-        referenceList: 'Device.Test.',
-      );
-      await registry.register(
-        subscriptionId: 'dup-sub',
-        notifType: 'ValueChange',
-        referenceList: 'Device.Test.',
-      );
+    test('duplicate subscriptionId skips strategy call', () async {
+      await registry.registerAll([
+        SubscriptionDef(
+          subscriptionId: 'dup-sub',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Test.',
+        ),
+      ]);
+      await registry.registerAll([
+        SubscriptionDef(
+          subscriptionId: 'dup-sub',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Test.',
+        ),
+      ]);
 
       verify(() => mockBridge.subscribe(
             subscriptionId: 'dup-sub',
@@ -83,47 +81,21 @@ void main() {
           )).called(1); // Only 1 call, not 2
     });
 
-    test('duplicate returns existing record', () async {
-      final first = await registry.register(
-        subscriptionId: 'dup-sub',
-        notifType: 'ValueChange',
-        referenceList: 'Device.Test.',
-      );
-      final second = await registry.register(
-        subscriptionId: 'dup-sub',
-        notifType: 'ValueChange',
-        referenceList: 'Device.Test.',
-      );
+    test('registers multiple subscriptions', () async {
+      await registry.registerAll([
+        SubscriptionDef(
+          subscriptionId: 'sub-1',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Test.1.',
+        ),
+        SubscriptionDef(
+          subscriptionId: 'sub-2',
+          notifType: 'ObjectCreation',
+          referenceList: 'Device.Test.2.',
+        ),
+      ]);
 
-      expect(identical(first, second), isTrue);
-    });
-
-    test('notifType conversion: ValueChange→1', () async {
-      await registry.register(
-        subscriptionId: 'vc',
-        notifType: 'ValueChange',
-        referenceList: 'Device.Test.',
-      );
-
-      verify(() => mockBridge.subscribe(
-            subscriptionId: any(named: 'subscriptionId'),
-            path: any(named: 'path'),
-            notifType: 1,
-          )).called(1);
-    });
-
-    test('notifType conversion: OperationComplete→4', () async {
-      await registry.register(
-        subscriptionId: 'oc',
-        notifType: 'OperationComplete',
-        referenceList: 'Device.Test.',
-      );
-
-      verify(() => mockBridge.subscribe(
-            subscriptionId: any(named: 'subscriptionId'),
-            path: any(named: 'path'),
-            notifType: 4,
-          )).called(1);
+      expect(registry.activeIds, containsAll(['sub-1', 'sub-2']));
     });
   });
 
@@ -131,12 +103,14 @@ void main() {
   // unregister
   // ---------------------------------------------------------------------------
   group('unregister', () {
-    test('calls bridge.unsubscribe', () async {
-      await registry.register(
-        subscriptionId: 'to-remove',
-        notifType: 'ValueChange',
-        referenceList: 'Device.Test.',
-      );
+    test('calls strategy.unregisterSubscriptions', () async {
+      await registry.registerAll([
+        SubscriptionDef(
+          subscriptionId: 'to-remove',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Test.',
+        ),
+      ]);
 
       await registry.unregister('to-remove');
 
@@ -146,116 +120,25 @@ void main() {
     });
 
     test('removes from activeIds', () async {
-      await registry.register(
-        subscriptionId: 'to-remove',
-        notifType: 'ValueChange',
-        referenceList: 'Device.Test.',
-      );
+      await registry.registerAll([
+        SubscriptionDef(
+          subscriptionId: 'to-remove',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Test.',
+        ),
+      ]);
 
       await registry.unregister('to-remove');
 
       expect(registry.activeIds, isNot(contains('to-remove')));
     });
 
-    test('unknown subscriptionId has no bridge call', () async {
+    test('unknown subscriptionId has no strategy call', () async {
       await registry.unregister('nonexistent');
 
       verifyNever(() => mockBridge.unsubscribe(
             subscriptionId: any(named: 'subscriptionId'),
           ));
-    });
-
-    test('bridge.unsubscribe failure still removes from map', () async {
-      when(() => mockBridge.unsubscribe(
-            subscriptionId: any(named: 'subscriptionId'),
-          )).thenThrow(Exception('network error'));
-
-      await registry.register(
-        subscriptionId: 'fail-unsub',
-        notifType: 'ValueChange',
-        referenceList: 'Device.Test.',
-      );
-
-      await registry.unregister('fail-unsub');
-
-      expect(registry.activeIds, isNot(contains('fail-unsub')));
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // resubscribeAll
-  // ---------------------------------------------------------------------------
-  group('resubscribeAll', () {
-    test('re-registers all tracked subscriptions', () async {
-      await registry.register(
-        subscriptionId: 'sub-1',
-        notifType: 'ValueChange',
-        referenceList: 'Device.WiFi.SSID.',
-      );
-      await registry.register(
-        subscriptionId: 'sub-2',
-        notifType: 'ObjectCreation',
-        referenceList: 'Device.Hosts.Host.',
-      );
-
-      reset(mockBridge);
-      when(() => mockBridge.subscribe(
-            subscriptionId: any(named: 'subscriptionId'),
-            path: any(named: 'path'),
-            notifType: any(named: 'notifType'),
-          )).thenAnswer((_) async => {});
-
-      await registry.resubscribeAll();
-
-      verify(() => mockBridge.subscribe(
-            subscriptionId: any(named: 'subscriptionId'),
-            path: any(named: 'path'),
-            notifType: any(named: 'notifType'),
-          )).called(2);
-    });
-
-    test('empty registry has no bridge calls', () async {
-      await registry.resubscribeAll();
-
-      verifyNever(() => mockBridge.subscribe(
-            subscriptionId: any(named: 'subscriptionId'),
-            path: any(named: 'path'),
-            notifType: any(named: 'notifType'),
-          ));
-    });
-
-    test('one failure does not stop others', () async {
-      await registry.register(
-        subscriptionId: 'sub-1',
-        notifType: 'ValueChange',
-        referenceList: 'Device.Test.',
-      );
-      await registry.register(
-        subscriptionId: 'sub-2',
-        notifType: 'ObjectCreation',
-        referenceList: 'Device.Test.',
-      );
-
-      reset(mockBridge);
-      var callCount = 0;
-      when(() => mockBridge.subscribe(
-            subscriptionId: any(named: 'subscriptionId'),
-            path: any(named: 'path'),
-            notifType: any(named: 'notifType'),
-          )).thenAnswer((_) async {
-        callCount++;
-        if (callCount == 1) throw Exception('first fails');
-        return {};
-      });
-
-      await registry.resubscribeAll();
-
-      // Both were attempted
-      verify(() => mockBridge.subscribe(
-            subscriptionId: any(named: 'subscriptionId'),
-            path: any(named: 'path'),
-            notifType: any(named: 'notifType'),
-          )).called(2);
     });
   });
 
@@ -264,16 +147,18 @@ void main() {
   // ---------------------------------------------------------------------------
   group('unregisterAll', () {
     test('unregisters each subscription', () async {
-      await registry.register(
-        subscriptionId: 'sub-1',
-        notifType: 'ValueChange',
-        referenceList: 'Device.Test.',
-      );
-      await registry.register(
-        subscriptionId: 'sub-2',
-        notifType: 'ObjectCreation',
-        referenceList: 'Device.Test.',
-      );
+      await registry.registerAll([
+        SubscriptionDef(
+          subscriptionId: 'sub-1',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Test.',
+        ),
+        SubscriptionDef(
+          subscriptionId: 'sub-2',
+          notifType: 'ObjectCreation',
+          referenceList: 'Device.Test.',
+        ),
+      ]);
 
       await registry.unregisterAll();
 
@@ -286,11 +171,13 @@ void main() {
     });
 
     test('activeIds empty after', () async {
-      await registry.register(
-        subscriptionId: 'sub-1',
-        notifType: 'ValueChange',
-        referenceList: 'Device.Test.',
-      );
+      await registry.registerAll([
+        SubscriptionDef(
+          subscriptionId: 'sub-1',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Test.',
+        ),
+      ]);
 
       await registry.unregisterAll();
 
@@ -299,63 +186,88 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // _notifTypeToInt (tested indirectly via register)
+  // onSseConnected
   // ---------------------------------------------------------------------------
-  group('notifType conversion', () {
-    test('ObjectCreation → 2', () async {
-      await registry.register(
-        subscriptionId: 'oc',
-        notifType: 'ObjectCreation',
-        referenceList: 'Device.Test.',
-      );
+  group('onSseConnected', () {
+    test('delegates to strategy.onSseConnected', () async {
+      await registry.registerAll([
+        SubscriptionDef(
+          subscriptionId: 'sub-1',
+          notifType: 'ValueChange',
+          referenceList: 'Device.WiFi.SSID.',
+        ),
+      ]);
 
-      verify(() => mockBridge.subscribe(
+      reset(mockBridge);
+      when(() => mockBridge.subscribe(
             subscriptionId: any(named: 'subscriptionId'),
             path: any(named: 'path'),
-            notifType: 2,
-          )).called(1);
-    });
+            notifType: any(named: 'notifType'),
+          )).thenAnswer((_) async => {});
 
-    test('ObjectDeletion → 3', () async {
-      await registry.register(
-        subscriptionId: 'od',
-        notifType: 'ObjectDeletion',
-        referenceList: 'Device.Test.',
-      );
+      await registry.onSseConnected();
 
+      // FakeSseOperationStrategy resubscribes on connect
       verify(() => mockBridge.subscribe(
-            subscriptionId: any(named: 'subscriptionId'),
-            path: any(named: 'path'),
-            notifType: 3,
-          )).called(1);
-    });
-
-    test('Event → 5', () async {
-      await registry.register(
-        subscriptionId: 'ev',
-        notifType: 'Event',
-        referenceList: 'Device.Test.',
-      );
-
-      verify(() => mockBridge.subscribe(
-            subscriptionId: any(named: 'subscriptionId'),
-            path: any(named: 'path'),
-            notifType: 5,
-          )).called(1);
-    });
-
-    test('unknown type defaults to 1', () async {
-      await registry.register(
-        subscriptionId: 'unknown',
-        notifType: 'CustomType',
-        referenceList: 'Device.Test.',
-      );
-
-      verify(() => mockBridge.subscribe(
-            subscriptionId: any(named: 'subscriptionId'),
-            path: any(named: 'path'),
+            subscriptionId: 'sub-1',
+            path: 'Device.WiFi.SSID.',
             notifType: 1,
           )).called(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // onSseDisconnected
+  // ---------------------------------------------------------------------------
+  group('onSseDisconnected', () {
+    test('intentional disconnect clears local state', () async {
+      await registry.registerAll([
+        SubscriptionDef(
+          subscriptionId: 'sub-1',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Test.',
+        ),
+      ]);
+
+      await registry.onSseDisconnected(intentional: true);
+
+      expect(registry.activeIds, isEmpty);
+    });
+
+    test('unintentional disconnect preserves local state', () async {
+      await registry.registerAll([
+        SubscriptionDef(
+          subscriptionId: 'sub-1',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Test.',
+        ),
+      ]);
+
+      await registry.onSseDisconnected(intentional: false);
+
+      expect(registry.activeIds, contains('sub-1'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // clearLocal
+  // ---------------------------------------------------------------------------
+  group('clearLocal', () {
+    test('clears in-memory state without backend call', () async {
+      await registry.registerAll([
+        SubscriptionDef(
+          subscriptionId: 'sub-1',
+          notifType: 'ValueChange',
+          referenceList: 'Device.Test.',
+        ),
+      ]);
+
+      registry.clearLocal();
+
+      expect(registry.activeIds, isEmpty);
+      verifyNever(() => mockBridge.unsubscribe(
+            subscriptionId: any(named: 'subscriptionId'),
+          ));
     });
   });
 }


### PR DESCRIPTION
## Summary
- Enable SSE and subscription functionality for Remote Assistance mode via Guardian proxy
- Introduce Strategy pattern to cleanly separate Local (usp-bridge) vs Remote (Guardian) behaviors
- Fix Guardian endpoint paths, auth token handling, and subscription ID conflicts

## Key Changes

### Strategy Pattern for SSE Operations
| Behavior | Local | Remote |
|----------|-------|--------|
| Register | Direct (bridge idempotent) | Unregister → delay → register |
| onSseConnected | Auto resubscribe | No-op (orchestrator controls) |
| Heartbeat watchdog | Enabled (45s) | Disabled |
| Auth check | Proactive refresh | Disabled (no refresh) |
| Cleanup on exit | Bridge handles | Fire-and-forget unregisterAll |

### Bug Fixes
- Add `/v1/guardians` prefix to Guardian endpoints
- Pass `baseUrl` to `UspClient.fromBuilder` for Remote mode
- Add `X-Linksys-Client-Type-Id` header for Guardian API calls
- Add `listSubscriptions()` API for subscription management

## Test Plan
- [x] All 2961 unit tests pass
- [x] New strategy tests cover Local/Remote behaviors (20 tests)
- [ ] Manual test: Remote Assistance SSE connection
- [ ] Manual test: Subscription register/unregister via Guardian
- [ ] Manual test: SSE notifications received in Remote mode

🤖 Generated with [Claude Code](https://claude.ai/code)