### PR TITLE
fix(sse): add 'remote-' prefix to Remote subscription IDs

### DIFF
--- a/lib/core/usp/services/sse_remote_strategy.dart
+++ b/lib/core/usp/services/sse_remote_strategy.dart
@@ -12,13 +12,20 @@ import 'usp_bridge_client.dart';
 /// - No auto resubscribe on reconnect (orchestrator controls)
 /// - Heartbeat watchdog disabled (Guardian doesn't send heartbeats)
 /// - No auth check (temporaryAccessToken cannot refresh)
+/// - Uses 'remote-' prefix for subscription IDs to avoid collision with Local
 class RemoteSseStrategy implements SseOperationStrategy {
   final UspBridgeClient _bridge;
+
+  /// Prefix for remote subscription IDs to avoid collision with Local mode.
+  static const _idPrefix = 'remote-';
 
   /// Delay between unregister and register to allow Guardian to process.
   static const _unregisterDelay = Duration(milliseconds: 100);
 
   RemoteSseStrategy(this._bridge);
+
+  String _toRemoteId(String id) => '$_idPrefix$id';
+  bool _isRemoteId(String id) => id.startsWith(_idPrefix);
 
   @override
   HeartbeatConfig get heartbeatConfig => HeartbeatConfig.remote;
@@ -33,23 +40,26 @@ class RemoteSseStrategy implements SseOperationStrategy {
     final records = <SseSubscriptionRecord>[];
 
     for (final sub in subscriptions) {
+      final remoteId = _toRemoteId(sub.subscriptionId);
       try {
-        logger.d('[SSE][Remote]: Registering ${sub.subscriptionId}');
+        logger
+            .d('[SSE][Remote]: Registering ${sub.subscriptionId} as $remoteId');
 
         // Unregister first to avoid ID conflict
         try {
-          await _bridge.unsubscribe(subscriptionId: sub.subscriptionId);
+          await _bridge.unsubscribe(subscriptionId: remoteId);
           await Future.delayed(_unregisterDelay);
         } catch (_) {
           // Ignore — subscription may not exist
         }
 
         await _bridge.subscribe(
-          subscriptionId: sub.subscriptionId,
+          subscriptionId: remoteId,
           path: sub.referenceList,
           notifType: _notifTypeToInt(sub.notifType),
         );
 
+        // Record uses original ID (transparent to Registry/Manager)
         records.add(SseSubscriptionRecord(
           subscriptionId: sub.subscriptionId,
           notifType: sub.notifType,
@@ -72,9 +82,10 @@ class RemoteSseStrategy implements SseOperationStrategy {
   @override
   Future<void> unregisterSubscriptions(List<String> subscriptionIds) async {
     for (final id in subscriptionIds) {
+      final remoteId = _toRemoteId(id);
       try {
-        await _bridge.unsubscribe(subscriptionId: id);
-        logger.d('[SSE][Remote]: Unregistered $id');
+        await _bridge.unsubscribe(subscriptionId: remoteId);
+        logger.d('[SSE][Remote]: Unregistered $id (as $remoteId)');
       } catch (e) {
         logger.w('[SSE][Remote]: Failed to unregister $id: $e');
       }
@@ -105,10 +116,12 @@ class RemoteSseStrategy implements SseOperationStrategy {
   }
 
   void _fireAndForgetCleanup() {
-    // Query existing subscriptions and unregister all (best-effort)
+    // Query existing subscriptions and unregister only remote ones (best-effort)
     _bridge.listSubscriptions().then((ids) {
       for (final id in ids) {
-        _bridge.unsubscribe(subscriptionId: id).ignore();
+        if (_isRemoteId(id)) {
+          _bridge.unsubscribe(subscriptionId: id).ignore();
+        }
       }
     }).ignore();
   }

--- a/test/core/usp/services/sse_remote_strategy_test.dart
+++ b/test/core/usp/services/sse_remote_strategy_test.dart
@@ -49,10 +49,11 @@ void main() {
         ),
       ]);
 
+      // Bridge receives prefixed ID
       verifyInOrder([
-        () => mockBridge.unsubscribe(subscriptionId: 'sub-1'),
+        () => mockBridge.unsubscribe(subscriptionId: 'remote-sub-1'),
         () => mockBridge.subscribe(
-              subscriptionId: 'sub-1',
+              subscriptionId: 'remote-sub-1',
               path: 'Device.WiFi.',
               notifType: 1,
             ),
@@ -73,8 +74,9 @@ void main() {
       ]);
 
       expect(records.length, 1);
+      // Bridge receives prefixed ID
       verify(() => mockBridge.subscribe(
-            subscriptionId: 'sub-1',
+            subscriptionId: 'remote-sub-1',
             path: 'Device.WiFi.',
             notifType: 1,
           )).called(1);
@@ -94,8 +96,9 @@ void main() {
     });
 
     test('continues on subscribe failure', () async {
+      // Mock uses prefixed ID
       when(() => mockBridge.subscribe(
-            subscriptionId: 'fail-sub',
+            subscriptionId: 'remote-fail-sub',
             path: any(named: 'path'),
             notifType: any(named: 'notifType'),
           )).thenThrow(Exception('guardian error'));
@@ -114,25 +117,30 @@ void main() {
       ]);
 
       expect(records.length, 1);
+      // Record stores original ID (transparent to Registry/Manager)
       expect(records.first.subscriptionId, 'ok-sub');
     });
   });
 
   group('unregisterSubscriptions', () {
-    test('calls bridge.unsubscribe for each id', () async {
+    test('calls bridge.unsubscribe for each id with prefix', () async {
       await strategy.unregisterSubscriptions(['sub-1', 'sub-2']);
 
-      verify(() => mockBridge.unsubscribe(subscriptionId: 'sub-1')).called(1);
-      verify(() => mockBridge.unsubscribe(subscriptionId: 'sub-2')).called(1);
+      // Bridge receives prefixed IDs
+      verify(() => mockBridge.unsubscribe(subscriptionId: 'remote-sub-1'))
+          .called(1);
+      verify(() => mockBridge.unsubscribe(subscriptionId: 'remote-sub-2'))
+          .called(1);
     });
 
     test('continues on failure', () async {
-      when(() => mockBridge.unsubscribe(subscriptionId: 'fail'))
+      when(() => mockBridge.unsubscribe(subscriptionId: 'remote-fail'))
           .thenThrow(Exception('error'));
 
       await strategy.unregisterSubscriptions(['fail', 'ok']);
 
-      verify(() => mockBridge.unsubscribe(subscriptionId: 'ok')).called(1);
+      verify(() => mockBridge.unsubscribe(subscriptionId: 'remote-ok'))
+          .called(1);
     });
   });
 
@@ -161,7 +169,7 @@ void main() {
   group('onSseDisconnected', () {
     test('intentional disconnect triggers fire-and-forget cleanup', () async {
       when(() => mockBridge.listSubscriptions())
-          .thenAnswer((_) async => ['sub-1', 'sub-2']);
+          .thenAnswer((_) async => ['remote-sub-1', 'remote-sub-2']);
 
       await strategy.onSseDisconnected(intentional: true);
 
@@ -169,6 +177,22 @@ void main() {
       // The actual cleanup happens asynchronously
       await Future.delayed(const Duration(milliseconds: 50));
       verify(() => mockBridge.listSubscriptions()).called(1);
+    });
+
+    test('cleanup only removes remote-prefixed subscriptions', () async {
+      when(() => mockBridge.listSubscriptions()).thenAnswer(
+          (_) async => ['remote-sub-1', 'local-sub', 'ethernet-valuechange']);
+
+      await strategy.onSseDisconnected(intentional: true);
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      // Only remote-prefixed subscription should be unsubscribed
+      verify(() => mockBridge.unsubscribe(subscriptionId: 'remote-sub-1'))
+          .called(1);
+      // Local subscriptions should NOT be touched
+      verifyNever(() => mockBridge.unsubscribe(subscriptionId: 'local-sub'));
+      verifyNever(
+          () => mockBridge.unsubscribe(subscriptionId: 'ethernet-valuechange'));
     });
 
     test('unintentional disconnect does not trigger cleanup', () async {


### PR DESCRIPTION
## Summary

- Add `remote-` prefix to Remote subscription IDs to avoid collision with Local mode when both connect to the same router

Closes #992

## Test plan

- [ ] Local mode SSE subscriptions work independently
- [ ] Remote mode SSE subscriptions use `remote-` prefix
- [ ] `_fireAndForgetCleanup()` only removes Remote subscriptions
- [ ] Both modes can coexist on same router without ID conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)