### PR TITLE
fix(wifi): unify guest WiFi detection on canonical alias rule

### DIFF
--- a/lib/page/_shared/utils/wifi_guest_detection.dart
+++ b/lib/page/_shared/utils/wifi_guest_detection.dart
@@ -1,0 +1,15 @@
+import 'package:privacy_gui/generated/wi_fi_ssids.g.dart';
+
+/// Canonical guest WiFi detection rule for the whole app.
+///
+/// A WiFi SSID is a guest network when its TR-181 `Alias` ends with the
+/// `-guest` suffix, which firmware auto-provisions from FW 1.2.1+
+/// (e.g. `wifi-2g-guest`, `wifi-5g-guest`).
+///
+/// This is the single source of truth for the Main-vs-Guest distinction.
+/// Do not reintroduce instance-index or radio-occupancy heuristics — those
+/// disagree with this rule and cause guest networks to be misclassified.
+bool isGuestSsidAlias(String? alias) => alias?.endsWith('-guest') ?? false;
+
+/// Convenience overload for a generated [WiFiSsid] instance.
+bool isGuestSsid(WiFiSsid ssid) => isGuestSsidAlias(ssid.alias);

--- a/lib/page/instant_setup/services/pnp_service.dart
+++ b/lib/page/instant_setup/services/pnp_service.dart
@@ -13,6 +13,7 @@ import 'package:privacy_gui/generated/wi_fi_access_points.g.dart';
 import 'package:privacy_gui/generated/wi_fi_ssids.g.dart';
 import 'package:privacy_gui/page/_shared/models/mesh_topology_info.dart';
 import 'package:privacy_gui/page/_shared/utils/mesh_topology_builder.dart';
+import 'package:privacy_gui/page/_shared/utils/wifi_guest_detection.dart';
 import 'package:privacy_gui/generated/wi_fi_radios.g.dart';
 import 'package:privacy_gui/page/instant_setup/models/pnp_isp_config.dart';
 import 'package:privacy_gui/page/instant_setup/models/pnp_wifi_band.dart';
