### PR TITLE
fix(dhcp): use Hosts.Active for online status indicator (#1034)

### DIFF
--- a/lib/ai/providers/usp_command_provider.dart
+++ b/lib/ai/providers/usp_command_provider.dart
@@ -504,7 +504,8 @@ class UspCommandProvider implements IRouterCommandProvider {
               'mac': c.mac,
               'ip': c.ip,
               'hostName': c.hostName,
-              'active': c.active,
+              'leaseActive': c.leaseActive,
+              'isOnline': c.isOnline,
               'leaseExpiry': c.leaseExpiryFormatted,
               'leaseRemaining': c.leaseTimeFormatted,
             })

--- a/lib/ai/providers/usp_command_provider.dart
+++ b/lib/ai/providers/usp_command_provider.dart
@@ -505,7 +505,7 @@ class UspCommandProvider implements IRouterCommandProvider {
               'ip': c.ip,
               'hostName': c.hostName,
               'leaseActive': c.leaseActive,
-              'isOnline': c.isOnline,
+              'isOnline': c.isOnline ?? false,
               'leaseExpiry': c.leaseExpiryFormatted,
               'leaseRemaining': c.leaseTimeFormatted,
             })

--- a/lib/page/_shared/models/dhcp_client_ui_model.dart
+++ b/lib/page/_shared/models/dhcp_client_ui_model.dart
@@ -1,20 +1,35 @@
 import 'package:equatable/equatable.dart';
 
