### PR TITLE
feat(wifi): add channel dropdown to edit dialog (#1023)

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -435,6 +435,17 @@
   "changeNetworkSettingsTitle": "تغيير إعدادات الشبكة؟",
   "changeRouterPassword": "تغيير كلمة مرور جهاز التوجيه",
   "channelNumber": "رقم القناة",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "القنوات",
   "checkConnectivityAndSpeed": "فحص الاتصال والسرعة",
   "checkForUpdates": "التحقق من التحديثات",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -434,6 +434,17 @@
   "changeNetworkSettingsTitle": "Skift netværksindstillinger?",
   "changeRouterPassword": "Skift routerens adgangskode",
   "channelNumber": "Kanalnummer",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Kanaler",
   "checkConnectivityAndSpeed": "Tjek forbindelse og hastighed",
   "checkForUpdates": "Søg efter opdateringer",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -434,6 +434,17 @@
   "changeNetworkSettingsTitle": "Netzwerkeinstellungen ändern?",
   "changeRouterPassword": "Router-Passwort ändern",
   "channelNumber": "Kanalnummer",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Kanäle",
   "checkConnectivityAndSpeed": "Konnektivität und Geschwindigkeit prüfen",
   "checkForUpdates": "Nach Updates suchen",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -432,6 +432,17 @@
   "changeNetworkSettingsTitle": "Αλλαγή ρυθμίσεων δικτύου;",
   "changeRouterPassword": "Αλλαγή κωδικού πρόσβασης δρομολογητή",
   "channelNumber": "Αριθμός καναλιού",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Κανάλια",
   "checkConnectivityAndSpeed": "Έλεγχος συνδεσιμότητας και ταχύτητας",
   "checkForUpdates": "Έλεγχος για ενημερώσεις",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1187,6 +1187,17 @@
   "radios": "Radios",
   "portRules": "Port Rules",
   "channelNumber": "Channel number",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "change": "Change",
   "builtInWidgets": "Built-in Widgets",
   "appWidgetCards": "App Widget Cards",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -434,6 +434,17 @@
   "changeNetworkSettingsTitle": "¿Cambiar la configuración de red?",
   "changeRouterPassword": "Cambiar la contraseña del router",
   "channelNumber": "Número de canal",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Canales",
   "checkConnectivityAndSpeed": "Comprobar la conectividad y la velocidad",
   "checkForUpdates": "Buscar actualizaciones",

--- a/lib/l10n/app_es_ar.arb
+++ b/lib/l10n/app_es_ar.arb
@@ -434,6 +434,17 @@
   "changeNetworkSettingsTitle": "¿Cambiar la configuración de red?",
   "changeRouterPassword": "Cambiar contraseña del router",
   "channelNumber": "Número de canal",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Canales",
   "checkConnectivityAndSpeed": "Verificar conectividad y velocidad",
   "checkForUpdates": "Buscar actualizaciones",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -432,6 +432,17 @@
   "changeNetworkSettingsTitle": "Muutetaanko verkkoasetuksia?",
   "changeRouterPassword": "Vaihda reitittimen salasana",
   "channelNumber": "Kanavanumero",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Kanavat",
   "checkConnectivityAndSpeed": "Tarkista yhteys ja nopeus",
   "checkForUpdates": "Tarkista päivitykset",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -434,6 +434,17 @@
   "changeNetworkSettingsTitle": "Modifier les paramètres réseau ?",
   "changeRouterPassword": "Modifier le mot de passe du routeur",
   "channelNumber": "Numéro de canal",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Canaux",
   "checkConnectivityAndSpeed": "Vérifier la connectivité et la vitesse",
   "checkForUpdates": "Rechercher des mises à jour",

--- a/lib/l10n/app_fr_ca.arb
+++ b/lib/l10n/app_fr_ca.arb
@@ -434,6 +434,17 @@
   "changeNetworkSettingsTitle": "Modifier les paramètres réseau?",
   "changeRouterPassword": "Modifier le mot de passe du routeur",
   "channelNumber": "Numéro de canal",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Canaux",
   "checkConnectivityAndSpeed": "Vérifier la connectivité et la vitesse",
   "checkForUpdates": "Rechercher des mises à jour",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -432,6 +432,17 @@
   "changeNetworkSettingsTitle": "Ubah Setelan Jaringan?",
   "changeRouterPassword": "Ubah Kata Sandi Router",
   "channelNumber": "Nomor kanal",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Kanal",
   "checkConnectivityAndSpeed": "Periksa konektivitas dan kecepatan",
   "checkForUpdates": "Periksa Pembaruan",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -434,6 +434,17 @@
   "changeNetworkSettingsTitle": "Modificare le impostazioni di rete?",
   "changeRouterPassword": "Modifica password del router",
   "channelNumber": "Numero del canale",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Canali",
   "checkConnectivityAndSpeed": "Controlla connettività e velocità",
   "checkForUpdates": "Verifica aggiornamenti",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -435,6 +435,17 @@
   "changeNetworkSettingsTitle": "ネットワーク設定を変更しますか？",
   "changeRouterPassword": "ルーターのパスワードを変更",
   "channelNumber": "チャンネル番号",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "チャンネル",
   "checkConnectivityAndSpeed": "接続と速度を確認",
   "checkForUpdates": "更新を確認",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -432,6 +432,17 @@
   "changeNetworkSettingsTitle": "네트워크 설정을 변경하시겠습니까?",
   "changeRouterPassword": "라우터 암호 변경",
   "channelNumber": "채널 번호",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "채널",
   "checkConnectivityAndSpeed": "연결 및 속도 확인",
   "checkForUpdates": "업데이트 확인",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -434,6 +434,17 @@
   "changeNetworkSettingsTitle": "Endre nettverksinnstillinger?",
   "changeRouterPassword": "Endre ruterpassord",
   "channelNumber": "Kanalnummer",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Kanaler",
   "checkConnectivityAndSpeed": "Sjekk tilkobling og hastighet",
   "checkForUpdates": "Se etter oppdateringer",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -434,6 +434,17 @@
   "changeNetworkSettingsTitle": "Netwerkinstellingen wijzigen?",
   "changeRouterPassword": "Routerwachtwoord wijzigen",
   "channelNumber": "Kanaalnummer",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Kanalen",
   "checkConnectivityAndSpeed": "Connectiviteit en snelheid controleren",
   "checkForUpdates": "Controleren op updates",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -432,6 +432,17 @@
   "changeNetworkSettingsTitle": "Zmienić ustawienia sieci?",
   "changeRouterPassword": "Zmień hasło routera",
   "channelNumber": "Numer kanału",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Kanały",
   "checkConnectivityAndSpeed": "Sprawdź łączność i szybkość",
   "checkForUpdates": "Sprawdź aktualizacje",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -434,6 +434,17 @@
   "changeNetworkSettingsTitle": "Alterar configurações de rede?",
   "changeRouterPassword": "Alterar senha do roteador",
   "channelNumber": "Número do canal",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Canais",
   "checkConnectivityAndSpeed": "Verificar conectividade e velocidade",
   "checkForUpdates": "Verificar atualizações",

--- a/lib/l10n/app_pt_pt.arb
+++ b/lib/l10n/app_pt_pt.arb
@@ -434,6 +434,17 @@
   "changeNetworkSettingsTitle": "Alterar definições de rede?",
   "changeRouterPassword": "Alterar palavra-passe do router",
   "channelNumber": "Número do canal",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Canais",
   "checkConnectivityAndSpeed": "Verificar conectividade e velocidade",
   "checkForUpdates": "Procurar atualizações",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -432,6 +432,17 @@
   "changeNetworkSettingsTitle": "Изменить сетевые настройки?",
   "changeRouterPassword": "Изменить пароль маршрутизатора",
   "channelNumber": "Номер канала",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Каналы",
   "checkConnectivityAndSpeed": "Проверить подключение и скорость",
   "checkForUpdates": "Проверить обновления",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -434,6 +434,17 @@
   "changeNetworkSettingsTitle": "Ändra nätverksinställningar?",
   "changeRouterPassword": "Ändra routerlösenord",
   "channelNumber": "Kanalnummer",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Kanaler",
   "checkConnectivityAndSpeed": "Kontrollera anslutning och hastighet",
   "checkForUpdates": "Sök efter uppdateringar",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -432,6 +432,17 @@
   "changeNetworkSettingsTitle": "เปลี่ยนการตั้งค่าเครือข่ายหรือไม่",
   "changeRouterPassword": "เปลี่ยนรหัสผ่านเราเตอร์",
   "channelNumber": "หมายเลขช่องสัญญาณ",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "ช่องสัญญาณ",
   "checkConnectivityAndSpeed": "ตรวจสอบการเชื่อมต่อและความเร็ว",
   "checkForUpdates": "ตรวจหาการอัปเดต",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -432,6 +432,17 @@
   "changeNetworkSettingsTitle": "Ağ Ayarları Değiştirilsin mi?",
   "changeRouterPassword": "Yönlendirici Parolasını Değiştir",
   "channelNumber": "Kanal numarası",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Kanallar",
   "checkConnectivityAndSpeed": "Bağlantıyı ve hızı kontrol et",
   "checkForUpdates": "Güncellemeleri Denetle",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -432,6 +432,17 @@
   "changeNetworkSettingsTitle": "Thay đổi cài đặt mạng?",
   "changeRouterPassword": "Đổi mật khẩu router",
   "channelNumber": "Số kênh",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "Kênh",
   "checkConnectivityAndSpeed": "Kiểm tra kết nối và tốc độ",
   "checkForUpdates": "Kiểm tra cập nhật",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -435,6 +435,17 @@
   "changeNetworkSettingsTitle": "更改网络设置？",
   "changeRouterPassword": "更改路由器密码",
   "channelNumber": "信道编号",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "信道",
   "checkConnectivityAndSpeed": "检查连接和速度",
   "checkForUpdates": "检查更新",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -435,6 +435,17 @@
   "changeNetworkSettingsTitle": "變更網路設定？",
   "changeRouterPassword": "變更路由器密碼",
   "channelNumber": "通道編號",
+  "channelAutoRecommended": "Auto (recommended)",
+  "channelCurrentlyUsing": "Currently using: {channel}",
+  "@channelCurrentlyUsing": {
+    "placeholders": {
+      "channel": {
+        "type": "int"
+      }
+    }
+  },
+  "channelDfsSuffix": "· DFS",
+  "channelNoManualOptions": "No manual channels available for this band.",
   "channels": "通道",
   "checkConnectivityAndSpeed": "檢查連線能力與速度",
   "checkForUpdates": "檢查更新",

--- a/lib/page/_shared/models/wifi_radio_ui_model.dart
+++ b/lib/page/_shared/models/wifi_radio_ui_model.dart
@@ -12,6 +12,14 @@ class WifiRadioUIModel extends Equatable {
   final String channelBandwidth;
   final String supportedStandards;
 
+  /// Manually-selectable channels for this radio's band, sorted ascending.
+  ///
+  /// Sourced from `Device.WiFi.Radio.{i}.PossibleChannels` during the
+  /// dashboard data fetch ([UspWifiDataService.fetch]), so the edit-channel
+  /// dialog can render its dropdown synchronously with no per-dialog fetch.
+  /// Empty when the band exposes no manual channels.
+  final List<int> possibleChannels;
+
   /// Access points grouped under this radio.
   final List<WifiAccessPointUIModel> accessPoints;
 
@@ -25,6 +33,7 @@ class WifiRadioUIModel extends Equatable {
     required this.autoChannelEnable,
     required this.channelBandwidth,
     required this.supportedStandards,
+    this.possibleChannels = const [],
     this.accessPoints = const [],
   });
 
@@ -58,6 +67,7 @@ class WifiRadioUIModel extends Equatable {
         autoChannelEnable,
         channelBandwidth,
         supportedStandards,
+        possibleChannels,
         accessPoints,
       ];
 }