@@ -107,9 +108,8 @@ class PnpService {
 
   /// Fetch current WiFi SSIDs + Access Points and return structured results.
   ///
-  /// Separates main vs guest SSIDs by detecting shared radios:
-  /// - First SSID per radio = main network
-  /// - Additional SSIDs sharing a radio = guest network
+  /// Separates main vs guest SSIDs via the canonical alias rule: an SSID whose
+  /// `Alias` ends with `-guest` is a guest network (see wifi_guest_detection).
   ///
   /// Supports both unified mode (all bands share SSID) and split mode
   /// (each band has different SSID, e.g. Du ISP routers).
@@ -148,18 +148,15 @@ class PnpService {
       return radios.items.where((r) => r.instancePath == radioPath).firstOrNull;
     }
 
-    // Separate main vs guest SSIDs by radio occupancy.
-    // First SSID per radio is "main", subsequent SSIDs on the same radio
-    // are "guest" (they share the radio via virtual AP).
-    final seenRadios = <String>{};
+    // Separate main vs guest SSIDs via the canonical alias rule (see
+    // wifi_guest_detection). Single source of truth shared across the app.
     final mainSsids = <WiFiSsid>[];
     final guestSsids = <WiFiSsid>[];
 
     for (final ssid in ssids.items) {
-      if (seenRadios.contains(ssid.lowerLayers)) {
+      if (isGuestSsid(ssid)) {
         guestSsids.add(ssid);
       } else {
-        seenRadios.add(ssid.lowerLayers);
         mainSsids.add(ssid);
       }
     }

--- a/lib/page/instant_setup/services/pnp_service.dart
+++ b/lib/page/instant_setup/services/pnp_service.dart
@@ -161,6 +161,15 @@ class PnpService {
       }
     }
 
+    // Diagnostic: multiple SSIDs but none matched the `-guest` alias rule
+    // usually means firmware did not provision guest aliases (see
+    // wifi_guest_detection). Guest/main split degrades silently otherwise.
+    if (guestSsids.isEmpty && ssids.items.length > 1) {
+      logger.w('[PnP] No SSID matched the "-guest" alias rule; '
+          'guest network will be treated as main. Aliases: '
+          '${ssids.items.map((s) => s.alias ?? "null").toList()}');
+    }
+
     // Primary SSID = first enabled main SSID
     if (mainSsids.isEmpty) {
       logger.e('[PnP] No main WiFi SSIDs found on router');

--- a/lib/page/wifi_settings/services/usp_wifi_data_service.dart
+++ b/lib/page/wifi_settings/services/usp_wifi_data_service.dart
@@ -168,6 +168,14 @@ class UspWifiDataService {
         if (isGuestSsid(ssid)) _ensureTrailingDot(ssid.instancePath),
     };
     logger.d('[USP][WiFi] Total guest SSID paths: ${guestSsidPaths.length}');
+    // Diagnostic: multiple SSIDs but none matched the `-guest` alias rule
+    // usually means firmware did not provision guest aliases (see
+    // wifi_guest_detection). Guest/main grouping degrades silently otherwise.
+    if (guestSsidPaths.isEmpty && ssids.items.length > 1) {
+      logger.w('[USP][WiFi] No SSID matched the "-guest" alias rule; '
+          'guest networks will be treated as main. Aliases: '
+          '${ssids.items.map((s) => s.alias ?? "null").toList()}');
+    }
 
     // Group APs by radio: AP.ssidReference → SSID.lowerLayers → Radio
     final apsByRadioPath =

--- a/lib/page/wifi_settings/services/usp_wifi_data_service.dart
+++ b/lib/page/wifi_settings/services/usp_wifi_data_service.dart
@@ -10,6 +10,7 @@ import 'package:privacy_gui/core/usp/providers/usp_client_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_client.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/page/_shared/models/client_connection_detail.dart';
+import 'package:privacy_gui/page/_shared/utils/wifi_guest_detection.dart';
 import 'package:privacy_gui/page/_shared/models/wifi_client_ui_model.dart';
 import 'package:privacy_gui/page/_shared/models/wifi_radio_ui_model.dart';
 
@@ -160,28 +161,12 @@ class UspWifiDataService {
       for (final s in ssids.items) _ensureTrailingDot(s.instancePath): s,
     };
 
-    // Determine guest SSIDs: per-radio, lowest instance index is Main
-    final guestSsidPaths = <String>{};
-    {
-      final ssidsByRadio = <String, List<WiFiSsid>>{};
-      for (final ssid in ssids.items) {
-        final radioKey = _ensureTrailingDot(ssid.lowerLayers);
-        (ssidsByRadio[radioKey] ??= []).add(ssid);
-      }
-      logger.d('[USP][WiFi] ssidsByRadio groups: ${ssidsByRadio.length}');
-      for (final entry in ssidsByRadio.entries) {
-        final group = entry.value;
-        group.sort((a, b) => _ssidInstanceIndex(a.instancePath)
-            .compareTo(_ssidInstanceIndex(b.instancePath)));
-        logger.d('[USP][WiFi] Radio ${entry.key}: '
-            '${group.map((s) => "${s.ssid}(${s.instancePath})").join(", ")}');
-        for (final ssid in group.skip(1)) {
-          guestSsidPaths.add(_ensureTrailingDot(ssid.instancePath));
-          logger.d(
-              '[USP][WiFi] Marked as guest: ${ssid.ssid} (${ssid.instancePath})');
-        }
-      }
-    }
+    // Determine guest SSIDs via the canonical alias rule (see
+    // wifi_guest_detection). Single source of truth shared across the app.
+    final guestSsidPaths = <String>{
+      for (final ssid in ssids.items)
+        if (isGuestSsid(ssid)) _ensureTrailingDot(ssid.instancePath),
+    };
     logger.d('[USP][WiFi] Total guest SSID paths: ${guestSsidPaths.length}');
 
     // Group APs by radio: AP.ssidReference → SSID.lowerLayers → Radio
@@ -223,12 +208,6 @@ class UspWifiDataService {
         accessPoints: apModels,
       );
     }).toList();
