### PR TITLE
fix: add loading indicator and retry for SmartConnect not ready in Add Nodes

### DIFF
--- a/lib/page/nodes/providers/add_nodes_exception.dart
+++ b/lib/page/nodes/providers/add_nodes_exception.dart
@@ -3,11 +3,6 @@ sealed class AddNodesException {
   AddNodesException({required this.message});
 }
 
-class ExceptionSmartConnectNotReady extends AddNodesException {
-  ExceptionSmartConnectNotReady()
-      : super(message: 'SmartConnect is not ready');
-}
-
 class ExceptionSmartConnectTimeout extends AddNodesException {
   ExceptionSmartConnectTimeout()
       : super(message: 'SmartConnect timeout after max retries');

--- a/lib/page/nodes/providers/add_nodes_exception.dart
+++ b/lib/page/nodes/providers/add_nodes_exception.dart
@@ -1,0 +1,14 @@
+sealed class AddNodesException {
+  final String? message;
+  AddNodesException({required this.message});
+}
+
+class ExceptionSmartConnectNotReady extends AddNodesException {
+  ExceptionSmartConnectNotReady()
+      : super(message: 'SmartConnect is not ready');
+}
+
+class ExceptionSmartConnectTimeout extends AddNodesException {
+  ExceptionSmartConnectTimeout()
+      : super(message: 'SmartConnect timeout after max retries');
+}

--- a/lib/page/nodes/providers/add_nodes_provider.dart
+++ b/lib/page/nodes/providers/add_nodes_provider.dart
@@ -176,6 +176,7 @@ class AddNodesNotifier extends AutoDisposeNotifier<AddNodesState> {
         onboardedMACList: onboardedMACList,
       );
     } finally {
+      state = state.copyWith(isLoading: false);
       polling.startPolling();
     }
   }

--- a/lib/page/nodes/providers/add_nodes_provider.dart
+++ b/lib/page/nodes/providers/add_nodes_provider.dart
@@ -11,6 +11,7 @@ import 'package:privacy_gui/core/jnap/router_repository.dart';
 import 'package:privacy_gui/core/utils/bench_mark.dart';
 import 'package:privacy_gui/core/utils/devices.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/page/nodes/providers/add_nodes_exception.dart';
 import 'package:privacy_gui/page/nodes/providers/add_nodes_state.dart';
 
 final addNodesProvider =
@@ -70,13 +71,32 @@ class AddNodesNotifier extends AutoDisposeNotifier<AddNodesState> {
 
     ref.read(pollingProvider.notifier).stopPolling();
 
-    // final nodeSnapshot =
-    //     List<LinksysDevice>.from(ref.read(deviceManagerProvider).deviceList)
-    //         .toList();
-
-    // Commence the auto-onboarding process
+    // Commence the auto-onboarding process with retry logic for SmartConnect not ready
     final repo = ref.read(routerRepositoryProvider);
-    await repo.send(JNAPAction.startBlueboothAutoOnboarding, auth: true);
+    const maxRetries = 20;
+    const retryDelay = Duration(seconds: 3);
+
+    for (var attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        await repo.send(JNAPAction.startBlueboothAutoOnboarding, auth: true);
+        logger.d(
+            '[AddNodes]: StartBluetoothAutoOnboarding succeeded on attempt $attempt');
+        break;
+      } on JNAPError catch (e) {
+        if (e.result == 'ErrorSmartConnectNotReady') {
+          logger.d(
+              '[AddNodes]: SmartConnect not ready, attempt $attempt/$maxRetries');
+          if (attempt == maxRetries) {
+            logger.e(
+                '[AddNodes]: SmartConnect not ready after $maxRetries attempts');
+            throw ExceptionSmartConnectTimeout();
+          }
+          await Future.delayed(retryDelay);
+        } else {
+          rethrow;
+        }
+      }
+    }
 
     bool onboardingProceed = false;
     // For AutoOnboarding 2 service, there has no deviceOnboardingStatus

