### PR TITLE
fix: Auto Master race condition in ISP Settings flow

### DIFF
--- a/lib/page/instant_setup/pnp_setup_view.dart
+++ b/lib/page/instant_setup/pnp_setup_view.dart
@@ -869,7 +869,7 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
         logger.w(
             '[PnP]: Caught unauthorized error during save - Auto Master may have completed');
         if (mounted) {
-          context.goNamed(RouteNamed.localLoginPassword);
+          context.goNamed(RouteNamed.pnp);
         }
         return;
       }
@@ -963,18 +963,17 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
   }
 
   Future<void> testConnection(
-      {required void Function() success, void Function()? failed}) {
+      {required FutureOr<void> Function() success,
+      void Function()? failed}) async {
     // Check router connected propor, then go to dashboard
-    return ref
-        .read(pnpProvider.notifier)
-        .testConnectionReconnected()
-        .then((value) {
-      success.call();
-    }).onError((error, stackTrace) {
+    try {
+      await ref.read(pnpProvider.notifier).testConnectionReconnected();
+      await success.call();
+    } catch (error) {
       logger.e('[PnP]: Cannot detect the expected WiFi connected!');
       showSimpleSnackBar(context, loc(context).pnpReconnectWiFi);
       failed?.call();
-    });
+    }
   }
 
   void _retryAutoMasterSave() {

--- a/lib/page/instant_setup/pnp_setup_view.dart
+++ b/lib/page/instant_setup/pnp_setup_view.dart
@@ -680,6 +680,7 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
                             logger.w(
                                 '[PnP]: WiFi settings mismatch - expected: $expectedSSIDs, current: $currentSSIDs. Re-saving...');
                             _wifiVerificationRetried = true;
+                            if (!mounted) return;
                             await _saveChanges();
                             return;
                           }
