### PR TITLE
fix(port-triggering): persist forwarded-port edits in port triggering (#1061)

### DIFF
--- a/lib/page/port_forwarding/services/usp_port_forwarding_service.dart
+++ b/lib/page/port_forwarding/services/usp_port_forwarding_service.dart
@@ -398,7 +398,13 @@ class UspPortForwardingService {
         }
       }
 
-      // 3. Update (parent-level only)
+      // 3. Update parent-level fields AND reconcile nested forward rules.
+      //
+      // The parent Set (PortTrigger.{i}) only carries the trigger fields
+      // (Enable/Description/Port/PortEndRange/Protocol). The forwarded ports
+      // live in a separate sub-table (PortTrigger.{i}.Rule.{j}) and MUST be
+      // reconciled with their own Add / Set / Delete calls — otherwise edits
+      // to the forwarded ports are silently dropped (#1061).
       final originalByPath = <String, PortTriggeringRuleUIModel>{
         for (final r in original)
           if (r.instancePath != null) r.instancePath!: r,
@@ -408,7 +414,14 @@ class UspPortForwardingService {
         if (cur.instancePath == null) continue;
         final orig = originalByPath[cur.instancePath!];
         if (orig == null) continue;
-        if (cur != orig) {
+        if (cur == orig) continue;
+
+        // 3a. Parent-level trigger fields.
+        if (cur.enabled != orig.enabled ||
+            cur.description != orig.description ||
+            cur.triggerPort != orig.triggerPort ||
+            cur.triggerPortEndRange != orig.triggerPortEndRange ||
+            cur.triggerProtocol != orig.triggerProtocol) {
           toUpdate.add(PortTriggerUpdate(
             instancePath: cur.instancePath!,
             enabled: cur.enabled,
@@ -417,6 +430,17 @@ class UspPortForwardingService {
             triggerPortEndRange: cur.triggerPortEndRange,
             triggerProtocol: cur.triggerProtocol,
           ));
+        }
+
+        // 3b. Nested forwarded-port rules.
+        if (cur.forwardRules != orig.forwardRules) {
+          final (int fwdOps, int fwdFailed) = await _reconcileForwardRules(
+            parentPath: cur.instancePath!,
+            original: orig.forwardRules,
+            current: cur.forwardRules,
+          );
+          totalOps += fwdOps;
+          failedOps += fwdFailed;
         }
       }
       if (toUpdate.isNotEmpty) {
@@ -453,5 +477,110 @@ class UspPortForwardingService {
       if (e is ServiceError) rethrow;
       throw mapUspErrorToServiceError(e);
     }
+  }
+
+  /// Reconcile the nested forwarded-port sub-rules of a single existing
+  /// port trigger (parent already persisted at [parentPath]).
+  ///
+  /// Diffs [original] vs [current] forward rules and issues the minimal set of
+  /// Add / Set / Delete calls against the `Rule.{j}` sub-table. Existing rules
+  /// (non-null instancePath) whose values changed are updated in place via
+  /// [UspClient.set]; rules that vanished are deleted; brand-new rules
+  /// (null instancePath) are added. Returns the number of operations attempted
+  /// and how many failed, so the caller can fold them into its lenient
+  /// all-or-nothing tally.
+  Future<(int, int)> _reconcileForwardRules({
+    required String parentPath,
+    required List<PortTriggerForwardRuleUIModel> original,
+    required List<PortTriggerForwardRuleUIModel> current,
+  }) async {
+    int ops = 0;
+    int failed = 0;
+
+    // 1. Delete forward rules that no longer exist in current.
+    final currentPaths = <String>{
+      for (final r in current)
+        if (r.instancePath != null) r.instancePath!,
+    };
+    final toDelete = original
+        .where((r) =>
+            r.instancePath != null && !currentPaths.contains(r.instancePath))
+        .toList();
+    for (final r in toDelete.reversed) {
+      ops++;
+      final result = await PortTriggering.deletePortTriggerForwardRule(
+          _usp, r.instancePath!);
+      final parsed = UspResultParser.parseDeleteResult(result);
+      switch (parsed) {
+        case UspSuccess():
+          break;
+        case UspPartialSuccess(failures: final f):
+          logger.w(
+              '[PortTriggering]: Forward delete partial: ${f.first.errorMessage}');
+        case UspFailure(errors: final e):
+          failed++;
+          logger.w(
+              '[PortTriggering]: Forward delete failed: ${e.first.errorMessage}');
+      }
+    }
+
+    // 2. Update existing forward rules whose values changed (in-place Set).
+    final originalByPath = <String, PortTriggerForwardRuleUIModel>{
+      for (final r in original)
+        if (r.instancePath != null) r.instancePath!: r,
+    };
+    final updateParams = <String, dynamic>{};
+    for (final cur in current) {
+      if (cur.instancePath == null) continue;
+      final orig = originalByPath[cur.instancePath!];
+      if (orig == null) continue;
+      if (cur == orig) continue;
+      updateParams['${cur.instancePath}Port'] = cur.forwardPort;
+      updateParams['${cur.instancePath}PortEndRange'] = cur.forwardPortEndRange;
+      updateParams['${cur.instancePath}Protocol'] = cur.forwardProtocol;
+    }
+    if (updateParams.isNotEmpty) {
+      ops++;
+      final result = await _usp.set(updateParams);
+      final parsed = UspResultParser.parseSetResult(result);
+      switch (parsed) {
+        case UspSuccess():
+          break;
+        case UspPartialSuccess(failures: final f):
+          logger.w(
+              '[PortTriggering]: Forward update partial: ${f.first.errorMessage}');
+        case UspFailure(errors: final e):
+          failed++;
+          logger.w(
+              '[PortTriggering]: Forward update failed: ${e.first.errorMessage}');
+      }
+    }
+
+    // 3. Add brand-new forward rules (null instancePath).
+    final toAdd = current.where((r) => r.instancePath == null).toList();
+    for (final fr in toAdd) {
+      ops++;
+      final result = await PortTriggering.addPortTriggerForwardRule(
+        _usp,
+        parentPath,
+        forwardPort: fr.forwardPort,
+        forwardPortEndRange: fr.forwardPortEndRange,
+        forwardProtocol: fr.forwardProtocol,
+      );
+      final parsed = UspResultParser.parseAddResult(result);
+      switch (parsed) {
+        case UspSuccess():
+          break;
+        case UspPartialSuccess(failures: final f):
+          logger.w(
+              '[PortTriggering]: Forward add partial: ${f.first.errorMessage}');
+        case UspFailure(errors: final e):
+          failed++;
+          logger.w(
+              '[PortTriggering]: Forward add failed: ${e.first.errorMessage}');
+      }
+    }
+
+    return (ops, failed);
   }
 }

--- a/lib/page/port_forwarding/views/components/usp_port_triggering_tab.dart
+++ b/lib/page/port_forwarding/views/components/usp_port_triggering_tab.dart
@@ -133,6 +133,23 @@ class UspPortTriggeringTab extends ConsumerWidget {
             triggerPort: result.triggerPort,
             triggerPortEndRange: result.triggerPortEndRange,
             triggerProtocol: result.triggerProtocol,
+            // Rebuild the forwarded-port rule from the dialog result so edits
+            // to the forwarded ports actually persist. Preserve the existing
+            // first rule's instancePath so the service updates it in place
+            // (rather than dropping the edit). Any additional forward rules
+            // beyond the first — which the single-mapping dialog cannot show —
+            // are carried through untouched.
+            forwardRules: [
+              PortTriggerForwardRuleUIModel(
+                instancePath: rule.forwardRules.isNotEmpty
+                    ? rule.forwardRules.first.instancePath
+                    : null,
+                forwardPort: result.forwardPort,
+                forwardPortEndRange: result.forwardPortEndRange,
+                forwardProtocol: result.forwardProtocol,
+              ),
+              ...rule.forwardRules.skip(1),
+            ],
           ),
         );
   }

