### PR TITLE
fix(wifi): write both SSID.Enable and AccessPoint.Enable for network toggle

### DIFF
--- a/lib/generated/wi_fi_access_points.g.dart
+++ b/lib/generated/wi_fi_access_points.g.dart
@@ -34,12 +34,14 @@ class WiFiAccessPoint {
 /// Update descriptor for WiFiAccessPoint instances
 class WiFiAccessPointUpdate {
   final String instancePath;
+  final bool? enable;
   final String? securityModeEnabled;
   final String? keyPassphrase;
   final bool? ssidAdvertisementEnabled;
 
   const WiFiAccessPointUpdate({
     required this.instancePath,
+    this.enable,
     this.securityModeEnabled,
     this.keyPassphrase,
     this.ssidAdvertisementEnabled,
@@ -164,6 +166,9 @@ class WiFiAccessPoints {
       {bool allowPartial = false}) async {
     final params = <String, dynamic>{};
     for (final update in updates) {
+      if (update.enable != null) {
+        params['${update.instancePath}Enable'] = update.enable;
+      }
       if (update.securityModeEnabled != null) {
         params['${update.instancePath}Security.ModeEnabled'] =
             update.securityModeEnabled;

--- a/lib/page/_shared/models/wifi_radio_ui_model.dart
+++ b/lib/page/_shared/models/wifi_radio_ui_model.dart
@@ -80,15 +80,32 @@ class WifiAccessPointUIModel extends Equatable {
   final String encryptionMode;
   final bool isGuest;
 
+  /// TR-181 instance path of the AccessPoint (e.g. Device.WiFi.AccessPoint.2.).
+  /// Needed by the Dashboard per-network toggle to mutate AccessPoint.Enable.
+  final String accessPointInstancePath;
+
+  /// TR-181 instance path of the SSID this AP serves (e.g. Device.WiFi.SSID.2.).
+  /// Needed by the Dashboard per-network toggle to mutate SSID.Enable.
+  final String ssidInstancePath;
+
   const WifiAccessPointUIModel({
     required this.enable,
     required this.ssidName,
     required this.securityMode,
     required this.encryptionMode,
     this.isGuest = false,
+    this.accessPointInstancePath = '',
+    this.ssidInstancePath = '',
   });
 
   @override
-  List<Object?> get props =>
-      [enable, ssidName, securityMode, encryptionMode, isGuest];
+  List<Object?> get props => [
+        enable,
+        ssidName,
+        securityMode,
+        encryptionMode,
+        isGuest,
+        accessPointInstancePath,
+        ssidInstancePath,
+      ];
 }

--- a/lib/page/instant_setup/services/pnp_service.dart
+++ b/lib/page/instant_setup/services/pnp_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_client_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_client.dart';
@@ -305,7 +306,8 @@ class PnpService {
       final ssidUpdates = config.ssidInstancePaths
           .map((path) => WiFiSsidUpdate(instancePath: path, ssid: config.ssid))
           .toList();
-      await WiFiSsids.update(_usp, ssidUpdates);
+      final ssidResult = await WiFiSsids.update(_usp, ssidUpdates);
+      _throwIfNotSuccess(ssidResult, 'Main WiFi SSID update');
     }
 
     if (config.isPasswordChanged) {
@@ -315,7 +317,8 @@ class PnpService {
                 keyPassphrase: config.password,
               ))
           .toList();
-      await WiFiAccessPoints.update(_usp, apUpdates);
+      final apResult = await WiFiAccessPoints.update(_usp, apUpdates);
+      _throwIfNotSuccess(apResult, 'Main WiFi password update');
     }
   }
 
@@ -340,10 +343,12 @@ class PnpService {
     }
 
     if (ssidUpdates.isNotEmpty) {
-      await WiFiSsids.update(_usp, ssidUpdates);
+      final ssidResult = await WiFiSsids.update(_usp, ssidUpdates);
+      _throwIfNotSuccess(ssidResult, 'Main WiFi SSID update');
     }
     if (apUpdates.isNotEmpty) {
-      await WiFiAccessPoints.update(_usp, apUpdates);
+      final apResult = await WiFiAccessPoints.update(_usp, apUpdates);
+      _throwIfNotSuccess(apResult, 'Main WiFi password update');
     }
   }
 
@@ -357,7 +362,21 @@ class PnpService {
                 enable: config.guestEnabled,
               ))
           .toList();
-      await WiFiSsids.update(_usp, guestSsidUpdates);
+      final ssidResult = await WiFiSsids.update(_usp, guestSsidUpdates);
+      _throwIfNotSuccess(ssidResult, 'Guest WiFi SSID update');
+
+      // Mirror enable state to AccessPoint layer (#972: SSID.Enable alone
+      // does not stop the AP broadcasting on this firmware).
+      if (config.isGuestEnabledChanged) {
+        final apEnableUpdates = config.guestAccessPointInstancePaths
+            .map((path) => WiFiAccessPointUpdate(
+                  instancePath: path,
+                  enable: config.guestEnabled,
+                ))
+            .toList();
+        final apResult = await WiFiAccessPoints.update(_usp, apEnableUpdates);
+        _throwIfNotSuccess(apResult, 'Guest WiFi AP enable update');
+      }
     }
 
     // Password
@@ -368,7 +387,8 @@ class PnpService {
                 keyPassphrase: config.guestPassword,
               ))
           .toList();
-      await WiFiAccessPoints.update(_usp, guestApUpdates);
+      final apResult = await WiFiAccessPoints.update(_usp, guestApUpdates);
+      _throwIfNotSuccess(apResult, 'Guest WiFi password update');
     }
   }
 