-  }
-
-  /// Extracts the numeric instance index from a TR-181 SSID path.
-  int _ssidInstanceIndex(String instancePath) {
-    final match = RegExp(r'Device\.WiFi\.SSID\.(\d+)').firstMatch(instancePath);
-    return match != null ? int.parse(match.group(1)!) : 0;
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/page/wifi_settings/services/usp_wifi_settings_service.dart
+++ b/lib/page/wifi_settings/services/usp_wifi_settings_service.dart
@@ -12,6 +12,7 @@ import 'package:privacy_gui/page/wifi_settings/models/wifi_quick_setup_network.d
 import 'package:privacy_gui/page/wifi_settings/models/wifi_settings_settings.dart';
 import 'package:privacy_gui/page/wifi_settings/models/wifi_settings_status.dart';
 import 'package:privacy_gui/page/wifi_settings/services/wifi_channel_bonding.dart';
+import 'package:privacy_gui/page/_shared/utils/wifi_guest_detection.dart';
 
 final uspWifiSettingsServiceProvider = Provider<UspWifiSettingsService>(
   (ref) => UspWifiSettingsService(ref.read(uspClientProvider)!),
@@ -74,8 +75,8 @@ class UspWifiSettingsService {
           'radio=${radio?.operatingFrequencyBand ?? "none"}, '
           'alias=${ssid.alias ?? "none"}');
 
-      // Guest detection via alias (FW 1.2.1+ auto-provisions wifi-*-guest aliases)
-      final isGuest = ssid.alias?.endsWith('-guest') ?? false;
+      // Guest detection via the canonical alias rule (see wifi_guest_detection).
+      final isGuest = isGuestSsid(ssid);
 
       // Parse Security.ModesSupported comma-separated string into a list.
       // e.g. "None, WPA2-Personal, WPA3-Personal" → ['None', 'WPA2-Personal', 'WPA3-Personal']

--- a/lib/page/wifi_settings/views/components/wifi_network_card.dart
+++ b/lib/page/wifi_settings/views/components/wifi_network_card.dart
@@ -71,6 +71,9 @@ class WifiNetworkCard extends ConsumerWidget {
               onTap: () => _editSsid(context, ref, n),
             ),
             // ── WiFi password & Security mode ────────────────────────────
+            // Shown for both main and guest whenever the AP reports supported
+            // security modes. Guest security mode is editable too — consistent
+            // with the Quick Setup card.
             if (n.supportedSecurityModes.isNotEmpty) ...[
               SettingBlock(
                 title: loc(context).password,
@@ -78,13 +81,12 @@ class WifiNetworkCard extends ConsumerWidget {
                 trailing: const AppIcon.font(AppFontIcons.edit),
                 onTap: () => _editPassword(context, ref, n),
               ),
-              if (!n.isGuest)
-                SettingBlock(
-                  title: loc(context).securityMode,
-                  value: n.securityMode,
-                  trailing: const AppIcon.font(AppFontIcons.edit),
-                  onTap: () => _editSecurityMode(context, ref, n),
-                ),
+              SettingBlock(
+                title: loc(context).securityMode,
+                value: n.securityMode,
+                trailing: const AppIcon.font(AppFontIcons.edit),
+                onTap: () => _editSecurityMode(context, ref, n),
+              ),
             ],
             // ── WiFi Mode ──────────────────────────────────────────────────
             if (!n.isGuest && n.supportedStandards.isNotEmpty)

--- a/test/mocks/test_data/wifi_settings_test_data.dart
+++ b/test/mocks/test_data/wifi_settings_test_data.dart
@@ -22,6 +22,7 @@ class WifiSettingsTestData {
     String ssid = 'TestNetwork',
     bool enable = true,
     String lowerLayers = 'Device.WiFi.Radio.1.',
+    String? alias,
   }) =>
       WiFiSsid(
         instancePath: instancePath,
@@ -30,6 +31,7 @@ class WifiSettingsTestData {
         status: enable ? 'Up' : 'Down',
         bssid: 'AA:BB:CC:DD:EE:FF',
         lowerLayers: lowerLayers,
+        alias: alias,
       );
 
   static WiFiAccessPoint createAccessPoint({
@@ -85,22 +87,28 @@ class WifiSettingsTestData {
   // Codegen collections
   // ---------------------------------------------------------------------------
 
-  /// Typical tri-band setup: 2.4 GHz + 5 GHz + guest.
+  /// Typical dual-band + guest setup: 2.4 GHz + 5 GHz + guest.
+  ///
+  /// Guest is identified by the canonical `-guest` alias suffix (see
+  /// wifi_guest_detection), matching firmware auto-provisioned aliases.
   static WiFiSsids createSsids() => WiFiSsids(items: [
         createSsid(
           instancePath: 'Device.WiFi.SSID.1.',
           ssid: 'Home',
           lowerLayers: 'Device.WiFi.Radio.1.',
+          alias: 'wifi-2g',
         ),
         createSsid(
           instancePath: 'Device.WiFi.SSID.2.',
           ssid: 'Home',
           lowerLayers: 'Device.WiFi.Radio.2.',
+          alias: 'wifi-5g',
         ),
         createSsid(
           instancePath: 'Device.WiFi.SSID.3.',
           ssid: 'Home-Guest',
           lowerLayers: 'Device.WiFi.Radio.1.',
+          alias: 'wifi-2g-guest',
         ),
       ]);
 
@@ -151,34 +159,40 @@ class WifiSettingsTestData {
           instancePath: 'Device.WiFi.SSID.1.',
           ssid: 'Home',
           lowerLayers: 'Device.WiFi.Radio.1.',
+          alias: 'wifi-2g',
         ),
         createSsid(
           instancePath: 'Device.WiFi.SSID.2.',
           ssid: 'Home',
           lowerLayers: 'Device.WiFi.Radio.2.',
+          alias: 'wifi-5g',
         ),
         createSsid(
           instancePath: 'Device.WiFi.SSID.3.',
           ssid: 'Home',
           lowerLayers: 'Device.WiFi.Radio.3.',
+          alias: 'wifi-6g',
         ),
         createSsid(
           instancePath: 'Device.WiFi.SSID.4.',
           ssid: 'Home-Guest',
           enable: false,
           lowerLayers: 'Device.WiFi.Radio.1.',
+          alias: 'wifi-2g-guest',
         ),
         createSsid(
           instancePath: 'Device.WiFi.SSID.5.',
           ssid: 'Home-Guest',
           enable: false,
           lowerLayers: 'Device.WiFi.Radio.2.',
+          alias: 'wifi-5g-guest',
         ),
         createSsid(
           instancePath: 'Device.WiFi.SSID.6.',
           ssid: 'Home-Guest',
           enable: false,
           lowerLayers: 'Device.WiFi.Radio.3.',
+          alias: 'wifi-6g-guest',
         ),
       ]);
 

--- a/test/page/instant_setup/services/pnp_service_test.dart
+++ b/test/page/instant_setup/services/pnp_service_test.dart
@@ -378,4 +378,129 @@ void main() {
       verifyNever(() => mockUsp.add(any()));
     });
   });
+
+  group('PnpService.fetchWizardData — guest detection via alias', () {
+    // Two radios, each with a main + guest SSID. Guest is identified purely by
+    // the `-guest` alias suffix (see wifi_guest_detection), NOT instance order.
+    const wifiSsidsResponse = <String, dynamic>{
+      'Device.WiFi.SSID.1.SSID': 'MyHome',
+      'Device.WiFi.SSID.1.Enable': true,
+      'Device.WiFi.SSID.1.Status': 'Up',
+      'Device.WiFi.SSID.1.BSSID': 'AA:BB:CC:DD:EE:01',
+      'Device.WiFi.SSID.1.LowerLayers': 'Device.WiFi.Radio.1.',
+      'Device.WiFi.SSID.1.Alias': 'wifi-2g',
+      'Device.WiFi.SSID.2.SSID': 'MyHome',
+      'Device.WiFi.SSID.2.Enable': true,
+      'Device.WiFi.SSID.2.Status': 'Up',
+      'Device.WiFi.SSID.2.BSSID': 'AA:BB:CC:DD:EE:02',
+      'Device.WiFi.SSID.2.LowerLayers': 'Device.WiFi.Radio.2.',
+      'Device.WiFi.SSID.2.Alias': 'wifi-5g',
+      'Device.WiFi.SSID.3.SSID': 'MyHome-Guest',
+      'Device.WiFi.SSID.3.Enable': false,
+      'Device.WiFi.SSID.3.Status': 'Down',
+      'Device.WiFi.SSID.3.BSSID': 'AA:BB:CC:DD:EE:03',
+      'Device.WiFi.SSID.3.LowerLayers': 'Device.WiFi.Radio.1.',
+      'Device.WiFi.SSID.3.Alias': 'wifi-2g-guest',
+      'Device.WiFi.SSID.4.SSID': 'MyHome-Guest',
+      'Device.WiFi.SSID.4.Enable': false,
+      'Device.WiFi.SSID.4.Status': 'Down',
+      'Device.WiFi.SSID.4.BSSID': 'AA:BB:CC:DD:EE:04',
+      'Device.WiFi.SSID.4.LowerLayers': 'Device.WiFi.Radio.2.',
+      'Device.WiFi.SSID.4.Alias': 'wifi-5g-guest',
+    };
+    const wifiApsResponse = <String, dynamic>{
+      'Device.WiFi.AccessPoint.1.Enable': true,
+      'Device.WiFi.AccessPoint.1.Status': 'Enabled',
+      'Device.WiFi.AccessPoint.1.Security.ModesSupported':
+          'WPA2-Personal,WPA3-Personal',
+      'Device.WiFi.AccessPoint.1.Security.ModeEnabled': 'WPA2-Personal',
+      'Device.WiFi.AccessPoint.1.Security.EncryptionMode': 'AES',
+      'Device.WiFi.AccessPoint.1.Security.KeyPassphrase': 'mainpass1',
+      'Device.WiFi.AccessPoint.1.SSIDAdvertisementEnabled': true,
+      'Device.WiFi.AccessPoint.1.SSIDReference': 'Device.WiFi.SSID.1.',
+      'Device.WiFi.AccessPoint.2.Enable': true,
+      'Device.WiFi.AccessPoint.2.Status': 'Enabled',
+      'Device.WiFi.AccessPoint.2.Security.ModesSupported':
+          'WPA2-Personal,WPA3-Personal',
+      'Device.WiFi.AccessPoint.2.Security.ModeEnabled': 'WPA2-Personal',
+      'Device.WiFi.AccessPoint.2.Security.EncryptionMode': 'AES',
+      'Device.WiFi.AccessPoint.2.Security.KeyPassphrase': 'mainpass2',
+      'Device.WiFi.AccessPoint.2.SSIDAdvertisementEnabled': true,
+      'Device.WiFi.AccessPoint.2.SSIDReference': 'Device.WiFi.SSID.2.',
+      'Device.WiFi.AccessPoint.3.Enable': false,
+      'Device.WiFi.AccessPoint.3.Status': 'Disabled',
+      'Device.WiFi.AccessPoint.3.Security.ModesSupported': '',
+      'Device.WiFi.AccessPoint.3.Security.ModeEnabled': 'None',
+      'Device.WiFi.AccessPoint.3.Security.EncryptionMode': 'None',
+      'Device.WiFi.AccessPoint.3.Security.KeyPassphrase': 'guestpass1',
+      'Device.WiFi.AccessPoint.3.SSIDAdvertisementEnabled': true,
+      'Device.WiFi.AccessPoint.3.SSIDReference': 'Device.WiFi.SSID.3.',
+      'Device.WiFi.AccessPoint.4.Enable': false,
+      'Device.WiFi.AccessPoint.4.Status': 'Disabled',
+      'Device.WiFi.AccessPoint.4.Security.ModesSupported': '',
+      'Device.WiFi.AccessPoint.4.Security.ModeEnabled': 'None',
+      'Device.WiFi.AccessPoint.4.Security.EncryptionMode': 'None',
+      'Device.WiFi.AccessPoint.4.Security.KeyPassphrase': 'guestpass2',
+      'Device.WiFi.AccessPoint.4.SSIDAdvertisementEnabled': true,
+      'Device.WiFi.AccessPoint.4.SSIDReference': 'Device.WiFi.SSID.4.',
+    };
+    Map<String, dynamic> radioFields(int i, String band, int channel) => {
+          'Device.WiFi.Radio.$i.Enable': true,
+          'Device.WiFi.Radio.$i.Status': 'Up',
+          'Device.WiFi.Radio.$i.Channel': channel,
+          'Device.WiFi.Radio.$i.OperatingFrequencyBand': band,
+          'Device.WiFi.Radio.$i.OperatingChannelBandwidth': '20MHz',
+          'Device.WiFi.Radio.$i.PossibleChannels': '1,6,11',
+          'Device.WiFi.Radio.$i.OperatingStandards': 'n',
+          'Device.WiFi.Radio.$i.SupportedStandards': 'b,g,n',
+          'Device.WiFi.Radio.$i.TransmitPower': 100,
+          'Device.WiFi.Radio.$i.MaxBitRate': 300,
+          'Device.WiFi.Radio.$i.AutoChannelEnable': true,
+          'Device.WiFi.Radio.$i.IEEE80211hEnabled': false,
+          'Device.WiFi.Radio.$i.SupportedOperatingChannelBandwidths':
+              'Auto,20MHz,40MHz',
+        };
+    final wifiRadiosResponse = <String, dynamic>{
+      ...radioFields(1, '2.4GHz', 6),
+      ...radioFields(2, '5GHz', 36),
+    };
+
+    void stubWifiFetches() {
+      when(() => mockUsp.get(any(), priority: any(named: 'priority')))
+          .thenAnswer((invocation) async {
+        final paths = invocation.positionalArguments[0] as List<String>;
+        final first = paths.isNotEmpty ? paths.first : '';
+        if (first.startsWith('Device.WiFi.SSID.')) {
+          return wifiSsidsResponse;
+        }
+        if (first.startsWith('Device.WiFi.AccessPoint.')) {
+          return wifiApsResponse;
+        }
+        if (first.startsWith('Device.WiFi.Radio.')) {
+          return wifiRadiosResponse;
+        }
+        return <String, dynamic>{};
+      });
+    }
+
+    test('classifies -guest alias SSIDs as guest, others as main', () async {
+      stubWifiFetches();
+
+      final result = await service.fetchWizardData();
+      final config = result.wifiConfig;
+
+      // Main network built from the non-guest SSIDs.
+      expect(config.ssid, 'MyHome');
+      // Guest network built from the -guest alias SSIDs.
+      expect(config.guestSsid, 'MyHome-Guest');
+      expect(config.guestEnabled, isFalse);
+      expect(
+          config.guestAccessPointInstancePaths,
+          containsAll(
+              ['Device.WiFi.AccessPoint.3.', 'Device.WiFi.AccessPoint.4.']));
+      // Guest AP paths must not leak into the main path list.
+      expect(config.accessPointInstancePaths,
+          isNot(contains('Device.WiFi.AccessPoint.3.')));
+    });
+  });
 }

