### PR TITLE
fix(dashboard): resolve card clipping and add mascot outside dismiss

### DIFF
--- a/lib/page/dashboard/mascot/dashboard_dialog_provider.dart
+++ b/lib/page/dashboard/mascot/dashboard_dialog_provider.dart
@@ -53,6 +53,7 @@ class DashboardDialogProvider extends MascotDialogProvider {
     return MascotDialogNode(
       id: 'main',
       text: '$greeting\nHow can I help you today?',
+      barrier: MascotDialogBarrier.dismissible,
       options: [
         const MascotDialogOption(
           id: 'ai_assistant',
@@ -218,6 +219,7 @@ class DashboardDialogProvider extends MascotDialogProvider {
     return const MascotDialogNode(
       id: 'diagnostics_menu',
       text: 'What would you like to check?',
+      barrier: MascotDialogBarrier.dismissible,
       options: [
         MascotDialogOption(
           id: 'full',
@@ -314,6 +316,7 @@ class DashboardDialogProvider extends MascotDialogProvider {
       text: result.message,
       type: type,
       suggestedAnimation: animation,
+      barrier: MascotDialogBarrier.dismissible,
       options: const [
         MascotDialogOption(
           id: 'back',
@@ -337,6 +340,7 @@ class DashboardDialogProvider extends MascotDialogProvider {
     return MascotDialogNode(
       id: 'faq_categories',
       text: 'What do you need help with?',
+      barrier: MascotDialogBarrier.dismissible,
       options: [
         ..._faqCategories.asMap().entries.map((entry) => MascotDialogOption(
               id: 'cat_${entry.key}',
@@ -357,6 +361,7 @@ class DashboardDialogProvider extends MascotDialogProvider {
     return MascotDialogNode(
       id: 'faq_items_$catIndex',
       text: getFaqCategoryTitle(category),
+      barrier: MascotDialogBarrier.dismissible,
       options: [
         ...category.items.asMap().entries.map((entry) => MascotDialogOption(
               id: 'item_${catIndex}_${entry.key}',

--- a/lib/page/dashboard/mascot/health_dialog_provider.dart
+++ b/lib/page/dashboard/mascot/health_dialog_provider.dart
@@ -66,6 +66,7 @@ class HealthDialogProvider extends MascotDialogProvider {
     return MascotDialogNode.custom(
       id: 'health_dashboard',
       text: greeting,
+      barrier: MascotDialogBarrier.dismissible,
       contentBuilder: (ctx, textColor) =>
           _buildHealthDashboard(textColor, greeting),
     );
@@ -167,6 +168,7 @@ class HealthDialogProvider extends MascotDialogProvider {
     controller.showDialog(MascotDialogNode.custom(
       id: 'dimension_${dimensionType.name}',
       text: dimension.displayName,
+      barrier: MascotDialogBarrier.dismissible,
       contentBuilder: (ctx, textColor) => DimensionDetailView(
         dimension: dimension,
         score: score,
@@ -261,6 +263,7 @@ class HealthDialogProvider extends MascotDialogProvider {
     return const MascotDialogNode(
       id: 'diagnostics_menu',
       text: 'What would you like to check?',
+      barrier: MascotDialogBarrier.dismissible,
       options: [
         MascotDialogOption(
           id: 'full',
@@ -338,6 +341,7 @@ class HealthDialogProvider extends MascotDialogProvider {
       text: result.message,
       type: type,
       suggestedAnimation: animation,
+      barrier: MascotDialogBarrier.dismissible,
       options: const [
         MascotDialogOption(
           id: 'back',
@@ -371,6 +375,7 @@ class HealthDialogProvider extends MascotDialogProvider {
     return MascotDialogNode(
       id: 'faq_categories',
       text: 'What do you need help with?',
+      barrier: MascotDialogBarrier.dismissible,
       options: [
         ..._faqCategories.asMap().entries.map((entry) => MascotDialogOption(
               id: 'cat_${entry.key}',
@@ -391,6 +396,7 @@ class HealthDialogProvider extends MascotDialogProvider {
     return MascotDialogNode(
       id: 'faq_items_$catIndex',
       text: getFaqCategoryTitle(category),
+      barrier: MascotDialogBarrier.dismissible,
       options: [
         ...category.items.asMap().entries.map((entry) => MascotDialogOption(
               id: 'item_${catIndex}_${entry.key}',

--- a/lib/page/dashboard/views/usp_sliver_dashboard_view.dart
+++ b/lib/page/dashboard/views/usp_sliver_dashboard_view.dart
@@ -578,9 +578,9 @@ class _UspSliverDashboardViewState
     );
 
     // SizedBox.expand ensures cards fill their grid cell.
-    // ClipRect prevents content from visually overflowing the cell boundary.
-    final displayedWidget =
-        SizedBox.expand(child: ClipRect(child: resolvedWidget));
+    // Note: ClipRect was removed because it clips shadows/borders causing
+    // visual truncation. Cards handle their own overflow via internal clipping.
+    final displayedWidget = SizedBox.expand(child: resolvedWidget);
 
     if (isEditMode) {
       // In edit mode: AbsorbPointer blocks content interactions while keeping

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,11 +59,11 @@ dependencies:
   ui_kit_library:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.25.1
+      ref: v2.26.0
   generative_ui:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.25.1
+      ref: v2.26.0
       path: generative_ui
   flutter_blue_plus: ^1.4.0
   crypto: ^3.0.2


### PR DESCRIPTION
## Summary
- Remove `ClipRect` from dashboard cards to prevent shadow/border truncation
- Add `barrier: MascotDialogBarrier.dismissible` to all mascot interactive dialogs for outside tap dismiss
- Bump `ui_kit_library` to v2.26.0

## Test plan
- [x] Verify dashboard cards display without clipped shadows/borders
- [x] Verify mascot dialog dismisses when tapping outside
- [x] All 2,976 tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)