@@ -376,6 +396,7 @@ class PnpService {
     // Collect all bands that have changes
     final ssidUpdates = <WiFiSsidUpdate>[];
     final apUpdates = <WiFiAccessPointUpdate>[];
+    final apEnableUpdates = <WiFiAccessPointUpdate>[];
 
     for (final band in config.guestBands) {
       // Always include enable state for guest bands
@@ -385,6 +406,14 @@ class PnpService {
           ssid: band.ssid,
           enable: config.guestEnabled,
         ));
+        // Mirror enable state to AccessPoint layer (#972)
+        if (config.isGuestEnabledChanged &&
+            band.accessPointInstancePath.isNotEmpty) {
+          apEnableUpdates.add(WiFiAccessPointUpdate(
+            instancePath: band.accessPointInstancePath,
+            enable: config.guestEnabled,
+          ));
+        }
       }
       if (band.isPasswordChanged && band.accessPointInstancePath.isNotEmpty) {
         apUpdates.add(WiFiAccessPointUpdate(
@@ -401,14 +430,29 @@ class PnpService {
           instancePath: band.ssidInstancePath,
           enable: config.guestEnabled,
         ));
+        // Mirror enable state to AccessPoint layer (#972)
+        if (band.accessPointInstancePath.isNotEmpty) {
+          apEnableUpdates.add(WiFiAccessPointUpdate(
+            instancePath: band.accessPointInstancePath,
+            enable: config.guestEnabled,
+          ));
+        }
       }
     }
 
     if (ssidUpdates.isNotEmpty) {
-      await WiFiSsids.update(_usp, ssidUpdates);
+      final ssidResult = await WiFiSsids.update(_usp, ssidUpdates);
+      _throwIfNotSuccess(ssidResult, 'Guest WiFi SSID update');
+    }
+    // Write AP enable state before password updates (enable first, then configure)
+    if (apEnableUpdates.isNotEmpty) {
+      final apEnableResult =
+          await WiFiAccessPoints.update(_usp, apEnableUpdates);
+      _throwIfNotSuccess(apEnableResult, 'Guest WiFi AP enable update');
     }
     if (apUpdates.isNotEmpty) {
-      await WiFiAccessPoints.update(_usp, apUpdates);
+      final apResult = await WiFiAccessPoints.update(_usp, apUpdates);
+      _throwIfNotSuccess(apResult, 'Guest WiFi password update');
     }
   }
 
@@ -528,6 +572,27 @@ class PnpService {
       return info.serialNumber;
     } catch (e) {
       throw mapUspErrorToServiceError(e);
+    }
+  }
+
+  /// Throws [UspPartialFailureError] or [UspCompleteFailureError] if [result]
+  /// is not a complete success. [label] prefixes the error summary.
+  void _throwIfNotSuccess(Map<String, dynamic> result, String label) {
+    final parsed = UspResultParser.parseSetResult(result);
+    switch (parsed) {
+      case UspSuccess():
+        return;
+      case UspPartialSuccess(failures: final f):
+        throw UspPartialFailureError(
+          summary: '$label partial failure: ${f.first.errorMessage}',
+          successPaths: [],
+          failures: f,
+        );
+      case UspFailure(errors: final e):
+        throw UspCompleteFailureError(
+          summary: '$label failed: ${e.first.errorMessage}',
+          failures: e,
+        );
     }
   }
 }