--- a/lib/page/nodes/providers/add_nodes_provider.dart
+++ b/lib/page/nodes/providers/add_nodes_provider.dart
@@ -3,7 +3,6 @@ import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/jnap/actions/better_action.dart';
 import 'package:privacy_gui/core/jnap/models/back_haul_info.dart';
-import 'package:privacy_gui/core/jnap/providers/device_manager_provider.dart';
 import 'package:privacy_gui/core/jnap/providers/device_manager_state.dart';
 import 'package:privacy_gui/core/jnap/providers/polling_provider.dart';
 import 'package:privacy_gui/core/jnap/result/jnap_result.dart';
@@ -73,6 +72,8 @@ class AddNodesNotifier extends AutoDisposeNotifier<AddNodesState> {
     polling.stopPolling();
 
     try {
+      state = state.copyWith(isLoading: true, loadingMessage: 'searching');
+
       // Commence the auto-onboarding process with retry logic for SmartConnect not ready
       final repo = ref.read(routerRepositoryProvider);
       const maxRetries = 20;
@@ -105,8 +106,6 @@ class AddNodesNotifier extends AutoDisposeNotifier<AddNodesState> {
     // only AutoOnboarding 3 service has deviceOnboardingStatus.
     bool anyOnboarded = false;
     var deviceOnboardingStatus = [];
-
-    state = state.copyWith(isLoading: true, loadingMessage: 'searching');
 
     await for (final result in pollAutoOnboardingStatus()) {
       logger.d('[AddNodes]: GetAutoOnboardingStatus result: $result');

--- a/lib/page/nodes/providers/add_nodes_provider.dart
+++ b/lib/page/nodes/providers/add_nodes_provider.dart
@@ -69,36 +69,38 @@ class AddNodesNotifier extends AutoDisposeNotifier<AddNodesState> {
     final benchMark = BenchMarkLogger(name: 'AutoOnboarding');
     benchMark.start();
 
-    ref.read(pollingProvider.notifier).stopPolling();
+    final polling = ref.read(pollingProvider.notifier);
+    polling.stopPolling();
 
-    // Commence the auto-onboarding process with retry logic for SmartConnect not ready
-    final repo = ref.read(routerRepositoryProvider);
-    const maxRetries = 20;
-    const retryDelay = Duration(seconds: 3);
+    try {
+      // Commence the auto-onboarding process with retry logic for SmartConnect not ready
+      final repo = ref.read(routerRepositoryProvider);
+      const maxRetries = 20;
+      const retryDelay = Duration(seconds: 3);
 
-    for (var attempt = 1; attempt <= maxRetries; attempt++) {
-      try {
-        await repo.send(JNAPAction.startBlueboothAutoOnboarding, auth: true);
-        logger.d(
-            '[AddNodes]: StartBluetoothAutoOnboarding succeeded on attempt $attempt');
-        break;
-      } on JNAPError catch (e) {
-        if (e.result == 'ErrorSmartConnectNotReady') {
+      for (var attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+          await repo.send(JNAPAction.startBlueboothAutoOnboarding, auth: true);
           logger.d(
-              '[AddNodes]: SmartConnect not ready, attempt $attempt/$maxRetries');
-          if (attempt == maxRetries) {
-            logger.e(
-                '[AddNodes]: SmartConnect not ready after $maxRetries attempts');
-            throw ExceptionSmartConnectTimeout();
+              '[AddNodes]: StartBluetoothAutoOnboarding succeeded on attempt $attempt');
+          break;
+        } on JNAPError catch (e) {
+          if (e.result == 'ErrorSmartConnectNotReady') {
+            logger.d(
+                '[AddNodes]: SmartConnect not ready, attempt $attempt/$maxRetries');
+            if (attempt == maxRetries) {
+              logger.e(
+                  '[AddNodes]: SmartConnect not ready after $maxRetries attempts');
+              throw ExceptionSmartConnectTimeout();
+            }
+            await Future.delayed(retryDelay);
+          } else {
+            rethrow;
           }
-          await Future.delayed(retryDelay);
-        } else {
-          rethrow;
         }
       }
-    }
 
-    bool onboardingProceed = false;
+      bool onboardingProceed = false;
     // For AutoOnboarding 2 service, there has no deviceOnboardingStatus
     // only AutoOnboarding 3 service has deviceOnboardingStatus.
     bool anyOnboarded = false;
@@ -155,25 +157,27 @@ class AddNodesNotifier extends AutoDisposeNotifier<AddNodesState> {
       await for (final result in pollNodesBackhaulInfo(childNodes)) {
         backhaulInfoList = result;
       }
-    }
-    childNodes.sort((a, b) => a.isAuthority ? -1 : 1);
-    final polling = ref.read(pollingProvider.notifier);
-    await polling.forcePolling().then((value) => polling.startPolling());
-    // logger.d('[AddNodes]: Update state: nodesSnapshot = $nodeSnapshot');
-    logger.d('[AddNodes]: Update state: addedDevices = $addedDevices');
-    logger.d(
-        '[AddNodes]: Update state: onboardingProceed = $onboardingProceed, anyOnboarded=$anyOnboarded');
-    benchMark.end();
+      }
+      childNodes.sort((a, b) => a.isAuthority ? -1 : 1);
+      await polling.forcePolling();
+      // logger.d('[AddNodes]: Update state: nodesSnapshot = $nodeSnapshot');
+      logger.d('[AddNodes]: Update state: addedDevices = $addedDevices');
+      logger.d(
+          '[AddNodes]: Update state: onboardingProceed = $onboardingProceed, anyOnboarded=$anyOnboarded');
+      benchMark.end();
 
-    state = state.copyWith(
-      // nodesSnapshot: nodeSnapshot,
-      onboardingProceed: onboardingProceed,
-      anyOnboarded: anyOnboarded,
-      addedNodes: addedDevices,
-      childNodes: collectChildNodeData(childNodes, backhaulInfoList),
-      isLoading: false,
-      onboardedMACList: onboardedMACList,
-    );
+      state = state.copyWith(
+        // nodesSnapshot: nodeSnapshot,
+        onboardingProceed: onboardingProceed,
+        anyOnboarded: anyOnboarded,
+        addedNodes: addedDevices,
+        childNodes: collectChildNodeData(childNodes, backhaulInfoList),
+        isLoading: false,
+        onboardedMACList: onboardedMACList,
+      );
+    } finally {
+      polling.startPolling();
+    }
   }
 
   Stream<List<LinksysDevice>> pollForNodesOnline(List<String> onboardedMACList,

--- a/lib/page/nodes/views/add_nodes_view.dart
+++ b/lib/page/nodes/views/add_nodes_view.dart
@@ -24,9 +24,11 @@ import 'package:privacygui_widgets/widgets/progress_bar/full_screen_spinner.dart
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/components/styled/styled_page_view.dart';
 import 'package:privacy_gui/page/components/views/arguments_view.dart';
+import 'package:privacy_gui/page/nodes/providers/add_nodes_exception.dart';
 import 'package:privacy_gui/page/nodes/providers/add_nodes_provider.dart';
 import 'package:privacy_gui/page/nodes/views/light_different_color_modal.dart';
 import 'package:privacy_gui/page/nodes/views/light_info_tile.dart';
+import 'package:privacy_gui/page/components/shortcuts/snack_bar.dart';
 
 class AddNodesView extends ArgumentsConsumerStatefulView {
   const AddNodesView({
@@ -71,10 +73,13 @@ class _AddNodesViewState extends ConsumerState<AddNodesView> {
     }
   }
 
+  bool get _isFromPnp => widget.args['callback'] != null;
+
   Widget _resultView(AddNodesState state) {
     return StyledAppPageView(
       scrollable: true,
       title: loc(context).addNodes,
+      hideTopbar: _isFromPnp,
       child: (context, constraints) => AppBasicLayout(
           content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -165,6 +170,7 @@ class _AddNodesViewState extends ConsumerState<AddNodesView> {
     return StyledAppPageView(
       scrollable: true,
       title: loc(context).addNodes,
+      hideTopbar: _isFromPnp,
       child: (context, constraints) => AppBasicLayout(
           content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -192,11 +198,17 @@ class _AddNodesViewState extends ConsumerState<AddNodesView> {
             },
           ),
           const AppGap.large3(),
-          AppFilledButton(
+          AppFilledButtonWithLoading(
             loc(context).next,
-            onTap: () {
+            onTap: () async {
               logger.d('[AddNodes]: Start to search for more nodes');
-              ref.read(addNodesProvider.notifier).startAutoOnboarding();
+              try {
+                await ref.read(addNodesProvider.notifier).startAutoOnboarding();
+              } on ExceptionSmartConnectTimeout {
+                if (context.mounted) {
+                  showSimpleSnackBar(context, loc(context).generalError);
+                }
+              }
             },
           )
         ],

--- a/lib/page/nodes/views/add_nodes_view.dart
+++ b/lib/page/nodes/views/add_nodes_view.dart
@@ -143,9 +143,20 @@ class _AddNodesViewState extends ConsumerState<AddNodesView> {
           const AppGap.medium(),
           AppTextButton.noPadding(
             loc(context).tryAgain,
-            onTap: () {
+            onTap: () async {
               logger.d('[AddNodes]: Retry to search for more nodes');
-              ref.read(addNodesProvider.notifier).startAutoOnboarding();
+              try {
+                await ref.read(addNodesProvider.notifier).startAutoOnboarding();
+              } on ExceptionSmartConnectTimeout {
+                if (context.mounted) {
+                  showFailedSnackBar(context, loc(context).generalError);
+                }
+              } catch (e) {
+                logger.e('[AddNodes]: Retry failed with error: $e');
+                if (context.mounted) {
+                  showFailedSnackBar(context, loc(context).generalError);
+                }
+              }
             },
           ),
           const AppGap.large3(),
@@ -206,7 +217,12 @@ class _AddNodesViewState extends ConsumerState<AddNodesView> {
                 await ref.read(addNodesProvider.notifier).startAutoOnboarding();
               } on ExceptionSmartConnectTimeout {
                 if (context.mounted) {
-                  showSimpleSnackBar(context, loc(context).generalError);
+                  showFailedSnackBar(context, loc(context).generalError);
+                }
+              } catch (e) {
+                logger.e('[AddNodes]: Start auto onboarding failed with error: $e');
+                if (context.mounted) {
+                  showFailedSnackBar(context, loc(context).generalError);
                 }
               }
             },


### PR DESCRIPTION
## Summary

- Replace `AppFilledButton` with `AppFilledButtonWithLoading` for the Next button in Add Nodes page
- Add retry logic (3s interval, 20 retries max = 60s) for `ErrorSmartConnectNotReady`
- Show error snackbar on timeout, allow manual retry
- Create `AddNodesException` sealed class for exception handling
- Hide topbar only when entering from PnP flow

**Note:** This fix provides visual feedback while waiting for SmartConnect to be ready. It does not address the root cause (SmartConnect startup time after PnP).

## Test plan

- [ ] Complete PnP flow and enter Add Nodes page
- [ ] Click Next button, verify loading spinner displays
- [ ] Verify button is disabled during loading (no repeated clicks)
- [ ] If SmartConnect ready, proceed to next step normally
- [ ] If timeout (60s), verify error snackbar appears
- [ ] Verify topbar is hidden when entering from PnP
- [ ] Verify topbar is visible when entering from other places (e.g. dashboard)

Closes #1018
Related: linksys/LinksysWRT#396

🤖 Generated with [Claude Code](https://claude.ai/code)