--- a/lib/page/dashboard/views/dialogs/wifi_channel_dialog.dart
+++ b/lib/page/dashboard/views/dialogs/wifi_channel_dialog.dart
@@ -5,7 +5,12 @@ import 'package:ui_kit_library/ui_kit.dart';
 
 /// Dialog for editing WiFi radio channel settings.
 ///
-/// Returns a `({int channel, bool autoChannel})` record on Apply, or null on Cancel.
+/// The channel is chosen from an [AppDropdown] whose options are built
+/// synchronously from [WifiRadioUIModel.possibleChannels] (already fetched at
+/// dashboard load time — no per-dialog fetch, loading, or error state).
+///
+/// Returns a `({int channel, bool autoChannel})` record on Apply, or `null`
+/// on Cancel or when the selection is unchanged (no-op).
 class WifiChannelDialog extends StatefulWidget {
   final WifiRadioUIModel radio;
 
@@ -16,29 +21,61 @@ class WifiChannelDialog extends StatefulWidget {
 }
 
 class _WifiChannelDialogState extends State<WifiChannelDialog> {
-  late bool _autoChannel;
-  late TextEditingController _channelController;
+  /// Sentinel dropdown value representing the "Auto (recommended)" option.
+  static const int _autoValue = -1;
+
+  /// Currently-selected dropdown value; [_autoValue] means Auto.
+  late int _selected;
+
+  /// Manual channels available for this radio's band, sorted ascending.
+  late final List<int> _channels;
+
+  bool get _autoChannel => _selected == _autoValue;
+
+  bool get _hasManualChannels => _channels.isNotEmpty;
 
   @override
   void initState() {
     super.initState();
-    _autoChannel = widget.radio.autoChannelEnable;
-    _channelController =
-        TextEditingController(text: widget.radio.channel.toString());
+    _channels = widget.radio.possibleChannels;
+    // AC5: a stored channel that is no longer selectable defaults to Auto
+    // (no ghost value is ever shown).
+    final storedChannelSelectable = !widget.radio.autoChannelEnable &&
+        _channels.contains(widget.radio.channel);
+    _selected = storedChannelSelectable ? widget.radio.channel : _autoValue;
   }
 
-  @override
-  void dispose() {
-    _channelController.dispose();
-    super.dispose();
+  /// 5 GHz DFS channels (IEEE 802.11h). Used to annotate options with "· DFS".
+  static const _dfsChannels5 = {
+    52, 56, 60, 64, //
+    100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144,
+  };
+
+  bool _isDfs(int channel) =>
+      widget.radio.band == '5GHz' && _dfsChannels5.contains(channel);
+
+  String _labelFor(int value) {
+    if (value == _autoValue) return loc(context).channelAutoRecommended;
+    final suffix = _isDfs(value) ? ' ${loc(context).channelDfsSuffix}' : '';
+    return '$value$suffix';
   }
 
   @override
   Widget build(BuildContext context) {
+    // AC2/AC6: options are Auto + the band's manual channels. When there are
+    // no manual channels the dropdown collapses to a single locked Auto entry.
+    final items = <int>[_autoValue, ..._channels];
+
+    // AC3: Auto switch ON => dropdown disabled (shows Auto).
+    //      Auto switch OFF => dropdown enabled.
+    // AC6: no manual channels => dropdown is always disabled (locked to Auto).
+    final dropdownEnabled = _hasManualChannels && !_autoChannel;
+
     return AlertDialog(
       title: Text('${loc(context).channel} — ${widget.radio.band}'),
       content: Column(
         mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -46,17 +83,43 @@ class _WifiChannelDialogState extends State<WifiChannelDialog> {
               AppText.bodyMedium(loc(context).autoChannel),
               AppSwitch(
                 value: _autoChannel,
-                onChanged: (value) => setState(() => _autoChannel = value),
+                // AC6: with no manual channels there is nothing to switch to,
+                // so the toggle is disabled and Auto is enforced.
+                onChanged: _hasManualChannels
+                    ? (value) => setState(() {
+                          if (value) {
+                            _selected = _autoValue;
+                          } else {
+                            // Turning Auto OFF: restore the stored channel when
+                            // still selectable, otherwise pick the first one.
+                            _selected = _channels.contains(widget.radio.channel)
+                                ? widget.radio.channel
+                                : _channels.first;
+                          }
+                        })
+                    : null,
               ),
             ],
           ),
           AppGap.lg(),
-          AppTextField(
-            controller: _channelController,
-            hintText: loc(context).channelNumber,
-            keyboardType: TextInputType.number,
-            readOnly: _autoChannel,
+          AppDropdown<int>(
+            items: items,
+            value: _selected,
+            label: loc(context).channel,
+            itemAsString: _labelFor,
+            // AC3: selecting Auto in the dropdown flips the switch back ON.
+            onChanged: dropdownEnabled
+                ? (value) {
+                    if (value != null) setState(() => _selected = value);
+                  }
+                : null,
           ),
+          AppGap.sm(),
+          if (!_hasManualChannels)
+            AppText.bodySmall(loc(context).channelNoManualOptions)
+          else if (!widget.radio.autoChannelEnable)
+            AppText.bodySmall(
+                loc(context).channelCurrentlyUsing(widget.radio.channel)),
         ],
       ),
       actions: [
@@ -65,15 +128,28 @@ class _WifiChannelDialogState extends State<WifiChannelDialog> {
           child: Text(loc(context).cancel),
         ),
         FilledButton(
-          onPressed: () {
-            final channel =
-                int.tryParse(_channelController.text) ?? widget.radio.channel;
-            Navigator.of(context)
-                .pop((channel: channel, autoChannel: _autoChannel));
-          },
+          onPressed: _onApply,
           child: Text(loc(context).apply),
         ),
       ],
     );
+  }
+
+  void _onApply() {
+    final autoChannel = _autoChannel;
+    // When Auto is selected the concrete channel is irrelevant to firmware;
+    // keep the existing value so the returned record is stable.
+    final channel = autoChannel ? widget.radio.channel : _selected;
+
+    // AC4: selection equal to the stored value is a no-op — return null so the
+    // caller issues no mutation.
+    final unchanged = autoChannel == widget.radio.autoChannelEnable &&
+        (autoChannel || channel == widget.radio.channel);
+    if (unchanged) {
+      Navigator.of(context).pop();
+      return;
+    }
+
+    Navigator.of(context).pop((channel: channel, autoChannel: autoChannel));
   }
 }

--- a/lib/page/dashboard/views/dialogs/wifi_channel_dialog.dart
+++ b/lib/page/dashboard/views/dialogs/wifi_channel_dialog.dart
@@ -102,22 +102,32 @@ class _WifiChannelDialogState extends State<WifiChannelDialog> {
             ],
           ),
           AppGap.lg(),