--- a/lib/page/wifi_settings/cards/usp_wifi_status_card.dart
+++ b/lib/page/wifi_settings/cards/usp_wifi_status_card.dart
@@ -58,20 +58,6 @@ class UspWifiStatusCard extends ConsumerWidget {
               UspStatusDot(isActive: radio.enable),
               AppGap.sm(),
               AppText.labelLarge(loc(context).radioBand(radio.band)),
-              const Spacer(),
-              AppSwitch(
-                value: radio.enable,
-                onChanged: isLoading
-                    ? null
-                    : (value) => performUspMutation(
-                          context,
-                          ref,
-                          loadingKey: 'wifi',
-                          mutation: () => ref
-                              .read(uspWifiSettingsProvider.notifier)
-                              .toggleRadio(radio.instancePath, value),
-                        ),
-              ),
             ],
           ),
           AppGap.sm(),

--- a/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
+++ b/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
@@ -325,19 +325,6 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
   // Dashboard quick actions — delegate to Service, then invalidate L1
   // ---------------------------------------------------------------------------
 
-  /// Toggles a WiFi radio on/off. Called from Dashboard card.
-  Future<void> toggleRadio(String instancePath, bool enable) async {
-    try {
-      await ref.read(uspMutationLockProvider).withLock(() async {
-        await _svc.toggleRadio(instancePath, enable);
-      });
-    } on ServiceError catch (e) {
-      logger.e('[USP][WiFi]: Toggle radio failed', error: e);
-      rethrow;
-    }
-    ref.invalidate(wifiDataProvider);
-  }
-
   /// Updates a WiFi radio's channel. Called from Dashboard card.
   Future<void> updateRadioChannel(
     String instancePath, {
@@ -364,10 +351,11 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
   Future<void> toggleSsidsByName(String ssidName, bool enable) async {
     final wifiData = await ref.read(wifiDataProvider.future);
     final ssids = wifiData.codegenContext.raw.ssids;
+    final accessPoints = wifiData.codegenContext.raw.accessPoints;
 
     try {
       final count = await ref.read(uspMutationLockProvider).withLock(() async {
-        return _svc.toggleSsidsByName(ssids, ssidName, enable);
+        return _svc.toggleSsidsByName(ssids, accessPoints, ssidName, enable);
       });
       if (count == 0) {
         logger.w('[USP][WiFi]: No SSIDs found matching the requested name');

--- a/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
+++ b/lib/page/wifi_settings/providers/usp_wifi_settings_provider.dart
@@ -175,26 +175,30 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
 
   @override
   Future<void> performSave() async {
-    await ref.read(uspMutationLockProvider).withLock(() async {
-      final current = state.settings.current;
-      if (current.quickSetupEnabled) {
-        await _svc.saveQuickSetup(
-          original: state.settings.original,
-          current: current,
-          status: state.status,
-        );
-      } else {
-        await _svc.saveAdvanced(
-          original: state.settings.original.networks,
-          current: current.networks,
-        );
-      }
-    });
-    // Refresh Layer 1 cache so post-save fetch() reads fresh data.
-    // Using refresh() instead of invalidate() because the latter only marks
-    // the provider dirty — without an active subscriber it won't rebuild,
-    // and the subsequent .future call would return stale data.
-    final _ = await ref.refresh(wifiDataProvider.future);
+    try {
+      await ref.read(uspMutationLockProvider).withLock(() async {
+        final current = state.settings.current;
+        if (current.quickSetupEnabled) {
+          await _svc.saveQuickSetup(
+            original: state.settings.original,
+            current: current,
+            status: state.status,
+          );
+        } else {
+          await _svc.saveAdvanced(
+            original: state.settings.original.networks,
+            current: current.networks,
+          );
+        }
+      });
+    } finally {
+      // Refresh Layer 1 cache so post-save fetch() reads fresh data.
+      // Using refresh() instead of invalidate() because the latter only marks
+      // the provider dirty — without an active subscriber it won't rebuild,
+      // and the subsequent .future call would return stale data.
+      // Wrapped in finally to ensure UI stays in sync even on partial failure.
+      final _ = await ref.refresh(wifiDataProvider.future);
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -342,20 +346,24 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
     } on ServiceError catch (e) {
       logger.e('[USP][WiFi]: Update radio channel failed', error: e);
       rethrow;
+    } finally {
+      ref.invalidate(wifiDataProvider);
     }
-    ref.invalidate(wifiDataProvider);
   }
 
   /// Toggles all SSIDs with a given name on/off across all bands.
   /// Called from Dashboard WiFi Networks card.
   Future<void> toggleSsidsByName(String ssidName, bool enable) async {
-    final wifiData = await ref.read(wifiDataProvider.future);
-    final ssids = wifiData.codegenContext.raw.ssids;
-    final accessPoints = wifiData.codegenContext.raw.accessPoints;
-
     try {
       final count = await ref.read(uspMutationLockProvider).withLock(() async {
-        return _svc.toggleSsidsByName(ssids, accessPoints, ssidName, enable);
+        // Read wifiData inside lock to avoid TOCTOU race with concurrent mutations
+        final wifiData = await ref.read(wifiDataProvider.future);
+        return _svc.toggleSsidsByName(
+          wifiData.codegenContext.raw.ssids,
+          wifiData.codegenContext.raw.accessPoints,
+          ssidName,
+          enable,
+        );
       });
       if (count == 0) {
         logger.w('[USP][WiFi]: No SSIDs found matching the requested name');
@@ -366,8 +374,9 @@ class UspWifiSettingsNotifier extends AutoDisposeNotifier<UspWifiSettingsState>
     } on ServiceError catch (e) {
       logger.e('[USP][WiFi]: Toggle SSIDs by name failed', error: e);
       rethrow;
+    } finally {
+      ref.invalidate(wifiDataProvider);
     }
-    ref.invalidate(wifiDataProvider);
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/page/wifi_settings/services/usp_wifi_data_service.dart
+++ b/lib/page/wifi_settings/services/usp_wifi_data_service.dart
@@ -193,13 +193,17 @@ class UspWifiDataService {
       final apModels = radioAps.map((a) {
         final isGuest =
             guestSsidPaths.contains(_ensureTrailingDot(a.ssid.instancePath));
-        // Use SSID.enable as the canonical enabled state (matches toggle mutation)
+        // Per-network enabled state = SSID.Enable. The Dashboard toggle mutates
+        // both SSID.Enable and AccessPoint.Enable together, so either would do;
+        // we read SSID.Enable as the single source of truth for the UI.
         return WifiAccessPointUIModel(
           enable: a.ssid.enable,
           ssidName: a.ssid.ssid.isNotEmpty ? a.ssid.ssid : a.ap.ssidReference,
           securityMode: a.ap.securityModeEnabled,
           encryptionMode: a.ap.encryptionMode,
           isGuest: isGuest,
+          accessPointInstancePath: a.ap.instancePath,
+          ssidInstancePath: a.ssid.instancePath,
         );
       }).toList();
       return WifiRadioUIModel(

--- a/lib/page/wifi_settings/services/usp_wifi_settings_service.dart
+++ b/lib/page/wifi_settings/services/usp_wifi_settings_service.dart
@@ -274,13 +274,16 @@ class UspWifiSettingsService {
           }
         }
 
-        // ── AP layer — only when password or securityMode changed ──────────
+        // ── AP layer — when password, securityMode, or enabled changed ─────
+        // enabled is mirrored onto AccessPoint.Enable alongside SSID.Enable
+        // because SSID.Enable alone does not stop broadcasting on this
+        // firmware (see #972).
         final passwordChanged =
             orig == null || orig.password != pending.password;
         final modeChanged =
             orig == null || orig.securityMode != pending.securityMode;
         if (aggregate.apInstancePaths.isNotEmpty &&
-            (passwordChanged || modeChanged)) {
+            (passwordChanged || modeChanged || enabledChanged)) {
           // Build a band lookup: AP instance path → band string.
           // Used to apply the 6 GHz security override (Wi-Fi 6E mandates WPA3).
           final bandByApPath = <String, String>{
@@ -289,6 +292,11 @@ class UspWifiSettingsService {
                 n.accessPointInstancePath!: n.band,
           };
 
+          // Whether the security layer (mode + passphrase) needs writing.
+          // When only `enabled` changed we mirror AccessPoint.Enable without
+          // re-sending security params, so an enable toggle never mutates the
+          // security mode (e.g. the 6 GHz WPA3 override).
+          final securityChanged = passwordChanged || modeChanged;
           for (final p in aggregate.apInstancePaths) {
             final band = bandByApPath[p] ?? '';
             final securityMode = _securityModeFor6GHz(
@@ -300,11 +308,13 @@ class UspWifiSettingsService {
               [
                 WiFiAccessPointUpdate(
                   instancePath: p,
+                  enable: enabledChanged ? pending.enabled : null,
                   // Omit an empty passphrase (e.g. when only securityMode
                   // changed to an open mode) so firmware does not reject it.
-                  keyPassphrase:
-                      pending.password.isNotEmpty ? pending.password : null,
-                  securityModeEnabled: securityMode,
+                  keyPassphrase: securityChanged && pending.password.isNotEmpty
+                      ? pending.password
+                      : null,
+                  securityModeEnabled: securityChanged ? securityMode : null,
                 )
               ],
             );
@@ -385,23 +395,37 @@ class UspWifiSettingsService {
         }
 
         // ── AccessPoint layer ───────────────────────────────────────────────
+        // Mirror the enabled flag onto AccessPoint.Enable alongside SSID.Enable:
+        // on this firmware SSID.Enable alone does not stop the AP broadcasting,
+        // so the enable state must be written to both layers (see #972).
+        //
+        // Each field is gated on its own diff so a pure enable toggle sends
+        // only AccessPoint.Enable and never re-writes the security mode or the
+        // advertisement flag (mirrors saveQuickSetup's AP gating).
         final ap = curr.accessPointInstancePath;
+        final enabledChanged = orig == null || orig.enabled != curr.enabled;
+        final securityChanged = orig == null ||
+            orig.keyPassphrase != curr.keyPassphrase ||
+            orig.securityMode != curr.securityMode;
+        final broadcastChanged = orig == null ||
+            orig.ssidAdvertisementEnabled != curr.ssidAdvertisementEnabled;
         if (ap != null &&
-            (orig == null ||
-                orig.keyPassphrase != curr.keyPassphrase ||
-                orig.securityMode != curr.securityMode ||
-                orig.ssidAdvertisementEnabled !=
-                    curr.ssidAdvertisementEnabled)) {
+            (enabledChanged || securityChanged || broadcastChanged)) {
           final result = await WiFiAccessPoints.update(
             _usp,
             [
               WiFiAccessPointUpdate(
                 instancePath: ap,
-                keyPassphrase:
-                    curr.keyPassphrase.isNotEmpty ? curr.keyPassphrase : null,
+                enable: enabledChanged ? curr.enabled : null,
+                keyPassphrase: securityChanged && curr.keyPassphrase.isNotEmpty
+                    ? curr.keyPassphrase
+                    : null,
                 securityModeEnabled:
-                    curr.securityMode.isNotEmpty ? curr.securityMode : null,
-                ssidAdvertisementEnabled: curr.ssidAdvertisementEnabled,
+                    securityChanged && curr.securityMode.isNotEmpty
+                        ? curr.securityMode
+                        : null,
+                ssidAdvertisementEnabled:
+                    broadcastChanged ? curr.ssidAdvertisementEnabled : null,
               )
             ],
           );
@@ -477,35 +501,6 @@ class UspWifiSettingsService {
   // Mutations — WiFi Radio quick actions (from Dashboard cards)
   // ---------------------------------------------------------------------------
 
-  /// Toggles a WiFi radio on or off.
-  Future<void> toggleRadio(String instancePath, bool enable) async {
-    try {
-      final result = await WiFiRadios.update(
-        _usp,
-        [WiFiRadioUpdate(instancePath: instancePath, enable: enable)],
-      );
-      final parsed = UspResultParser.parseSetResult(result);
-      switch (parsed) {
-        case UspSuccess():
-          break;
-        case UspPartialSuccess(failures: final f):
-          throw UspPartialFailureError(
-            summary: 'Toggle radio partial failure: ${f.first.errorMessage}',
-            successPaths: [],
-            failures: f,
-          );
-        case UspFailure(errors: final e):
-          throw UspCompleteFailureError(
-            summary: 'Toggle radio failed: ${e.first.errorMessage}',
-            failures: e,
-          );
-      }
-    } catch (e) {
-      if (e is ServiceError) rethrow;
-      throw mapUspErrorToServiceError(e);
-    }
-  }
-
   /// Updates a WiFi radio's channel and auto-channel setting.
   Future<void> updateRadioChannel(
     String instancePath, {
@@ -546,46 +541,76 @@ class UspWifiSettingsService {
     }
   }
 
-  /// Toggles all SSIDs with a given name on or off across all bands.
+  /// Toggles all networks with a given SSID name on or off across all bands.
   ///
-  /// Finds all SSID instances matching [ssidName] from [ssids] and toggles them.
+  /// Finds all SSID instances matching [ssidName] and toggles both their
+  /// SSID.Enable and the matching AccessPoint.Enable. Writing both layers is
+  /// required because SSID.Enable alone does not stop the AP broadcasting on
+  /// this firmware (see #972). The AccessPoint match is resolved via
+  /// AccessPoint.SSIDReference → SSID.instancePath.
+  ///
   /// Returns the number of SSIDs toggled.
   Future<int> toggleSsidsByName(
     WiFiSsids ssids,
+    WiFiAccessPoints accessPoints,
     String ssidName,
     bool enable,
   ) async {
-    final instancePaths = ssids.items
+    final ssidPaths = ssids.items
         .where((s) => s.ssid == ssidName)
         .map((s) => s.instancePath)
         .toList();
 
-    if (instancePaths.isEmpty) return 0;
+    if (ssidPaths.isEmpty) return 0;
+
+    // Resolve AccessPoint paths whose SSIDReference points at a matched SSID.
+    final matchedSsidPathSet = ssidPaths.map(_ensureTrailingDot).toSet();
+    final apPaths = accessPoints.items
+        .where((ap) =>
+            matchedSsidPathSet.contains(_ensureTrailingDot(ap.ssidReference)))
+        .map((ap) => ap.instancePath)
+        .toList();
 
     try {
-      final updates = instancePaths
+      final ssidUpdates = ssidPaths
           .map((p) => WiFiSsidUpdate(instancePath: p, enable: enable))
           .toList();
-      final result = await WiFiSsids.update(_usp, updates);
-      final parsed = UspResultParser.parseSetResult(result);
-      switch (parsed) {
-        case UspSuccess():
-          return instancePaths.length;
-        case UspPartialSuccess(failures: final f):
-          throw UspPartialFailureError(
-            summary: 'Toggle SSIDs partial failure: ${f.first.errorMessage}',
-            successPaths: [],
-            failures: f,
-          );
-        case UspFailure(errors: final e):
-          throw UspCompleteFailureError(
-            summary: 'Toggle SSIDs failed: ${e.first.errorMessage}',
-            failures: e,
-          );
+      final ssidResult = await WiFiSsids.update(_usp, ssidUpdates);
+      _throwIfNotSuccess(ssidResult, 'Toggle SSIDs');
+
+      if (apPaths.isNotEmpty) {
+        final apUpdates = apPaths
+            .map((p) => WiFiAccessPointUpdate(instancePath: p, enable: enable))
+            .toList();
+        final apResult = await WiFiAccessPoints.update(_usp, apUpdates);
+        _throwIfNotSuccess(apResult, 'Toggle AccessPoints');
       }
+
+      return ssidPaths.length;
     } catch (e) {
       if (e is ServiceError) rethrow;
       throw mapUspErrorToServiceError(e);
+    }
+  }
+
+  /// Parses a USP Set result and throws the appropriate [ServiceError] when it
+  /// is not a complete success. [label] prefixes the error summary.
+  void _throwIfNotSuccess(Map<String, dynamic> result, String label) {
+    final parsed = UspResultParser.parseSetResult(result);
+    switch (parsed) {
+      case UspSuccess():
+        return;
+      case UspPartialSuccess(failures: final f):
+        throw UspPartialFailureError(
+          summary: '$label partial failure: ${f.first.errorMessage}',
+          successPaths: [],
+          failures: f,
+        );
+      case UspFailure(errors: final e):
+        throw UspCompleteFailureError(
+          summary: '$label failed: ${e.first.errorMessage}',
+          failures: e,
+        );
     }
   }
 

--- a/test/page/wifi_settings/providers/usp_wifi_settings_notifier_test.dart
+++ b/test/page/wifi_settings/providers/usp_wifi_settings_notifier_test.dart
@@ -593,8 +593,9 @@ void main() {
       final notifier = container.read(uspWifiSettingsProvider.notifier);
       notifier.updateNetworkField('Device.WiFi.SSID.1.', ssid: 'Changed');
 
-      expect(
-        () => notifier.save(),
+      // Use await + expectLater so the finally block completes before dispose
+      await expectLater(
+        notifier.save(),
         throwsA(isA<NetworkError>()),
       );
       container.dispose();

--- a/test/page/wifi_settings/services/usp_wifi_settings_service_test.dart
+++ b/test/page/wifi_settings/services/usp_wifi_settings_service_test.dart
@@ -774,10 +774,10 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  // toggleRadio
+  // toggleSsidsByName — writes SSID.Enable + matched AccessPoint.Enable (#972)
   // -------------------------------------------------------------------------
 
-  group('toggleRadio', () {
+  group('toggleSsidsByName', () {
     late MockUspClient mockUsp;
     late UspWifiSettingsService writeSvc;
 
@@ -786,34 +786,79 @@ void main() {
       writeSvc = UspWifiSettingsService(mockUsp);
     });
 
-    test('succeeds on UspSuccess', () async {
+    WiFiSsid ssid(String path, String name, String radio) => WiFiSsid(
+          instancePath: path,
+          ssid: name,
+          enable: true,
+          status: 'Up',
+          bssid: '',
+          lowerLayers: radio,
+        );
+    WiFiAccessPoint ap(String path, String ssidRef) => WiFiAccessPoint(
+          instancePath: path,
+          alias: '',
+          enable: true,
+          status: 'Up',
+          modesSupported: '',
+          securityModeEnabled: '',
+          encryptionMode: '',
+          keyPassphrase: '',
+          ssidAdvertisementEnabled: true,
+          ssidReference: ssidRef,
+        );
+
+    Set<String> capturedKeys() {
+      final captured = verify(() => mockUsp.set(captureAny(),
+          allowPartial: any(named: 'allowPartial'))).captured;
+      final keys = <String>{};
+      for (final arg in captured) {
+        if (arg is Map) keys.addAll(arg.keys.cast<String>());
+      }
+      return keys;
+    }
+
+    test('toggles matched SSIDs and their AccessPoints across bands', () async {
       when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
           .thenAnswer((_) async => uspSuccess());
 
-      await writeSvc.toggleRadio('Device.WiFi.Radio.1.', true);
+      final ssids = WiFiSsids(items: [
+        ssid('Device.WiFi.SSID.1.', 'Home', 'Device.WiFi.Radio.1.'),
+        ssid('Device.WiFi.SSID.2.', 'Home', 'Device.WiFi.Radio.2.'),
+        ssid('Device.WiFi.SSID.3.', 'Home-Guest', 'Device.WiFi.Radio.1.'),
+      ]);
+      final aps = WiFiAccessPoints(items: [
+        ap('Device.WiFi.AccessPoint.1.', 'Device.WiFi.SSID.1.'),
+        ap('Device.WiFi.AccessPoint.2.', 'Device.WiFi.SSID.2.'),
+        ap('Device.WiFi.AccessPoint.3.', 'Device.WiFi.SSID.3.'),
+      ]);
 
-      verify(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
-          .called(1);
+      final count = await writeSvc.toggleSsidsByName(ssids, aps, 'Home', false);
+
+      expect(count, 2); // SSID.1 + SSID.2 (both named "Home")
+      final keys = capturedKeys();
+      expect(keys, contains('Device.WiFi.SSID.1.Enable'));
+      expect(keys, contains('Device.WiFi.SSID.2.Enable'));
+      expect(keys, contains('Device.WiFi.AccessPoint.1.Enable'));
+      expect(keys, contains('Device.WiFi.AccessPoint.2.Enable'));
+      // The guest network (SSID.3) must be untouched.
+      expect(keys, isNot(contains('Device.WiFi.SSID.3.Enable')));
+      expect(keys, isNot(contains('Device.WiFi.AccessPoint.3.Enable')));
     });
 
-    test('throws UspCompleteFailureError on UspFailure', () async {
-      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
-          .thenAnswer((_) async => uspFailure());
+    test('returns 0 and issues no writes when no SSID matches', () async {
+      final ssids = WiFiSsids(items: [
+        ssid('Device.WiFi.SSID.1.', 'Home', 'Device.WiFi.Radio.1.'),
+      ]);
+      final aps = WiFiAccessPoints(items: [
+        ap('Device.WiFi.AccessPoint.1.', 'Device.WiFi.SSID.1.'),
+      ]);
 
-      expect(
-        () => writeSvc.toggleRadio('Device.WiFi.Radio.1.', true),
-        throwsA(isA<UspCompleteFailureError>()),
-      );
-    });
+      final count =
+          await writeSvc.toggleSsidsByName(ssids, aps, 'Nonexistent', false);
 
-    test('maps transport error to ServiceError', () async {
-      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
-          .thenThrow('Set failed: Transport error: HTTP error: HTTP 504');
-
-      expect(
-        () => writeSvc.toggleRadio('Device.WiFi.Radio.1.', true),
-        throwsA(isA<NetworkError>()),
-      );
+      expect(count, 0);
+      verifyNever(
+          () => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')));
     });
   });
 
@@ -939,6 +984,37 @@ void main() {
       verifyNever(
           () => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')));
     });
+
+    test('enable-only toggle writes SSID.Enable + AP.Enable, not security',
+        () async {
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => uspSuccess());
+
+      final original = [makeNetwork(enabled: true)];
+      final current = [makeNetwork(enabled: false)];
+
+      await writeSvc.saveAdvanced(original: original, current: current);
+
+      final captured = verify(() => mockUsp.set(captureAny(),
+          allowPartial: any(named: 'allowPartial'))).captured;
+      final keys = <String>{};
+      for (final arg in captured) {
+        if (arg is Map) keys.addAll(arg.keys.cast<String>());
+      }
+      // Both enable layers are written…
+      expect(keys, contains('Device.WiFi.SSID.1.Enable'));
+      expect(keys, contains('Device.WiFi.AccessPoint.1.Enable'));
+      // …but the security/advertisement params are NOT re-sent on a pure
+      // enable toggle (mirrors saveQuickSetup gating).
+      expect(keys,
+          isNot(contains('Device.WiFi.AccessPoint.1.Security.KeyPassphrase')));
+      expect(keys,
+          isNot(contains('Device.WiFi.AccessPoint.1.Security.ModeEnabled')));
+      expect(
+          keys,
+          isNot(
+              contains('Device.WiFi.AccessPoint.1.SSIDAdvertisementEnabled')));
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -993,7 +1069,8 @@ void main() {
       return keys;
     }
 
-    test('skips AP write when only guest enabled toggled', () async {
+    test('writes AP.Enable but not Security when only enabled toggled',
+        () async {
       // Guest group: only `enabled` changed. No SSID-name change, no AP change.
       final guestAgg = WifiQuickSetupNetwork(
         isGuest: true,
@@ -1038,7 +1115,10 @@ void main() {
       final keys = capturedKeys();
       // SSID enable write happens…
       expect(keys, contains('Device.WiFi.SSID.3.Enable'));
-      // …but AP layer (KeyPassphrase / Security.ModeEnabled) must NOT be touched.
+      // …and AP.Enable is mirrored so the AP actually stops broadcasting (#972)…
+      expect(keys, contains('Device.WiFi.AccessPoint.3.Enable'));
+      // …but the AP security layer (KeyPassphrase / Security.*) must NOT be
+      // touched when only the enabled flag changed.
       expect(
         keys.any((k) => k.startsWith('Device.WiFi.AccessPoint.3.Security.')),
         isFalse,


### PR DESCRIPTION
## Summary

- Fix WiFi Settings page showing inconsistent enabled state compared to Dashboard (#971)
- Fix WiFi Settings toggle not actually stopping WiFi broadcasting (#972)

## Root Cause

The WiFi Settings page only wrote `SSID.Enable` when toggling networks, while Dashboard wrote `Radio.Enable`. According to TR-181 spec:

- `Radio.Enable` — controls physical RF hardware (affects all SSIDs on that radio)
- `SSID.Enable` — controls the logical BSS interface
- `AccessPoint.Enable` — controls the AP service (beacon broadcasting)

Writing only `SSID.Enable=false` left `AccessPoint.Enable=true`, so the AP continued broadcasting.

## Solution

All WiFi control points now write **both** `SSID.Enable` and `AccessPoint.Enable` together:

| Location | Method | Behavior |
|----------|--------|----------|
| Dashboard WiFi Networks | `toggleSsidsByName` | Toggle all SSIDs with matching name across bands |
| WiFi Settings Quick Setup | `saveQuickSetup` | Toggle all main/guest networks |
| WiFi Settings Advanced | `saveAdvanced` | Toggle individual network per band |
| PnP Guest WiFi | `_saveGuestWifi*` | Toggle guest networks during setup |

Additional changes:
- Remove radio-level toggle from Dashboard WiFi Status card (now read-only status display)
- Add `writable: true` to `AccessPoint.Enable` in usp-codegen YAML (separate PR in usp_framework)
- Add error handling with `_throwIfNotSuccess` in PnP service
- Remove dead code: `toggleNetwork` method (replaced by `toggleSsidsByName`)

## Verification

Tested on real hardware with firmware. All scenarios confirmed working:

| Test | Action | Result |
|------|--------|--------|
| 1 | Dashboard enable Guest WiFi | SSID.Enable=true, AP.Enable=true, Status=Up/Enabled |
| 2 | Quick Setup disable Guest WiFi | SSID.Enable=false, AP.Enable=false, Status=Down/Disabled |
| 3 | Advanced enable 5G Guest only | SSID.4.Enable=true, AP.4.Enable=true |
| 4 | Advanced rename + disable Broadcast | SSIDAdvertisementEnabled=0 |
| 5 | Advanced disable 5G Guest | SSID.4.Enable=false, AP.4.Enable=false, Status=Down/Disabled |

WiFi scanner confirmed: SSID disappears from scan results when disabled.

## Dependencies

- Requires usp_framework PR: HankYuLinksys/usp_framework (adds `writable: true` to AccessPoint.Enable)

## Test Plan

- [ ] Verify Dashboard WiFi Networks card can toggle guest WiFi on/off
- [ ] Verify WiFi Settings Quick Setup can disable all guest networks
- [ ] Verify WiFi Settings Advanced can toggle individual band's guest network
- [ ] Verify PnP flow can enable/disable guest WiFi
- [ ] Verify WiFi scanner shows SSID disappearing when disabled

Closes #971, Closes #972
