### PR TITLE
fix(static-routing): block interface change without gateway update (#1082)

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "عنوان MAC الوجهة غير صالح",
   "invalidDns": "DNS غير صالح",
   "invalidGatewayIpAddress": "عنوان IP للبوابة غير صالح",
+  "gatewayMustBeWithinLanSubnet": "بوابة يجب أن تكون ضمن شبكة LAN الفرعية",
+  "gatewayMustBeOutsideLanSubnet": "بوابة يجب أن تكون خارج شبكة LAN الفرعية",
   "invalidInput": "إدخال غير صالح",
   "invalidIpAddress": "عنوان IP غير صالح",
   "invalidMACAddress": "عنوان MAC غير صالح.",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Ugyldig destinations-MAC-adresse",
   "invalidDns": "Ugyldigt DNS",
   "invalidGatewayIpAddress": "Ugyldig IP-adresse på gatewayen",
+  "gatewayMustBeWithinLanSubnet": "Gateway skal være inden for LAN-subnet",
+  "gatewayMustBeOutsideLanSubnet": "Gateway skal være uden for LAN-subnet",
   "invalidInput": "Ugyldigt input",
   "invalidIpAddress": "Ugyldig IP-adresse",
   "invalidMACAddress": "Ugyldig MAC-adresse.",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Ungültige Ziel MAC-Adresse",
   "invalidDns": "Ungültiges DNS.",
   "invalidGatewayIpAddress": "Ungültige IP-Adresse des Gateways",
+  "gatewayMustBeWithinLanSubnet": "Gateway muss innerhalb des LAN-Subnetzes liegen",
+  "gatewayMustBeOutsideLanSubnet": "Gateway muss außerhalb des LAN-Subnetzes liegen",
   "invalidInput": "Ungültige Eingabe",
   "invalidIpAddress": "Ungültige IP-Adresse",
   "invalidMACAddress": "Ungültige MAC-Adresse.",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Μη έγκυρη διεύθυνση MAC προορισμού",
   "invalidDns": "Μη έγκυρο DNS",
   "invalidGatewayIpAddress": "Μη έγκυρη διεύθυνση IP πύλης",
+  "gatewayMustBeWithinLanSubnet": "Η πύλη πρέπει να είναι εντός του υποδικτύου LAN",
+  "gatewayMustBeOutsideLanSubnet": "Η πύλη πρέπει να είναι εκτός του υποδικτύου LAN",
   "invalidInput": "Μη έγκυρη καταχώριση",
   "invalidIpAddress": "Μη έγκυρη διεύθυνση IP",
   "invalidMACAddress": "Μη έγκυρη διεύθυνση MAC.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -219,6 +219,8 @@
   "invalidDestinationMacAddress": "Invalid destination MAC address",
   "invalidDns": "Invalid DNS",
   "invalidGatewayIpAddress": "Invalid gateway IP address",
+  "gatewayMustBeWithinLanSubnet": "Gateway must be within LAN subnet",
+  "gatewayMustBeOutsideLanSubnet": "Gateway must be outside LAN subnet",
   "invalidInput": "Invalid input",
   "invalidIpAddress": "Invalid IP address",
   "invalidMACAddress": "Invalid MAC address.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Dirección MAC de destino no válida",
   "invalidDns": "DNS no válido",
   "invalidGatewayIpAddress": "Dirección IP de la puerta de enlace no válida",
+  "gatewayMustBeWithinLanSubnet": "La puerta de enlace debe estar dentro de la subred LAN",
+  "gatewayMustBeOutsideLanSubnet": "La puerta de enlace debe estar fuera de la subred LAN",
   "invalidInput": "Entrada no válida",
   "invalidIpAddress": "Dirección IP no válida",
   "invalidMACAddress": "Dirección MAC no válida.",

--- a/lib/l10n/app_es_ar.arb
+++ b/lib/l10n/app_es_ar.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Dirección MAC de destino no válida",
   "invalidDns": "DNS no válido",
   "invalidGatewayIpAddress": "Dirección IP de la puerta de enlace no válida",
+  "gatewayMustBeWithinLanSubnet": "La puerta de enlace debe estar dentro de la subred LAN",
+  "gatewayMustBeOutsideLanSubnet": "La puerta de enlace debe estar fuera de la subred LAN",
   "invalidInput": "Respuesta incorrecta",
   "invalidIpAddress": "Dirección IP no válida",
   "invalidMACAddress": "Dirección MAC no válida.",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Virheellinen kohteen MAC-osoite",
   "invalidDns": "Virheellinen DNS",
   "invalidGatewayIpAddress": "Virheellinen yhdyskäytävän IP-osoite",
+  "gatewayMustBeWithinLanSubnet": "Yhdyskäytävän on oltava LAN-aliverkon sisällä",
+  "gatewayMustBeOutsideLanSubnet": "Yhdyskäytävän on oltava LAN-aliverkon ulkopuolella",
   "invalidInput": "Virheellinen syöte",
   "invalidIpAddress": "Virheellinen IP-osoite",
   "invalidMACAddress": "Virheellinen MAC-osoite.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Adresse MAC de destination non valide",
   "invalidDns": "DNS non valide",
   "invalidGatewayIpAddress": "Adresse IP de la passerelle invalide",
+  "gatewayMustBeWithinLanSubnet": "La passerelle doit être dans le sous-réseau LAN",
+  "gatewayMustBeOutsideLanSubnet": "La passerelle doit être en dehors du sous-réseau LAN",
   "invalidInput": "Entrée non valide",
   "invalidIpAddress": "Adresse IP non valide",
   "invalidMACAddress": "Adresse MAC incorrecte.",

--- a/lib/l10n/app_fr_ca.arb
+++ b/lib/l10n/app_fr_ca.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Adresse MAC de destination non valide",
   "invalidDns": "DNS non valide",
   "invalidGatewayIpAddress": "Adresse IP de la passerelle invalide",
+  "gatewayMustBeWithinLanSubnet": "La passerelle doit être dans le sous-réseau LAN",
+  "gatewayMustBeOutsideLanSubnet": "La passerelle doit être en dehors du sous-réseau LAN",
   "invalidInput": "Saisie incorrecte",
   "invalidIpAddress": "Adresse IP non valide",
   "invalidMACAddress": "Adresse MAC non valide.",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Alamat MAC tujuan tidak valid",
   "invalidDns": "DNS Tidak Valid",
   "invalidGatewayIpAddress": "Alamat IP gateway tidak valid",
+  "gatewayMustBeWithinLanSubnet": "Gateway harus berada dalam subnet LAN",
+  "gatewayMustBeOutsideLanSubnet": "Gateway harus berada di luar subnet LAN",
   "invalidInput": "Input tidak valid",
   "invalidIpAddress": "Alamat IP tidak valid",
   "invalidMACAddress": "Alamat MAC tidak valid.",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Indirizzo MAC di destinazione non valido",
   "invalidDns": "DNS non valido",
   "invalidGatewayIpAddress": "Indirizzo IP del gateway non valido",
+  "gatewayMustBeWithinLanSubnet": "Il gateway deve essere all'interno della subnet LAN",
+  "gatewayMustBeOutsideLanSubnet": "Il gateway deve essere al di fuori della subnet LAN",
   "invalidInput": "Inserimento non valido",
   "invalidIpAddress": "Indirizzo IP non valido",
   "invalidMACAddress": "Indirizzo MAC non valido.",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "無効な宛先MACアドレス",
   "invalidDns": "無効なDNSです。",
   "invalidGatewayIpAddress": "無効なゲートウェイIPアドレス",
+  "gatewayMustBeWithinLanSubnet": "ゲートウェイはLANサブネット内である必要があります",
+  "gatewayMustBeOutsideLanSubnet": "ゲートウェイはLANサブネット外である必要があります",
   "invalidInput": "無効な入力です。",
   "invalidIpAddress": "無効なIPアドレスです。",
   "invalidMACAddress": "無効な MAC アドレスです。",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "잘못된 대상 MAC 주소",
   "invalidDns": "잘못된 DNS",
   "invalidGatewayIpAddress": "잘못된 게이트웨이 IP 주소",
+  "gatewayMustBeWithinLanSubnet": "게이트웨이는 LAN 서브넷 내에 있어야 합니다",
+  "gatewayMustBeOutsideLanSubnet": "게이트웨이는 LAN 서브넷 외부에 있어야 합니다",
   "invalidInput": "잘못된 입력",
   "invalidIpAddress": "잘못된 IP 주소",
   "invalidMACAddress": "잘못된 MAC 주소입니다.",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Ugyldig destinasjons-MAC-adresse",
   "invalidDns": "Ugyldig DNS",
   "invalidGatewayIpAddress": "Ugyldig gateway-IP-adresse",
+  "gatewayMustBeWithinLanSubnet": "Gateway må være innenfor LAN-undernett",
+  "gatewayMustBeOutsideLanSubnet": "Gateway må være utenfor LAN-undernett",
   "invalidInput": "Ugyldige inndata",
   "invalidIpAddress": "Ugyldig IP-adresse",
   "invalidMACAddress": "Ugyldig MAC-adresse.",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Ongeldig bestemmings-MAC-adres",
   "invalidDns": "Ongeldige DNS",
   "invalidGatewayIpAddress": "Ongeldig gateway-IP-adres",
+  "gatewayMustBeWithinLanSubnet": "Gateway moet binnen het LAN-subnet zijn",
+  "gatewayMustBeOutsideLanSubnet": "Gateway moet buiten het LAN-subnet zijn",
   "invalidInput": "Ongeldige invoer",
   "invalidIpAddress": "Ongeldig IP-adres",
   "invalidMACAddress": "Ongeldig MAC-adres.",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Nieprawidłowy docelowy adres MAC",
   "invalidDns": "Nieprawidłowy DNS",
   "invalidGatewayIpAddress": "Nieprawidłowy adres IP bramy",
+  "gatewayMustBeWithinLanSubnet": "Brama musi znajdować się w podsieci LAN",
+  "gatewayMustBeOutsideLanSubnet": "Brama musi znajdować się poza podsiecią LAN",
   "invalidInput": "Nieprawidłowe dane wejściowe",
   "invalidIpAddress": "Nieprawidłowy adres IP",
   "invalidMACAddress": "Nieprawidłowy adres MAC.",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Endereço MAC de destino inválido",
   "invalidDns": "DNS inválido",
   "invalidGatewayIpAddress": "Endereço IP de gateway inválido",
+  "gatewayMustBeWithinLanSubnet": "O gateway deve estar dentro da sub-rede LAN",
+  "gatewayMustBeOutsideLanSubnet": "O gateway deve estar fora da sub-rede LAN",
   "invalidInput": "Entrada inválida",
   "invalidIpAddress": "Endereço IP inválido",
   "invalidMACAddress": "Endereço MAC inválido.",

--- a/lib/l10n/app_pt_pt.arb
+++ b/lib/l10n/app_pt_pt.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Endereço MAC de destino inválido",
   "invalidDns": "DNS inválido",
   "invalidGatewayIpAddress": "Endereço IP de gateway inválido",
+  "gatewayMustBeWithinLanSubnet": "O gateway deve estar dentro da sub-rede LAN",
+  "gatewayMustBeOutsideLanSubnet": "O gateway deve estar fora da sub-rede LAN",
   "invalidInput": "Entrada inválida",
   "invalidIpAddress": "Endereço IP inválido",
   "invalidMACAddress": "Endereço MAC inválido.",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Недействительный MAC-адрес назначения",
   "invalidDns": "Недопустимый DNS-сервер",
   "invalidGatewayIpAddress": "Недействительный IP-адрес шлюза",
+  "gatewayMustBeWithinLanSubnet": "Шлюз должен находиться в подсети LAN",
+  "gatewayMustBeOutsideLanSubnet": "Шлюз должен находиться вне подсети LAN",
   "invalidInput": "Неверный ввод",
   "invalidIpAddress": "Недопустимый IP-адрес",
   "invalidMACAddress": "Недопустимый MAC-адрес.",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Ogiltig MAC-adress för destination",
   "invalidDns": "Ogiltig DNS",
   "invalidGatewayIpAddress": "Ogiltig IP-adress för gatewayen",
+  "gatewayMustBeWithinLanSubnet": "Gateway måste vara inom LAN-undernätet",
+  "gatewayMustBeOutsideLanSubnet": "Gateway måste vara utanför LAN-undernätet",
   "invalidInput": "Ogiltiga indata",
   "invalidIpAddress": "Ogiltig IP-adress",
   "invalidMACAddress": "Ogiltig MAC-adress.",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "แอดเดรส MAC ปลายทางไม่ถูกต้อง",
   "invalidDns": "DNS ไม่ถูกต้อง",
   "invalidGatewayIpAddress": "IP แอดเดรสเกตเวย์ไม่ถูกต้อง",
+  "gatewayMustBeWithinLanSubnet": "เกตเวย์ต้องอยู่ภายในซับเน็ต LAN",
+  "gatewayMustBeOutsideLanSubnet": "เกตเวย์ต้องอยู่นอกซับเน็ต LAN",
   "invalidInput": "ป้อนข้อมูลไม่ถูกต้อง",
   "invalidIpAddress": "IP แอดเดรสไม่ถูกต้อง",
   "invalidMACAddress": "แอดเดรส MAC ไม่ถูกต้อง",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Geçersiz hedef MAC adresi",
   "invalidDns": "Geçersiz DNS",
   "invalidGatewayIpAddress": "Geçersiz ağ geçidi IP adresi",
+  "gatewayMustBeWithinLanSubnet": "Ağ geçidi LAN alt ağı içinde olmalıdır",
+  "gatewayMustBeOutsideLanSubnet": "Ağ geçidi LAN alt ağı dışında olmalıdır",
   "invalidInput": "Geçersiz giriş",
   "invalidIpAddress": "Geçersiz IP adresi",
   "invalidMACAddress": "Geçersiz MAC adresi.",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "Địa chỉ MAC đích không hợp lệ",
   "invalidDns": "DNS không hợp lệ",
   "invalidGatewayIpAddress": "Địa chỉ IP cổng không hợp lệ",
+  "gatewayMustBeWithinLanSubnet": "Cổng phải nằm trong mạng con LAN",
+  "gatewayMustBeOutsideLanSubnet": "Cổng phải nằm ngoài mạng con LAN",
   "invalidInput": "Dữ liệu nhập không hợp lệ",
   "invalidIpAddress": "Địa chỉ IP không hợp lệ",
   "invalidMACAddress": "Địa chỉ MAC không hợp lệ.",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "目标MAC地址无效",
   "invalidDns": "无效的DNS",
   "invalidGatewayIpAddress": "网关IP地址无效",
+  "gatewayMustBeWithinLanSubnet": "网关必须在 LAN 子网内",
+  "gatewayMustBeOutsideLanSubnet": "网关必须在 LAN 子网外",
   "invalidInput": "输入无效",
   "invalidIpAddress": "无效的IP地址",
   "invalidMACAddress": "无效的MAC地址。",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -126,6 +126,8 @@
   "invalidDestinationMacAddress": "目標MAC地址無效",
   "invalidDns": "DNS 不正確",
   "invalidGatewayIpAddress": "網關IP地址無效",
+  "gatewayMustBeWithinLanSubnet": "閘道必須在 LAN 子網路內",
+  "gatewayMustBeOutsideLanSubnet": "閘道必須在 LAN 子網路外",
   "invalidInput": "輸入無效",
   "invalidIpAddress": "IP 位址不正確",
   "invalidMACAddress": "MAC 位址不正確。",

--- a/lib/page/static_routing/services/usp_static_routing_service.dart
+++ b/lib/page/static_routing/services/usp_static_routing_service.dart
@@ -7,6 +7,7 @@ import 'package:privacy_gui/core/usp/providers/usp_client_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_client.dart';
 import 'package:privacy_gui/page/static_routing/models/static_routing_ui_model.dart';
 import 'package:privacy_gui/util/network_utils.dart';
+import 'package:privacy_gui/validator_rules/rules.dart';
 
 final uspStaticRoutingServiceProvider = Provider<UspStaticRoutingService>(
   (ref) => UspStaticRoutingService(ref.read(uspClientProvider)!),
@@ -199,21 +200,17 @@ class UspStaticRoutingService {
 
   /// Validate a route entry. Returns a map of field → error message.
   ///
-  /// When editing an existing route, pass [interfaceName],
-  /// [originalInterfaceName] and [originalGateway] to enable the
-  /// interface↔gateway consistency check: changing the interface
-  /// (LAN↔Internet) without also updating the gateway is not allowed,
-  /// because the old gateway belongs to the previously selected interface's
-  /// subnet. These parameters are optional so that Add mode (no original
-  /// values) skips the check.
+  /// When [lanIp] and [lanSubnetMask] are provided, validates gateway subnet:
+  /// - LAN interface: gateway must be within LAN subnet
+  /// - Internet interface: gateway must be outside LAN subnet
   static Map<String, String> validateRoute({
     required String name,
     required String destIp,
     required String subnetMask,
     required String gateway,
     String? interfaceName,
-    String? originalInterfaceName,
-    String? originalGateway,
+    String? lanIp,
+    String? lanSubnetMask,
   }) {
     final errors = <String, String>{};
     if (name.isEmpty) {
@@ -233,13 +230,21 @@ class UspStaticRoutingService {
     }
     if (gateway.isNotEmpty && !NetworkUtils.isValidIpAddress(gateway)) {
       errors['gateway'] = 'Invalid IP address';
-    } else if (originalInterfaceName != null &&
+    } else if (gateway.isNotEmpty &&
         interfaceName != null &&
-        originalGateway != null &&
-        interfaceName != originalInterfaceName &&
-        gateway == originalGateway) {
-      // Interface was changed but the gateway was left unchanged.
-      errors['gateway'] = 'Update the gateway to match the selected interface';
+        lanIp != null &&
+        lanSubnetMask != null) {
+      // Validate gateway subnet based on interface selection.
+      final lanSubnetRule = HostValidForGivenRouterIPAddressAndSubnetMaskRule(
+        lanIp,
+        lanSubnetMask,
+      );
+      final isInLan = lanSubnetRule.validate(gateway);
+      if (interfaceName == 'LAN' && !isInLan) {
+        errors['gateway'] = 'Gateway must be within LAN subnet';
+      } else if (interfaceName == 'Internet' && isInLan) {
+        errors['gateway'] = 'Gateway must be outside LAN subnet';
+      }
     }
     return errors;
   }

--- a/lib/page/static_routing/services/usp_static_routing_service.dart
+++ b/lib/page/static_routing/services/usp_static_routing_service.dart
@@ -13,6 +13,19 @@ final uspStaticRoutingServiceProvider = Provider<UspStaticRoutingService>(
   (ref) => UspStaticRoutingService(ref.read(uspClientProvider)!),
 );
 
+/// Error keys returned by [UspStaticRoutingService.validateRoute].
+/// Use these to map to l10n strings in the View layer.
+class StaticRoutingErrorKeys {
+  static const nameRequired = 'nameRequired';
+  static const nameTooLong = 'nameTooLong';
+  static const destIpRequired = 'destIpRequired';
+  static const invalidIpAddress = 'invalidIpAddress';
+  static const subnetMaskRequired = 'subnetMaskRequired';
+  static const invalidSubnetMask = 'invalidSubnetMask';
+  static const gatewayMustBeWithinLanSubnet = 'gatewayMustBeWithinLanSubnet';
+  static const gatewayMustBeOutsideLanSubnet = 'gatewayMustBeOutsideLanSubnet';
+}
+
 /// Service layer for Static Routing — encapsulates codegen CRUD + transform + validation.
 class UspStaticRoutingService {
   final UspClient _usp;
@@ -214,22 +227,22 @@ class UspStaticRoutingService {
   }) {
     final errors = <String, String>{};
     if (name.isEmpty) {
-      errors['name'] = 'Name is required';
+      errors['name'] = StaticRoutingErrorKeys.nameRequired;
     } else if (name.length > 32) {
-      errors['name'] = 'Name must be 32 characters or less';
+      errors['name'] = StaticRoutingErrorKeys.nameTooLong;
     }
     if (destIp.isEmpty) {
-      errors['destIp'] = 'Destination IP is required';
+      errors['destIp'] = StaticRoutingErrorKeys.destIpRequired;
     } else if (!NetworkUtils.isValidIpAddress(destIp)) {
-      errors['destIp'] = 'Invalid IP address';
+      errors['destIp'] = StaticRoutingErrorKeys.invalidIpAddress;
     }
     if (subnetMask.isEmpty) {
-      errors['subnetMask'] = 'Subnet mask is required';
+      errors['subnetMask'] = StaticRoutingErrorKeys.subnetMaskRequired;
     } else if (!NetworkUtils.isValidSubnetMask(subnetMask)) {
-      errors['subnetMask'] = 'Invalid subnet mask';
+      errors['subnetMask'] = StaticRoutingErrorKeys.invalidSubnetMask;
     }
     if (gateway.isNotEmpty && !NetworkUtils.isValidIpAddress(gateway)) {
-      errors['gateway'] = 'Invalid IP address';
+      errors['gateway'] = StaticRoutingErrorKeys.invalidIpAddress;
     } else if (gateway.isNotEmpty &&
         interfaceName != null &&
         lanIp != null &&
@@ -241,9 +254,10 @@ class UspStaticRoutingService {
       );
       final isInLan = lanSubnetRule.validate(gateway);
       if (interfaceName == 'LAN' && !isInLan) {
-        errors['gateway'] = 'Gateway must be within LAN subnet';
+        errors['gateway'] = StaticRoutingErrorKeys.gatewayMustBeWithinLanSubnet;
       } else if (interfaceName == 'Internet' && isInLan) {
-        errors['gateway'] = 'Gateway must be outside LAN subnet';
+        errors['gateway'] =
+            StaticRoutingErrorKeys.gatewayMustBeOutsideLanSubnet;
       }
     }
     return errors;

--- a/lib/page/static_routing/services/usp_static_routing_service.dart
+++ b/lib/page/static_routing/services/usp_static_routing_service.dart
@@ -198,11 +198,22 @@ class UspStaticRoutingService {
   // ---------------------------------------------------------------------------
 
   /// Validate a route entry. Returns a map of field → error message.
+  ///
+  /// When editing an existing route, pass [interfaceName],
+  /// [originalInterfaceName] and [originalGateway] to enable the
+  /// interface↔gateway consistency check: changing the interface
+  /// (LAN↔Internet) without also updating the gateway is not allowed,
+  /// because the old gateway belongs to the previously selected interface's
+  /// subnet. These parameters are optional so that Add mode (no original
+  /// values) skips the check.
   static Map<String, String> validateRoute({
     required String name,
     required String destIp,
     required String subnetMask,
     required String gateway,
+    String? interfaceName,
+    String? originalInterfaceName,
+    String? originalGateway,
   }) {
     final errors = <String, String>{};
     if (name.isEmpty) {
@@ -222,6 +233,13 @@ class UspStaticRoutingService {
     }
     if (gateway.isNotEmpty && !NetworkUtils.isValidIpAddress(gateway)) {
       errors['gateway'] = 'Invalid IP address';
+    } else if (originalInterfaceName != null &&
+        interfaceName != null &&
+        originalGateway != null &&
+        interfaceName != originalInterfaceName &&
+        gateway == originalGateway) {
+      // Interface was changed but the gateway was left unchanged.
+      errors['gateway'] = 'Update the gateway to match the selected interface';
     }
     return errors;
   }

--- a/lib/page/static_routing/services/usp_static_routing_service.dart
+++ b/lib/page/static_routing/services/usp_static_routing_service.dart
@@ -246,7 +246,11 @@ class UspStaticRoutingService {
     } else if (gateway.isNotEmpty &&
         interfaceName != null &&
         lanIp != null &&
-        lanSubnetMask != null) {
+        lanIp.isNotEmpty &&
+        lanSubnetMask != null &&
+        lanSubnetMask.isNotEmpty &&
+        NetworkUtils.isValidIpAddress(lanIp) &&
+        NetworkUtils.isValidSubnetMask(lanSubnetMask)) {
       // Validate gateway subnet based on interface selection.
       final lanSubnetRule = HostValidForGivenRouterIPAddressAndSubnetMaskRule(
         lanIp,

--- a/lib/page/static_routing/views/dialogs/static_route_dialog.dart
+++ b/lib/page/static_routing/views/dialogs/static_route_dialog.dart
@@ -26,10 +26,18 @@ class StaticRouteDialogResult {
 /// Dialog for adding or editing a static route.
 ///
 /// Pass [route] to pre-fill for editing; omit for adding.
+/// Pass [lanIp] and [lanSubnetMask] to enable gateway subnet validation.
 class StaticRouteDialog extends StatefulWidget {
   final StaticRouteUIModel? route;
+  final String? lanIp;
+  final String? lanSubnetMask;
 
-  const StaticRouteDialog({super.key, this.route});
+  const StaticRouteDialog({
+    super.key,
+    this.route,
+    this.lanIp,
+    this.lanSubnetMask,
+  });
 
   @override
   State<StaticRouteDialog> createState() => _StaticRouteDialogState();
@@ -76,8 +84,8 @@ class _StaticRouteDialogState extends State<StaticRouteDialog> {
       subnetMask: _subnetMaskController.text.trim(),
       gateway: _gatewayController.text.trim(),
       interfaceName: _interfaceName,
-      originalInterfaceName: widget.route?.interfaceName,
-      originalGateway: widget.route?.gatewayIpAddress,
+      lanIp: widget.lanIp,
+      lanSubnetMask: widget.lanSubnetMask,
     );
   }
 
@@ -136,8 +144,10 @@ class _StaticRouteDialogState extends State<StaticRouteDialog> {
                           ButtonSegment(value: name, label: Text(name)))
                       .toList(),
                   selected: {_interfaceName},
-                  onSelectionChanged: (v) =>
-                      setState(() => _interfaceName = v.first),
+                  onSelectionChanged: (v) {
+                    setState(() => _interfaceName = v.first);
+                    _validate();
+                  },
                 ),
               ],
             ),

--- a/lib/page/static_routing/views/dialogs/static_route_dialog.dart
+++ b/lib/page/static_routing/views/dialogs/static_route_dialog.dart
@@ -66,7 +66,10 @@ class _StaticRouteDialogState extends State<StaticRouteDialog> {
     _gatewayController = TextEditingController(text: r?.gatewayIpAddress ?? '');
     _interfaceName = r?.interfaceName ?? 'LAN';
     _enabled = r?.enabled ?? true;
-    _errors = _computeErrors();
+    // Pre-populate validation state only in edit mode. On add-dialog open all
+    // fields are empty, so computing errors immediately would show "required"
+    // errors before the user has typed anything (confusing, non-standard UX).
+    _errors = _isEdit ? _computeErrors() : {};
   }
 
   @override

--- a/lib/page/static_routing/views/dialogs/static_route_dialog.dart
+++ b/lib/page/static_routing/views/dialogs/static_route_dialog.dart
@@ -118,7 +118,12 @@ class _StaticRouteDialogState extends State<StaticRouteDialog> {
     };
   }
 
-  bool get _isFormValid => _errors.isEmpty;
+  // Compute validity from the live field values rather than the cached
+  // [_errors] map. In add mode [_errors] starts empty (errors are suppressed
+  // on open for UX), so relying on it would enable the Save button on a blank
+  // form and allow submitting an empty route. Recomputing here reflects the
+  // true form state without surfacing "required" errors before the user types.
+  bool get _isFormValid => _computeErrors().isEmpty;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/page/static_routing/views/dialogs/static_route_dialog.dart
+++ b/lib/page/static_routing/views/dialogs/static_route_dialog.dart
@@ -69,26 +69,25 @@ class _StaticRouteDialogState extends State<StaticRouteDialog> {
     super.dispose();
   }
 
-  void _validate() {
-    setState(() {
-      _errors = UspStaticRoutingService.validateRoute(
-        name: _nameController.text.trim(),
-        destIp: _destIpController.text.trim(),
-        subnetMask: _subnetMaskController.text.trim(),
-        gateway: _gatewayController.text.trim(),
-      );
-    });
-  }
-
-  bool get _isFormValid {
-    final errors = UspStaticRoutingService.validateRoute(
+  Map<String, String> _computeErrors() {
+    return UspStaticRoutingService.validateRoute(
       name: _nameController.text.trim(),
       destIp: _destIpController.text.trim(),
       subnetMask: _subnetMaskController.text.trim(),
       gateway: _gatewayController.text.trim(),
+      interfaceName: _interfaceName,
+      originalInterfaceName: widget.route?.interfaceName,
+      originalGateway: widget.route?.gatewayIpAddress,
     );
-    return errors.isEmpty;
   }
+
+  void _validate() {
+    setState(() {
+      _errors = _computeErrors();
+    });
+  }
+
+  bool get _isFormValid => _computeErrors().isEmpty;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/page/static_routing/views/dialogs/static_route_dialog.dart
+++ b/lib/page/static_routing/views/dialogs/static_route_dialog.dart
@@ -66,6 +66,7 @@ class _StaticRouteDialogState extends State<StaticRouteDialog> {
     _gatewayController = TextEditingController(text: r?.gatewayIpAddress ?? '');
     _interfaceName = r?.interfaceName ?? 'LAN';
     _enabled = r?.enabled ?? true;
+    _errors = _computeErrors();
   }
 
   @override
@@ -95,7 +96,26 @@ class _StaticRouteDialogState extends State<StaticRouteDialog> {
     });
   }
 
-  bool get _isFormValid => _computeErrors().isEmpty;
+  /// Convert error key to localized string.
+  String? _localizeError(String? key) {
+    if (key == null) return null;
+    final l = loc(context);
+    return switch (key) {
+      StaticRoutingErrorKeys.nameRequired => l.invalidInput,
+      StaticRoutingErrorKeys.nameTooLong => l.invalidInput,
+      StaticRoutingErrorKeys.destIpRequired => l.ipAddressRequired,
+      StaticRoutingErrorKeys.invalidIpAddress => l.invalidIpAddress,
+      StaticRoutingErrorKeys.subnetMaskRequired => l.invalidInput,
+      StaticRoutingErrorKeys.invalidSubnetMask => l.invalidInput,
+      StaticRoutingErrorKeys.gatewayMustBeWithinLanSubnet =>
+        l.gatewayMustBeWithinLanSubnet,
+      StaticRoutingErrorKeys.gatewayMustBeOutsideLanSubnet =>
+        l.gatewayMustBeOutsideLanSubnet,
+      _ => key,
+    };
+  }
+
+  bool get _isFormValid => _errors.isEmpty;
 
   @override
   Widget build(BuildContext context) {
@@ -109,28 +129,28 @@ class _StaticRouteDialogState extends State<StaticRouteDialog> {
             AppTextField(
               controller: _nameController,
               hintText: loc(context).routeName,
-              errorText: _errors['name'],
+              errorText: _localizeError(_errors['name']),
               onChanged: (_) => _validate(),
             ),
             AppGap.lg(),
             AppIpv4TextField(
               controller: _destIpController,
               label: loc(context).destinationIp,
-              errorText: _errors['destIp'],
+              errorText: _localizeError(_errors['destIp']),
               onChanged: (_) => _validate(),
             ),
             AppGap.lg(),
             AppIpv4TextField(
               controller: _subnetMaskController,
               label: loc(context).subnetMask,
-              errorText: _errors['subnetMask'],
+              errorText: _localizeError(_errors['subnetMask']),
               onChanged: (_) => _validate(),
             ),
             AppGap.lg(),
             AppIpv4TextField(
               controller: _gatewayController,
               label: loc(context).gatewayIp,
-              errorText: _errors['gateway'],
+              errorText: _localizeError(_errors['gateway']),
               onChanged: (_) => _validate(),
             ),
             AppGap.lg(),

--- a/lib/page/static_routing/views/usp_static_routing_view.dart
+++ b/lib/page/static_routing/views/usp_static_routing_view.dart
@@ -195,7 +195,18 @@ class UspStaticRoutingView extends ConsumerWidget {
     // while lanDataProvider is still AsyncLoading (cold start / network reset).
     // valueOrNull would return null there and silently skip validateRoute's
     // gateway-subnet block — the core #1082 fix.
-    final lanData = await ref.read(lanDataProvider.future);
+    final LanData lanData;
+    try {
+      lanData = await ref.read(lanDataProvider.future);
+    } catch (e) {
+      // lanDataProvider can be in AsyncError (router offline, USP timeout,
+      // auth failure). Surface it like _onSave instead of letting the throw
+      // propagate through the onTap lambda and get swallowed silently.
+      if (context.mounted) {
+        showFailedSnackBar(context, localizeServiceError(context, e));
+      }
+      return;
+    }
     if (!context.mounted) return;
     final result = await showAppDialog<StaticRouteDialogResult>(
       context: context,
@@ -221,7 +232,16 @@ class UspStaticRoutingView extends ConsumerWidget {
       StaticRouteUIModel route) async {
     // Await LAN data (see _showAddDialog) so edit-mode subnet validation is not
     // bypassed while lanDataProvider is still loading.
-    final lanData = await ref.read(lanDataProvider.future);
+    final LanData lanData;
+    try {
+      lanData = await ref.read(lanDataProvider.future);
+    } catch (e) {
+      // See _showAddDialog: surface AsyncError instead of swallowing it.
+      if (context.mounted) {
+        showFailedSnackBar(context, localizeServiceError(context, e));
+      }
+      return;
+    }
     if (!context.mounted) return;
     final result = await showAppDialog<StaticRouteDialogResult>(
       context: context,

--- a/lib/page/static_routing/views/usp_static_routing_view.dart
+++ b/lib/page/static_routing/views/usp_static_routing_view.dart
@@ -191,12 +191,17 @@ class UspStaticRoutingView extends ConsumerWidget {
   // ---------------------------------------------------------------------------
 
   Future<void> _showAddDialog(BuildContext context, WidgetRef ref) async {
-    final lanData = ref.read(lanDataProvider).valueOrNull;
+    // Await the LAN data so subnet validation is never bypassed by a fast tap
+    // while lanDataProvider is still AsyncLoading (cold start / network reset).
+    // valueOrNull would return null there and silently skip validateRoute's
+    // gateway-subnet block — the core #1082 fix.
+    final lanData = await ref.read(lanDataProvider.future);
+    if (!context.mounted) return;
     final result = await showAppDialog<StaticRouteDialogResult>(
       context: context,
       builder: (_) => StaticRouteDialog(
-        lanIp: lanData?.model.ipAddress,
-        lanSubnetMask: lanData?.model.subnetMask,
+        lanIp: lanData.model.ipAddress,
+        lanSubnetMask: lanData.model.subnetMask,
       ),
     );
     if (result == null || !context.mounted) return;
@@ -214,13 +219,16 @@ class UspStaticRoutingView extends ConsumerWidget {
 
   Future<void> _showEditDialog(BuildContext context, WidgetRef ref, int index,
       StaticRouteUIModel route) async {
-    final lanData = ref.read(lanDataProvider).valueOrNull;
+    // Await LAN data (see _showAddDialog) so edit-mode subnet validation is not
+    // bypassed while lanDataProvider is still loading.
+    final lanData = await ref.read(lanDataProvider.future);
+    if (!context.mounted) return;
     final result = await showAppDialog<StaticRouteDialogResult>(
       context: context,
       builder: (_) => StaticRouteDialog(
         route: route,
-        lanIp: lanData?.model.ipAddress,
-        lanSubnetMask: lanData?.model.subnetMask,
+        lanIp: lanData.model.ipAddress,
+        lanSubnetMask: lanData.model.subnetMask,
       ),
     );
     if (result == null || !context.mounted) return;

--- a/lib/page/static_routing/views/usp_static_routing_view.dart
+++ b/lib/page/static_routing/views/usp_static_routing_view.dart
@@ -9,6 +9,7 @@ import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/_shared/components/detail_widgets.dart';
 import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
 import 'package:privacy_gui/route/constants.dart';
+import 'package:privacy_gui/page/local_network/providers/lan_data_provider.dart';
 import 'package:privacy_gui/page/static_routing/models/static_routing_feature_state.dart';
 import 'package:privacy_gui/page/static_routing/models/static_routing_ui_model.dart';
 import 'package:privacy_gui/page/static_routing/providers/usp_static_routing_notifier.dart';
@@ -190,9 +191,13 @@ class UspStaticRoutingView extends ConsumerWidget {
   // ---------------------------------------------------------------------------
 
   Future<void> _showAddDialog(BuildContext context, WidgetRef ref) async {
+    final lanData = ref.read(lanDataProvider).valueOrNull;
     final result = await showAppDialog<StaticRouteDialogResult>(
       context: context,
-      builder: (_) => const StaticRouteDialog(),
+      builder: (_) => StaticRouteDialog(
+        lanIp: lanData?.model.ipAddress,
+        lanSubnetMask: lanData?.model.subnetMask,
+      ),
     );
     if (result == null || !context.mounted) return;
     ref.read(uspStaticRoutingProvider.notifier).addRoute(
@@ -209,9 +214,14 @@ class UspStaticRoutingView extends ConsumerWidget {
 
   Future<void> _showEditDialog(BuildContext context, WidgetRef ref, int index,
       StaticRouteUIModel route) async {
+    final lanData = ref.read(lanDataProvider).valueOrNull;
     final result = await showAppDialog<StaticRouteDialogResult>(
       context: context,
-      builder: (_) => StaticRouteDialog(route: route),
+      builder: (_) => StaticRouteDialog(
+        route: route,
+        lanIp: lanData?.model.ipAddress,
+        lanSubnetMask: lanData?.model.subnetMask,
+      ),
     );
     if (result == null || !context.mounted) return;
     ref.read(uspStaticRoutingProvider.notifier).editRoute(

--- a/test/page/static_routing/services/usp_static_routing_service_test.dart
+++ b/test/page/static_routing/services/usp_static_routing_service_test.dart
@@ -152,7 +152,7 @@ void main() {
         subnetMask: '255.255.255.0',
         gateway: '',
       );
-      expect(errors['name'], 'Name is required');
+      expect(errors['name'], StaticRoutingErrorKeys.nameRequired);
     });
 
     test('name over 32 chars returns error', () {
@@ -162,7 +162,7 @@ void main() {
         subnetMask: '255.255.255.0',
         gateway: '',
       );
-      expect(errors['name'], 'Name must be 32 characters or less');
+      expect(errors['name'], StaticRoutingErrorKeys.nameTooLong);
     });
 
     test('name exactly 32 chars is valid', () {
@@ -182,7 +182,7 @@ void main() {
         subnetMask: '255.255.255.0',
         gateway: '',
       );
-      expect(errors['destIp'], 'Destination IP is required');
+      expect(errors['destIp'], StaticRoutingErrorKeys.destIpRequired);
     });
 
     test('invalid destIp returns error', () {
@@ -192,7 +192,7 @@ void main() {
         subnetMask: '255.255.255.0',
         gateway: '',
       );
-      expect(errors['destIp'], 'Invalid IP address');
+      expect(errors['destIp'], StaticRoutingErrorKeys.invalidIpAddress);
     });
 
     test('empty subnetMask returns error', () {
@@ -202,7 +202,7 @@ void main() {
         subnetMask: '',
         gateway: '',
       );
-      expect(errors['subnetMask'], 'Subnet mask is required');
+      expect(errors['subnetMask'], StaticRoutingErrorKeys.subnetMaskRequired);
     });
 
     test('invalid subnetMask returns error', () {
@@ -212,7 +212,7 @@ void main() {
         subnetMask: '255.255.0.128',
         gateway: '',
       );
-      expect(errors['subnetMask'], 'Invalid subnet mask');
+      expect(errors['subnetMask'], StaticRoutingErrorKeys.invalidSubnetMask);
     });
 
     test('empty gateway is valid (optional)', () {
@@ -232,7 +232,7 @@ void main() {
         subnetMask: '255.255.255.0',
         gateway: 'not-an-ip',
       );
-      expect(errors['gateway'], 'Invalid IP address');
+      expect(errors['gateway'], StaticRoutingErrorKeys.invalidIpAddress);
     });
 
     test('multiple errors returned simultaneously', () {
@@ -270,7 +270,8 @@ void main() {
         lanIp: '192.168.1.1',
         lanSubnetMask: '255.255.255.0',
       );
-      expect(errors['gateway'], 'Gateway must be within LAN subnet');
+      expect(errors['gateway'],
+          StaticRoutingErrorKeys.gatewayMustBeWithinLanSubnet);
     });
 
     test('Internet interface: gateway outside LAN subnet is valid', () {
@@ -296,7 +297,8 @@ void main() {
         lanIp: '192.168.1.1',
         lanSubnetMask: '255.255.255.0',
       );
-      expect(errors['gateway'], 'Gateway must be outside LAN subnet');
+      expect(errors['gateway'],
+          StaticRoutingErrorKeys.gatewayMustBeOutsideLanSubnet);
     });
 
     test('subnet validation skipped when lanIp/lanSubnetMask not provided', () {
@@ -320,7 +322,7 @@ void main() {
         lanIp: '192.168.1.1',
         lanSubnetMask: '255.255.255.0',
       );
-      expect(errors['gateway'], 'Invalid IP address');
+      expect(errors['gateway'], StaticRoutingErrorKeys.invalidIpAddress);
     });
   });
 

--- a/test/page/static_routing/services/usp_static_routing_service_test.dart
+++ b/test/page/static_routing/services/usp_static_routing_service_test.dart
@@ -244,6 +244,73 @@ void main() {
       );
       expect(errors, hasLength(4));
     });
+
+    // --- interface↔gateway consistency (issue #1082) ---
+
+    test('editing: interface changed but gateway unchanged returns error', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'Route1',
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: '192.168.187.1',
+        interfaceName: 'LAN',
+        originalInterfaceName: 'Internet',
+        originalGateway: '192.168.187.1',
+      );
+      expect(errors['gateway'],
+          'Update the gateway to match the selected interface');
+    });
+
+    test('editing: interface changed and gateway also changed is valid', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'Route1',
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: '10.0.0.254',
+        interfaceName: 'LAN',
+        originalInterfaceName: 'Internet',
+        originalGateway: '192.168.187.1',
+      );
+      expect(errors.containsKey('gateway'), isFalse);
+    });
+
+    test('editing: interface unchanged and gateway unchanged is valid', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'Route1',
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: '192.168.187.1',
+        interfaceName: 'Internet',
+        originalInterfaceName: 'Internet',
+        originalGateway: '192.168.187.1',
+      );
+      expect(errors.containsKey('gateway'), isFalse);
+    });
+
+    test('adding (no original values): consistency check is skipped', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'Route1',
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: '192.168.187.1',
+        interfaceName: 'LAN',
+      );
+      expect(errors.containsKey('gateway'), isFalse);
+    });
+
+    test('editing: invalid gateway format takes precedence over consistency',
+        () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'Route1',
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: 'not-an-ip',
+        interfaceName: 'LAN',
+        originalInterfaceName: 'Internet',
+        originalGateway: 'not-an-ip',
+      );
+      expect(errors['gateway'], 'Invalid IP address');
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/test/page/static_routing/services/usp_static_routing_service_test.dart
+++ b/test/page/static_routing/services/usp_static_routing_service_test.dart
@@ -312,6 +312,26 @@ void main() {
       expect(errors.containsKey('gateway'), isFalse);
     });
 
+    test(
+        'empty-string lanIp/lanSubnetMask (LanData.empty fallback) skips subnet '
+        'check — no false-positive Internet error', () {
+      // Regression for W-NEW-1: LanData.empty() returns ipAddress:'' /
+      // subnetMask:'' (empty strings, not null). ipToNum('') == 0, so the LAN
+      // subnet rule would incorrectly report isInLan == true for ANY gateway,
+      // firing a permanent false-positive gatewayMustBeOutsideLanSubnet error
+      // on Internet-interface routes while LAN data is still loading.
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'Route1',
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: '8.8.8.8',
+        interfaceName: 'Internet',
+        lanIp: '',
+        lanSubnetMask: '',
+      );
+      expect(errors.containsKey('gateway'), isFalse);
+    });
+
     test('invalid gateway format takes precedence over subnet check', () {
       final errors = UspStaticRoutingService.validateRoute(
         name: 'Route1',

--- a/test/page/static_routing/services/usp_static_routing_service_test.dart
+++ b/test/page/static_routing/services/usp_static_routing_service_test.dart
@@ -245,69 +245,80 @@ void main() {
       expect(errors, hasLength(4));
     });
 
-    // --- interface↔gateway consistency (issue #1082) ---
+    // --- gateway subnet validation (issue #1082) ---
 
-    test('editing: interface changed but gateway unchanged returns error', () {
+    test('LAN interface: gateway within LAN subnet is valid', () {
       final errors = UspStaticRoutingService.validateRoute(
         name: 'Route1',
         destIp: '10.0.0.0',
         subnetMask: '255.255.255.0',
-        gateway: '192.168.187.1',
+        gateway: '192.168.1.100',
         interfaceName: 'LAN',
-        originalInterfaceName: 'Internet',
-        originalGateway: '192.168.187.1',
-      );
-      expect(errors['gateway'],
-          'Update the gateway to match the selected interface');
-    });
-
-    test('editing: interface changed and gateway also changed is valid', () {
-      final errors = UspStaticRoutingService.validateRoute(
-        name: 'Route1',
-        destIp: '10.0.0.0',
-        subnetMask: '255.255.255.0',
-        gateway: '10.0.0.254',
-        interfaceName: 'LAN',
-        originalInterfaceName: 'Internet',
-        originalGateway: '192.168.187.1',
+        lanIp: '192.168.1.1',
+        lanSubnetMask: '255.255.255.0',
       );
       expect(errors.containsKey('gateway'), isFalse);
     });
 
-    test('editing: interface unchanged and gateway unchanged is valid', () {
+    test('LAN interface: gateway outside LAN subnet returns error', () {
       final errors = UspStaticRoutingService.validateRoute(
         name: 'Route1',
         destIp: '10.0.0.0',
         subnetMask: '255.255.255.0',
-        gateway: '192.168.187.1',
+        gateway: '8.8.8.8',
+        interfaceName: 'LAN',
+        lanIp: '192.168.1.1',
+        lanSubnetMask: '255.255.255.0',
+      );
+      expect(errors['gateway'], 'Gateway must be within LAN subnet');
+    });
+
+    test('Internet interface: gateway outside LAN subnet is valid', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'Route1',
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: '100.64.1.1',
         interfaceName: 'Internet',
-        originalInterfaceName: 'Internet',
-        originalGateway: '192.168.187.1',
+        lanIp: '192.168.1.1',
+        lanSubnetMask: '255.255.255.0',
       );
       expect(errors.containsKey('gateway'), isFalse);
     });
 
-    test('adding (no original values): consistency check is skipped', () {
+    test('Internet interface: gateway within LAN subnet returns error', () {
       final errors = UspStaticRoutingService.validateRoute(
         name: 'Route1',
         destIp: '10.0.0.0',
         subnetMask: '255.255.255.0',
-        gateway: '192.168.187.1',
+        gateway: '192.168.1.50',
+        interfaceName: 'Internet',
+        lanIp: '192.168.1.1',
+        lanSubnetMask: '255.255.255.0',
+      );
+      expect(errors['gateway'], 'Gateway must be outside LAN subnet');
+    });
+
+    test('subnet validation skipped when lanIp/lanSubnetMask not provided', () {
+      final errors = UspStaticRoutingService.validateRoute(
+        name: 'Route1',
+        destIp: '10.0.0.0',
+        subnetMask: '255.255.255.0',
+        gateway: '8.8.8.8',
         interfaceName: 'LAN',
       );
       expect(errors.containsKey('gateway'), isFalse);
     });
 
-    test('editing: invalid gateway format takes precedence over consistency',
-        () {
+    test('invalid gateway format takes precedence over subnet check', () {
       final errors = UspStaticRoutingService.validateRoute(
         name: 'Route1',
         destIp: '10.0.0.0',
         subnetMask: '255.255.255.0',
-        gateway: 'not-an-ip',
+        gateway: 'bad-ip',
         interfaceName: 'LAN',
-        originalInterfaceName: 'Internet',
-        originalGateway: 'not-an-ip',
+        lanIp: '192.168.1.1',
+        lanSubnetMask: '255.255.255.0',
       );
       expect(errors['gateway'], 'Invalid IP address');
     });


### PR DESCRIPTION
## Summary

Fixes the static-route edit dialog allowing an interface/gateway-inconsistent route to save (issue #1082, 2.x / USP line, Maintainer / minimal-diff).

**Root cause** (confirmed by triage on the issue — code + UI log): when editing a static route, `validateRoute()` only checked each field's format in isolation. Changing the Interface (LAN↔Internet) while leaving the Gateway unchanged still passed validation and submitted the `SET`. Since the old gateway belongs to the *previously selected* interface's subnet, the resulting route is inconsistent — but the backend accepts it (`SET → UspSuccess`), so it "saves successfully" instead of being blocked client-side.

## Change

- `usp_static_routing_service.dart` — `validateRoute()` gains three **optional** params (`interfaceName`, `originalInterfaceName`, `originalGateway`). In edit mode, if the interface changed but the gateway is unchanged, it returns a `gateway` error. Add mode (no original values) skips the check. Invalid-gateway-*format* still takes precedence over the consistency error.
- `static_route_dialog.dart` — wires the original values (`widget.route?.interfaceName` / `?.gatewayIpAddress`) and the currently selected `_interfaceName` into validation via a shared `_computeErrors()` helper (used by both `_validate()` and `_isFormValid`). The Save button stays disabled while the inconsistency stands.
- Tests — 5 new `validateRoute` cases covering: interface changed + gateway unchanged (error), interface + gateway both changed (ok), interface unchanged (ok), Add mode skip, and format-error precedence.

## Acceptance (Expected Result from issue)

> Should not allow changing the Internet/LAN interface without changing the gateway settings.

Save is now blocked (button disabled + gateway error text) exactly in that case.

## Verification (real output)

```
flutter test .../usp_static_routing_service_test.dart   → 00:00 +31: All tests passed!
flutter test .../usp_static_routing_notifier_test.dart  → 00:00 +10: All tests passed!  (no regression)
flutter analyze <3 changed files>                        → No issues found!
dart format --output=none --set-exit-if-changed lib/ test/ → Formatted 1055 files (0 changed), exit 0
```

`git diff --stat`:
```
 .../services/usp_static_routing_service.dart       | 18 ++++++
 .../views/dialogs/static_route_dialog.dart         | 27 +++++----
 .../services/usp_static_routing_service_test.dart  | 67 ++++++++++++++++++++++
 3 files changed, 98 insertions(+), 14 deletions(-)
```

Refs #1082