--- a/test/page/wifi_settings/services/usp_wifi_data_service_test.dart
+++ b/test/page/wifi_settings/services/usp_wifi_data_service_test.dart
@@ -45,16 +45,19 @@ Map<String, dynamic> _buildSsidsResponse() => {
       'Device.WiFi.SSID.1.Status': 'Up',
       'Device.WiFi.SSID.1.BSSID': 'AA:BB:CC:DD:EE:01',
       'Device.WiFi.SSID.1.LowerLayers': 'Device.WiFi.Radio.1.',
+      'Device.WiFi.SSID.1.Alias': 'wifi-2g',
       'Device.WiFi.SSID.2.SSID': 'Home',
       'Device.WiFi.SSID.2.Enable': true,
       'Device.WiFi.SSID.2.Status': 'Up',
       'Device.WiFi.SSID.2.BSSID': 'AA:BB:CC:DD:EE:02',
       'Device.WiFi.SSID.2.LowerLayers': 'Device.WiFi.Radio.2.',
+      'Device.WiFi.SSID.2.Alias': 'wifi-5g',
       'Device.WiFi.SSID.3.SSID': 'Home-Guest',
       'Device.WiFi.SSID.3.Enable': true,
       'Device.WiFi.SSID.3.Status': 'Up',
       'Device.WiFi.SSID.3.BSSID': 'AA:BB:CC:DD:EE:03',
       'Device.WiFi.SSID.3.LowerLayers': 'Device.WiFi.Radio.1.',
+      'Device.WiFi.SSID.3.Alias': 'wifi-2g-guest',
     };
 
 /// Raw USP response map for 3 access points.