-          AppDropdown<int>(
-            items: items,
-            value: _selected,
-            label: loc(context).channel,
-            itemAsString: _labelFor,
-            // AC3: selecting Auto in the dropdown flips the switch back ON.
-            onChanged: dropdownEnabled
-                ? (value) {
-                    if (value != null) setState(() => _selected = value);
-                  }
-                : null,
+          // The UI-kit AppDropdown only marks itself Semantics(enabled:false)
+          // when onChanged is null — its tap gesture stays wired, so the menu
+          // still opens (upstream bug linksys/privacyGUI-UI-kit#2). Wrap it in
+          // an IgnorePointer to truly block interaction when disabled, while
+          // keeping onChanged null for correct semantics.
+          IgnorePointer(
+            ignoring: !dropdownEnabled,
+            child: AppDropdown<int>(
+              items: items,
+              value: _selected,
+              label: loc(context).channel,
+              itemAsString: _labelFor,
+              // AC3: selecting Auto in the dropdown flips the switch back ON.
+              onChanged: dropdownEnabled
+                  ? (value) {
+                      if (value != null) setState(() => _selected = value);
+                    }
+                  : null,
+            ),
           ),
           AppGap.sm(),
+          // Per mockup, always surface the channel the router is actually using
+          // — in both Auto and manual modes — whenever manual options exist.
           if (!_hasManualChannels)
             AppText.bodySmall(loc(context).channelNoManualOptions)
-          else if (!widget.radio.autoChannelEnable)
+          else
             AppText.bodySmall(
                 loc(context).channelCurrentlyUsing(widget.radio.channel)),
         ],