-/// Presentation Layer Model for an active DHCP client lease.
+/// Presentation Layer Model for a DHCP client lease.
+///
+/// - [leaseActive]: Whether the DHCP lease is valid (from TR-181 DHCPv4.Server.Pool.*.Client.*.Active)
+/// - [isOnline]: Whether the device is currently connected (from TR-181 Hosts.Host.*.Active)
 class DhcpClientUIModel extends Equatable {
+  /// MAC address (normalized to uppercase).
   final String mac;
   final String ip;
-  final bool active;
+
+  /// Whether the DHCP lease is active (not expired).
+  /// This comes from `Device.DHCPv4.Server.Pool.*.Client.*.Active`.
+  final bool leaseActive;
+
+  /// Whether the device is currently online (connected to the network).
+  /// This comes from `Device.Hosts.Host.*.Active` via join on MAC address.
+  /// Null if no matching host entry found.
+  final bool? isOnline;
+
   final String hostName;
   final DateTime? leaseExpiry;
 
-  const DhcpClientUIModel({
-    required this.mac,
+  /// Creates a DHCP client UI model. MAC is normalized to uppercase.
+  DhcpClientUIModel({
+    required String mac,
     required this.ip,
-    required this.active,
+    required this.leaseActive,
+    this.isOnline,
     this.hostName = '',
     this.leaseExpiry,
-  });
+  }) : mac = mac.toUpperCase();
 
   /// Human-readable lease status.
   ///
@@ -27,7 +42,7 @@ class DhcpClientUIModel extends Equatable {
     if (leaseExpiry == null) return '';
     final remaining = leaseExpiry!.difference(DateTime.now());
     if (remaining.isNegative) {
-      return active ? '' : 'Expired';
+      return leaseActive ? '' : 'Expired';
     }
     final days = remaining.inDays;
     final hours = remaining.inHours % 24;
@@ -54,5 +69,6 @@ class DhcpClientUIModel extends Equatable {
   String get displayName => hostName.isNotEmpty ? hostName : mac;
 
   @override
-  List<Object?> get props => [mac, ip, active, hostName, leaseExpiry];
+  List<Object?> get props =>
+      [mac, ip, leaseActive, isOnline, hostName, leaseExpiry];
 }

--- a/lib/page/_shared/models/dhcp_reservation_ui_model.dart
+++ b/lib/page/_shared/models/dhcp_reservation_ui_model.dart
@@ -6,16 +6,19 @@ import 'package:equatable/equatable.dart';
 /// that have not yet been saved to the device.
 class DhcpReservationUIModel extends Equatable {
   final String? instancePath;
+
+  /// MAC address (normalized to uppercase).
   final String mac;
   final String ip;
   final bool enable;
 
-  const DhcpReservationUIModel({
+  /// Creates a DHCP reservation UI model. MAC is normalized to uppercase.
+  DhcpReservationUIModel({
     this.instancePath,
-    required this.mac,
+    required String mac,
     required this.ip,
     required this.enable,
-  });
+  }) : mac = mac.toUpperCase();
 
   DhcpReservationUIModel copyWith({
     String? instancePath,

--- a/lib/page/_shared/services/usp_pdf_service.dart
+++ b/lib/page/_shared/services/usp_pdf_service.dart
@@ -429,7 +429,7 @@ class UspPdfService {
                   c.displayName,
                   c.mac,
                   c.ip,
-                  c.isOnline == true ? 'Yes' : 'No',
+                  (c.isOnline ?? false) ? 'Yes' : 'No',
                   c.leaseTimeFormatted.isNotEmpty ? c.leaseTimeFormatted : '—',
                 ])
             .toList(),

--- a/lib/page/_shared/services/usp_pdf_service.dart
+++ b/lib/page/_shared/services/usp_pdf_service.dart
@@ -423,13 +423,13 @@ class UspPdfService {
         cellStyle: const pw.TextStyle(fontSize: 8),
         cellPadding: const pw.EdgeInsets.symmetric(horizontal: 4, vertical: 2),
         headerDecoration: const pw.BoxDecoration(color: PdfColors.grey200),
-        headers: ['Name', 'MAC', 'IP', 'Active', 'Lease'],
+        headers: ['Name', 'MAC', 'IP', 'Online', 'Lease'],
         data: clients
             .map((c) => [
                   c.displayName,
                   c.mac,
                   c.ip,
-                  c.active ? 'Yes' : 'No',
+                  c.isOnline == true ? 'Yes' : 'No',
                   c.leaseTimeFormatted.isNotEmpty ? c.leaseTimeFormatted : '—',
                 ])
             .toList(),

--- a/lib/page/dhcp/providers/dhcp_client_filter_provider.dart
+++ b/lib/page/dhcp/providers/dhcp_client_filter_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Filter options for DHCP client list display.
+enum DhcpClientFilter { all, onlineOnly }
+
+/// Persists the selected DHCP client filter across page navigation.
+final dhcpClientFilterProvider = StateProvider<DhcpClientFilter>(
+  (ref) => DhcpClientFilter.all,
+);

--- a/lib/page/dhcp/views/components/usp_dhcp_active_leases_card.dart
+++ b/lib/page/dhcp/views/components/usp_dhcp_active_leases_card.dart
@@ -5,19 +5,36 @@ import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
 import 'package:privacy_gui/page/_shared/models/dhcp_client_ui_model.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
-/// Read-only card displaying active DHCP client leases.
-class UspDhcpActiveLeasesCard extends StatelessWidget {
+enum _DhcpClientFilter { all, onlineOnly }
+
+/// Read-only card displaying DHCP client leases with filter chips.
+class UspDhcpActiveLeasesCard extends StatefulWidget {
   final List<DhcpClientUIModel> clients;
 
   const UspDhcpActiveLeasesCard({super.key, required this.clients});
 
   @override
+  State<UspDhcpActiveLeasesCard> createState() =>
+      _UspDhcpActiveLeasesCardState();
+}
+
+class _UspDhcpActiveLeasesCardState extends State<UspDhcpActiveLeasesCard> {
+  _DhcpClientFilter _filter = _DhcpClientFilter.all;
+
+  @override
   Widget build(BuildContext context) {
-    final activeCount = clients.where((c) => c.active).length;
-    final sorted = List<DhcpClientUIModel>.from(clients)
+    final onlineCount = widget.clients.where((c) => c.isOnline == true).length;
+
+    final filtered = _filter == _DhcpClientFilter.onlineOnly
+        ? widget.clients.where((c) => c.isOnline == true).toList()
+        : widget.clients;
+
+    final sorted = List<DhcpClientUIModel>.from(filtered)
       ..sort((a, b) {
-        // Active first, then by displayName
-        if (a.active != b.active) return a.active ? -1 : 1;
+        // Online first, then by displayName
+        final aOnline = a.isOnline == true;
+        final bOnline = b.isOnline == true;
+        if (aOnline != bOnline) return aOnline ? -1 : 1;
         return a.displayName
             .toLowerCase()
             .compareTo(b.displayName.toLowerCase());
@@ -32,9 +49,11 @@ class UspDhcpActiveLeasesCard extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               AppText.titleSmall(loc(context).activeLeases),
-              AppText.labelLarge('$activeCount / ${clients.length}'),
+              AppText.labelLarge('$onlineCount / ${widget.clients.length}'),
             ],
           ),
+          AppGap.sm(),
+          _buildFilterChips(context),
           AppGap.md(),
           if (sorted.isEmpty)
             DetailEmptyBlock(
@@ -45,6 +64,25 @@ class UspDhcpActiveLeasesCard extends StatelessWidget {
             ...sorted.map((c) => _buildClientRow(context, c)),
         ],
       ),
+    );
+  }
+
+  Widget _buildFilterChips(BuildContext context) {
+    return Row(
+      children: [
+        FilterChip(
+          label: Text(loc(context).all),
+          selected: _filter == _DhcpClientFilter.all,
+          onSelected: (_) => setState(() => _filter = _DhcpClientFilter.all),
+        ),
+        AppGap.sm(),
+        FilterChip(
+          label: Text(loc(context).online),
+          selected: _filter == _DhcpClientFilter.onlineOnly,
+          onSelected: (_) =>
+              setState(() => _filter = _DhcpClientFilter.onlineOnly),
+        ),
+      ],
     );
   }
 
@@ -60,7 +98,8 @@ class UspDhcpActiveLeasesCard extends StatelessWidget {
             Icon(
               Icons.circle,
               size: 8,
-              color: client.active ? Colors.green : colorScheme.outline,
+              color:
+                  client.isOnline == true ? Colors.green : colorScheme.outline,
             ),
             AppGap.sm(),
             Expanded(
@@ -68,14 +107,11 @@ class UspDhcpActiveLeasesCard extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   AppText.bodyMedium(client.displayName),
-                  AppText.bodySmall(
-                    [
-                      if (client.hostName.isNotEmpty) client.mac,
-                      if (client.leaseExpiryFormatted.isNotEmpty)
-                        loc(context).leaseExpiry(client.leaseExpiryFormatted),
-                    ].join(' · '),
-                    color: colorScheme.onSurfaceVariant,
-                  ),
+                  if (client.hostName.isNotEmpty)
+                    AppText.bodySmall(
+                      client.mac,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
                 ],
               ),
             ),
@@ -86,15 +122,24 @@ class UspDhcpActiveLeasesCard extends StatelessWidget {
                 color: colorScheme.onSurfaceVariant,
               ),
             ),
-            if (lease.isNotEmpty)
-              SizedBox(
-                width: context.colWidth(1),
-                child: AppText.bodySmall(
-                  lease,
-                  color: colorScheme.onSurfaceVariant,
-                  textAlign: TextAlign.end,
-                ),
+            SizedBox(
+              width: context.colWidth(2),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  if (lease.isNotEmpty)
+                    AppText.bodySmall(
+                      lease,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  if (client.leaseExpiryFormatted.isNotEmpty)
+                    AppText.bodySmall(
+                      client.leaseExpiryFormatted,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                ],
               ),
+            ),
           ],
         ),
       ),

--- a/lib/page/dhcp/views/components/usp_dhcp_active_leases_card.dart
+++ b/lib/page/dhcp/views/components/usp_dhcp_active_leases_card.dart
@@ -1,33 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/_shared/components/detail_widgets.dart';
 import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
 import 'package:privacy_gui/page/_shared/models/dhcp_client_ui_model.dart';
+import 'package:privacy_gui/page/dhcp/providers/dhcp_client_filter_provider.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
-enum _DhcpClientFilter { all, onlineOnly }
-
 /// Read-only card displaying DHCP client leases with filter chips.
-class UspDhcpActiveLeasesCard extends StatefulWidget {
+class UspDhcpActiveLeasesCard extends ConsumerWidget {
   final List<DhcpClientUIModel> clients;
 
   const UspDhcpActiveLeasesCard({super.key, required this.clients});
 
   @override
-  State<UspDhcpActiveLeasesCard> createState() =>
-      _UspDhcpActiveLeasesCardState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filter = ref.watch(dhcpClientFilterProvider);
+    final onlineCount = clients.where((c) => c.isOnline == true).length;
 
-class _UspDhcpActiveLeasesCardState extends State<UspDhcpActiveLeasesCard> {
-  _DhcpClientFilter _filter = _DhcpClientFilter.all;
-
-  @override
-  Widget build(BuildContext context) {
-    final onlineCount = widget.clients.where((c) => c.isOnline == true).length;
-
-    final filtered = _filter == _DhcpClientFilter.onlineOnly
-        ? widget.clients.where((c) => c.isOnline == true).toList()
-        : widget.clients;
+    final filtered = filter == DhcpClientFilter.onlineOnly
+        ? clients.where((c) => c.isOnline == true).toList()
+        : clients;
 
     final sorted = List<DhcpClientUIModel>.from(filtered)
       ..sort((a, b) {
@@ -49,11 +42,11 @@ class _UspDhcpActiveLeasesCardState extends State<UspDhcpActiveLeasesCard> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               AppText.titleSmall(loc(context).activeLeases),
-              AppText.labelLarge('$onlineCount / ${widget.clients.length}'),
+              AppText.labelLarge('$onlineCount / ${clients.length}'),
             ],
           ),
           AppGap.sm(),
-          _buildFilterChips(context),
+          _buildFilterChips(context, ref, filter),
           AppGap.md(),
           if (sorted.isEmpty)
             DetailEmptyBlock(
@@ -67,23 +60,35 @@ class _UspDhcpActiveLeasesCardState extends State<UspDhcpActiveLeasesCard> {
     );
   }
 
-  Widget _buildFilterChips(BuildContext context) {
-    return Row(
-      children: [
-        FilterChip(
-          label: Text(loc(context).all),
-          selected: _filter == _DhcpClientFilter.all,
-          onSelected: (_) => setState(() => _filter = _DhcpClientFilter.all),
-        ),
-        AppGap.sm(),
-        FilterChip(
-          label: Text(loc(context).online),
-          selected: _filter == _DhcpClientFilter.onlineOnly,
-          onSelected: (_) =>
-              setState(() => _filter = _DhcpClientFilter.onlineOnly),
-        ),
-      ],
+  Widget _buildFilterChips(
+    BuildContext context,
+    WidgetRef ref,
+    DhcpClientFilter filter,
+  ) {
+    const filters = DhcpClientFilter.values;
+    return AppChipGroup(
+      chips: filters
+          .map((f) => ChipItem(label: _filterLabel(context, f)))
+          .toList(),
+      selectedIndices: {filters.indexOf(filter)},
+      selectionMode: ChipSelectionMode.single,
+      onSelectionChanged: (indices) {
+        if (indices.isNotEmpty) {
+          ref.read(dhcpClientFilterProvider.notifier).state =
+              filters[indices.first];
+        }
+      },
+      wrap: false,
     );
+  }
+
+  String _filterLabel(BuildContext context, DhcpClientFilter filter) {
+    switch (filter) {
+      case DhcpClientFilter.all:
+        return loc(context).all;
+      case DhcpClientFilter.onlineOnly:
+        return loc(context).online;
+    }
   }
 
   Widget _buildClientRow(BuildContext context, DhcpClientUIModel client) {

--- a/lib/page/local_network/cards/usp_dhcp_reservations_card.dart
+++ b/lib/page/local_network/cards/usp_dhcp_reservations_card.dart
@@ -24,7 +24,8 @@ class UspDhcpReservationsCard extends ConsumerWidget {
     if (dhcpData == null) return const CardSkeleton.list(rows: 3);
     final reservations = dhcpData.reservationModels;
     final clients = dhcpData.clientModels;
-    final activeClients = clients.where((c) => c.active).toList();
+    // Dashboard shows only online clients (based on Hosts.Active, not DHCP lease).
+    final onlineClients = clients.where((c) => c.isOnline == true).toList();
     final isLoading = ref.watch(uspMutationLoadingProvider) == 'dhcp';
 
     return DashboardCardTemplate.multiSection(
@@ -34,7 +35,7 @@ class UspDhcpReservationsCard extends ConsumerWidget {
         onTap: isLoading ? null : () => _showAddDhcpDialog(context, ref),
       ),
       detailRoute: RouteNamed.uspDhcpDetail,
-      itemCount: reservations.length + activeClients.length,
+      itemCount: reservations.length + onlineClients.length,
       sections: [
         CardSection(
           title: loc(context).reservations,
@@ -52,14 +53,14 @@ class UspDhcpReservationsCard extends ConsumerWidget {
         ),
         CardSection(
           title: loc(context).activeLeases,
-          titleBadge: AppText.labelMedium('${activeClients.length}'),
-          isEmpty: clients.isEmpty,
+          titleBadge: AppText.labelMedium('${onlineClients.length}'),
+          isEmpty: onlineClients.isEmpty,
           emptyMessage: 'No DHCP clients',
           content: Column(
             children: [
-              for (var i = 0; i < clients.length; i++) ...[
-                _buildClientRow(context, clients[i]),
-                if (i < clients.length - 1) AppGap.sm(),
+              for (var i = 0; i < onlineClients.length; i++) ...[
+                _buildClientRow(context, onlineClients[i]),
+                if (i < onlineClients.length - 1) AppGap.sm(),
               ],
             ],
           ),
@@ -104,7 +105,7 @@ class UspDhcpReservationsCard extends ConsumerWidget {
         height: 8,
         decoration: BoxDecoration(
           shape: BoxShape.circle,
-          color: client.active
+          color: client.isOnline == true
               ? (appColors?.semanticSuccess ?? Colors.green)
               : colorScheme.outline,
         ),

--- a/lib/page/local_network/providers/dhcp_data_provider.dart
+++ b/lib/page/local_network/providers/dhcp_data_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
@@ -45,9 +46,18 @@ class DhcpDataNotifier extends AsyncNotifier<DhcpData> {
     });
 
     // Devices listener: device online status changes affect DHCP client
-    // isOnline enrichment. Re-fetch to get fresh data.
-    ref.listen(devicesDataProvider, (_, next) {
-      if (next.hasValue && state.hasValue) {
+    // isOnline enrichment. Only re-fetch when the online-status map actually
+    // changed — DevicesData emits on any device field change (RSSI, band,
+    // SSID), so a naive listener would trigger needless DHCP re-fetches.
+    ref.listen(devicesDataProvider, (prev, next) {
+      if (!next.hasValue || !state.hasValue) return;
+      final prevOnline = <String, bool>{
+        for (final d in prev?.valueOrNull?.deviceModels ?? []) d.mac: d.isActive
+      };
+      final nextOnline = <String, bool>{
+        for (final d in next.value!.deviceModels) d.mac: d.isActive
+      };
+      if (!const MapEquality<String, bool>().equals(prevOnline, nextOnline)) {
         _debouncedInvalidate();
       }
     });

--- a/lib/page/local_network/providers/dhcp_data_provider.dart
+++ b/lib/page/local_network/providers/dhcp_data_provider.dart
@@ -52,10 +52,11 @@ class DhcpDataNotifier extends AsyncNotifier<DhcpData> {
     ref.listen(devicesDataProvider, (prev, next) {
       if (!next.hasValue || !state.hasValue) return;
       final prevOnline = <String, bool>{
-        for (final d in prev?.valueOrNull?.deviceModels ?? []) d.mac: d.isActive
+        for (final d in prev?.valueOrNull?.clientDevices ?? [])
+          d.mac: d.isActive
       };
       final nextOnline = <String, bool>{
-        for (final d in next.value!.deviceModels) d.mac: d.isActive
+        for (final d in next.value!.clientDevices) d.mac: d.isActive
       };
       if (!const MapEquality<String, bool>().equals(prevOnline, nextOnline)) {
         _debouncedInvalidate();
@@ -72,9 +73,10 @@ class DhcpDataNotifier extends AsyncNotifier<DhcpData> {
     // Enrichment: read pre-computed maps from devices provider.
     final devicesData = ref.read(devicesDataProvider).valueOrNull;
     final hostNameByMac = devicesData?.hostNameByMac ?? const {};
-    // Compute isOnlineByMac inline from deviceModels.
+    // Compute isOnlineByMac inline from clientDevices (mesh nodes never hold
+    // DHCP leases, so their MACs cannot appear in DHCP client models).
     final isOnlineByMac = <String, bool>{
-      for (final d in devicesData?.deviceModels ?? []) d.mac: d.isActive,
+      for (final d in devicesData?.clientDevices ?? []) d.mac: d.isActive,
     };
 
     final result = await svc.fetch(

--- a/lib/page/local_network/providers/dhcp_data_provider.dart
+++ b/lib/page/local_network/providers/dhcp_data_provider.dart
@@ -21,10 +21,7 @@ class DhcpData extends Equatable {
   });
 
   @override
-  List<Object?> get props => [
-        clientModels.length,
-        reservationModels.length,
-      ];
+  List<Object?> get props => [clientModels, reservationModels];
 }
 
 // ── Provider ──

--- a/lib/page/local_network/providers/dhcp_data_provider.dart
+++ b/lib/page/local_network/providers/dhcp_data_provider.dart
@@ -46,6 +46,15 @@ class DhcpDataNotifier extends AsyncNotifier<DhcpData> {
         _debouncedInvalidate();
       }
     });
+
+    // Devices listener: device online status changes affect DHCP client
+    // isOnline enrichment. Re-fetch to get fresh data.
+    ref.listen(devicesDataProvider, (_, next) {
+      if (next.hasValue && state.hasValue) {
+        _debouncedInvalidate();
+      }
+    });
+
     ref.onDispose(() => _debounce?.cancel());
     return _fetch();
   }
@@ -53,11 +62,18 @@ class DhcpDataNotifier extends AsyncNotifier<DhcpData> {
   Future<DhcpData> _fetch() async {
     final svc = ref.read(uspDhcpDataServiceProvider);
 
-    // Hostname enrichment: read pre-computed map from devices provider.
+    // Enrichment: read pre-computed maps from devices provider.
     final devicesData = ref.read(devicesDataProvider).valueOrNull;
     final hostNameByMac = devicesData?.hostNameByMac ?? const {};
+    // Compute isOnlineByMac inline from deviceModels.
+    final isOnlineByMac = <String, bool>{
+      for (final d in devicesData?.deviceModels ?? []) d.mac: d.isActive,
+    };
 
-    final result = await svc.fetch(hostNameByMac: hostNameByMac);
+    final result = await svc.fetch(
+      hostNameByMac: hostNameByMac,
+      isOnlineByMac: isOnlineByMac,
+    );
 
     logger.d('[USP][DhcpData]: Fetched — '
         'clients: ${result.clientModels.length}, '

--- a/lib/page/local_network/services/usp_dhcp_data_service.dart
+++ b/lib/page/local_network/services/usp_dhcp_data_service.dart
@@ -51,9 +51,10 @@ class UspDhcpDataService {
   UspDhcpDataService(this._usp);
 
   /// Fetches DHCP clients + reservations in parallel, applies hostname
-  /// enrichment, and returns UI models.
+  /// and online status enrichment, and returns UI models.
   Future<DhcpDataFetchResult> fetch({
     required Map<String, String> hostNameByMac,
+    required Map<String, bool> isOnlineByMac,
   }) async {
     try {
       final results = await Future.wait([
@@ -64,15 +65,17 @@ class UspDhcpDataService {
       final clients = results[0] as DhcpClients;
       final reservations = results[1] as DhcpReservations;
 
-      final clientModels = clients.items
-          .map((c) => DhcpClientUIModel(
-                mac: c.chaddr,
-                ip: c.ipAddress,
-                active: c.active,
-                hostName: hostNameByMac[c.chaddr.trim().toUpperCase()] ?? '',
-                leaseExpiry: c.leaseTimeRemaining,
-              ))
-          .toList();
+      final clientModels = clients.items.map((c) {
+        final normalizedMac = c.chaddr.trim().toUpperCase();
+        return DhcpClientUIModel(
+          mac: c.chaddr,
+          ip: c.ipAddress,
+          leaseActive: c.active,
+          isOnline: isOnlineByMac[normalizedMac],
+          hostName: hostNameByMac[normalizedMac] ?? '',
+          leaseExpiry: c.leaseTimeRemaining,
+        );
+      }).toList();
 
       final reservationModels = reservations.items
           .map((r) => DhcpReservationUIModel(

--- a/test/golden_test/page/dashboard/cards/fixtures/cards_test_data.dart
+++ b/test/golden_test/page/dashboard/cards/fixtures/cards_test_data.dart
@@ -294,7 +294,7 @@ final testDevicesEmptyData = DevicesData(
 // DHCP Reservations & Clients
 // ---------------------------------------------------------------------------
 
-const testDhcpReservations = [
+final testDhcpReservations = [
   DhcpReservationUIModel(
     instancePath: 'Device.DHCPv4.Server.Pool.1.StaticAddress.1.',
     mac: 'AA:BB:CC:DD:EE:01',
@@ -319,21 +319,24 @@ final testDhcpClients = [
   DhcpClientUIModel(
     mac: 'AA:BB:CC:DD:EE:02',
     ip: '192.168.1.102',
-    active: true,
+    leaseActive: true,
+    isOnline: true,
     hostName: 'iPhone-15',
     leaseExpiry: DateTime(2024, 6, 16, 14, 30),
   ),
   DhcpClientUIModel(
     mac: 'AA:BB:CC:DD:EE:03',
     ip: '192.168.1.103',
-    active: true,
+    leaseActive: true,
+    isOnline: true,
     hostName: 'MacBook-Air',
     leaseExpiry: DateTime(2024, 6, 16, 10, 00),
   ),
   DhcpClientUIModel(
     mac: 'AA:BB:CC:DD:EE:04',
     ip: '192.168.1.104',
-    active: true,
+    leaseActive: true,
+    isOnline: true,
     hostName: 'Smart-Speaker',
     leaseExpiry: DateTime(2024, 6, 16, 8, 00),
   ),

--- a/test/golden_test/page/devices/fixtures/devices_test_data.dart
+++ b/test/golden_test/page/devices/fixtures/devices_test_data.dart
@@ -80,7 +80,7 @@ const wifiDevicePoor = DeviceUIModel(
   parentNodeName: 'Bedroom',
 );
 
-const testReservation = DhcpReservationUIModel(
+final testReservation = DhcpReservationUIModel(
   instancePath: 'Device.DHCPv4.Server.Pool.1.StaticAddress.1.',
   mac: 'AA:BB:CC:DD:EE:01',
   ip: '192.168.1.100',

--- a/test/golden_test/page/dhcp/fixtures/dhcp_test_data.dart
+++ b/test/golden_test/page/dhcp/fixtures/dhcp_test_data.dart
@@ -21,34 +21,38 @@ final testClients = [
   DhcpClientUIModel(
     mac: 'AA:BB:CC:DD:EE:01',
     ip: '192.168.1.100',
-    active: true,
+    leaseActive: true,
+    isOnline: true,
     hostName: 'iPhone-15-Pro',
     leaseExpiry: DateTime.now().add(const Duration(hours: 12)),
   ),
   DhcpClientUIModel(
     mac: 'AA:BB:CC:DD:EE:02',
     ip: '192.168.1.101',
-    active: true,
+    leaseActive: true,
+    isOnline: true,
     hostName: 'MacBook-Air',
     leaseExpiry: DateTime.now().add(const Duration(hours: 6, minutes: 30)),
   ),
   DhcpClientUIModel(
     mac: 'AA:BB:CC:DD:EE:03',
     ip: '192.168.1.102',
-    active: true,
+    leaseActive: true,
+    isOnline: true,
     hostName: 'PlayStation-5',
     leaseExpiry: DateTime.now().add(const Duration(hours: 23, minutes: 45)),
   ),
   DhcpClientUIModel(
     mac: 'AA:BB:CC:DD:EE:04',
     ip: '192.168.1.103',
-    active: false,
+    leaseActive: false,
+    isOnline: false,
     hostName: 'iPad-Mini',
     leaseExpiry: DateTime.now().subtract(const Duration(hours: 2)),
   ),
 ];
 
-const testReservations = [
+final testReservations = [
   DhcpReservationUIModel(
     instancePath: 'Device.DHCPv4.Server.Pool.1.StaticAddress.1.',
     mac: 'AA:BB:CC:DD:EE:01',
@@ -70,9 +74,10 @@ const testReservations = [
 ];
 
 DhcpReservationsFeatureState dataState({
-  List<DhcpReservationUIModel> reservations = testReservations,
+  List<DhcpReservationUIModel>? reservations,
 }) {
-  final settings = DhcpReservationList(reservations: reservations);
+  final res = reservations ?? testReservations;
+  final settings = DhcpReservationList(reservations: res);
   return DhcpReservationsFeatureState(
     settings: Preservable(original: settings, current: settings),
     status: const DhcpReservationsStatus(),
@@ -80,11 +85,11 @@ DhcpReservationsFeatureState dataState({
 }
 
 DhcpReservationsFeatureState dirtyState() {
-  final original = const DhcpReservationList(reservations: testReservations);
+  final original = DhcpReservationList(reservations: testReservations);
   final current = DhcpReservationList(
     reservations: [
       ...testReservations,
-      const DhcpReservationUIModel(
+      DhcpReservationUIModel(
         mac: 'FF:EE:DD:CC:BB:AA',
         ip: '192.168.1.160',
         enable: true,

--- a/test/page/devices/providers/device_detail_provider_test.dart
+++ b/test/page/devices/providers/device_detail_provider_test.dart
@@ -28,7 +28,7 @@ void main() {
     isWifi: false,
   );
 
-  const reservation = DhcpReservationUIModel(
+  final reservation = DhcpReservationUIModel(
     instancePath: 'Device.DHCPv4.Server.Pool.1.StaticAddress.1.',
     mac: 'AA:BB:CC:DD:EE:01',
     ip: '192.168.1.100',
@@ -39,8 +39,8 @@ void main() {
     deviceModels: [wifiDevice, ethernetDevice],
   );
 
-  const dhcpData = DhcpData(
-    clientModels: [],
+  final dhcpData = DhcpData(
+    clientModels: const [],
     reservationModels: [reservation],
   );
 

--- a/test/page/local_network/providers/dhcp_data_provider_test.dart
+++ b/test/page/local_network/providers/dhcp_data_provider_test.dart
@@ -217,13 +217,13 @@ void main() {
       container.dispose();
     });
 
-    test('DhcpData props uses lengths for equality', () async {
+    test('DhcpData props uses full lists for equality', () async {
       final container = createContainer();
       final data1 = await container.read(dhcpDataProvider.future);
       final data2 = await container.read(dhcpDataProvider.future);
 
       expect(data1, equals(data2));
-      expect(data1.props, [2, 1]); // 2 clients, 1 reservation
+      expect(data1.props, [data1.clientModels, data1.reservationModels]);
       container.dispose();
     });
 

--- a/test/page/local_network/providers/dhcp_data_provider_test.dart
+++ b/test/page/local_network/providers/dhcp_data_provider_test.dart
@@ -9,6 +9,7 @@ import 'package:privacy_gui/core/usp/providers/sse_invalidation_provider.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/core/usp/providers/usp_client_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_client.dart';
+import 'package:privacy_gui/page/_shared/models/device_ui_model.dart';
 import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
 import 'package:privacy_gui/page/local_network/providers/dhcp_data_provider.dart';
 
@@ -107,8 +108,8 @@ void main() {
       // Verify client fields
       expect(data.clientModels[0].mac, 'AA:BB:CC:DD:EE:01');
       expect(data.clientModels[0].ip, '192.168.1.101');
-      expect(data.clientModels[0].active, isTrue);
-      expect(data.clientModels[1].active, isFalse);
+      expect(data.clientModels[0].leaseActive, isTrue);
+      expect(data.clientModels[1].leaseActive, isFalse);
 
       // Verify reservation fields
       expect(data.reservationModels[0].mac, 'AA:BB:CC:DD:EE:01');
@@ -131,6 +132,55 @@ void main() {
       expect(data.clientModels[0].displayName, 'MyLaptop');
       // Client 2 has no hostname entry
       expect(data.clientModels[1].hostName, isEmpty);
+      container.dispose();
+    });
+
+    test('isOnline enrichment from devicesData deviceModels', () async {
+      final container = createContainer(
+        devicesData: const DevicesData(
+          hostNameByMac: {'AA:BB:CC:DD:EE:01': 'MyLaptop'},
+          deviceModels: [
+            DeviceUIModel(
+              mac: 'AA:BB:CC:DD:EE:01',
+              ip: '192.168.1.101',
+              hostName: 'MyLaptop',
+              isActive: true,
+              isWifi: true,
+            ),
+            DeviceUIModel(
+              mac: 'AA:BB:CC:DD:EE:02',
+              ip: '192.168.1.102',
+              hostName: '',
+              isActive: false,
+              isWifi: false,
+            ),
+          ],
+        ),
+      );
+      await container.read(devicesDataProvider.future);
+      final data = await container.read(dhcpDataProvider.future);
+
+      // Client 1: online (from Hosts.Active)
+      expect(data.clientModels[0].isOnline, isTrue);
+      // Client 2: offline (from Hosts.Active)
+      expect(data.clientModels[1].isOnline, isFalse);
+      container.dispose();
+    });
+
+    test('isOnline is null when no matching device in devicesData', () async {
+      // Empty deviceModels - no Hosts data available
+      final container = createContainer(
+        devicesData: const DevicesData(
+          hostNameByMac: {},
+          deviceModels: [],
+        ),
+      );
+      await container.read(devicesDataProvider.future);
+      final data = await container.read(dhcpDataProvider.future);
+
+      // No matching device, isOnline should be null
+      expect(data.clientModels[0].isOnline, isNull);
+      expect(data.clientModels[1].isOnline, isNull);
       container.dispose();
     });
 


### PR DESCRIPTION
## Summary
- Fix DHCP client indicator showing green for offline devices by using `Hosts.Host.Active` instead of `DHCPv4.Client.Active`
- Add `isOnline` field to `DhcpClientUIModel` for actual device connectivity status
- Dashboard DHCP card now filters to show only online clients
- DHCP Detail page shows all clients with filter chips (All / Online)
- Normalize MAC addresses to uppercase in model constructors

## Test plan
- [ ] Connect a device to router WiFi → Dashboard DHCP card shows green dot
- [ ] Disconnect the device → Dashboard card no longer shows the device
- [ ] Navigate to DHCP Detail page → device shows with gray dot
- [ ] Toggle filter chips (All / Online) works correctly
- [ ] MAC addresses display in uppercase

Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1034