--- a/test/page/port_forwarding/services/usp_port_forwarding_service_test.dart
+++ b/test/page/port_forwarding/services/usp_port_forwarding_service_test.dart
@@ -663,6 +663,195 @@ void main() {
       expect(result.updated, 1);
     });
 
+    // -------------------------------------------------------------------------
+    // #1061 regression: editing the forwarded-port of an EXISTING trigger must
+    // persist. Before the fix, saveTriggeringBatch only patched parent-level
+    // fields and never touched the nested Rule.* sub-table, so the edit was
+    // silently dropped.
+    // -------------------------------------------------------------------------
+
+    test('#1061: editing forwarded-port of existing rule issues Set on Rule.*',
+        () async {
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => uspSuccess());
+
+      final original = [
+        PortTriggeringRuleUIModel(
+          instancePath: 'Device.NAT.PortTrigger.1.',
+          enabled: true,
+          description: 'FTP',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+          forwardRules: const [
+            PortTriggerForwardRuleUIModel(
+              instancePath: 'Device.NAT.PortTrigger.1.Rule.1.',
+              forwardPort: 1024,
+              forwardPortEndRange: 1030,
+              forwardProtocol: 'TCP',
+            ),
+          ],
+        ),
+      ];
+      final current = [
+        PortTriggeringRuleUIModel(
+          instancePath: 'Device.NAT.PortTrigger.1.',
+          enabled: true,
+          description: 'FTP',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+          forwardRules: const [
+            PortTriggerForwardRuleUIModel(
+              instancePath: 'Device.NAT.PortTrigger.1.Rule.1.',
+              forwardPort: 2048, // changed
+              forwardPortEndRange: 2050, // changed
+              forwardProtocol: 'UDP', // changed
+            ),
+          ],
+        ),
+      ];
+
+      await service.saveTriggeringBatch(original: original, current: current);
+
+      // The forward-rule edit is reconciled via an in-place Set carrying the
+      // Rule.{j} param paths with the NEW values.
+      final captured = verify(() => mockUsp.set(captureAny())).captured;
+      expect(captured, hasLength(1));
+      final params = captured.first as Map<String, dynamic>;
+      expect(params['Device.NAT.PortTrigger.1.Rule.1.Port'], 2048);
+      expect(params['Device.NAT.PortTrigger.1.Rule.1.PortEndRange'], 2050);
+      expect(params['Device.NAT.PortTrigger.1.Rule.1.Protocol'], 'UDP');
+    });
+
+    test('#1061: adding a forward rule to existing trigger calls add on Rule.',
+        () async {
+      when(() => mockUsp.add(any())).thenAnswer(
+          (_) async => uspAddSuccess(['Device.NAT.PortTrigger.1.Rule.2.']));
+
+      final original = [
+        PortTriggeringRuleUIModel(
+          instancePath: 'Device.NAT.PortTrigger.1.',
+          enabled: true,
+          description: 'FTP',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+          forwardRules: const [
+            PortTriggerForwardRuleUIModel(
+              instancePath: 'Device.NAT.PortTrigger.1.Rule.1.',
+              forwardPort: 1024,
+              forwardProtocol: 'TCP',
+            ),
+          ],
+        ),
+      ];
+      final current = [
+        PortTriggeringRuleUIModel(
+          instancePath: 'Device.NAT.PortTrigger.1.',
+          enabled: true,
+          description: 'FTP',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+          forwardRules: const [
+            PortTriggerForwardRuleUIModel(
+              instancePath: 'Device.NAT.PortTrigger.1.Rule.1.',
+              forwardPort: 1024,
+              forwardProtocol: 'TCP',
+            ),
+            PortTriggerForwardRuleUIModel(
+              // new local rule, no instancePath yet
+              forwardPort: 3000,
+              forwardProtocol: 'UDP',
+            ),
+          ],
+        ),
+      ];
+
+      await service.saveTriggeringBatch(original: original, current: current);
+
+      final captured = verify(() => mockUsp.add(captureAny())).captured;
+      expect(captured, hasLength(1));
+      final items = captured.first as List;
+      expect(items.first['path'], 'Device.NAT.PortTrigger.1.Rule.');
+      expect(items.first['params']['Port'], 3000);
+      expect(items.first['params']['Protocol'], 'UDP');
+    });
+
+    test('#1061: removing a forward rule from existing trigger calls delete',
+        () async {
+      when(() => mockUsp.delete(any())).thenAnswer((_) async => uspSuccess());
+
+      final original = [
+        PortTriggeringRuleUIModel(
+          instancePath: 'Device.NAT.PortTrigger.1.',
+          enabled: true,
+          description: 'FTP',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+          forwardRules: const [
+            PortTriggerForwardRuleUIModel(
+              instancePath: 'Device.NAT.PortTrigger.1.Rule.1.',
+              forwardPort: 1024,
+              forwardProtocol: 'TCP',
+            ),
+            PortTriggerForwardRuleUIModel(
+              instancePath: 'Device.NAT.PortTrigger.1.Rule.2.',
+              forwardPort: 3000,
+              forwardProtocol: 'UDP',
+            ),
+          ],
+        ),
+      ];
+      final current = [
+        PortTriggeringRuleUIModel(
+          instancePath: 'Device.NAT.PortTrigger.1.',
+          enabled: true,
+          description: 'FTP',
+          triggerPort: 21,
+          triggerProtocol: 'TCP',
+          forwardRules: const [
+            PortTriggerForwardRuleUIModel(
+              instancePath: 'Device.NAT.PortTrigger.1.Rule.1.',
+              forwardPort: 1024,
+              forwardProtocol: 'TCP',
+            ),
+          ],
+        ),
+      ];
+
+      await service.saveTriggeringBatch(original: original, current: current);
+
+      final captured = verify(() => mockUsp.delete(captureAny())).captured;
+      expect(captured, hasLength(1));
+      expect(captured.first, ['Device.NAT.PortTrigger.1.Rule.2.']);
+    });
+
+    test('#1061: unchanged forward rules issue no Rule.* operations', () async {
+      when(() => mockUsp.set(any(), allowPartial: any(named: 'allowPartial')))
+          .thenAnswer((_) async => uspSuccess());
+
+      final rule = PortTriggeringRuleUIModel(
+        instancePath: 'Device.NAT.PortTrigger.1.',
+        enabled: true,
+        description: 'FTP',
+        triggerPort: 21,
+        triggerProtocol: 'TCP',
+        forwardRules: const [
+          PortTriggerForwardRuleUIModel(
+            instancePath: 'Device.NAT.PortTrigger.1.Rule.1.',
+            forwardPort: 1024,
+            forwardProtocol: 'TCP',
+          ),
+        ],
+      );
+      // Only the parent-level field (enabled) changes; forward rules identical.
+      final current = [rule.copyWith(enabled: false)];
+
+      await service.saveTriggeringBatch(original: [rule], current: current);
+
+      // Parent Set fires once (Enable). No forward Set/add/delete.
+      verifyNever(() => mockUsp.add(any()));
+      verifyNever(() => mockUsp.delete(any()));
+    });
+
     test('mixed batch: delete + add + update', () async {
       when(() => mockUsp.delete(any())).thenAnswer((_) async => uspSuccess());
       when(() => mockUsp.add(any())).thenAnswer(


### PR DESCRIPTION
Refs #1061

## Root Cause (two layers)
1. **UI layer** (`usp_port_triggering_tab.dart`): `_showEditDialog` rebuilt the rule via `copyWith` but
   omitted `forwardRules`, so the edited forwarded-port values were immediately discarded in the UI.
2. **Service layer** (`usp_port_forwarding_service.dart`): `saveTriggeringBatch`'s update path only
   issued a `Set` on the parent `PortTrigger.{i}` fields. The nested `Rule.{j}` sub-table was never
   touched, so even if the UI had passed the values through, the edit would have been silently dropped.

## Changes
| File | What changed |
|------|-------------|
| `lib/page/port_forwarding/views/components/usp_port_triggering_tab.dart` | `copyWith` now rebuilds `forwardRules` from dialog result, preserving `instancePath` of the first existing rule so the service can update it in-place. Extra rules beyond the first are carried through untouched. |
| `lib/page/port_forwarding/services/usp_port_forwarding_service.dart` | Added `_reconcileForwardRules` (Set/Add/Delete diff of `Rule.{j}` sub-table). Hooked into update path at step 3b. |
| `test/page/port_forwarding/services/usp_port_forwarding_service_test.dart` | 4 new regression tests for `#1061` (edit→Set, add→Add, delete→Delete, unchanged→no-op). |

## Acceptance criteria vs evidence
| AC | Evidence |
|----|----------|
| Edit forwarded-port persists | Test `#1061: editing forwarded-port of existing rule issues Set on Rule.*` — verifies `Set` is called with new port/endRange/protocol values on `Rule.1.` path |
| Add new forward rule persists | Test `#1061: adding a forward rule to existing trigger calls add on Rule.` — verifies `add` is called with correct parent path + params |
| Delete forward rule persists | Test `#1061: removing a forward rule from existing trigger calls delete` — verifies `delete` is called on the removed rule's path |
| No spurious ops when unchanged | Test `#1061: unchanged forward rules issue no Rule.* operations` — verifies `add`/`delete` never called when forward rules unchanged |

## Test results (verify re-run)
```
flutter test test/page/port_forwarding/
59/59 All tests passed! (00:13)
```

## Quality gates (verify re-run)
- `dart format --output=none --set-exit-if-changed .` → **exit 0** (1077 files, 0 changed)
- `flutter analyze lib/page/port_forwarding/` → **No issues found!**
- No `generated/` imports in View layer
- mocktail used (not mockito) in test
- `mapUspErrorToServiceError` used in service catch blocks (Article XIII)
- mutation lock held in Provider layer (Article IV) — unchanged by this diff
- diff: exactly 3 files, +337/-2

<!-- verify stamp: PASS, verify-worker, 2026-07-08 -->
