### PR TITLE
fix(dashboard): unify card rows + navigation fixes

### DIFF
--- a/lib/page/_shared/components/layout_blocks/row_blocks.dart
+++ b/lib/page/_shared/components/layout_blocks/row_blocks.dart
@@ -125,3 +125,238 @@ class NetworkBadgeWidget extends StatelessWidget {
     );
   }
 }
+
+// =============================================================================
+// ToggleRow - Row with leading switch toggle
+// =============================================================================
+
+/// Toggle row block with leading switch, title, subtitle, and optional trailing.
+///
+/// Uses [AppListTile] from UI Kit for consistent styling.
+/// Use for DHCP reservations, port forwarding rules, etc.
+class ToggleRow extends StatelessWidget {
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+  final String title;
+  final String? subtitle;
+  final Widget? trailing;
+  final VoidCallback? onTap;
+
+  const ToggleRow({
+    super.key,
+    required this.value,
+    this.onChanged,
+    required this.title,
+    this.subtitle,
+    this.trailing,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return AppListTile(
+      backgroundColor: colorScheme.surfaceContainerHighest
+          .withValues(alpha: BlockConstants.backgroundAlpha),
+      leading: SizedBox(
+        width: 44,
+        child: Center(
+          child: AppSwitch(
+            value: value,
+            onChanged: onChanged,
+            scale: 0.8,
+          ),
+        ),
+      ),
+      title: AppText.bodyMedium(
+        title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: subtitle != null
+          ? AppText.bodySmall(
+              subtitle!,
+              color: colorScheme.onSurfaceVariant,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            )
+          : null,
+      trailing: trailing,
+      onTap: onTap,
+    );
+  }
+}
+
+// =============================================================================
+// NetworkRow - WiFi network row with badges and switch
+// =============================================================================
+
+/// Network row block for WiFi networks with band badges, client count, and toggle.
+///
+/// Uses [AppListTile] from UI Kit for consistent styling.
+class NetworkRow extends StatelessWidget {
+  final String ssidName;
+  final List<String> bands;
+  final bool isGuest;
+  final bool isEnabled;
+  final int clientCount;
+  final ValueChanged<bool>? onChanged;
+  final VoidCallback? onShareTap;
+
+  const NetworkRow({
+    super.key,
+    required this.ssidName,
+    required this.bands,
+    this.isGuest = false,
+    required this.isEnabled,
+    required this.clientCount,
+    this.onChanged,
+    this.onShareTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Opacity(
+      opacity: isEnabled ? 1.0 : BlockConstants.disabledAlpha,
+      child: AppListTile(
+        backgroundColor: colorScheme.surfaceContainerHighest
+            .withValues(alpha: BlockConstants.backgroundAlpha),
+        title: Row(
+          children: [
+            Flexible(
+              child: AppText.bodyLarge(
+                ssidName,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            if (isGuest) ...[
+              AppGap.sm(),
+              _GuestBadge(),
+            ],
+          ],
+        ),
+        subtitle: Row(
+          children: [
+            ...bands.map((band) => Padding(
+                  padding: const EdgeInsets.only(right: AppSpacing.xs),
+                  child: NetworkBadgeWidget(badge: NetworkBadge.fromBand(band)),
+                )),
+            AppGap.sm(),
+            Icon(
+              Icons.devices,
+              size: 14,
+              color: colorScheme.onSurfaceVariant,
+            ),
+            AppGap.xxs(),
+            AppText.labelSmall(
+              '$clientCount',
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ],
+        ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isEnabled && onShareTap != null) ...[
+              _ShareButton(onTap: onShareTap!),
+              AppGap.sm(),
+            ],
+            AppSwitch(
+              value: isEnabled,
+              onChanged: onChanged,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GuestBadge extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: 2,
+      ),
+      decoration: BoxDecoration(
+        color: colorScheme.secondary
+            .withValues(alpha: BlockConstants.badgeBackgroundAlpha),
+        borderRadius: BorderRadius.circular(AppSpacing.xs),
+      ),
+      child: AppText.labelSmall(
+        'Guest',
+        color: colorScheme.secondary,
+      ),
+    );
+  }
+}
+
+class _ShareButton extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _ShareButton({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppSpacing.sm),
+        child: Container(
+          padding: const EdgeInsets.all(AppSpacing.sm),
+          decoration: BoxDecoration(
+            color: colorScheme.surfaceContainerHighest,
+            borderRadius: BorderRadius.circular(AppSpacing.sm),
+            border: Border.all(
+                color: colorScheme.outline
+                    .withValues(alpha: BlockConstants.borderAlpha)),
+          ),
+          child: Icon(
+            Icons.qr_code_2,
+            size: 24,
+            color: colorScheme.onSurface,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// =============================================================================
+// ProtocolBadge - Protocol indicator badge (TCP/UDP/Both)
+// =============================================================================
+
+/// Protocol badge for port forwarding/triggering rules.
+class ProtocolBadge extends StatelessWidget {
+  final String protocol;
+
+  const ProtocolBadge({super.key, required this.protocol});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: AppText.labelSmall(
+        protocol,
+        color: colorScheme.onPrimaryContainer,
+      ),
+    );
+  }
+}

--- a/lib/page/_shared/components/layout_blocks/row_blocks.dart
+++ b/lib/page/_shared/components/layout_blocks/row_blocks.dart
@@ -279,22 +279,9 @@ class NetworkRow extends StatelessWidget {
 class _GuestBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.sm,
-        vertical: 2,
-      ),
-      decoration: BoxDecoration(
-        color: colorScheme.secondary
-            .withValues(alpha: BlockConstants.badgeBackgroundAlpha),
-        borderRadius: BorderRadius.circular(AppSpacing.xs),
-      ),
-      child: AppText.labelSmall(
-        'Guest',
-        color: colorScheme.secondary,
-      ),
+    return AppBadge(
+      label: 'Guest',
+      color: Theme.of(context).colorScheme.secondary,
     );
   }
 }
@@ -306,29 +293,9 @@ class _ShareButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(AppSpacing.sm),
-        child: Container(
-          padding: const EdgeInsets.all(AppSpacing.sm),
-          decoration: BoxDecoration(
-            color: colorScheme.surfaceContainerHighest,
-            borderRadius: BorderRadius.circular(AppSpacing.sm),
-            border: Border.all(
-                color: colorScheme.outline
-                    .withValues(alpha: BlockConstants.borderAlpha)),
-          ),
-          child: Icon(
-            Icons.qr_code_2,
-            size: 24,
-            color: colorScheme.onSurface,
-          ),
-        ),
-      ),
+    return AppIconButton(
+      icon: AppIcon.font(Icons.qr_code_2, size: 24),
+      onTap: onTap,
     );
   }
 }
@@ -345,18 +312,9 @@ class ProtocolBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-      decoration: BoxDecoration(
-        color: colorScheme.primaryContainer,
-        borderRadius: BorderRadius.circular(4),
-      ),
-      child: AppText.labelSmall(
-        protocol,
-        color: colorScheme.onPrimaryContainer,
-      ),
+    return AppBadge(
+      label: protocol,
+      color: Theme.of(context).colorScheme.primary,
     );
   }
 }

--- a/lib/page/_shared/models/system_monitor_state.dart
+++ b/lib/page/_shared/models/system_monitor_state.dart
@@ -7,6 +7,7 @@ class SystemSnapshot extends Equatable {
   final int memoryPercent;
   final int totalMemoryKb;
   final int freeMemoryKb;
+  final int uptimeSeconds;
 
   const SystemSnapshot({
     required this.timestamp,
@@ -14,9 +15,22 @@ class SystemSnapshot extends Equatable {
     required this.memoryPercent,
     required this.totalMemoryKb,
     required this.freeMemoryKb,
+    required this.uptimeSeconds,
   });
 
   int get usedMemoryKb => totalMemoryKb - freeMemoryKb;
+
+  /// Formatted uptime string (e.g. "2d 5h 30m").
+  String get formattedUptime {
+    final days = uptimeSeconds ~/ 86400;
+    final hours = (uptimeSeconds % 86400) ~/ 3600;
+    final minutes = (uptimeSeconds % 3600) ~/ 60;
+    final parts = <String>[];
+    if (days > 0) parts.add('${days}d');
+    if (hours > 0) parts.add('${hours}h');
+    if (minutes > 0 || parts.isEmpty) parts.add('${minutes}m');
+    return parts.join(' ');
+  }
 
   @override
   List<Object?> get props => [
@@ -25,6 +39,7 @@ class SystemSnapshot extends Equatable {
         memoryPercent,
         totalMemoryKb,
         freeMemoryKb,
+        uptimeSeconds,
       ];
 }
 

--- a/lib/page/_shared/services/usp_system_monitor_service.dart
+++ b/lib/page/_shared/services/usp_system_monitor_service.dart
@@ -46,6 +46,7 @@ class UspSystemMonitorService {
       memoryPercent: memPercent,
       totalMemoryKb: info.totalMemory,
       freeMemoryKb: info.freeMemory,
+      uptimeSeconds: info.uptime,
     );
   }
 }

--- a/lib/page/admin/cards/usp_device_info_card.dart
+++ b/lib/page/admin/cards/usp_device_info_card.dart
@@ -39,7 +39,7 @@ class UspDeviceInfoCard extends ConsumerWidget {
 
     return DashboardCardTemplate(
       title: loc(context).deviceInformation,
-      footer: masterNode != null
+      footer: masterNode != null && masterNode.deviceId.isNotEmpty
           ? _buildNodeDetailFooter(context, masterNode.deviceId)
           : null,
       content: Column(

--- a/lib/page/admin/cards/usp_device_info_card.dart
+++ b/lib/page/admin/cards/usp_device_info_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/core/utils/device_image_helper.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/core/utils/icon_rules.dart';
@@ -38,7 +39,9 @@ class UspDeviceInfoCard extends ConsumerWidget {
 
     return DashboardCardTemplate(
       title: loc(context).deviceInformation,
-      detailRoute: RouteNamed.uspAdmin,
+      footer: masterNode != null
+          ? _buildNodeDetailFooter(context, masterNode.deviceId)
+          : null,
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -125,6 +128,48 @@ class UspDeviceInfoCard extends ConsumerWidget {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildNodeDetailFooter(BuildContext context, String deviceId) {
+    final label = loc(context).viewDetails;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppDivider(),
+        AppGap.md(),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            Semantics(
+              button: true,
+              label: label,
+              child: InkWell(
+                onTap: () => context.pushNamed(
+                  RouteNamed.uspNodeDetail,
+                  queryParameters: {'deviceId': deviceId},
+                ),
+                borderRadius: BorderRadius.circular(4),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    AppText.labelMedium(
+                      label,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                    AppGap.xs(),
+                    Icon(
+                      Icons.arrow_forward,
+                      size: 14,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/lib/page/admin/views/components/usp_password_card.dart
+++ b/lib/page/admin/views/components/usp_password_card.dart
@@ -34,13 +34,7 @@ class UspPasswordCard extends StatelessWidget {
                       size: 20, color: colorScheme.onSurfaceVariant),
                   AppGap.md(),
                   Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        AppText.bodyMedium(adminUser.username),
-                        AppText.labelLarge('\u2022' * 12),
-                      ],
-                    ),
+                    child: AppText.labelLarge('\u2022' * 12),
                   ),
                   AppButton.text(
                     label: loc(context).change,

--- a/lib/page/dashboard/orchestrator/dashboard_orchestrator.dart
+++ b/lib/page/dashboard/orchestrator/dashboard_orchestrator.dart
@@ -175,6 +175,7 @@ class DashboardOrchestrator extends AsyncNotifier<DashboardOrchestratorState> {
                 memoryPercent: model.memoryPercent,
                 totalMemoryKb: model.totalMemory,
                 freeMemoryKb: model.freeMemory,
+                uptimeSeconds: model.uptime,
               ),
             );
       }).catchError((e) {

--- a/lib/page/dashboard/views/components/usp_system_status_card.dart
+++ b/lib/page/dashboard/views/components/usp_system_status_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/_shared/utils/usp_formatters.dart';
 import 'package:privacy_gui/page/_shared/models/system_info_ui_model.dart';
@@ -12,6 +13,7 @@ import 'package:privacy_gui/page/_shared/providers/usp_traffic_analysis_notifier
 import 'package:privacy_gui/page/_shared/components/card_skeleton.dart';
 import 'package:privacy_gui/page/_shared/components/dashboard_card_template.dart';
 import 'package:privacy_gui/page/_shared/components/usp_info_row.dart';
+import 'package:privacy_gui/route/constants.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
 /// System Performance Dashboard — 4-tab card (F-021).
@@ -31,8 +33,7 @@ class UspSystemStatusCard extends ConsumerStatefulWidget {
 class _UspSystemStatusCardState extends ConsumerState<UspSystemStatusCard> {
   static const _cardId = 'system_status';
 
-  List<(Duration?, String)> _intervalOptions(BuildContext context) => [
-        (null, loc(context).off),
+  List<(Duration, String)> _intervalOptions(BuildContext context) => [
         (Duration(seconds: 10), '10s'),
         (Duration(seconds: 30), '30s'),
         (Duration(minutes: 1), '60s'),
@@ -47,6 +48,7 @@ class _UspSystemStatusCardState extends ConsumerState<UspSystemStatusCard> {
 
     return DashboardCardTemplate.tabbed(
       title: loc(context).systemStatus,
+      footer: _buildStatisticsFooter(context, 2),
       titleBadge: monitorState.isFetching
           ? SizedBox(
               width: 14,
@@ -105,6 +107,48 @@ class _UspSystemStatusCardState extends ConsumerState<UspSystemStatusCard> {
       ),
     );
   }
+
+  Widget _buildStatisticsFooter(BuildContext context, int tabIndex) {
+    final label = loc(context).viewDetails;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppDivider(),
+        AppGap.md(),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            Semantics(
+              button: true,
+              label: label,
+              child: InkWell(
+                onTap: () => context.pushNamed(
+                  RouteNamed.uspStatistics,
+                  queryParameters: {'tab': tabIndex.toString()},
+                ),
+                borderRadius: BorderRadius.circular(4),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    AppText.labelMedium(
+                      label,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                    AppGap.xs(),
+                    Icon(
+                      Icons.arrow_forward,
+                      size: 14,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
 }
 
 // =============================================================================
@@ -118,11 +162,11 @@ class _MonitorView extends StatelessWidget {
   const _MonitorView({required this.info, required this.monitorState});
 
   String _formatIntervalLabel(BuildContext context, Duration? interval) {
-    if (interval == null) return loc(context).off;
+    if (interval == null) return '—';
     if (interval.inSeconds == 10) return '10s';
     if (interval.inSeconds == 30) return '30s';
     if (interval.inSeconds == 60) return '60s';
-    return loc(context).off;
+    return '${interval.inSeconds}s';
   }
 
   @override
@@ -143,7 +187,10 @@ class _MonitorView extends StatelessWidget {
 
     return Column(
       children: [
-        UspInfoRow(label: loc(context).uptime, value: info.formattedUptime),
+        UspInfoRow(
+          label: loc(context).uptime,
+          value: latest?.formattedUptime ?? info.formattedUptime,
+        ),
         AppGap.md(),
         Expanded(
           child: Row(

--- a/lib/page/dashboard/views/components/usp_traffic_analysis_card.dart
+++ b/lib/page/dashboard/views/components/usp_traffic_analysis_card.dart
@@ -3,12 +3,14 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/_shared/utils/usp_formatters.dart';
 import 'package:privacy_gui/page/_shared/models/traffic_analysis_state.dart';
 import 'package:privacy_gui/page/_shared/providers/card_tab_state_provider.dart';
 import 'package:privacy_gui/page/_shared/providers/usp_traffic_analysis_notifier.dart';
 import 'package:privacy_gui/page/_shared/components/dashboard_card_template.dart';
+import 'package:privacy_gui/route/constants.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
 /// Unified traffic monitor card — real-time WAN speed + multi-interface
@@ -30,8 +32,7 @@ class _UspTrafficAnalysisCardState
     extends ConsumerState<UspTrafficAnalysisCard> {
   static const _cardId = 'traffic_analysis';
 
-  List<(Duration?, String)> _intervalOptions(BuildContext context) => [
-        (null, loc(context).off),
+  List<(Duration, String)> _intervalOptions(BuildContext context) => [
         (Duration(seconds: 2), '2s'),
         (Duration(seconds: 5), '5s'),
         (Duration(seconds: 10), '10s'),
@@ -44,6 +45,7 @@ class _UspTrafficAnalysisCardState
 
     return DashboardCardTemplate.tabbed(
       title: loc(context).trafficMonitor,
+      footer: _buildStatisticsFooter(context, 0),
       titleBadge: analysisState.isFetching
           ? SizedBox(
               width: 14,
@@ -91,11 +93,12 @@ class _UspTrafficAnalysisCardState
   }
 
   String _intervalLabel(BuildContext context, Duration? interval) {
+    if (interval == null) return '—';
     return _intervalOptions(context)
             .where((e) => e.$1 == interval)
             .map((e) => e.$2)
             .firstOrNull ??
-        loc(context).off;
+        '${interval.inSeconds}s';
   }
 
   Widget _buildChartView(
@@ -132,6 +135,48 @@ class _UspTrafficAnalysisCardState
         message,
         color: Theme.of(context).colorScheme.onSurfaceVariant,
       ),
+    );
+  }
+
+  Widget _buildStatisticsFooter(BuildContext context, int tabIndex) {
+    final label = loc(context).viewDetails;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppDivider(),
+        AppGap.md(),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            Semantics(
+              button: true,
+              label: label,
+              child: InkWell(
+                onTap: () => context.pushNamed(
+                  RouteNamed.uspStatistics,
+                  queryParameters: {'tab': tabIndex.toString()},
+                ),
+                borderRadius: BorderRadius.circular(4),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    AppText.labelMedium(
+                      label,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                    AppGap.xs(),
+                    Icon(
+                      Icons.arrow_forward,
+                      size: 14,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/lib/page/local_network/cards/usp_dhcp_reservations_card.dart
+++ b/lib/page/local_network/cards/usp_dhcp_reservations_card.dart
@@ -70,39 +70,25 @@ class UspDhcpReservationsCard extends ConsumerWidget {
 
   Widget _buildReservationRow(BuildContext context, WidgetRef ref,
       DhcpReservationUIModel reservation, bool isLoading) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return LayoutBlock(
-      child: Row(
-        children: [
-          AppSwitch(
-            value: reservation.enable,
-            scale: 0.8,
-            onChanged: isLoading
-                ? null
-                : (value) => performUspMutation(
-                      context,
-                      ref,
-                      loadingKey: 'dhcp',
-                      mutation: () => ref
-                          .read(uspDhcpReservationsProvider.notifier)
-                          .immediateToggle(reservation.instancePath!, value),
-                    ),
-          ),
-          AppGap.sm(),
-          Expanded(child: AppText.bodyMedium(reservation.mac)),
-          AppText.bodySmall(
-            reservation.ip,
-            color: colorScheme.onSurfaceVariant,
-          ),
-          AppGap.sm(),
-          AppIconButton(
-            icon: AppIcon.font(Icons.delete_outline, size: 18),
-            onTap: isLoading
-                ? null
-                : () => _confirmDeleteDhcp(context, ref, reservation),
-          ),
-        ],
+    return ToggleRow(
+      value: reservation.enable,
+      onChanged: isLoading
+          ? null
+          : (value) => performUspMutation(
+                context,
+                ref,
+                loadingKey: 'dhcp',
+                mutation: () => ref
+                    .read(uspDhcpReservationsProvider.notifier)
+                    .immediateToggle(reservation.instancePath!, value),
+              ),
+      title: reservation.mac,
+      subtitle: reservation.ip,
+      trailing: AppIconButton(
+        icon: AppIcon.font(Icons.delete_outline, size: 18),
+        onTap: isLoading
+            ? null
+            : () => _confirmDeleteDhcp(context, ref, reservation),
       ),
     );
   }
@@ -112,33 +98,22 @@ class UspDhcpReservationsCard extends ConsumerWidget {
     final appColors = Theme.of(context).extension<AppColorScheme>();
     final lease = client.leaseTimeFormatted;
 
-    return LayoutBlock(
-      child: Row(
+    return DeviceRow(
+      icon: Container(
+        width: 8,
+        height: 8,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: client.active
+              ? (appColors?.semanticSuccess ?? Colors.green)
+              : colorScheme.outline,
+        ),
+      ),
+      title: client.displayName,
+      subtitle: client.hostName.isNotEmpty ? client.mac : null,
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Container(
-            width: 8,
-            height: 8,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: client.active
-                  ? (appColors?.semanticSuccess ?? Colors.green)
-                  : colorScheme.outline,
-            ),
-          ),
-          AppGap.sm(),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                AppText.bodyMedium(client.displayName),
-                if (client.hostName.isNotEmpty)
-                  AppText.bodySmall(
-                    client.mac,
-                    color: colorScheme.onSurfaceVariant,
-                  ),
-              ],
-            ),
-          ),
           AppText.bodySmall(client.ip, color: colorScheme.onSurfaceVariant),
           if (lease.isNotEmpty) ...[
             AppGap.md(),

--- a/lib/page/local_network/cards/usp_dhcp_reservations_card.dart
+++ b/lib/page/local_network/cards/usp_dhcp_reservations_card.dart
@@ -72,7 +72,7 @@ class UspDhcpReservationsCard extends ConsumerWidget {
       DhcpReservationUIModel reservation, bool isLoading) {
     return ToggleRow(
       value: reservation.enable,
-      onChanged: isLoading
+      onChanged: isLoading || reservation.instancePath == null
           ? null
           : (value) => performUspMutation(
                 context,

--- a/lib/page/local_network/cards/usp_ethernet_ports_card.dart
+++ b/lib/page/local_network/cards/usp_ethernet_ports_card.dart
@@ -7,7 +7,6 @@ import 'package:privacy_gui/page/local_network/providers/ethernet_data_provider.
 import 'package:privacy_gui/page/_shared/components/card_skeleton.dart';
 import 'package:privacy_gui/page/_shared/components/dashboard_card_template.dart';
 import 'package:privacy_gui/page/dashboard/views/dialogs/ethernet_port_detail_dialog.dart';
-import 'package:privacy_gui/route/constants.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
 class UspEthernetPortsCard extends ConsumerWidget {
@@ -30,7 +29,6 @@ class UspEthernetPortsCard extends ConsumerWidget {
 
     return DashboardCardTemplate(
       title: loc(context).ethernetPorts,
-      detailRoute: RouteNamed.uspLocalNetwork,
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/page/port_forwarding/cards/usp_port_forwarding_card.dart
+++ b/lib/page/port_forwarding/cards/usp_port_forwarding_card.dart
@@ -73,74 +73,41 @@ class UspPortForwardingCard extends ConsumerWidget {
 
   Widget _buildPortForwardingRow(BuildContext context, WidgetRef ref,
       PortForwardingRuleUIModel rule, bool isLoading) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return LayoutBlock(
-      child: Row(
-        children: [
-          AppSwitch(
-            value: rule.enabled,
-            scale: 0.8,
-            onChanged: isLoading
-                ? null
-                : (value) => performUspMutation(
-                      context,
-                      ref,
-                      loadingKey: 'portForwarding',
-                      mutation: () => ref
-                          .read(uspPortForwardingPageProvider.notifier)
-                          .immediateToggleForwarding(rule.instancePath!, value),
-                    ),
-          ),
-          AppGap.sm(),
-          Expanded(
-            child: AppText.bodyMedium(rule.displayName),
-          ),
-          AppText.bodySmall(
-            rule.portSummary,
-            color: colorScheme.onSurfaceVariant,
-          ),
-          AppGap.md(),
-          _ProtocolBadge(protocol: rule.protocol),
-        ],
-      ),
+    return ToggleRow(
+      value: rule.enabled,
+      onChanged: isLoading
+          ? null
+          : (value) => performUspMutation(
+                context,
+                ref,
+                loadingKey: 'portForwarding',
+                mutation: () => ref
+                    .read(uspPortForwardingPageProvider.notifier)
+                    .immediateToggleForwarding(rule.instancePath!, value),
+              ),
+      title: rule.displayName,
+      subtitle: rule.portSummary,
+      trailing: ProtocolBadge(protocol: rule.protocol),
     );
   }
 
   Widget _buildPortTriggeringRow(BuildContext context, WidgetRef ref,
       PortTriggeringRuleUIModel trigger, bool isLoading) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return LayoutBlock(
-      child: Row(
-        children: [
-          AppSwitch(
-            value: trigger.enabled,
-            scale: 0.8,
-            onChanged: isLoading
-                ? null
-                : (value) => performUspMutation(
-                      context,
-                      ref,
-                      loadingKey: 'portForwarding',
-                      mutation: () => ref
-                          .read(uspPortForwardingPageProvider.notifier)
-                          .immediateToggleTriggering(
-                              trigger.instancePath!, value),
-                    ),
-          ),
-          AppGap.sm(),
-          Expanded(
-            child: AppText.bodyMedium(trigger.displayName),
-          ),
-          AppText.bodySmall(
-            '${trigger.triggerPortDisplay} → ${trigger.forwardPortDisplay}',
-            color: colorScheme.onSurfaceVariant,
-          ),
-          AppGap.md(),
-          _ProtocolBadge(protocol: trigger.triggerProtocol),
-        ],
-      ),
+    return ToggleRow(
+      value: trigger.enabled,
+      onChanged: isLoading
+          ? null
+          : (value) => performUspMutation(
+                context,
+                ref,
+                loadingKey: 'portForwarding',
+                mutation: () => ref
+                    .read(uspPortForwardingPageProvider.notifier)
+                    .immediateToggleTriggering(trigger.instancePath!, value),
+              ),
+      title: trigger.displayName,
+      subtitle: '${trigger.triggerPortDisplay} → ${trigger.forwardPortDisplay}',
+      trailing: ProtocolBadge(protocol: trigger.triggerProtocol),
     );
   }
 
@@ -166,27 +133,6 @@ class UspPortForwardingCard extends ConsumerWidget {
             enabled: result.enabled,
           ),
       successMessage: loc(context).ruleAdded,
-    );
-  }
-}
-
-class _ProtocolBadge extends StatelessWidget {
-  final String protocol;
-  const _ProtocolBadge({required this.protocol});
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-      decoration: BoxDecoration(
-        color: colorScheme.primaryContainer,
-        borderRadius: BorderRadius.circular(4),
-      ),
-      child: AppText.labelSmall(
-        protocol,
-        color: colorScheme.onPrimaryContainer,
-      ),
     );
   }
 }

--- a/lib/page/statistics/views/usp_statistics_view.dart
+++ b/lib/page/statistics/views/usp_statistics_view.dart
@@ -10,7 +10,9 @@ import 'package:ui_kit_library/ui_kit.dart';
 /// USP Statistics / Monitoring page — consolidates all dashboard chart views
 /// into 3 scrollable category tabs: Network, Devices, System.
 class UspStatisticsView extends ConsumerStatefulWidget {
-  const UspStatisticsView({super.key});
+  final int initialTab;
+
+  const UspStatisticsView({super.key, this.initialTab = 0});
 
   @override
   ConsumerState<UspStatisticsView> createState() => _UspStatisticsViewState();
@@ -23,7 +25,11 @@ class _UspStatisticsViewState extends ConsumerState<UspStatisticsView>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 3, vsync: this);
+    _tabController = TabController(
+      length: 3,
+      vsync: this,
+      initialIndex: widget.initialTab.clamp(0, 2),
+    );
   }
 
   @override

--- a/lib/page/topology/cards/usp_network_topology_card.dart
+++ b/lib/page/topology/cards/usp_network_topology_card.dart
@@ -55,7 +55,7 @@ class UspNetworkTopologyCard extends ConsumerWidget {
       titleBadge: AppBadge(
           label: loc(context)
               .nOnlineOfTotal(onlineCount.toString(), totalCount.toString())),
-      detailRoute: RouteNamed.uspDeviceList,
+      detailRoute: RouteNamed.uspTopology,
       scrollable: false,
       content: ClipRect(
         child: _withTopologyAnimation(

--- a/lib/page/unified_diagnostics/views/unified_diagnostics_view.dart
+++ b/lib/page/unified_diagnostics/views/unified_diagnostics_view.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
-import 'package:privacy_gui/route/constants.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
 import '../models/diagnostic_state.dart';
@@ -114,7 +113,7 @@ class _UnifiedDiagnosticsViewState
           AppGap.xxxl(),
           AppButton(
             label: loc(context).returnToDashboard,
-            onTap: () => _returnToDashboard(context, ref),
+            onTap: () => _returnToMenu(context, ref),
           ),
         ],
       ),
@@ -129,12 +128,12 @@ class _UnifiedDiagnosticsViewState
     final notifier = ref.read(unifiedDiagnosticsProvider.notifier);
     final handledInternally = notifier.goBack();
     if (!handledInternally) {
-      _returnToDashboard(context, ref);
+      _returnToMenu(context, ref);
     }
   }
 
-  void _returnToDashboard(BuildContext context, WidgetRef ref) {
+  void _returnToMenu(BuildContext context, WidgetRef ref) {
     ref.read(unifiedDiagnosticsProvider.notifier).cancel();
-    context.goNamed(RouteNamed.uspDashboard);
+    context.pop();
   }
 }

--- a/lib/page/unified_diagnostics/views/unified_diagnostics_view.dart
+++ b/lib/page/unified_diagnostics/views/unified_diagnostics_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
+import 'package:privacy_gui/route/constants.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
 import '../models/diagnostic_state.dart';
@@ -134,6 +135,10 @@ class _UnifiedDiagnosticsViewState
 
   void _returnToMenu(BuildContext context, WidgetRef ref) {
     ref.read(unifiedDiagnosticsProvider.notifier).cancel();
-    context.pop();
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      context.goNamed(RouteNamed.uspMenu);
+    }
   }
 }

--- a/lib/page/wifi_settings/cards/usp_wifi_networks_card.dart
+++ b/lib/page/wifi_settings/cards/usp_wifi_networks_card.dart
@@ -7,6 +7,7 @@ import 'package:privacy_gui/page/_shared/models/client_connection_detail.dart';
 import 'package:privacy_gui/page/_shared/models/wifi_radio_ui_model.dart';
 import 'package:privacy_gui/page/_shared/components/card_skeleton.dart';
 import 'package:privacy_gui/page/_shared/components/dashboard_card_template.dart';
+import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
 import 'package:privacy_gui/page/_shared/components/usp_mutation_helper.dart';
 import 'package:privacy_gui/page/wifi_settings/providers/usp_wifi_settings_provider.dart';
 import 'package:privacy_gui/page/wifi_settings/providers/wifi_data_provider.dart';
@@ -93,159 +94,19 @@ class UspWifiNetworksCard extends ConsumerWidget {
     WidgetRef ref,
     _WifiNetworkEntry network,
   ) {
-    final scheme = Theme.of(context).colorScheme;
     final isLoading = ref.watch(uspMutationLoadingProvider) == 'wifi_network';
 
-    return Container(
-      padding: const EdgeInsets.all(AppSpacing.md),
-      decoration: BoxDecoration(
-        color: scheme.surfaceContainerHighest.withValues(alpha: 0.5),
-        borderRadius: BorderRadius.circular(AppSpacing.sm),
-        border: Border.all(
-          color: network.isGuest
-              ? scheme.secondary.withValues(alpha: 0.3)
-              : scheme.outline.withValues(alpha: 0.2),
-        ),
-      ),
-      child: Row(
-        children: [
-          // Network info
-          Expanded(
-            child: Opacity(
-              opacity: network.isEnabled ? 1.0 : 0.5,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // SSID name with guest indicator
-                  Row(
-                    children: [
-                      Flexible(
-                        child: AppText.bodyLarge(
-                          network.ssidName,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                      if (network.isGuest) ...[
-                        AppGap.sm(),
-                        _buildGuestBadge(context),
-                      ],
-                    ],
-                  ),
-                  AppGap.xs(),
-                  // Band badges and client count
-                  Row(
-                    children: [
-                      ...network.bands.map((band) => Padding(
-                            padding:
-                                const EdgeInsets.only(right: AppSpacing.xs),
-                            child: _buildBandBadge(context, band),
-                          )),
-                      AppGap.sm(),
-                      Icon(
-                        Icons.devices,
-                        size: 14,
-                        color: scheme.onSurfaceVariant,
-                      ),
-                      AppGap.xxs(),
-                      AppText.labelSmall(
-                        '${network.clientCount}',
-                        color: scheme.onSurfaceVariant,
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          ),
-          // QR / Share button
-          if (network.isEnabled && onShareTap != null) ...[
-            _buildShareButton(context, network.ssidName),
-            AppGap.sm(),
-          ],
-          // Enable/Disable toggle
-          AppSwitch(
-            value: network.isEnabled,
-            onChanged: isLoading
-                ? null
-                : (value) =>
-                    _confirmToggleNetwork(context, ref, network, value),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildBandBadge(BuildContext context, String band) {
-    final scheme = Theme.of(context).colorScheme;
-
-    final (color, label) = switch (band.toLowerCase()) {
-      String b when b.contains('2.4') => (const Color(0xFF4A9EFF), '2.4G'),
-      String b when b.contains('5') && !b.contains('6') => (
-          const Color(0xFF4ADE80),
-          '5G'
-        ),
-      String b when b.contains('6') => (const Color(0xFFA78BFA), '6G'),
-      _ => (scheme.outline, band),
-    };
-
-    return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.sm,
-        vertical: 2,
-      ),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(AppSpacing.xs),
-      ),
-      child: AppText.labelSmall(
-        label,
-        color: color,
-      ),
-    );
-  }
-
-  Widget _buildGuestBadge(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-
-    return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.sm,
-        vertical: 2,
-      ),
-      decoration: BoxDecoration(
-        color: scheme.secondary.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(AppSpacing.xs),
-      ),
-      child: AppText.labelSmall(
-        'Guest',
-        color: scheme.secondary,
-      ),
-    );
-  }
-
-  Widget _buildShareButton(BuildContext context, String ssid) {
-    final scheme = Theme.of(context).colorScheme;
-
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        onTap: () => onShareTap?.call(ssid),
-        borderRadius: BorderRadius.circular(AppSpacing.sm),
-        child: Container(
-          padding: const EdgeInsets.all(AppSpacing.sm),
-          decoration: BoxDecoration(
-            color: scheme.surfaceContainerHighest,
-            borderRadius: BorderRadius.circular(AppSpacing.sm),
-            border: Border.all(color: scheme.outline.withValues(alpha: 0.3)),
-          ),
-          child: Icon(
-            Icons.qr_code_2,
-            size: 24,
-            color: scheme.onSurface,
-          ),
-        ),
-      ),
+    return NetworkRow(
+      ssidName: network.ssidName,
+      bands: network.bands,
+      isGuest: network.isGuest,
+      isEnabled: network.isEnabled,
+      clientCount: network.clientCount,
+      onChanged: isLoading
+          ? null
+          : (value) => _confirmToggleNetwork(context, ref, network, value),
+      onShareTap:
+          onShareTap != null ? () => onShareTap!(network.ssidName) : null,
     );
   }
 

--- a/lib/page/wifi_settings/cards/usp_wifi_performance_card.dart
+++ b/lib/page/wifi_settings/cards/usp_wifi_performance_card.dart
@@ -10,7 +10,6 @@ import 'package:privacy_gui/page/_shared/providers/card_tab_state_provider.dart'
 import 'package:privacy_gui/page/_shared/components/dashboard_card_template.dart';
 import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
 import 'package:privacy_gui/page/wifi_settings/providers/wifi_data_provider.dart';
-import 'package:privacy_gui/route/constants.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
 /// WiFi Performance Analytics card — 3-tab view.
@@ -54,7 +53,6 @@ class UspWifiPerformanceCard extends ConsumerWidget {
       title: loc(context).wifiPerformance,
       titleBadge:
           AppBadge(label: loc(context).clientsCount(activeClients.length)),
-      detailRoute: RouteNamed.uspWifiSettings,
       tabs: [
         CardTab(
           label: loc(context).signal,

--- a/lib/route/route_usp_dashboard.dart
+++ b/lib/route/route_usp_dashboard.dart
@@ -24,6 +24,13 @@ final uspDashboardRoute = ShellRoute(
       name: RouteNamed.uspMenu,
       path: RoutePath.uspMenu,
       builder: (context, state) => const UspMenuView(),
+      routes: [
+        LinksysRoute(
+          name: RouteNamed.uspUnifiedDiagnostics,
+          path: RoutePath.uspUnifiedDiagnostics,
+          builder: (context, state) => const UnifiedDiagnosticsView(),
+        ),
+      ],
     ),
     LinksysRoute(
       name: RouteNamed.uspSupport,
@@ -102,7 +109,11 @@ final uspDashboardRoute = ShellRoute(
     LinksysRoute(
       name: RouteNamed.uspStatistics,
       path: RoutePath.uspStatistics,
-      builder: (context, state) => const UspStatisticsView(),
+      builder: (context, state) {
+        final tabParam = state.uri.queryParameters['tab'];
+        final initialTab = int.tryParse(tabParam ?? '') ?? 0;
+        return UspStatisticsView(initialTab: initialTab);
+      },
     ),
     LinksysRoute(
       name: RouteNamed.uspAdvancedSettings,
@@ -178,11 +189,6 @@ final uspDashboardRoute = ShellRoute(
       name: RouteNamed.uspApps,
       path: RoutePath.uspApps,
       builder: (context, state) => const UspAppsView(),
-    ),
-    LinksysRoute(
-      name: RouteNamed.uspUnifiedDiagnostics,
-      path: RoutePath.uspUnifiedDiagnostics,
-      builder: (context, state) => const UnifiedDiagnosticsView(),
     ),
     LinksysRoute(
       name: RouteNamed.uspSpeedTest,

--- a/test/golden_test/page/dashboard/cards/fixtures/cards_test_data.dart
+++ b/test/golden_test/page/dashboard/cards/fixtures/cards_test_data.dart
@@ -624,6 +624,7 @@ final testSystemMonitorWithHistory = SystemMonitorState(
       memoryPercent: 55 + (i * 2) % 20,
       totalMemoryKb: 524288,
       freeMemoryKb: 234288 - i * 5000,
+      uptimeSeconds: 86400 + i * 10,
     ),
   ),
   refreshInterval: Duration(seconds: 10),

--- a/test/golden_test/page/statistics/fixtures/statistics_test_data.dart
+++ b/test/golden_test/page/statistics/fixtures/statistics_test_data.dart
@@ -85,6 +85,7 @@ SystemMonitorState get testSystemMonitorState => SystemMonitorState(
           memoryPercent: 60 + (i * 2) % 20,
           totalMemoryKb: 524288,
           freeMemoryKb: 209715 - i * 5000,
+          uptimeSeconds: 86400 + i * 30,
         ),
       ),
       refreshInterval: const Duration(seconds: 30),

--- a/test/page/_shared/providers/usp_system_monitor_notifier_test.dart
+++ b/test/page/_shared/providers/usp_system_monitor_notifier_test.dart
@@ -87,6 +87,7 @@ void main() {
         memoryPercent: 60,
         totalMemoryKb: 1000,
         freeMemoryKb: 400,
+        uptimeSeconds: 3600,
       );
       notifier.pushSnapshot(snapshot);
 
@@ -108,6 +109,7 @@ void main() {
           memoryPercent: i,
           totalMemoryKb: 1000,
           freeMemoryKb: 500,
+          uptimeSeconds: 3600 + i * 60,
         ));
       }
 


### PR DESCRIPTION
## Summary
- Add reusable `ToggleRow`, `NetworkRow`, `ProtocolBadge` components to `row_blocks.dart`
- Refactor dashboard cards (Port Forwarding, DHCP Reservations, WiFi Networks) to use unified `AppListTile` base
- Add View Details navigation for Topology, Device Info, System Status, and Traffic Analysis cards
- Fix multiple issues (#1014, #1012, #1009, #1002)

## Changes

### Unified Row Components
- **ToggleRow**: Leading switch + title/subtitle + optional trailing (Port Forwarding, DHCP)
- **NetworkRow**: WiFi network with band badges, client count, QR share, toggle
- **ProtocolBadge**: TCP/UDP/Both badge extracted from Port Forwarding card

### Navigation Fixes
- Network Topology card → `uspTopology` page
- Device Info card → `uspNodeDetail` with deviceId param
- System Status card → Statistics (tab=2)
- Traffic Analysis card → Statistics (tab=0)
- Network Diagnostics back button → returns to Menu (#1002)

### Bug Fixes
- Remove "off" option from polling interval cards (#1012)
- Remove "admin" username display from password card (#1009)
- Fix uptime not updating by including `uptimeSeconds` in `SystemSnapshot`

## Test Plan
- [x] All 2976 tests pass
- [x] Static analysis clean (no errors/warnings)
- [ ] Manual: Verify dashboard cards visual consistency
- [ ] Manual: Verify View Details navigations work correctly
- [ ] Manual: Verify diagnostics back button returns to Menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)