### PR TITLE
fix: only show DFS confirmation when DFS is being enabled

### DIFF
--- a/lib/page/wifi_settings/views/wifi_advanced_settings_view.dart
+++ b/lib/page/wifi_settings/views/wifi_advanced_settings_view.dart
@@ -69,7 +69,11 @@ class _WifiAdvancedSettingsViewState
       bottomBar: PageBottomBar(
           isPositiveEnabled: isPositiveEnabled,
           onPositiveTap: () {
-            if (ref.read(wifiAdvancedProvider).isDFSEnabled == true) {
+            final currentState = ref.read(wifiAdvancedProvider);
+            // Only show DFS confirmation when DFS is being turned ON (was off, now on)
+            final isDFSBeingEnabled = _preservedState?.isDFSEnabled != true &&
+                currentState.isDFSEnabled == true;
+            if (isDFSBeingEnabled) {
               _showConfirmDFSModal().then((value) {
                 if (value == true) {
                   save();


### PR DESCRIPTION
## Summary
- Fix DFS confirmation dialog showing incorrectly when saving other WiFi advanced settings

## Problem
The DFS confirmation dialog was appearing whenever **any** WiFi advanced setting was saved, as long as DFS was already enabled. This caused confusion when users only changed IPTV or other settings but saw a DFS warning.

## Root Cause
The save button logic checked `isDFSEnabled == true` (current state) instead of checking whether DFS was **being changed** from off to on.

## Fix
Compare `_preservedState` (original state) with current state to only show the confirmation when DFS is being turned ON:
```dart
final isDFSBeingEnabled = _preservedState?.isDFSEnabled != true &&
    currentState.isDFSEnabled == true;
```

## Test plan
- [ ] DFS already enabled, change only IPTV → Save should proceed without DFS dialog
- [ ] DFS disabled, enable DFS → Save should show DFS confirmation dialog
- [ ] DFS disabled, change only IPTV → Save should proceed without DFS dialog

Fixes #1004
Related: linksys/LinksysWRT#399

🤖 Generated with [Claude Code](https://claude.ai/code)