### PR TITLE
fix(dashboard): reset top/bottom bar visibility when navigating back

### DIFF
--- a/lib/route/route_usp_dashboard.dart
+++ b/lib/route/route_usp_dashboard.dart
@@ -10,7 +10,15 @@ final uspDashboardRoute = ShellRoute(
     LinksysRoute(
       name: RouteNamed.uspDashboard,
       path: RoutePath.uspDashboard,
-      builder: (context, state) => const UspDashboardView(),
+      builder: (context, state) {
+        // Reset bars visibility on every route enter (including pop back)
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          final container = ProviderScope.containerOf(context);
+          container.read(uspBarsVisibleProvider.notifier).state = true;
+          container.read(uspMenuController).setMenuVisible(true);
+        });
+        return const UspDashboardView();
+      },
     ),
     LinksysRoute(
       name: RouteNamed.uspMenu,

--- a/lib/route/router_provider.dart
+++ b/lib/route/router_provider.dart
@@ -23,6 +23,7 @@ import 'constants.dart';
 import 'navigation_extra.dart';
 
 // USP dashboard imports
+import 'package:privacy_gui/page/_shared/providers/usp_bars_visible_provider.dart';
 import 'package:privacy_gui/page/dashboard/views/usp_dashboard_view.dart';
 import 'package:privacy_gui/page/menu/views/usp_menu_view.dart';
 import 'package:privacy_gui/page/support/views/usp_support_view.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,11 +59,11 @@ dependencies:
   ui_kit_library:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.25.0
+      ref: v2.25.1
   generative_ui:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.25.0
+      ref: v2.25.1
       path: generative_ui
   flutter_blue_plus: ^1.4.0
   crypto: ^3.0.2


### PR DESCRIPTION
## Summary
- Fix dashboard top bar and bottom navigation bar remaining hidden after navigating back from sub-pages
- When user scrolls down on dashboard (hiding bars), navigates to a sub-page, then pops back, bars now correctly reset to visible
- Bump ui_kit_library and generative_ui to v2.25.1

## Root Cause
The dashboard widget stays in the navigation stack during push, so `initState` doesn't re-run on pop. The `uspBarsVisibleProvider` state remained `false` even though scroll position was reset.

## Solution
Reset `uspBarsVisibleProvider` and `MenuController.isVisible` in the route builder's `postFrameCallback`, which runs on every route enter including pop-back scenarios.

## Test plan
- [ ] On dashboard, scroll down until top bar and bottom nav hide
- [ ] Tap any card that navigates to a sub-page (e.g., device detail, wifi settings)
- [ ] Press back to return to dashboard
- [ ] Verify top bar and bottom nav are visible

Closes #966
Closes #961

🤖 Generated with [Claude Code](https://claude.ai/claude-code)