### PR TITLE
fix: display CPU utilization as integer without decimal places

### DIFF
--- a/lib/page/instant_verify/views/instant_verify_view.dart
+++ b/lib/page/instant_verify/views/instant_verify_view.dart
@@ -366,7 +366,7 @@ class _InstantVerifyViewState extends ConsumerState<InstantVerifyView>
                   children: [
                     AppText.bodySmall(loc(context).cpuUtilization),
                     AppText.labelMedium(
-                        '${((double.tryParse(cpuLoad.padLeft(2, '0')) ?? 0) * 100).toStringAsFixed(2)}%'),
+                        '${((double.tryParse(cpuLoad.padLeft(2, '0')) ?? 0) * 100).toInt()}%'),
                   ],
                 ),
               ),
@@ -933,7 +933,7 @@ class _InstantVerifyViewState extends ConsumerState<InstantVerifyView>
           '${loc(context).firmwareVersion}: ${master.unit.firmwareVersion ?? '--'}'),
       if (cpuLoad != null)
         pw.Text(
-            'CPU Utilization: ${((double.tryParse(cpuLoad.padLeft(2, '0')) ?? 0) * 100).toStringAsFixed(2)}%'),
+            'CPU Utilization: ${((double.tryParse(cpuLoad.padLeft(2, '0')) ?? 0) * 100).toInt()}%'),
       if (memoryLoad != null)
         pw.Text(
             'Memory Utilization: ${((double.tryParse(memoryLoad.padLeft(2, '0')) ?? 0) * 100).toStringAsFixed(2)}%'),


### PR DESCRIPTION
## Summary
- Remove unnecessary two decimal places from CPU utilization display on Instant Verify page
- Values now show as "0%" instead of "0.00%" and "18%" instead of "18.00%"

## Changes
- Updated UI display formatting (`toStringAsFixed(2)` → `toInt()`)
- Updated PDF print formatting to match

## Related Issues
- Fixes #1095
- Related: LinksysWRT#411

## Test plan
- [ ] Open Instant Verify page and verify CPU utilization shows as integer (e.g., "0%", "18%")
- [ ] Print PDF from Instant Verify and verify CPU utilization shows as integer

🤖 Generated with [Claude Code](https://claude.com/claude-code)