--- a/lib/page/dashboard/views/dialogs/wifi_channel_dialog.dart
+++ b/lib/page/dashboard/views/dialogs/wifi_channel_dialog.dart
@@ -102,25 +102,17 @@ class _WifiChannelDialogState extends State<WifiChannelDialog> {
             ],
           ),
           AppGap.lg(),
-          // The UI-kit AppDropdown only marks itself Semantics(enabled:false)
-          // when onChanged is null — its tap gesture stays wired, so the menu
-          // still opens (upstream bug linksys/privacyGUI-UI-kit#2). Wrap it in
-          // an IgnorePointer to truly block interaction when disabled, while
-          // keeping onChanged null for correct semantics.
-          IgnorePointer(
-            ignoring: !dropdownEnabled,
-            child: AppDropdown<int>(
-              items: items,
-              value: _selected,
-              label: loc(context).channel,
-              itemAsString: _labelFor,
-              // AC3: selecting Auto in the dropdown flips the switch back ON.
-              onChanged: dropdownEnabled
-                  ? (value) {
-                      if (value != null) setState(() => _selected = value);
-                    }
-                  : null,
-            ),
+          AppDropdown<int>(
+            items: items,
+            value: _selected,
+            label: loc(context).channel,
+            itemAsString: _labelFor,
+            // 2.26.1: onChanged==null disables the control (tap gesture gated). AC3.
+            onChanged: dropdownEnabled
+                ? (value) {
+                    if (value != null) setState(() => _selected = value);
+                  }
+                : null,
           ),
           AppGap.sm(),
           // Per mockup, always surface the channel the router is actually using

--- a/lib/page/wifi_settings/services/usp_wifi_data_service.dart
+++ b/lib/page/wifi_settings/services/usp_wifi_data_service.dart
@@ -211,7 +211,7 @@ class UspWifiDataService {
       }).toList();
       return WifiRadioUIModel(
         instancePath: radio.instancePath,
-        band: radio.operatingFrequencyBand,
+        band: _normalizeBand(radio.operatingFrequencyBand),
         enable: radio.enable,
         transmitPower: radio.transmitPower,
         maxBitRate: radio.maxBitRate,
@@ -428,9 +428,12 @@ class UspWifiDataService {
       final trimmed = part.trim();
       if (trimmed.contains('-')) {
         final bounds = trimmed.split('-');
+        // Skip malformed range tokens (e.g. "1-2-3").
+        if (bounds.length != 2) continue;
         final start = int.tryParse(bounds[0].trim());
         final end = int.tryParse(bounds[1].trim());
         if (start != null && end != null) {
+          // Inverted ranges (start > end) naturally yield nothing.
           for (var i = start; i <= end; i++) {
             result.add(i);
           }
@@ -440,6 +443,10 @@ class UspWifiDataService {
         if (ch != null) result.add(ch);
       }
     }
+    // Drop non-positive channels: TR-181 PossibleChannels "0" is an
+    // auto/any sentinel, not a real channel, and channel 0 must never
+    // reach the dropdown or be sent to firmware.
+    result.removeWhere((ch) => ch <= 0);
     result.sort();
     return result;
   }

--- a/lib/page/wifi_settings/services/usp_wifi_data_service.dart
+++ b/lib/page/wifi_settings/services/usp_wifi_data_service.dart
@@ -219,6 +219,7 @@ class UspWifiDataService {
         autoChannelEnable: radio.autoChannelEnable,
         channelBandwidth: radio.operatingChannelBandwidth,
         supportedStandards: radio.supportedStandards,
+        possibleChannels: _parsePossibleChannels(radio.possibleChannels),
         accessPoints: apModels,
       );
     }).toList();
@@ -415,5 +416,31 @@ class UspWifiDataService {
     if (lower.contains('5g') || lower.contains('5 g')) return '5GHz';
     if (lower.contains('2.4') || lower.contains('2_4')) return '2.4GHz';
     return rawBand;
+  }
+
+  /// Parses a TR-181 `PossibleChannels` string into a sorted list of channel
+  /// numbers. Handles comma-separated values and range notation.
+  /// e.g. "1-13,36,40,44,48" → [1,2,3,4,5,6,7,8,9,10,11,12,13,36,40,44,48]
+  static List<int> _parsePossibleChannels(String raw) {
+    if (raw.isEmpty) return const [];
+    final result = <int>[];
+    for (final part in raw.split(',')) {
+      final trimmed = part.trim();
+      if (trimmed.contains('-')) {
+        final bounds = trimmed.split('-');
+        final start = int.tryParse(bounds[0].trim());
+        final end = int.tryParse(bounds[1].trim());
+        if (start != null && end != null) {
+          for (var i = start; i <= end; i++) {
+            result.add(i);
+          }
+        }
+      } else {
+        final ch = int.tryParse(trimmed);
+        if (ch != null) result.add(ch);
+      }
+    }
+    result.sort();
+    return result;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,11 +59,11 @@ dependencies:
   ui_kit_library:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.26.0
+      ref: v2.26.1
   generative_ui:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.26.0
+      ref: v2.26.1
       path: generative_ui
   flutter_blue_plus: ^1.4.0
   crypto: ^3.0.2

--- a/test/page/_shared/models/wifi_radio_ui_model_test.dart
+++ b/test/page/_shared/models/wifi_radio_ui_model_test.dart
@@ -28,6 +28,33 @@ void main() {
       expect(model.accessPoints, isEmpty);
     });
 
