### PR TITLE
fix(internet-settings): remove unnecessary DHCP renew result parsing

### DIFF
--- a/lib/page/internet_settings/services/usp_internet_settings_service.dart
+++ b/lib/page/internet_settings/services/usp_internet_settings_service.dart
@@ -357,8 +357,7 @@ class UspInternetSettingsService {
 
   Future<void> renewDhcpLease() async {
     try {
-      final result = await WanOperations.renewDhcpLease(_usp);
-      _handleOperateResult(result);
+      await WanOperations.renewDhcpLease(_usp);
     } catch (e) {
       if (e is ServiceError) rethrow;
       throw mapUspErrorToServiceError(e);
@@ -367,8 +366,7 @@ class UspInternetSettingsService {
 
   Future<void> renewDhcpv6Lease() async {
     try {
-      final result = await WanOperations.renewDhcpv6Lease(_usp);
-      _handleOperateResult(result);
+      await WanOperations.renewDhcpv6Lease(_usp);
     } catch (e) {
       if (e is ServiceError) rethrow;
       throw mapUspErrorToServiceError(e);
@@ -409,30 +407,6 @@ class UspInternetSettingsService {
       case UspFailure(:final errorSummary, :final errors):
         throw UspCompleteFailureError(
           summary: 'WAN update failed: $errorSummary',
-          failures: errors,
-        );
-    }
-  }
-
-  /// Parse and validate OPERATE result using standard UspResultParser (Strict mode).
-  void _handleOperateResult(Map<String, dynamic> result) {
-    final parsed = UspResultParser.parseOperateResult(result);
-    switch (parsed) {
-      case UspSuccess():
-        break;
-      case UspPartialSuccess(
-          :final errorSummary,
-          :final successes,
-          :final failures
-        ):
-        throw UspPartialFailureError(
-          summary: 'WAN operation partial failure: $errorSummary',
-          successPaths: successes.map((s) => s.requestedPath).toList(),
-          failures: failures,
-        );
-      case UspFailure(:final errorSummary, :final errors):
-        throw UspCompleteFailureError(
-          summary: 'WAN operation failed: $errorSummary',
           failures: errors,
         );
     }

--- a/test/page/internet_settings/services/usp_internet_settings_service_test.dart
+++ b/test/page/internet_settings/services/usp_internet_settings_service_test.dart
@@ -705,28 +705,6 @@ void main() {
       );
     });
 
-    test('renewDhcpLease throws UspCompleteFailureError on OPERATE failure',
-        () async {
-      // WASM v0.11.0 format: success=false for OPERATE
-      when(() => mockUsp.operate(any())).thenAnswer((_) async => {
-            'success': false,
-            'result': {
-              'data': <String, dynamic>{},
-              'error': {
-                'Device.DHCPv4.Client.1.Renew()': {
-                  'errorCode': 7012,
-                  'errorMessage': 'Command failure',
-                },
-              },
-            },
-          });
-
-      expect(
-        () => service.renewDhcpLease(),
-        throwsA(isA<UspCompleteFailureError>()),
-      );
-    });
-
     test('UspCompleteFailureError contains correct error message', () async {
       // Mock for _resolveInstance()
       when(() => mockUsp.get(any())).thenAnswer((_) async => aliasResponse);


### PR DESCRIPTION
## Summary
- Remove unnecessary result parsing for DHCP Renew/Renew6 operations
- These operations return void - no need to validate the result
- Fixes false-positive errors on firmware versions with non-standard response formats

## Test plan
- [x] `dart format` passes
- [x] `flutter analyze` passes  
- [x] All 25 affected tests pass
- [x] Manual test: Renew Lease in App works without error
- [x] SSH verification: `bbfdm operate Device.DHCPv4.Client.1.Renew()` returns empty output (success)

Closes #967

🤖 Generated with [Claude Code](https://claude.ai/claude-code)