### PR TITLE
fix(dashboard): consistent device counts excluding mesh nodes (#1020, #1022, #1024)

### DIFF
--- a/lib/page/_shared/models/mesh_topology_info.dart
+++ b/lib/page/_shared/models/mesh_topology_info.dart
@@ -12,17 +12,29 @@ class MeshTopologyInfo extends Equatable {
   /// Client MAC (uppercase) → node device ID mapping.
   final Map<String, String> clientToNodeMap;
 
+  /// Client MAC (uppercase) → signal strength (RSSI dBm).
+  ///
+  /// Populated from DataElements STA.SignalStrength for clients on ALL nodes,
+  /// including child nodes. Used as fallback when WifiClients doesn't have
+  /// signal data (WifiClients only covers master node clients).
+  final Map<String, int> clientSignalMap;
+
   const MeshTopologyInfo({
     required this.nodes,
     required this.clientToNodeMap,
+    this.clientSignalMap = const {},
   });
 
   /// Empty result — used as fallback when DataElements is not supported.
-  static const empty = MeshTopologyInfo(nodes: [], clientToNodeMap: {});
+  static const empty = MeshTopologyInfo(
+    nodes: [],
+    clientToNodeMap: {},
+    clientSignalMap: {},
+  );
 
   bool get isEmpty => nodes.isEmpty;
   bool get isNotEmpty => nodes.isNotEmpty;
 
   @override
-  List<Object?> get props => [nodes, clientToNodeMap];
+  List<Object?> get props => [nodes, clientToNodeMap, clientSignalMap];
 }

--- a/lib/page/_shared/providers/device_analytics_persistence.dart
+++ b/lib/page/_shared/providers/device_analytics_persistence.dart
@@ -2,21 +2,37 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/device_analytics_state.dart';
 
-const _prefsKey = 'usp_device_analytics';
+const _prefsKeyPrefix = 'usp_device_analytics';
+
+/// Build storage key scoped to a specific router by serial number.
+///
+/// This ensures analytics history from different routers don't mix.
+String _buildKey(String? serialNumber) {
+  if (serialNumber == null || serialNumber.isEmpty) {
+    return _prefsKeyPrefix;
+  }
+  return '${_prefsKeyPrefix}_$serialNumber';
+}
 
 /// Save hourly history + known MACs to SharedPreferences.
-Future<void> saveDeviceAnalytics(DeviceAnalyticsState state) async {
+///
+/// [serialNumber] scopes the data to a specific router (master SN).
+Future<void> saveDeviceAnalytics(
+  DeviceAnalyticsState state, {
+  String? serialNumber,
+}) async {
   final prefs = await SharedPreferences.getInstance();
-  await prefs.setString(_prefsKey, state.toJsonString());
+  await prefs.setString(_buildKey(serialNumber), state.toJsonString());
 }
 
 /// Load hourly history from SharedPreferences.
 ///
+/// [serialNumber] scopes the data to a specific router (master SN).
 /// Returns a state with only historical data (no current distribution).
 /// Automatically prunes entries older than 24 hours.
-Future<DeviceAnalyticsState> loadDeviceAnalytics() async {
+Future<DeviceAnalyticsState> loadDeviceAnalytics({String? serialNumber}) async {
   final prefs = await SharedPreferences.getInstance();
-  final json = prefs.getString(_prefsKey);
+  final json = prefs.getString(_buildKey(serialNumber));
   if (json == null) return const DeviceAnalyticsState();
 
   final loaded = DeviceAnalyticsState.fromJsonString(json);

--- a/lib/page/_shared/providers/usp_device_analytics_notifier.dart
+++ b/lib/page/_shared/providers/usp_device_analytics_notifier.dart
@@ -3,6 +3,7 @@ import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/page/_shared/models/device_analytics_state.dart';
 import 'package:privacy_gui/page/_shared/models/device_ui_model.dart';
 import 'package:privacy_gui/page/_shared/providers/device_analytics_persistence.dart';
+import 'package:privacy_gui/page/admin/providers/system_info_data_provider.dart';
 import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
 
 /// Device connection analytics provider — computes distributions, hourly
@@ -16,24 +17,29 @@ final uspDeviceAnalyticsProvider =
 );
 
 class UspDeviceAnalyticsNotifier extends Notifier<DeviceAnalyticsState> {
+  /// Cached serial number for persistence key scoping.
+  String? _serialNumber;
+
+  /// Whether persisted history has been loaded.
+  bool _historyLoaded = false;
+
   @override
   DeviceAnalyticsState build() {
-    // Load persisted history on init
-    _loadPersistedHistory();
-
     // Listen to device data changes for future updates
     ref.listen(devicesDataProvider, (previous, next) {
       final data = next.valueOrNull;
       if (data == null) return;
-      _onDashboardUpdated(data.deviceModels);
+      _onDashboardUpdated(data.clientDevices);
     });
 
-    // Process current device data after build() completes
-    // (same pattern as UspTrafficMonitorNotifier)
-    Future.microtask(() {
+    // Wait for systemInfoDataProvider to load, then load persisted history
+    // and process current device data
+    Future.microtask(() async {
+      await _loadPersistedHistory();
+
       final data = ref.read(devicesDataProvider).valueOrNull;
       if (data != null) {
-        _onDashboardUpdated(data.deviceModels);
+        _onDashboardUpdated(data.clientDevices);
       }
     });
 
@@ -41,19 +47,69 @@ class UspDeviceAnalyticsNotifier extends Notifier<DeviceAnalyticsState> {
   }
 
   Future<void> _loadPersistedHistory() async {
+    if (_historyLoaded) return;
+
     try {
-      final persisted = await loadDeviceAnalytics();
+      // Wait for systemInfoDataProvider to have data
+      final sysInfo = ref.read(systemInfoDataProvider).valueOrNull;
+      if (sysInfo == null) {
+        // Try to wait for it
+        try {
+          await ref
+              .read(systemInfoDataProvider.future)
+              .timeout(const Duration(seconds: 3));
+        } catch (_) {
+          // Timeout or error — proceed without SN (uses legacy key)
+        }
+      }
+
+      _serialNumber =
+          ref.read(systemInfoDataProvider).valueOrNull?.model.serialNumber;
+
+      final persisted = await loadDeviceAnalytics(serialNumber: _serialNumber);
       if (persisted.hourlyHistory.isNotEmpty) {
+        // Get router MACs to filter out from persisted history
+        // (legacy data may contain mesh node MACs before the fix)
+        final routerMacs = _getRouterMacs();
+
+        // Clean router MACs from persisted data
+        final cleanedHistory = persisted.hourlyHistory
+            .map((h) => HourlyAggregate(
+                  hour: h.hour,
+                  wifiCount: h.wifiCount,
+                  wiredCount: h.wiredCount,
+                  activeMacs: h.activeMacs
+                      .where((m) => !routerMacs.contains(m))
+                      .toSet(),
+                ))
+            .toList();
+
+        final cleanedMacs = persisted.allKnownMacs
+            .where((m) => !routerMacs.contains(m))
+            .toSet();
+
         state = state.copyWith(
-          hourlyHistory: persisted.hourlyHistory,
-          allKnownMacs: persisted.allKnownMacs,
+          hourlyHistory: cleanedHistory,
+          allKnownMacs: cleanedMacs,
           macDisplayNames: persisted.macDisplayNames,
         );
       }
+
+      _historyLoaded = true;
     } catch (e) {
       logger
           .w('[USP][Monitor][Analytics]: Failed to load persisted history: $e');
     }
+  }
+
+  /// Returns the set of router MACs (master + slave nodes).
+  Set<String> _getRouterMacs() {
+    final allDeviceModels =
+        ref.read(devicesDataProvider).valueOrNull?.deviceModels ?? [];
+    return allDeviceModels
+        .where((d) => d.deviceRole == 'master' || d.deviceRole == 'slave')
+        .map((d) => d.mac)
+        .toSet();
   }
 
   void _onDashboardUpdated(List<DeviceUIModel> devices) {
@@ -97,10 +153,13 @@ class UspDeviceAnalyticsNotifier extends Notifier<DeviceAnalyticsState> {
     final cutoff = now.subtract(Duration(hours: DeviceAnalyticsState.maxHours));
     history = history.where((h) => h.hour.isAfter(cutoff)).toList();
 
-    // Rebuild allKnownMacs from history
+    // Get router MACs to filter out from history (mesh nodes should not appear)
+    final routerMacs = _getRouterMacs();
+
+    // Rebuild allKnownMacs from history, excluding router MACs
     final allMacs = <String>{};
     for (final h in history) {
-      allMacs.addAll(h.activeMacs);
+      allMacs.addAll(h.activeMacs.where((mac) => !routerMacs.contains(mac)));
     }
 
     state = state.copyWith(
@@ -165,7 +224,7 @@ class UspDeviceAnalyticsNotifier extends Notifier<DeviceAnalyticsState> {
 
   Future<void> _persistState() async {
     try {
-      await saveDeviceAnalytics(state);
+      await saveDeviceAnalytics(state, serialNumber: _serialNumber);
     } catch (e) {
       logger.w('[USP][Monitor][Analytics]: Failed to persist: $e');
     }

--- a/lib/page/_shared/providers/usp_device_analytics_notifier.dart
+++ b/lib/page/_shared/providers/usp_device_analytics_notifier.dart
@@ -25,6 +25,10 @@ class UspDeviceAnalyticsNotifier extends Notifier<DeviceAnalyticsState> {
 
   @override
   DeviceAnalyticsState build() {
+    // Reset instance state on rebuild (e.g., after invalidate)
+    _historyLoaded = false;
+    _serialNumber = null;
+
     // Listen to device data changes for future updates
     ref.listen(devicesDataProvider, (previous, next) {
       final data = next.valueOrNull;
@@ -107,7 +111,7 @@ class UspDeviceAnalyticsNotifier extends Notifier<DeviceAnalyticsState> {
     final allDeviceModels =
         ref.read(devicesDataProvider).valueOrNull?.deviceModels ?? [];
     return allDeviceModels
-        .where((d) => d.deviceRole == 'master' || d.deviceRole == 'slave')
+        .where((d) => d.isMeshNode)
         .map((d) => d.mac)
         .toSet();
   }
@@ -223,6 +227,9 @@ class UspDeviceAnalyticsNotifier extends Notifier<DeviceAnalyticsState> {
   }
 
   Future<void> _persistState() async {
+    // Don't persist before history is loaded — _serialNumber isn't set yet,
+    // and we'd write to the legacy key instead of the scoped key.
+    if (!_historyLoaded) return;
     try {
       await saveDeviceAnalytics(state, serialNumber: _serialNumber);
     } catch (e) {

--- a/lib/page/_shared/providers/usp_device_analytics_notifier.dart
+++ b/lib/page/_shared/providers/usp_device_analytics_notifier.dart
@@ -103,6 +103,11 @@ class UspDeviceAnalyticsNotifier extends Notifier<DeviceAnalyticsState> {
     } catch (e) {
       logger
           .w('[USP][Monitor][Analytics]: Failed to load persisted history: $e');
+      // Mark as loaded even on failure so subsequent _persistState() calls are
+      // not permanently gated by `if (!_historyLoaded) return`. Otherwise a
+      // one-off load error (e.g. SharedPreferences cold-start race, corrupted
+      // JSON) would silently drop every future write for this provider's life.
+      _historyLoaded = true;
     }
   }
 

--- a/lib/page/_shared/providers/usp_device_analytics_notifier.dart
+++ b/lib/page/_shared/providers/usp_device_analytics_notifier.dart
@@ -110,10 +110,7 @@ class UspDeviceAnalyticsNotifier extends Notifier<DeviceAnalyticsState> {
   Set<String> _getRouterMacs() {
     final allDeviceModels =
         ref.read(devicesDataProvider).valueOrNull?.deviceModels ?? [];
-    return allDeviceModels
-        .where((d) => d.isMeshNode)
-        .map((d) => d.mac)
-        .toSet();
+    return allDeviceModels.where((d) => d.isMeshNode).map((d) => d.mac).toSet();
   }
 
   void _onDashboardUpdated(List<DeviceUIModel> devices) {

--- a/lib/page/_shared/services/usp_pdf_service.dart
+++ b/lib/page/_shared/services/usp_pdf_service.dart
@@ -352,7 +352,11 @@ class UspPdfService {
   // ===========================================================================
 
   static List<pw.Widget> _buildDevices(PdfReportData data) {
-    final devices = data.deviceModels ?? [];
+    final allDevices = data.deviceModels ?? [];
+    // Exclude mesh nodes (routers) — only show client devices in report
+    final devices = allDevices
+        .where((d) => d.deviceRole != 'master' && d.deviceRole != 'slave')
+        .toList();
     final online = devices.where((d) => d.isActive).toList();
     final offline = devices.where((d) => !d.isActive).toList();
 

--- a/lib/page/_shared/services/usp_pdf_service.dart
+++ b/lib/page/_shared/services/usp_pdf_service.dart
@@ -354,9 +354,7 @@ class UspPdfService {
   static List<pw.Widget> _buildDevices(PdfReportData data) {
     final allDevices = data.deviceModels ?? [];
     // Exclude mesh nodes (routers) — only show client devices in report
-    final devices = allDevices
-        .where((d) => d.deviceRole != 'master' && d.deviceRole != 'slave')
-        .toList();
+    final devices = allDevices.where((d) => d.isClientDevice).toList();
     final online = devices.where((d) => d.isActive).toList();
     final offline = devices.where((d) => !d.isActive).toList();
 

--- a/lib/page/_shared/utils/mesh_topology_builder.dart
+++ b/lib/page/_shared/utils/mesh_topology_builder.dart
@@ -23,18 +23,25 @@ class MeshTopologyBuilder {
   }) {
     final nodes = <NodeUIModel>[];
     final clientToNodeMap = <String, String>{};
+    final clientSignalMap = <String, int>{};
 
     for (final node in network.items) {
       final rawId = node.id.trim().toUpperCase();
       final nodeDeviceId = rawId.isNotEmpty ? rawId : node.instancePath;
 
-      // Build client MAC → node ID mapping from station list
+      // Build client MAC → node ID mapping and signal strength from station list
       for (final radio in node.radios) {
         for (final bss in radio.bssList) {
           for (final sta in bss.stations) {
             final mac = sta.macAddress.trim();
             if (mac.isNotEmpty && nodeDeviceId.isNotEmpty) {
-              clientToNodeMap[mac.toUpperCase()] = nodeDeviceId;
+              final upperMac = mac.toUpperCase();
+              clientToNodeMap[upperMac] = nodeDeviceId;
+              // DataElements STA.SignalStrength is RCPI (0-220), convert to RSSI
+              final rssi = rcpiToRssi(sta.signalStrength);
+              if (rssi != null) {
+                clientSignalMap[upperMac] = rssi;
+              }
             }
           }
         }
@@ -88,6 +95,10 @@ class MeshTopologyBuilder {
       ));
     }
 
-    return MeshTopologyInfo(nodes: nodes, clientToNodeMap: clientToNodeMap);
+    return MeshTopologyInfo(
+      nodes: nodes,
+      clientToNodeMap: clientToNodeMap,
+      clientSignalMap: clientSignalMap,
+    );
   }
 }

--- a/lib/page/dashboard/mascot/triggers/mascot_trigger_provider.dart
+++ b/lib/page/dashboard/mascot/triggers/mascot_trigger_provider.dart
@@ -112,7 +112,7 @@ class MascotTriggerNotifier extends AutoDisposeNotifier<MascotTriggerState> {
 
     state = MascotTriggerState(
       previousWanUp: wan?.model.isUp,
-      previousDeviceCount: devices?.deviceModels.length,
+      previousDeviceCount: devices?.clientDevices.length,
       previousFirewallEnabled: firewall?.firewallModel.isIPv4FirewallEnabled,
       previousDisabledRadios: disabledRadios,
     );
@@ -203,7 +203,7 @@ class MascotTriggerNotifier extends AutoDisposeNotifier<MascotTriggerState> {
     final devices = ref.read(devicesDataProvider).valueOrNull;
     if (devices == null) return null;
 
-    final currentCount = devices.deviceModels.length;
+    final currentCount = devices.clientDevices.length;
     final previousCount = state.previousDeviceCount;
 
     // Update state for next comparison
@@ -214,10 +214,10 @@ class MascotTriggerNotifier extends AutoDisposeNotifier<MascotTriggerState> {
     if (currentCount <= previousCount) return null;
 
     // Find the newest device (last in list by convention)
-    final newDevice = devices.deviceModels.isNotEmpty
-        ? (devices.deviceModels.last.hostName.isNotEmpty
-            ? devices.deviceModels.last.hostName
-            : devices.deviceModels.last.mac)
+    final newDevice = devices.clientDevices.isNotEmpty
+        ? (devices.clientDevices.last.hostName.isNotEmpty
+            ? devices.clientDevices.last.hostName
+            : devices.clientDevices.last.mac)
         : 'Unknown device';
 
     debugPrint('[Mascot][Trigger]: New device joined — $newDevice');

--- a/lib/page/dashboard/views/components/usp_device_analytics_card.dart
+++ b/lib/page/dashboard/views/components/usp_device_analytics_card.dart
@@ -269,6 +269,12 @@ class _TrendView extends StatelessWidget {
             (s) => s.hour.hour % 3 == 0 ? '${s.hour.hour}'.padLeft(2, '0') : '')
         .toList();
 
+    // Calculate Y-axis bounds to avoid duplicate labels when count is small
+    final maxCount =
+        slots.map((s) => s.wifi + s.wired).reduce((a, b) => a > b ? a : b);
+    final yMax = maxCount < 2 ? 2.0 : (maxCount + 1).toDouble();
+    final yInterval = yMax <= 4 ? 1.0 : (yMax / 4).ceilToDouble();
+
     return Column(
       children: [
         Expanded(
@@ -285,6 +291,7 @@ class _TrendView extends StatelessWidget {
             ],
             stacked: true,
             xLabels: xLabels,
+            yAxis: AppChartAxis(min: 0, max: yMax, interval: yInterval),
             showTooltip: false,
           ),
         ),

--- a/lib/page/dashboard/views/components/usp_stats_panel.dart
+++ b/lib/page/dashboard/views/components/usp_stats_panel.dart
@@ -20,7 +20,7 @@ class UspStatsPanel extends ConsumerWidget {
     final ethernetData = ref.watch(ethernetDataProvider).valueOrNull;
     if (devicesData == null) return const CardSkeleton.stats();
 
-    final devices = devicesData.deviceModels;
+    final devices = devicesData.clientDevices;
     final onlineCount = devices.where((d) => d.isActive).length;
     final nodeCount = devicesData.nodeModels.length;
     final wifiData = ref.watch(wifiDataProvider).valueOrNull;

--- a/lib/page/devices/services/usp_devices_data_service.dart
+++ b/lib/page/devices/services/usp_devices_data_service.dart
@@ -491,9 +491,14 @@ class UspDevicesDataService {
           .map((e) => e.address)
           .where((a) => a.isNotEmpty)
           .toList(),
-      // Prefer Hosts data, fallback to WiFi STA table data.
-      signalStrength:
-          isWifi ? (device.signalStrength ?? wifiClient?.signalStrength) : null,
+      // Prefer Hosts data, fallback to WiFi STA table, then DataElements.
+      // DataElements provides signal for clients on ALL nodes (including child nodes),
+      // while WifiClients only covers master node clients.
+      signalStrength: isWifi
+          ? (device.signalStrength ??
+              wifiClient?.signalStrength ??
+              meshTopology.clientSignalMap[mac])
+          : null,
       downlinkRate: isWifi
           ? (device.lastDataDownlinkRate ?? wifiClient?.lastDataDownlinkRate)
           : null,

--- a/lib/page/dhcp/views/components/usp_dhcp_reservations_detail_card.dart
+++ b/lib/page/dhcp/views/components/usp_dhcp_reservations_detail_card.dart
@@ -108,7 +108,7 @@ class UspDhcpReservationsDetailCard extends ConsumerWidget {
   ({List<AppAutoCompleteOption> mac, List<AppAutoCompleteOption> ip})
       _buildDeviceOptions(WidgetRef ref) {
     final devices =
-        ref.read(devicesDataProvider).valueOrNull?.deviceModels ?? [];
+        ref.read(devicesDataProvider).valueOrNull?.clientDevices ?? [];
     final macOptions = devices
         .where((d) => d.mac.isNotEmpty)
         .map((d) => AppAutoCompleteOption(

--- a/lib/page/ipv6_port_service/views/usp_ipv6_port_service_view.dart
+++ b/lib/page/ipv6_port_service/views/usp_ipv6_port_service_view.dart
@@ -192,7 +192,7 @@ class UspIpv6PortServiceView extends ConsumerWidget {
 
   List<AppAutoCompleteOption> _buildIpv6DeviceOptions(WidgetRef ref) {
     final devices =
-        ref.read(devicesDataProvider).valueOrNull?.deviceModels ?? [];
+        ref.read(devicesDataProvider).valueOrNull?.clientDevices ?? [];
     return devices
         .expand((d) => d.ipv6Addresses.map((addr) => AppAutoCompleteOption(
               label: d.displayName,

--- a/lib/page/port_forwarding/views/components/usp_single_port_tab.dart
+++ b/lib/page/port_forwarding/views/components/usp_single_port_tab.dart
@@ -101,7 +101,7 @@ class UspSinglePortTab extends ConsumerWidget {
 
   List<AppAutoCompleteOption> _buildIpv4DeviceOptions(WidgetRef ref) {
     final devices =
-        ref.read(devicesDataProvider).valueOrNull?.deviceModels ?? [];
+        ref.read(devicesDataProvider).valueOrNull?.clientDevices ?? [];
     return devices
         .where((d) => d.ip.isNotEmpty)
         .map((d) => AppAutoCompleteOption(

--- a/lib/page/topology/helpers/usp_topology_builder.dart
+++ b/lib/page/topology/helpers/usp_topology_builder.dart
@@ -260,19 +260,22 @@ class UspTopologyBuilder {
 
   /// Converts RSSI to LinkQuality using wifi.dart thresholds.
   ///
+  /// Maps [NodeSignalLevel] 1:1 to [LinkQuality] for consistency with
+  /// [UspSignalStrengthIndicator] and other signal displays.
+  ///
   /// Thresholds from [signalThresholdRSSI]: [-65, -71, -78]
-  /// - >= -65: excellent/strong
-  /// - >= -71: good/medium
-  /// - >= -78: fair/medium
-  /// - < -78: poor/weak
+  /// - >= -65: excellent
+  /// - >= -71: good
+  /// - >= -78: fair
+  /// - < -78: poor (unknown in LinkQuality)
   static LinkQuality _rssiToLinkQuality(int? rssi) {
     if (rssi == null) return LinkQuality.unknown;
     final level = getWifiSignalLevel(rssi);
     return switch (level) {
       NodeSignalLevel.excellent => LinkQuality.excellent,
-      NodeSignalLevel.good => LinkQuality.excellent,
-      NodeSignalLevel.fair => LinkQuality.good,
-      NodeSignalLevel.poor => LinkQuality.fair,
+      NodeSignalLevel.good => LinkQuality.good,
+      NodeSignalLevel.fair => LinkQuality.fair,
+      NodeSignalLevel.poor => LinkQuality.unknown,
       NodeSignalLevel.none => LinkQuality.unknown,
       NodeSignalLevel.wired => LinkQuality.stable,
     };

--- a/lib/page/topology/views/usp_topology_view.dart
+++ b/lib/page/topology/views/usp_topology_view.dart
@@ -60,16 +60,14 @@ class _UspTopologyViewState extends ConsumerState<UspTopologyView> {
               nodeModels: data.nodeModels,
             );
 
-            return _buildTopologyCard(
-                context, topology, data.deviceModels.length);
+            return _buildTopologyCard(context, topology);
           },
         );
       },
     );
   }
 
-  Widget _buildTopologyCard(
-      BuildContext context, MeshTopology topology, int deviceCount) {
+  Widget _buildTopologyCard(BuildContext context, MeshTopology topology) {
     final router = GoRouter.of(context);
     final colorScheme = Theme.of(context).colorScheme;
 

--- a/test/page/_shared/providers/usp_device_analytics_notifier_test.dart
+++ b/test/page/_shared/providers/usp_device_analytics_notifier_test.dart
@@ -3,7 +3,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:privacy_gui/page/_shared/models/device_analytics_state.dart';
 import 'package:privacy_gui/page/_shared/models/device_ui_model.dart';
+import 'package:privacy_gui/page/_shared/models/system_info_ui_model.dart';
 import 'package:privacy_gui/page/_shared/providers/usp_device_analytics_notifier.dart';
+import 'package:privacy_gui/page/admin/providers/system_info_data_provider.dart';
 import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
 
 /// Test-only devices data notifier returning canned data.
@@ -16,6 +18,29 @@ class _TestDevicesDataNotifier extends DevicesDataNotifier {
   Future<DevicesData> build() async {
     if (shouldThrow) throw Exception('devices fetch failed');
     return _data;
+  }
+}
+
+/// Test-only system info notifier returning canned data.
+class _TestSystemInfoDataNotifier extends SystemInfoDataNotifier {
+  final String serialNumber;
+  _TestSystemInfoDataNotifier({this.serialNumber = 'TEST_SN_001'});
+
+  @override
+  Future<SystemInfoData> build() async {
+    return SystemInfoData(
+      model: SystemInfoUIModel(
+        modelName: 'TestRouter',
+        hardwareVersion: '1.0',
+        manufacturer: 'Test',
+        serialNumber: serialNumber,
+        softwareVersion: '1.0.0',
+        uptime: 3600,
+        totalMemory: 512000,
+        freeMemory: 256000,
+        cpuUsage: 25,
+      ),
+    );
   }
 }
 
@@ -65,13 +90,18 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  ProviderContainer createContainer(
-      {DevicesData? data, bool shouldThrow = false}) {
+  ProviderContainer createContainer({
+    DevicesData? data,
+    bool shouldThrow = false,
+    String serialNumber = 'TEST_SN_001',
+  }) {
     final devicesData = data ?? testDevicesData;
     final container = ProviderContainer(
       overrides: [
         devicesDataProvider.overrideWith(() =>
             _TestDevicesDataNotifier(devicesData, shouldThrow: shouldThrow)),
+        systemInfoDataProvider.overrideWith(
+            () => _TestSystemInfoDataNotifier(serialNumber: serialNumber)),
       ],
     );
     return container;
@@ -244,6 +274,52 @@ void main() {
       container.dispose();
     });
 
+    test('excludes mesh nodes from distribution', () async {
+      // Add mesh nodes (master and slave routers) to the device list
+      const masterNode = DeviceUIModel(
+        mac: 'AA:BB:CC:DD:EE:05',
+        ip: '192.168.1.1',
+        hostName: 'Router',
+        isActive: true,
+        isWifi: false,
+        deviceRole: 'master',
+      );
+      const slaveNode = DeviceUIModel(
+        mac: 'AA:BB:CC:DD:EE:06',
+        ip: '192.168.1.2',
+        hostName: 'Extender',
+        isActive: true,
+        isWifi: true,
+        band: '5GHz',
+        signalStrength: -50,
+        deviceRole: 'slave',
+      );
+      // Include mesh nodes alongside regular client devices
+      final dataWithMesh = DevicesData(
+        deviceModels: [...testDevices, masterNode, slaveNode],
+      );
+      final container = createContainer(data: dataWithMesh);
+      await waitForAnalytics(container);
+
+      final state = container.read(uspDeviceAnalyticsProvider);
+      expect(state.current, isNotNull);
+
+      final dist = state.current!;
+      // Mesh nodes should NOT be counted — same as without them
+      // 2 wifi online + 1 wired online = 3 online, 1 offline (no mesh nodes)
+      expect(dist.onlineCount, 3);
+      expect(dist.offlineCount, 1);
+      expect(dist.wifiCount, 2);
+      expect(dist.wiredCount, 1);
+      expect(dist.totalCount, 4);
+
+      // Band distribution should NOT include the slave's 5GHz
+      expect(dist.bandDistribution['5GHz'], 1); // Only wifiDevice5g
+      expect(dist.bandDistribution['2.4GHz'], 1);
+      expect(dist.bandDistribution['Wired'], 1);
+      container.dispose();
+    });
+
     test('band signal quality computes average per band', () async {
       // Two 5GHz devices with different signal strengths
       const wifi5a = DeviceUIModel(
@@ -272,6 +348,95 @@ void main() {
       // Average quality for 5GHz = (1.0 + 0.0) / 2 = 0.5
       expect(dist.bandSignalQuality['5GHz'], closeTo(0.5, 0.01));
       container.dispose();
+    });
+
+    test('filters router MACs from persisted history on load', () async {
+      // Simulate legacy persisted data that includes router MACs
+      final now = DateTime.now();
+      final currentHour = DateTime(now.year, now.month, now.day, now.hour);
+      const routerMac = 'AA:BB:CC:DD:EE:05'; // Will be marked as master
+      const clientMac = 'AA:BB:CC:DD:EE:01'; // Regular client
+
+      final legacyState = DeviceAnalyticsState(
+        hourlyHistory: [
+          HourlyAggregate(
+            hour: currentHour.subtract(Duration(hours: 1)),
+            wifiCount: 2,
+            wiredCount: 0,
+            activeMacs: {routerMac, clientMac}, // Legacy: contains router MAC
+          ),
+        ],
+        allKnownMacs: {routerMac, clientMac},
+        macDisplayNames: {routerMac: 'Router', clientMac: 'Phone'},
+      );
+
+      // Pre-populate SharedPreferences with legacy data
+      SharedPreferences.setMockInitialValues({
+        'flutter.usp_device_analytics_LEGACY_SN': legacyState.toJsonString(),
+      });
+
+      // Create container with a mesh node that has the router MAC
+      const masterNode = DeviceUIModel(
+        mac: routerMac,
+        ip: '192.168.1.1',
+        hostName: 'Router',
+        isActive: true,
+        isWifi: false,
+        deviceRole: 'master',
+      );
+      final dataWithRouter = DevicesData(
+        deviceModels: [wifiDevice5g, masterNode],
+      );
+
+      final container = createContainer(
+        data: dataWithRouter,
+        serialNumber: 'LEGACY_SN',
+      );
+      await waitForAnalytics(container);
+
+      final state = container.read(uspDeviceAnalyticsProvider);
+
+      // Router MAC should be filtered out from allKnownMacs
+      expect(state.allKnownMacs, isNot(contains(routerMac)));
+      expect(state.allKnownMacs, contains(clientMac));
+
+      // Hourly history activeMacs should also exclude router MAC
+      for (final h in state.hourlyHistory) {
+        expect(h.activeMacs, isNot(contains(routerMac)));
+      }
+
+      container.dispose();
+    });
+
+    test('persistence is scoped by router serial number', () async {
+      // First router with SN "ROUTER_A"
+      final containerA = createContainer(serialNumber: 'ROUTER_A');
+      await waitForAnalytics(containerA);
+      final stateA = containerA.read(uspDeviceAnalyticsProvider);
+      expect(stateA.hourlyHistory, hasLength(1));
+      containerA.dispose();
+
+      // Second router with different SN "ROUTER_B"
+      final containerB = createContainer(
+        data: const DevicesData(deviceModels: []),
+        serialNumber: 'ROUTER_B',
+      );
+      await waitForAnalytics(containerB);
+      final stateB = containerB.read(uspDeviceAnalyticsProvider);
+      // Should NOT inherit history from Router A — different SN means different key
+      expect(stateB.hourlyHistory, hasLength(1)); // Only its own empty entry
+      expect(stateB.current!.onlineCount, 0); // Empty device list
+      containerB.dispose();
+
+      // Back to Router A — should still have its data
+      final containerA2 = createContainer(serialNumber: 'ROUTER_A');
+      await waitForAnalytics(containerA2);
+      final stateA2 = containerA2.read(uspDeviceAnalyticsProvider);
+      // Should have 2 entries now (original + this session's update)
+      expect(stateA2.hourlyHistory.isNotEmpty, isTrue);
+      expect(
+          stateA2.current!.onlineCount, 3); // Has devices from testDevicesData
+      containerA2.dispose();
     });
   });
 }

--- a/test/page/topology/helpers/usp_topology_builder_test.dart
+++ b/test/page/topology/helpers/usp_topology_builder_test.dart
@@ -357,7 +357,7 @@ void main() {
 
     test('medium wifi signal maps to medium level', () {
       // wifi.dart thresholds: [-65, -71, -78]
-      // -75 is >= -78 (fair) → level 0.4, LinkQuality.good
+      // -75 is >= -78 (fair) → level 0.4, LinkQuality.fair
       const device = DeviceUIModel(
         mac: 'AA:AA:AA:AA:AA:AA',
         ip: '192.168.1.1',
@@ -376,12 +376,12 @@ void main() {
       final client =
           topo.nodes.firstWhere((n) => n.type == MeshNodeType.client);
       expect(client.level, 0.4);
-      expect(client.linkQuality, LinkQuality.good);
+      expect(client.linkQuality, LinkQuality.fair);
     });
 
     test('good wifi signal (-68) maps to level 0.65', () {
       // wifi.dart thresholds: [-65, -71, -78]
-      // -68 is in (-71, -65] → good → level 0.65, LinkQuality.excellent
+      // -68 is in (-71, -65] → good → level 0.65, LinkQuality.good
       const device = DeviceUIModel(
         mac: 'AA:AA:AA:AA:AA:AB',
         ip: '192.168.1.1',
@@ -400,12 +400,12 @@ void main() {
       final client =
           topo.nodes.firstWhere((n) => n.type == MeshNodeType.client);
       expect(client.level, 0.65);
-      expect(client.linkQuality, LinkQuality.excellent);
+      expect(client.linkQuality, LinkQuality.good);
     });
 
     test('weak wifi signal maps to low level', () {
       // wifi.dart thresholds: [-65, -71, -78]
-      // -80 is < -78 (poor) → LinkQuality.fair
+      // -80 is < -78 (poor) → LinkQuality.unknown
       const device = DeviceUIModel(
         mac: 'AA:AA:AA:AA:AA:AA',
         ip: '192.168.1.1',
@@ -424,7 +424,7 @@ void main() {
       final client =
           topo.nodes.firstWhere((n) => n.type == MeshNodeType.client);
       expect(client.level, 0.1);
-      expect(client.linkQuality, LinkQuality.fair);
+      expect(client.linkQuality, LinkQuality.unknown);
     });
 
     test('ethernet device maps to wired signal quality and level 1.0', () {

--- a/test/page/topology/helpers/usp_topology_builder_test.dart
+++ b/test/page/topology/helpers/usp_topology_builder_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:privacy_gui/page/_shared/utils/device_classifier.dart';
 import 'package:privacy_gui/core/utils/oui_lookup.dart';
+import 'package:privacy_gui/core/utils/wifi.dart';
 import 'package:privacy_gui/page/_shared/models/device_ui_model.dart';
 import 'package:privacy_gui/page/_shared/models/system_info_ui_model.dart';
 import 'package:privacy_gui/page/topology/models/node_ui_model.dart';
@@ -460,6 +461,56 @@ void main() {
           topo.nodes.firstWhere((n) => n.type == MeshNodeType.client);
       expect(client.level, 0.0);
       expect(client.linkQuality, LinkQuality.unknown);
+    });
+
+    test('LinkQuality mapping is consistent with getWifiSignalLevel SSoT', () {
+      // Defense test: ensures topology LinkQuality stays in sync with
+      // getWifiSignalLevel() from wifi.dart — the single source of truth.
+      // If this test fails, someone changed the mapping without updating
+      // both places, causing #1024-like inconsistencies.
+
+      // Test boundary RSSI values for each threshold
+      const testCases = [
+        // (rssi, expectedLevel, expectedLinkQuality)
+        (-64, NodeSignalLevel.excellent, LinkQuality.excellent), // >= -65
+        (-65, NodeSignalLevel.excellent, LinkQuality.excellent), // exactly -65
+        (-66, NodeSignalLevel.good, LinkQuality.good), // < -65, >= -71
+        (-71, NodeSignalLevel.good, LinkQuality.good), // exactly -71
+        (-72, NodeSignalLevel.fair, LinkQuality.fair), // < -71, >= -78
+        (-78, NodeSignalLevel.fair, LinkQuality.fair), // exactly -78
+        (-79, NodeSignalLevel.poor, LinkQuality.unknown), // < -78
+        (-90, NodeSignalLevel.poor, LinkQuality.unknown), // very weak
+      ];
+
+      for (final (rssi, expectedSignalLevel, expectedLinkQuality)
+          in testCases) {
+        // Verify getWifiSignalLevel returns expected level
+        final actualSignalLevel = getWifiSignalLevel(rssi);
+        expect(actualSignalLevel, expectedSignalLevel,
+            reason: 'getWifiSignalLevel($rssi) should be $expectedSignalLevel');
+
+        // Verify topology builder produces consistent LinkQuality
+        final device = DeviceUIModel(
+          mac: 'AA:AA:AA:AA:AA:AA',
+          ip: '192.168.1.1',
+          hostName: 'Test',
+          isActive: true,
+          isWifi: true,
+          signalStrength: rssi,
+        );
+
+        final topo = UspTopologyBuilder.build(
+          info: sysInfo,
+          devices: [device],
+          nodeModels: [],
+        );
+
+        final client =
+            topo.nodes.firstWhere((n) => n.type == MeshNodeType.client);
+        expect(client.linkQuality, expectedLinkQuality,
+            reason: 'RSSI $rssi (${actualSignalLevel.name}) should map to '
+                '$expectedLinkQuality, but got ${client.linkQuality}');
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- **#1020**: Dashboard "Devices" stat now uses `clientDevices` (excludes mesh routers)
- **#1022**: Device Analytics excludes mesh nodes from counts and activity heatmap; persistence scoped by router serial number
- **#1024**: Network Topology signal indicator uses 1:1 RSSI→LinkQuality mapping consistent with `UspSignalStrengthIndicator`

## Changes
- Use `clientDevices` instead of `deviceModels` across dashboard stats, mascot triggers, PDF export, and feature dropdowns (port forwarding, DHCP, IPv6 port service)
- Add serial number scoping to analytics persistence to prevent data mixing between routers
- Filter router MACs from persisted history on load (legacy data cleanup)
- Fix `_rssiToLinkQuality()` mapping to match `getWifiSignalLevel()` SSoT: good→good, fair→fair, poor→unknown

## Test plan
- [x] `flutter analyze` passes
- [x] `./run_tests.sh` — all 2979 tests pass
- [ ] Manual: Dashboard "Devices" stat excludes routers
- [ ] Manual: Device Analytics donut shows 0 when no clients connected
- [ ] Manual: Topology signal colors match Connected Devices widget
- [ ] Manual: Port forwarding/DHCP dropdowns exclude mesh nodes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)