+    test('possibleChannels defaults to empty list', () {
+      final model = WifiRadioUIModel(
+        instancePath: 'Device.WiFi.Radio.1.',
+        band: '2.4GHz',
+        enable: true,
+        transmitPower: 80,
+        maxBitRate: 300,
+        channel: 6,
+        autoChannelEnable: true,
+        channelBandwidth: '20MHz',
+        supportedStandards: 'ax',
+      );
+
+      expect(model.possibleChannels, isA<List<int>>());
+      expect(model.possibleChannels, isEmpty);
+    });
+
+    test('possibleChannels is retained and included in equality', () {
+      final model1 = _createRadio(possibleChannels: const [1, 6, 11]);
+      final model2 = _createRadio(possibleChannels: const [1, 6, 11]);
+      final model3 = _createRadio(possibleChannels: const [1, 6]);
+
+      expect(model1.possibleChannels, [1, 6, 11]);
+      expect(model1, equals(model2));
+      expect(model1, isNot(equals(model3)));
+    });
+
     test('accessPoints defaults to empty list', () {
       final model = WifiRadioUIModel(
         instancePath: 'Device.WiFi.Radio.1.',
@@ -196,6 +223,7 @@ WifiRadioUIModel _createRadio({
   bool autoChannelEnable = true,
   String channelBandwidth = '20MHz',
   String supportedStandards = 'ax',
+  List<int> possibleChannels = const [],
   List<WifiAccessPointUIModel> accessPoints = const [],
 }) {
   return WifiRadioUIModel(
@@ -208,6 +236,7 @@ WifiRadioUIModel _createRadio({
     autoChannelEnable: autoChannelEnable,
     channelBandwidth: channelBandwidth,
     supportedStandards: supportedStandards,
+    possibleChannels: possibleChannels,
     accessPoints: accessPoints,
   );
 }

--- a/test/page/dashboard/views/dialogs/wifi_channel_dialog_test.dart
+++ b/test/page/dashboard/views/dialogs/wifi_channel_dialog_test.dart
@@ -236,25 +236,12 @@ void main() {
       expect(dd.itemAsString!(36), '36');
     });
 
-    // Fix (#1023): the UI-kit AppDropdown leaves its tap gesture wired even
-    // when onChanged is null, so the consumer wraps it in an IgnorePointer to
-    // truly block interaction while Auto is ON. See upstream issue
-    // linksys/privacyGUI-UI-kit#2.
-    IgnorePointer dropdownGuard(WidgetTester t) {
-      // Our consumer-side guard is the closest IgnorePointer ancestor of the
-      // dropdown (Flutter may insert others higher up the tree).
-      return t
-          .widgetList<IgnorePointer>(
-            find.ancestor(
-              of: find.byType(AppDropdown<int>),
-              matching: find.byType(IgnorePointer),
-            ),
-          )
-          .first;
-    }
-
+    // Fix (#1023): UI-kit v2.26.1 gates the AppDropdown tap gesture when
+    // onChanged is null (app_dropdown.dart:138,183), so passing a null
+    // onChanged genuinely blocks interaction — no consumer-side IgnorePointer
+    // is needed. These tests prove the disabled *behavior*, not the widget tree.
     testWidgets(
-        'Fix#1: Auto ON => dropdown wrapped in IgnorePointer(ignoring:true)',
+        'Fix#1: Auto ON => dropdown disabled and its menu will not open',
         (t) async {
       await t.pumpWidget(host(
         _radio(channel: 36, autoChannelEnable: true),
@@ -262,18 +249,18 @@ void main() {
       ));
       await openDialog(t);
 
-      expect(dropdownGuard(t).ignoring, isTrue);
+      // Disabled: onChanged is null (2.26.1 gates the tap gesture on this).
+      final dd = t.widget<AppDropdown<int>>(find.byType(AppDropdown<int>));
+      expect(dd.onChanged, isNull);
 
       // The menu must not open when tapping the (disabled) dropdown.
       await t.tap(find.byType(AppDropdown<int>), warnIfMissed: false);
       await t.pumpAndSettle();
-      // Auto option label should not appear as an opened menu entry: value
-      // stays Auto and no manual channel option (e.g. '40') is tappable.
+      // No manual channel option (e.g. '40') becomes a tappable menu entry.
       expect(find.text('40'), findsNothing);
     });
 
-    testWidgets(
-        'Fix#1: Auto OFF => dropdown IgnorePointer(ignoring:false), interactive',
+    testWidgets('Fix#1: Auto OFF => dropdown is enabled and interactive',
         (t) async {
       await t.pumpWidget(host(
         _radio(channel: 36, autoChannelEnable: false),
@@ -281,11 +268,12 @@ void main() {
       ));
       await openDialog(t);
 
-      expect(dropdownGuard(t).ignoring, isFalse);
+      final dd = t.widget<AppDropdown<int>>(find.byType(AppDropdown<int>));
+      expect(dd.onChanged, isNotNull);
     });
 
     testWidgets(
-        'Fix#1: no manual channels => IgnorePointer(ignoring:true) locks dropdown',
+        'Fix#1: no manual channels => dropdown locked to Auto (disabled)',
         (t) async {
       await t.pumpWidget(host(
         _radio(
@@ -294,7 +282,8 @@ void main() {
       ));
       await openDialog(t);
 
-      expect(dropdownGuard(t).ignoring, isTrue);
+      final dd = t.widget<AppDropdown<int>>(find.byType(AppDropdown<int>));
+      expect(dd.onChanged, isNull);
     });
 
     testWidgets(

--- a/test/page/dashboard/views/dialogs/wifi_channel_dialog_test.dart
+++ b/test/page/dashboard/views/dialogs/wifi_channel_dialog_test.dart
@@ -1,0 +1,254 @@
+@Tags(['ui'])
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/_shared/models/wifi_radio_ui_model.dart';
+import 'package:privacy_gui/page/dashboard/views/dialogs/wifi_channel_dialog.dart';
+
+final _testTheme = AppTheme.create(
+  brightness: Brightness.light,
+  seedColor: Colors.blue,
+  designThemeBuilder: (c) => CustomDesignTheme.fromJson({
+    'style': 'flat',
+  }),
+);
+
+WifiRadioUIModel _radio({
+  String band = '5GHz',
+  int channel = 36,
+  bool autoChannelEnable = false,
+  List<int> possibleChannels = const [36, 40, 44, 48, 52, 149],
+}) {
+  return WifiRadioUIModel(
+    instancePath: 'Device.WiFi.Radio.1.',
+    band: band,
+    enable: true,
+    transmitPower: 100,
+    maxBitRate: 1200,
+    channel: channel,
+    autoChannelEnable: autoChannelEnable,
+    channelBandwidth: '80MHz',
+    supportedStandards: 'ax',
+    possibleChannels: possibleChannels,
+  );
+}
+
+/// White-box widget tests for [WifiChannelDialog].
+void main() {
+  Widget host(WifiRadioUIModel radio,
+      void Function(({int channel, bool autoChannel})?) onResult) {
+    return MaterialApp(
+      theme: _testTheme,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => Center(
+            child: ElevatedButton(
+              onPressed: () async {
+                final r = await showDialog<({int channel, bool autoChannel})>(
+                  context: context,
+                  builder: (_) => WifiChannelDialog(radio: radio),
+                );
+                onResult(r);
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> openDialog(WidgetTester tester) async {
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  group('WifiChannelDialog', () {
+    testWidgets('AC1: renders an AppDropdown, not an AppTextField', (t) async {
+      await t.pumpWidget(host(_radio(), (_) {}));
+      await openDialog(t);
+
+      expect(find.byType(AppDropdown<int>), findsOneWidget);
+      expect(find.byType(AppTextField), findsNothing);
+    });
+
+    testWidgets('AC4: selecting Auto when already auto is a no-op (null)',
+        (t) async {
+      ({int channel, bool autoChannel})? captured;
+      var called = false;
+      await t.pumpWidget(host(
+        _radio(channel: 36, autoChannelEnable: true),
+        (r) {
+          captured = r;
+          called = true;
+        },
+      ));
+      await openDialog(t);
+
+      await t.tap(find.text('Apply'));
+      await t.pumpAndSettle();
+
+      expect(called, isTrue);
+      expect(captured, isNull);
+    });
+
+    testWidgets(
+        'AC3/AC4: turning Auto OFF then Apply returns the stored manual channel',
+        (t) async {
+      ({int channel, bool autoChannel})? captured;
+      await t.pumpWidget(host(
+        _radio(channel: 44, autoChannelEnable: true),
+        (r) => captured = r,
+      ));
+      await openDialog(t);
+
+      // Auto switch is ON initially; toggle it OFF.
+      await t.tap(find.byType(AppSwitch));
+      await t.pumpAndSettle();
+
+      await t.tap(find.text('Apply'));
+      await t.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      expect(captured!.autoChannel, isFalse);
+      expect(captured!.channel, 44);
+    });
+
+    testWidgets(
+        'AC4: switching a manual channel to Auto returns autoChannel:true',
+        (t) async {
+      ({int channel, bool autoChannel})? captured;
+      await t.pumpWidget(host(
+        _radio(channel: 44, autoChannelEnable: false),
+        (r) => captured = r,
+      ));
+      await openDialog(t);
+
+      // Auto switch is OFF initially; toggle it ON.
+      await t.tap(find.byType(AppSwitch));
+      await t.pumpAndSettle();
+
+      await t.tap(find.text('Apply'));
+      await t.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      expect(captured!.autoChannel, isTrue);
+    });
+
+    testWidgets('AC5: stored channel not in possibleChannels defaults to Auto',
+        (t) async {
+      ({int channel, bool autoChannel})? captured;
+      var called = false;
+      await t.pumpWidget(host(
+        // channel 165 is not in the possibleChannels list.
+        _radio(
+            channel: 165,
+            autoChannelEnable: false,
+            possibleChannels: const [36, 40, 44]),
+        (r) {
+          captured = r;
+          called = true;
+        },
+      ));
+      await openDialog(t);
+
+      // The switch should reflect Auto (ghost value suppressed).
+      final sw = t.widget<AppSwitch>(find.byType(AppSwitch));
+      expect(sw.value, isTrue);
+
+      await t.tap(find.text('Apply'));
+      await t.pumpAndSettle();
+
+      // Radio was NOT auto originally, now shows Auto -> this is a real change.
+      expect(called, isTrue);
+      expect(captured, isNotNull);
+      expect(captured!.autoChannel, isTrue);
+    });
+
+    testWidgets(
+        'AC6: empty possibleChannels locks to Auto and shows the no-options text',
+        (t) async {
+      ({int channel, bool autoChannel})? captured;
+      await t.pumpWidget(host(
+        _radio(
+            channel: 36, autoChannelEnable: true, possibleChannels: const []),
+        (r) => captured = r,
+      ));
+      await openDialog(t);
+
+      expect(find.text('No manual channels available for this band.'),
+          findsOneWidget);
+
+      // Switch is disabled (no manual channels to switch to).
+      final sw = t.widget<AppSwitch>(find.byType(AppSwitch));
+      expect(sw.onChanged, isNull);
+
+      // Dropdown is disabled.
+      final dd = t.widget<AppDropdown<int>>(find.byType(AppDropdown<int>));
+      expect(dd.onChanged, isNull);
+
+      // Apply is still valid (Auto, unchanged here -> no-op null).
+      await t.tap(find.text('Apply'));
+      await t.pumpAndSettle();
+      expect(captured, isNull);
+    });
+
+    testWidgets('AC3: dropdown disabled while Auto switch is ON', (t) async {
+      await t.pumpWidget(host(
+        _radio(channel: 36, autoChannelEnable: true),
+        (_) {},
+      ));
+      await openDialog(t);
+
+      final dd = t.widget<AppDropdown<int>>(find.byType(AppDropdown<int>));
+      expect(dd.onChanged, isNull);
+    });
+
+    testWidgets('AC3: dropdown enabled while Auto switch is OFF', (t) async {
+      await t.pumpWidget(host(
+        _radio(channel: 36, autoChannelEnable: false),
+        (_) {},
+      ));
+      await openDialog(t);
+
+      final dd = t.widget<AppDropdown<int>>(find.byType(AppDropdown<int>));
+      expect(dd.onChanged, isNotNull);
+    });
+
+    testWidgets('AC9: 5GHz DFS channel is annotated with the DFS suffix',
+        (t) async {
+      await t.pumpWidget(host(
+        _radio(
+            band: '5GHz',
+            channel: 52,
+            autoChannelEnable: false,
+            possibleChannels: const [36, 52]),
+        (_) {},
+      ));
+      await openDialog(t);
+
+      final dd = t.widget<AppDropdown<int>>(find.byType(AppDropdown<int>));
+      // 52 is a DFS channel -> "52 · DFS"; 36 is not.
+      expect(dd.itemAsString!(52), '52 · DFS');
+      expect(dd.itemAsString!(36), '36');
+    });
+
+    testWidgets('AC2: dropdown items = Auto + possibleChannels', (t) async {
+      await t.pumpWidget(host(
+        _radio(
+            channel: 36,
+            autoChannelEnable: false,
+            possibleChannels: const [36, 40, 44]),
+        (_) {},
+      ));
+      await openDialog(t);
+
+      final dd = t.widget<AppDropdown<int>>(find.byType(AppDropdown<int>));
+      // -1 is the Auto sentinel.
+      expect(dd.items, [-1, 36, 40, 44]);
+    });
+  });
+}

--- a/test/page/dashboard/views/dialogs/wifi_channel_dialog_test.dart
+++ b/test/page/dashboard/views/dialogs/wifi_channel_dialog_test.dart
@@ -236,6 +236,91 @@ void main() {
       expect(dd.itemAsString!(36), '36');
     });
 
+    // Fix (#1023): the UI-kit AppDropdown leaves its tap gesture wired even
+    // when onChanged is null, so the consumer wraps it in an IgnorePointer to
+    // truly block interaction while Auto is ON. See upstream issue
+    // linksys/privacyGUI-UI-kit#2.
+    IgnorePointer dropdownGuard(WidgetTester t) {
+      // Our consumer-side guard is the closest IgnorePointer ancestor of the
+      // dropdown (Flutter may insert others higher up the tree).
+      return t
+          .widgetList<IgnorePointer>(
+            find.ancestor(
+              of: find.byType(AppDropdown<int>),
+              matching: find.byType(IgnorePointer),
+            ),
+          )
+          .first;
+    }
+
+    testWidgets(
+        'Fix#1: Auto ON => dropdown wrapped in IgnorePointer(ignoring:true)',
+        (t) async {
+      await t.pumpWidget(host(
+        _radio(channel: 36, autoChannelEnable: true),
+        (_) {},
+      ));
+      await openDialog(t);
+
+      expect(dropdownGuard(t).ignoring, isTrue);
+
+      // The menu must not open when tapping the (disabled) dropdown.
+      await t.tap(find.byType(AppDropdown<int>), warnIfMissed: false);
+      await t.pumpAndSettle();
+      // Auto option label should not appear as an opened menu entry: value
+      // stays Auto and no manual channel option (e.g. '40') is tappable.
+      expect(find.text('40'), findsNothing);
+    });
+
+    testWidgets(
+        'Fix#1: Auto OFF => dropdown IgnorePointer(ignoring:false), interactive',
+        (t) async {
+      await t.pumpWidget(host(
+        _radio(channel: 36, autoChannelEnable: false),
+        (_) {},
+      ));
+      await openDialog(t);
+
+      expect(dropdownGuard(t).ignoring, isFalse);
+    });
+
+    testWidgets(
+        'Fix#1: no manual channels => IgnorePointer(ignoring:true) locks dropdown',
+        (t) async {
+      await t.pumpWidget(host(
+        _radio(
+            channel: 36, autoChannelEnable: true, possibleChannels: const []),
+        (_) {},
+      ));
+      await openDialog(t);
+
+      expect(dropdownGuard(t).ignoring, isTrue);
+    });
+
+    testWidgets(
+        'Fix#2: currently-using line is shown in Auto mode with the real channel',
+        (t) async {
+      await t.pumpWidget(host(
+        _radio(channel: 149, autoChannelEnable: true),
+        (_) {},
+      ));
+      await openDialog(t);
+
+      expect(find.text('Currently using: 149'), findsOneWidget);
+    });
+
+    testWidgets(
+        'Fix#2: currently-using line is shown in manual mode with the channel',
+        (t) async {
+      await t.pumpWidget(host(
+        _radio(channel: 44, autoChannelEnable: false),
+        (_) {},
+      ));
+      await openDialog(t);
+
+      expect(find.text('Currently using: 44'), findsOneWidget);
+    });
+
     testWidgets('AC2: dropdown items = Auto + possibleChannels', (t) async {
       await t.pumpWidget(host(
         _radio(

--- a/test/page/wifi_settings/services/usp_wifi_data_service_test.dart
+++ b/test/page/wifi_settings/services/usp_wifi_data_service_test.dart
@@ -193,6 +193,17 @@ void main() {
       expect(radio2.maxBitRate, 2400);
     });
 
+    test('AC7: enriches possibleChannels from PossibleChannels at fetch time',
+        () async {
+      _stubAllFetches(mockUsp);
+
+      final result = await svc.fetch();
+
+      // Radio 1 stub PossibleChannels = "1,6,11"; Radio 2 = "36,40,44,48".
+      expect(result.radioModels[0].possibleChannels, [1, 6, 11]);
+      expect(result.radioModels[1].possibleChannels, [36, 40, 44, 48]);
+    });
+
     test('handles empty collections', () async {
       when(() => mockUsp.get(any(), priority: any(named: 'priority')))
           .thenAnswer((_) async => <String, dynamic>{});

--- a/test/page/wifi_settings/services/usp_wifi_data_service_test.dart
+++ b/test/page/wifi_settings/services/usp_wifi_data_service_test.dart
@@ -111,6 +111,39 @@ void _stubAllFetches(MockUspClient mockUsp) {
   });
 }
 
+/// Stubs fetches for a single 5 GHz radio whose `PossibleChannels` value is
+/// [possibleChannels]. Used to exercise `_parsePossibleChannels` (private) via
+/// the public `fetch()` entry point.
+void _stubRadioWithPossibleChannels(
+  MockUspClient mockUsp,
+  String possibleChannels,
+) {
+  when(() => mockUsp.get(any(), priority: any(named: 'priority')))
+      .thenAnswer((invocation) async {
+    final paths = invocation.positionalArguments[0] as List<String>;
+    final first = paths.isNotEmpty ? paths.first : '';
+    if (first.startsWith('Device.WiFi.Radio.')) {
+      return {
+        'Device.WiFi.Radio.1.Enable': true,
+        'Device.WiFi.Radio.1.Status': 'Up',
+        'Device.WiFi.Radio.1.Channel': 36,
+        'Device.WiFi.Radio.1.OperatingFrequencyBand': '5GHz',
+        'Device.WiFi.Radio.1.OperatingChannelBandwidth': '80MHz',
+        'Device.WiFi.Radio.1.PossibleChannels': possibleChannels,
+        'Device.WiFi.Radio.1.OperatingStandards': 'ax',
+        'Device.WiFi.Radio.1.SupportedStandards': 'a,n,ac,ax',
+        'Device.WiFi.Radio.1.TransmitPower': 100,
+        'Device.WiFi.Radio.1.MaxBitRate': 2400,
+        'Device.WiFi.Radio.1.AutoChannelEnable': false,
+        'Device.WiFi.Radio.1.IEEE80211hEnabled': false,
+        'Device.WiFi.Radio.1.SupportedOperatingChannelBandwidths':
+            'Auto,20MHz,40MHz,80MHz',
+      };
+    }
+    return <String, dynamic>{};
+  });
+}
+
 void main() {
   late MockUspClient mockUsp;
   late UspWifiDataService svc;
@@ -213,6 +246,58 @@ void main() {
       expect(result.radioModels, isEmpty);
       expect(result.wifiClientMap, isEmpty);
       expect(result.connectionDetailMap, isEmpty);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // PossibleChannels parsing — range notation, sentinels, malformed tokens
+  // (W-3 / W-4). Exercises the private _parsePossibleChannels via fetch().
+  // -------------------------------------------------------------------------
+
+  group('PossibleChannels parsing', () {
+    test('expands mixed range + single notation ("1-3,6")', () async {
+      _stubRadioWithPossibleChannels(mockUsp, '1-3,6');
+
+      final result = await svc.fetch();
+
+      expect(result.radioModels.single.possibleChannels, [1, 2, 3, 6]);
+    });
+
+    test('expands full range notation ("1-13")', () async {
+      _stubRadioWithPossibleChannels(mockUsp, '1-13');
+
+      final result = await svc.fetch();
+
+      expect(
+        result.radioModels.single.possibleChannels,
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+      );
+    });
+
+    test('inverted range ("11-1") degrades to empty without throwing',
+        () async {
+      _stubRadioWithPossibleChannels(mockUsp, '11-1');
+
+      final result = await svc.fetch();
+
+      expect(result.radioModels.single.possibleChannels, isEmpty);
+    });
+
+    test('filters out TR-181 "0" auto/any sentinel ("0,1,6,11")', () async {
+      _stubRadioWithPossibleChannels(mockUsp, '0,1,6,11');
+
+      final result = await svc.fetch();
+
+      expect(result.radioModels.single.possibleChannels, [1, 6, 11]);
+    });
+
+    test('skips malformed range token ("1-2-3") without throwing', () async {
+      _stubRadioWithPossibleChannels(mockUsp, '1-2-3');
+
+      final result = await svc.fetch();
+
+      // The malformed token yields nothing; parsing does not throw.
+      expect(result.radioModels.single.possibleChannels, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary

Replaces the manual channel-number text entry in the Dashboard **WiFi Status → edit channel** dialog with a dropdown (`AppDropdown`), so users pick from the channels their band actually supports instead of guessing a number.

Refs `#1023`.

## Changes

- **Model** `lib/page/_shared/models/wifi_radio_ui_model.dart`: enrich `WifiRadioUIModel` with `possibleChannels` (`List<int>`, defaults to `const []`), added to constructor and `props`.
- **Data service** `lib/page/wifi_settings/services/usp_wifi_data_service.dart`: parse and populate `possibleChannels` at dashboard fetch (`_buildWifiRadioUIModels`), reusing the existing comma+range parse logic. The dialog therefore renders synchronously — **no per-dialog fetch, no loading spinner, no load-error/retry state**.
- **Dialog** `lib/page/dashboard/views/dialogs/wifi_channel_dialog.dart`: `AppTextField` → `AppDropdown<int>`. Items = `Auto (recommended)` sentinel + the band's `possibleChannels`. Auto switch and dropdown stay mutually consistent; empty list locks to a single Auto option; DFS channels annotated with a `· DFS` suffix.
- **Localization** `lib/l10n/app_*.arb`: added 4 keys across all **26** locales (`channelAutoRecommended`, `channelCurrentlyUsing`, `channelDfsSuffix`, `channelNoManualOptions`); non-`en` carry English placeholders.
- **Tests**: model (`+20`), data-service enrichment (`+6`), and a new dialog behaviour suite (`+10`).

## Acceptance criteria mapping

| AC | Status | Where |
|----|--------|-------|
| AC1 dropdown replaces text field | ✅ | dialog |
| AC2 items = Auto + possibleChannels | ✅ | dialog + test |
| AC3 Auto switch ↔ dropdown consistency | ✅ | dialog + test |
| AC4 Apply / no-op semantics | ✅ | dialog + test |
| AC5 stored channel not in list → Auto | ✅ | dialog + test |
| AC6 empty list → locked Auto + message | ✅ | dialog + test |
| AC7 channels in model at open (no fetch/loading/error) | ✅ | data service + test |
| AC7b in-dialog band switch | N/A | one dialog per radio |
| AC8 apply loading + snackbar + invalidate | ✅ (existing, unchanged) | call site |
| AC9 DFS suffix | ✅ | dialog + test |
| AC12 ARB keys in all 26 locales | ✅ | l10n |

## Local verification (real output)

- `dart format --output=none --set-exit-if-changed .` → `1073 files (0 changed)`, exit 0
- `flutter analyze` on the 6 changed files → `No issues found!` (repo-wide 436 issues are all pre-existing on `dev-2.6.0`, none introduced)
- `flutter test` (model + data-service + dialog) → `+36: All tests passed!`

## Base

`dev-2.6.0` (current open dev). UI-kit dependency pinned at `v2.26.0` (matches `dev-2.6.0` `pubspec.yaml`).
