### PR TITLE
fix: extract inline scripts to external JS for CSP compliance

### DIFF
--- a/web/early-bootstrap.js
+++ b/web/early-bootstrap.js
@@ -1,0 +1,46 @@
+// early-bootstrap.js
+// Extracted inline scripts for CSP compliance (removes need for 'unsafe-inline' in script-src)
+// These scripts must run synchronously before body renders.
+
+(function () {
+  'use strict';
+
+  // 1. PWA install prompt early capture
+  window.deferredBeforeInstallPromptEvent = null;
+  window.addEventListener('beforeinstallprompt', function (e) {
+    e.preventDefault();
+    window.deferredBeforeInstallPromptEvent = e;
+    console.log('PWA: Early capture of beforeinstallprompt');
+  });
+
+  // 2. Theme detection and application
+  var appSettingsString = window.localStorage.getItem('flutter.AppSettings');
+
+  if (appSettingsString) {
+    try {
+      var settings = JSON.parse(JSON.parse(appSettingsString));
+      var themeMode = settings.themeMode;
+      if (themeMode === 'system') {
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+      } else {
+        document.documentElement.setAttribute('data-theme', themeMode);
+      }
+    } catch (error) {
+      console.error('app settings parse error: ', error);
+    }
+  } else {
+    console.log('app settings not found, by system');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+  }
+
+  // 3. Splash screen removal utility
+  window.removeSplashFromWeb = function () {
+    var splash = document.getElementById('splash');
+    var branding = document.getElementById('splash-branding');
+    if (splash) splash.remove();
+    if (branding) branding.remove();
+    document.body.style.background = 'transparent';
+  };
+})();

--- a/web/index.html
+++ b/web/index.html
@@ -23,15 +23,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Linksys Now">
 
-  <script>
-    // Capture PWA install prompt event early prevents missing it due to Flutter loading time.
-    window.deferredBeforeInstallPromptEvent = null;
-    window.addEventListener('beforeinstallprompt', (e) => {
-      e.preventDefault();
-      window.deferredBeforeInstallPromptEvent = e;
-      console.log('PWA: Early capture of beforeinstallprompt');
-    });
-  </script>
+  <script src="early-bootstrap.js"></script>
   <link rel="apple-touch-icon" sizes="180x180" href="logo_icons/logo-icon-180.png">
 
   <!-- Favicon -->
@@ -105,38 +97,6 @@
       right: 0;
     }
   </style>
-  <script>
-    (function() {
-      const appSettingsString = window.localStorage.getItem('flutter.AppSettings');
-
-      if (appSettingsString) {
-        try {
-          // Parse twice since it stores as string with double quotes
-          const settings = JSON.parse(JSON.parse(appSettingsString));
-          const themeMode = settings.themeMode;
-          if (themeMode === 'system') {
-            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-            document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
-          } else {
-            document.documentElement.setAttribute('data-theme', themeMode);
-          }
-        } catch (error) {
-          console.error("app settings parse error: ", error);
-        }
-      } else {
-        console.log("app settings not found, by system");
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
-      }
-    })();
-  </script>
-  <script id="splash-screen-script">
-    function removeSplashFromWeb() {
-      document.getElementById("splash")?.remove();
-      document.getElementById("splash-branding")?.remove();
-      document.body.style.background = "transparent";
-    }
-  </script>
   <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport">
 </head>
 <body>


### PR DESCRIPTION
## Summary

Port #926 / #927 CSP fix to dev-2.6.0 branch.

- Extract 3 inline `<script>` blocks from `web/index.html` to external `web/early-bootstrap.js`
- Enables removal of `'unsafe-inline'` from CSP `script-src` directive

## Changes

| File | Change |
|------|--------|
| `web/early-bootstrap.js` | New file: PWA prompt capture, theme detection, splash removal utility |
| `web/index.html` | Replace 3 inline scripts with single `<script src="early-bootstrap.js">` |

## Test plan

- [ ] Splash screen displays and removes correctly after Flutter loads
- [ ] Dark/Light theme applies on page load without flicker
- [ ] PWA install prompt capture works (browser console shows "PWA: Early capture of beforeinstallprompt")

## Related

- Closes #1084
- Port of #926 / #927
- Ref: linksys/LinksysWRT#352 (F-116: CSP permits `'unsafe-inline'` for script [CVSS 5.4 Medium])

🤖 Generated with [Claude Code](https://claude.ai/claude-code)