### PR TITLE
feat: add Failed status support for Auto Master

### DIFF
--- a/lib/core/jnap/models/auto_master_status.dart
+++ b/lib/core/jnap/models/auto_master_status.dart
@@ -1,13 +1,15 @@
 import 'package:equatable/equatable.dart';
 
 /// AutoMasterStatus represents the status of the Auto Master process.
-/// - idle: Auto Master is not running or failed
+/// - idle: Auto Master is not running
 /// - running: Auto Master is in progress
 /// - complete: Auto Master finished successfully (password changed to WiFi password)
+/// - failed: Auto Master failed (e.g., found another Master on network, password still admin)
 enum AutoMasterStatus {
   idle,
   running,
   complete,
+  failed,
   ;
 
   String toValue() {
@@ -15,6 +17,7 @@ enum AutoMasterStatus {
       AutoMasterStatus.idle => 'Idle',
       AutoMasterStatus.running => 'Running',
       AutoMasterStatus.complete => 'Complete',
+      AutoMasterStatus.failed => 'Failed',
     };
   }
 
@@ -23,6 +26,7 @@ enum AutoMasterStatus {
       'Idle' => AutoMasterStatus.idle,
       'Running' => AutoMasterStatus.running,
       'Complete' => AutoMasterStatus.complete,
+      'Failed' => AutoMasterStatus.failed,
       _ => null,
     };
   }

--- a/lib/page/instant_setup/data/pnp_provider.dart
+++ b/lib/page/instant_setup/data/pnp_provider.dart
@@ -770,7 +770,8 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
               final status = AutoMasterStatus.fromValue(
                   result.output['autoMasterStatus'] as String?);
               return status == AutoMasterStatus.complete ||
-                  status == AutoMasterStatus.idle;
+                  status == AutoMasterStatus.idle ||
+                  status == AutoMasterStatus.failed;
             }
             return false;
           },

--- a/lib/page/instant_setup/pnp_admin_view.dart
+++ b/lib/page/instant_setup/pnp_admin_view.dart
@@ -569,11 +569,22 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
 
           if (pollStatus == AutoMasterStatus.complete ||
               pollStatus == AutoMasterStatus.idle) {
+            // Auto Master completed successfully, password may have changed
             setState(() {
               _isWaitingForAutoMaster = false;
             });
             throw ExceptionInterruptAndExit(
                 route: RouteNamed.localLoginPassword);
+          }
+
+          if (pollStatus == AutoMasterStatus.failed) {
+            // Auto Master failed (e.g., found another Master), password is still admin
+            // Continue normal PnP flow
+            logger.i('[PnP]: Auto Master failed, continuing PnP flow');
+            setState(() {
+              _isWaitingForAutoMaster = false;
+            });
+            return;
           }
         }
       }

--- a/lib/page/instant_setup/pnp_setup_view.dart
+++ b/lib/page/instant_setup/pnp_setup_view.dart
@@ -678,6 +678,7 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
 
       int consecutiveFailures = 0;
       const maxConsecutiveFailures = 3;
+      bool autoMasterFailed = false;
 
       await for (final pollStatus
           in ref.read(pnpProvider.notifier).pollAutoMasterStatus()) {
@@ -707,35 +708,48 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
             }
             return;
           }
+
+          if (pollStatus == AutoMasterStatus.failed) {
+            // Auto Master failed (e.g., found another Master), password is still admin
+            // Continue normal save flow
+            logger.i('[PnP]: Auto Master failed, continuing save flow');
+            autoMasterFailed = true;
+            break;
+          }
         }
       }
 
-      // Polling exceeded max retry (timeout)
-      logger.w('[PnP]: Auto Master polling timeout, checking router connection');
+      // Skip timeout handling if Auto Master failed - continue to save logic
+      if (autoMasterFailed) {
+        logger.d('[PnP]: Auto Master failed, skipping timeout handling');
+      } else {
+        // Polling exceeded max retry (timeout)
+        logger.w('[PnP]: Auto Master polling timeout, checking router connection');
 
-      if (autoMasterSaveAttempt >= _maxAutoMasterSaveAttempts) {
-        logger.e(
-            '[PnP]: Auto Master retry limit reached after $autoMasterSaveAttempt attempts');
-        setState(() {
-          _showAutoMasterConnectionError = true;
-        });
-        return;
-      }
+        if (autoMasterSaveAttempt >= _maxAutoMasterSaveAttempts) {
+          logger.e(
+              '[PnP]: Auto Master retry limit reached after $autoMasterSaveAttempt attempts');
+          setState(() {
+            _showAutoMasterConnectionError = true;
+          });
+          return;
+        }
 
-      try {
-        await ref.read(pnpProvider.notifier).testConnectionReconnected();
-        logger.i(
-            '[PnP]: Router connected after timeout, attempt ${autoMasterSaveAttempt + 1}/$_maxAutoMasterSaveAttempts');
-        setState(() {
-          _setupStep = _PnpSetupStep.config;
-        });
-        return _saveChanges(autoMasterSaveAttempt: autoMasterSaveAttempt + 1);
-      } catch (e) {
-        logger.e('[PnP]: Router not connected after timeout');
-        setState(() {
-          _showAutoMasterConnectionError = true;
-        });
-        return;
+        try {
+          await ref.read(pnpProvider.notifier).testConnectionReconnected();
+          logger.i(
+              '[PnP]: Router connected after timeout, attempt ${autoMasterSaveAttempt + 1}/$_maxAutoMasterSaveAttempts');
+          setState(() {
+            _setupStep = _PnpSetupStep.config;
+          });
+          return _saveChanges(autoMasterSaveAttempt: autoMasterSaveAttempt + 1);
+        } catch (e) {
+          logger.e('[PnP]: Router not connected after timeout');
+          setState(() {
+            _showAutoMasterConnectionError = true;
+          });
+          return;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Add `failed` status to `AutoMasterStatus` enum to support FW's new status
- When Auto Master status is `Failed`, continue normal PnP flow instead of redirecting to login page, since password is still `admin`

## Background
FW team added a new `Failed` status for `GetAutoMasterStatus` JNAP (LinksysWRT#383). This status indicates Auto Master exited without configuring the device (e.g., found another Master on network). In this case, the admin password remains `admin`, so the app should continue the normal PnP flow.

## Changes
- `lib/core/jnap/models/auto_master_status.dart`: Add `failed` enum value
- `lib/page/instant_setup/pnp_admin_view.dart`: Handle `Failed` status in polling loop

## Behavior

| Auto Master Status | Password | App Behavior |
|--------------------|----------|--------------|
| `Complete` | Changed to WiFi password | Redirect to login page |
| `Idle` | May have changed | Redirect to login page |
| `Failed` | Still `admin` | Continue PnP flow |

## Test plan
- [ ] Test with FW v1.2.3.26070216 or later that supports `Failed` status
- [ ] Verify PnP flow continues correctly when Auto Master returns `Failed`

Ref: LinksysWRT#383

🤖 Generated with [Claude Code](https://claude.ai/code)