@@ -883,6 +884,7 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
       final errorMsg = innerError?.toString() ?? loc(context).generalError;
       showSimpleSnackBar(context, 'Unexpected error! <$errorMsg>');
     }, test: (error) => error is ExceptionSavingChanges).whenComplete(() async {
+      if (!mounted) return;
       // Use showYourNetwork logic to handle both Unconfigured and AutoParent scenarios
       final showYourNetwork = isUnconfigured || !_isPrePaired;
       logger.d(

--- a/lib/page/instant_setup/pnp_setup_view.dart
+++ b/lib/page/instant_setup/pnp_setup_view.dart
@@ -3,10 +3,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' as service;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/constants/error_code.dart';
 import 'package:privacy_gui/core/jnap/actions/better_action.dart';
+import 'package:privacy_gui/core/jnap/result/jnap_result.dart';
 import 'package:privacy_gui/core/jnap/actions/jnap_service_supported.dart';
 import 'package:privacy_gui/core/jnap/models/auto_configuration_settings.dart';
 import 'package:privacy_gui/core/jnap/models/auto_master_status.dart';
+import 'package:privacy_gui/core/jnap/command/base_command.dart';
+import 'package:privacy_gui/core/jnap/models/radio_info.dart';
+import 'package:privacy_gui/core/jnap/router_repository.dart';
 import 'package:privacy_gui/core/jnap/providers/firmware_update_provider.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
@@ -70,6 +75,7 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
   bool _forceLogin = false;
   bool _fetchError = false;
   bool _showAutoMasterConnectionError = false;
+  bool _wifiVerificationRetried = false; // Prevent infinite loop in WiFi verification
   PnpStep? _currentStep;
   ({void Function() stepCancel, void Function() stepContinue})? _stepController;
 
@@ -616,6 +622,76 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
                     final showYourNetwork = _isUnconfigured || !_isPrePaired;
                     logger.i(
                         '[PnP]: The customized WiFi has been reconnected - isUnconfigured=$_isUnconfigured, isPrePaired=$_isPrePaired, showYourNetwork=$showYourNetwork');
+
+                    // Verify WiFi settings were applied correctly (only retry once)
+                    if (!_wifiVerificationRetried) {
+                      final wifiData = ref
+                              .read(pnpProvider)
+                              .stepStateList[PersonalWiFiStep.id]
+                              ?.data ??
+                          {};
+                      final isSplitMode =
+                          wifiData['isSplitMode'] as bool? ?? false;
+
+                      // Collect expected SSIDs (support split mode)
+                      Set<String> expectedSSIDs = {};
+                      if (isSplitMode) {
+                        final perBandSettings = wifiData['perBandSettings']
+                                as Map<String, dynamic>? ??
+                            {};
+                        for (final entry in perBandSettings.entries) {
+                          final value =
+                              entry.value as Map<String, dynamic>? ?? {};
+                          final ssid = value['ssid'] as String?;
+                          if (ssid != null && ssid.isNotEmpty) {
+                            expectedSSIDs.add(ssid);
+                          }
+                        }
+                      } else {
+                        final ssid = wifiData['ssid'] as String?;
+                        if (ssid != null && ssid.isNotEmpty) {
+                          expectedSSIDs.add(ssid);
+                        }
+                      }
+
+                      // Only verify if user has set SSID
+                      if (expectedSSIDs.isNotEmpty) {
+                        try {
+                          // Fetch current WiFi settings from router
+                          final radioInfoResult = await ref
+                              .read(routerRepositoryProvider)
+                              .send(
+                                JNAPAction.getRadioInfo,
+                                auth: true,
+                                fetchRemote: true,
+                                cacheLevel: CacheLevel.noCache,
+                              );
+                          final radioInfo =
+                              GetRadioInfo.fromMap(radioInfoResult.output);
+                          final currentSSIDs = radioInfo.radios
+                              .map((r) => r.settings.ssid)
+                              .toSet();
+
+                          // Check if any expected SSID matches current settings
+                          final hasMatch = expectedSSIDs
+                              .any((ssid) => currentSSIDs.contains(ssid));
+
+                          if (!hasMatch) {
+                            logger.w(
+                                '[PnP]: WiFi settings mismatch - expected: $expectedSSIDs, current: $currentSSIDs. Re-saving...');
+                            _wifiVerificationRetried = true;
+                            await _saveChanges();
+                            return;
+                          }
+                          logger.d('[PnP]: WiFi settings verified - SSID matches');
+                        } catch (e) {
+                          // API call failed, log warning but continue flow
+                          logger.w(
+                              '[PnP]: Failed to verify WiFi settings: $e. Continuing...');
+                        }
+                      }
+                    }
+
                     final password = ref
                         .read(pnpProvider.notifier)
                         .getDefaultWiFiSettings()
@@ -785,12 +861,27 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
       });
       // }
     }, test: (error) => error is ExceptionNeedToReconnect).catchError((error) {
+      final innerError = error is ExceptionSavingChanges ? error.error : error;
+
+      // Check if this is an Unauthorized error (Auto Master completed during save)
+      if (innerError is JNAPError &&
+          innerError.result == errorJNAPUnauthorized) {
+        logger.w(
+            '[PnP]: Caught unauthorized error during save - Auto Master may have completed');
+        if (mounted) {
+          context.goNamed(RouteNamed.localLoginPassword);
+        }
+        return;
+      }
+
+      // Original error handling
+      if (!mounted) return;
       setState(() {
         logger.e('[PnP]: Caught a saving error: $error. Setup step = config');
         _setupStep = _PnpSetupStep.config;
       });
-      final err = error is ExceptionSavingChanges ? error.error : error;
-      showSimpleSnackBar(context, 'Unexceped error! <$err}>');
+      final errorMsg = innerError?.toString() ?? loc(context).generalError;
+      showSimpleSnackBar(context, 'Unexpected error! <$errorMsg>');
     }, test: (error) => error is ExceptionSavingChanges).whenComplete(() async {
       // Use showYourNetwork logic to handle both Unconfigured and AutoParent scenarios
       final showYourNetwork = isUnconfigured || !_isPrePaired;

--- a/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
+++ b/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
@@ -244,7 +244,10 @@ class _PnpIspSaveSettingsViewState
       return PnpAutoMasterWaitingView(
         showConnectionError: _showAutoMasterConnectionError,
         onRetry: () {
-          setState(() => _showAutoMasterConnectionError = false);
+          setState(() {
+            _showAutoMasterConnectionError = false;
+            _waitingForAutoMaster = false;
+          });
           _saveNewSettings();
         },
       );

--- a/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
+++ b/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/core/jnap/models/auto_master_status.dart';
 import 'package:privacy_gui/core/jnap/providers/side_effect_provider.dart';
 import 'package:privacy_gui/core/jnap/result/jnap_result.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
@@ -12,6 +13,7 @@ import 'package:privacy_gui/page/components/views/arguments_view.dart';
 import 'package:privacy_gui/page/instant_setup/data/pnp_exception.dart';
 import 'package:privacy_gui/page/instant_setup/data/pnp_provider.dart';
 import 'package:privacy_gui/page/instant_setup/troubleshooter/providers/pnp_troubleshooter_provider.dart';
+import 'package:privacy_gui/page/instant_setup/widgets/pnp_auto_master_waiting_view.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/util/error_code_helper.dart';
 import 'package:privacygui_widgets/widgets/progress_bar/full_screen_spinner.dart';
@@ -34,6 +36,10 @@ class _PnpIspSaveSettingsViewState
   String? _spinnerText; //TODO: all spinner text is not confirmed
   StreamSubscription? subscription;
 
+  // Auto Master state
+  bool _waitingForAutoMaster = false;
+  bool _showAutoMasterConnectionError = false;
+
   @override
   void initState() {
     super.initState();
@@ -44,10 +50,96 @@ class _PnpIspSaveSettingsViewState
   @override
   void dispose() {
     _passwordController.dispose();
+    subscription?.cancel();
     super.dispose();
   }
 
-  Future<void> _saveNewSettings() {
+  /// Check Auto Master status before saving ISP settings.
+  /// Returns true if save should continue, false if redirected or waiting.
+  Future<bool> _checkAndWaitForAutoMaster() async {
+    AutoMasterStatus? status;
+    try {
+      status = await ref.read(pnpProvider.notifier).checkAutoMasterStatus();
+    } on ExceptionAutoMasterUnauthorized {
+      // Session expired, redirect to PnP entry
+      logger.w('[PnP]: Troubleshooter - Auto Master check unauthorized');
+      if (mounted) context.goNamed(RouteNamed.pnp);
+      return false;
+    }
+
+    // null means Auto Master not supported, continue save
+    if (status == null) {
+      logger.d(
+          '[PnP]: Troubleshooter - Auto Master not supported, continue save');
+      return true;
+    }
+
+    if (status == AutoMasterStatus.running) {
+      if (!mounted) return false;
+      setState(() {
+        _waitingForAutoMaster = true;
+        _showAutoMasterConnectionError = false;
+      });
+
+      int consecutiveFailures = 0;
+      const maxConsecutiveFailures = 3;
+
+      await for (final pollStatus
+          in ref.read(pnpProvider.notifier).pollAutoMasterStatus()) {
+        if (!mounted) return false;
+
+        if (pollStatus == null) {
+          consecutiveFailures++;
+          logger.w(
+              '[PnP]: Troubleshooter - Auto Master polling failed, consecutive: $consecutiveFailures');
+          if (consecutiveFailures >= maxConsecutiveFailures) {
+            setState(() => _showAutoMasterConnectionError = true);
+            return false;
+          }
+        } else {
+          consecutiveFailures = 0;
+          if (pollStatus == AutoMasterStatus.complete ||
+              pollStatus == AutoMasterStatus.idle) {
+            logger.i(
+                '[PnP]: Troubleshooter - Auto Master completed, redirect to PnP');
+            if (mounted) context.goNamed(RouteNamed.pnp);
+            return false;
+          }
+          if (pollStatus == AutoMasterStatus.failed) {
+            logger
+                .i('[PnP]: Troubleshooter - Auto Master failed, continue save');
+            if (mounted) setState(() => _waitingForAutoMaster = false);
+            return true;
+          }
+        }
+      }
+
+      // Polling timeout
+      logger.w('[PnP]: Troubleshooter - Auto Master polling timeout');
+      try {
+        await ref.read(pnpProvider.notifier).testConnectionReconnected();
+        if (mounted) setState(() => _waitingForAutoMaster = false);
+        return true;
+      } catch (e) {
+        if (mounted) setState(() => _showAutoMasterConnectionError = true);
+        return false;
+      }
+    }
+
+    if (status == AutoMasterStatus.complete) {
+      logger.i(
+          '[PnP]: Troubleshooter - Auto Master already completed, redirect to PnP');
+      if (mounted) context.goNamed(RouteNamed.pnp);
+      return false;
+    }
+
+    return true; // idle/failed → continue save
+  }
+
+  Future<void> _saveNewSettings() async {
+    // Check Auto Master status before saving
+    final shouldContinue = await _checkAndWaitForAutoMaster();
+    if (!shouldContinue) return;
     String? settingError;
     final wanType = WanType.resolve(
       newSettings.ipv4Setting.ipv4ConnectionType,
@@ -148,6 +240,15 @@ class _PnpIspSaveSettingsViewState
 
   @override
   Widget build(BuildContext context) {
+    if (_waitingForAutoMaster) {
+      return PnpAutoMasterWaitingView(
+        showConnectionError: _showAutoMasterConnectionError,
+        onRetry: () {
+          setState(() => _showAutoMasterConnectionError = false);
+          _saveNewSettings();
+        },
+      );
+    }
     return AppFullScreenSpinner(text: _spinnerText);
   }
 }


### PR DESCRIPTION
## Summary
- Add Auto Master status check before saving ISP settings to prevent race condition
- Handle unauthorized errors when Auto Master completes during PnP save operations  
- Add WiFi SSID verification after reconnect with automatic retry (supports split mode)
- Fix async callback exception handling in testConnection method
- Reset _waitingForAutoMaster state properly in onRetry callback

## Related Issue
Fixes #1006 - QA test cases 3, 4, 6, 7, 9, 10

## Test plan
- [ ] Case 3: Static IP settings with WAN cable triggering Auto Master → Show waiting view or redirect
- [ ] Case 4: Auto Master completes when clicking Next → Redirect to PnP entry
- [ ] Case 6: WiFi settings save timeout then reconnect → Verify SSID and retry
- [ ] Case 7: Auto Master completes during save causing 401 → Redirect to PnP entry
- [ ] Case 9: SSID not updated after PPPoE settings → Auto verify and retry
- [ ] Case 10: Auto Master completes during PPPoE settings → Show waiting view or redirect
- [ ] Regression: Normal ISP Settings flow (without Auto Master) still works
- [ ] Regression: Normal PnP flow still works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)