@@ -200,6 +203,9 @@ void main() {
       expect(radio1.accessPoints.length, 2);
       expect(radio1.accessPoints[0].ssidName, 'Home');
       expect(radio1.accessPoints[1].ssidName, 'Home-Guest');
+      // Guest detection via alias suffix (-guest), not instance ordering.
+      expect(radio1.accessPoints[0].isGuest, isFalse);
+      expect(radio1.accessPoints[1].isGuest, isTrue);
 
       // Radio 2 (5GHz): SSID.2 → AP.2
       final radio2 = result.radioModels[1];


### PR DESCRIPTION
## Summary
- Guest WiFi detection was implemented three different ways across the app (alias suffix, per-radio instance ordering, radio occupancy), which disagreed with each other and caused the guest card to be misclassified as main — wrong "Main" title, and hidden password / security-mode fields.
- Add a shared helper `isGuestSsid` in `lib/page/_shared/utils/wifi_guest_detection.dart` as the single source of truth: an SSID is guest when its TR-181 `Alias` ends with `-guest`.
- Converge all three call sites on the helper:
  - `usp_wifi_settings_service`: replace inline alias check
  - `usp_wifi_data_service`: drop per-radio instance-ordering + dead `_ssidInstanceIndex` helper
  - `pnp_service`: drop radio-occupancy heuristic
- `wifi_network_card`: allow guest networks to edit security mode too, consistent with the Quick Setup card.
- Tests: give shared WiFi test data proper `-guest` aliases; add guest-detection assertions to the data service and pnp service tests.

## Related issues
Addresses the app-side portion of #1001, #1040, #1046. The visible fix on-device still depends on firmware providing correct `-guest` aliases and populating guest AP `Security.ModesSupported` (tracked as `blocked:fw-support`).

## Testing
- `dart format` + `flutter analyze` on all changed files — clean
- Affected functional unit tests (wifi_settings, instant_setup services/providers) — all passing