### PR TITLE
refactor(dhcp): centralize reservation device-option data source

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,12 +6,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/pr_gate.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/pr_gate.py\"",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "staged=$(git diff --cached --name-only --diff-filter=ACM -- '*.dart'); if [ -n \"$staged\" ]; then if command -v fvm >/dev/null 2>&1; then echo \"$staged\" | xargs fvm dart format; else echo \"$staged\" | xargs dart format; fi; echo \"$staged\" | xargs git add; fi",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" || exit 0; staged=$(git diff --cached --name-only --diff-filter=ACM -- '*.dart'); if [ -n \"$staged\" ]; then if command -v fvm >/dev/null 2>&1; then echo \"$staged\" | xargs fvm dart format; else echo \"$staged\" | xargs dart format; fi; echo \"$staged\" | xargs git add; fi",
             "timeout": 30,
             "statusMessage": "Formatting staged Dart files..."
           }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -474,6 +474,8 @@
   "confirmationRequired": "التأكيد مطلوب",
   "confirmingNewFirmware": "جارٍ التأكد من تشغيل البرنامج الثابت الجديد…",
   "connect": "اتصال",
+  "duplicateMacAddress": "عنوان MAC هذا محجوز بالفعل",
+  "duplicateIpAddress": "عنوان IP هذا محجوز بالفعل",
   "connectedDevices": "الأجهزة المتصلة",
   "connecting": "جارٍ الاتصال...",
   "connectingToRouter": "جارٍ الاتصال بجهاز التوجيه...",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -473,6 +473,8 @@
   "confirmationRequired": "Bekræftelse påkrævet",
   "confirmingNewFirmware": "Bekræfter, at den nye firmware kører…",
   "connect": "Tilslut",
+  "duplicateMacAddress": "Denne MAC-adresse er allerede reserveret",
+  "duplicateIpAddress": "Denne IP-adresse er allerede reserveret",
   "connectedDevices": "Tilsluttede enheder",
   "connecting": "Tilslutter...",
   "connectingToRouter": "Tilslutter til router...",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -473,6 +473,8 @@
   "confirmationRequired": "Bestätigung erforderlich",
   "confirmingNewFirmware": "Es wird bestätigt, dass die neue Firmware läuft…",
   "connect": "Verbinden",
+  "duplicateMacAddress": "Diese MAC-Adresse ist bereits reserviert",
+  "duplicateIpAddress": "Diese IP-Adresse ist bereits reserviert",
   "connectedDevices": "Verbundene Geräte",
   "connecting": "Verbindung wird hergestellt...",
   "connectingToRouter": "Verbindung zum Router wird hergestellt...",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -471,6 +471,8 @@
   "confirmationRequired": "Απαιτείται επιβεβαίωση",
   "confirmingNewFirmware": "Επιβεβαίωση ότι εκτελείται το νέο firmware…",
   "connect": "Σύνδεση",
+  "duplicateMacAddress": "Αυτή η διεύθυνση MAC έχει ήδη δεσμευτεί",
+  "duplicateIpAddress": "Αυτή η διεύθυνση IP έχει ήδη δεσμευτεί",
   "connectedDevices": "Συνδεδεμένες συσκευές",
   "connecting": "Σύνδεση...",
   "connectingToRouter": "Σύνδεση με τον δρομολογητή...",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -473,6 +473,8 @@
   "confirmationRequired": "Confirmación requerida",
   "confirmingNewFirmware": "Confirmando que el nuevo firmware está en ejecución…",
   "connect": "Conectar",
+  "duplicateMacAddress": "Esta dirección MAC ya está reservada",
+  "duplicateIpAddress": "Esta dirección IP ya está reservada",
   "connectedDevices": "Dispositivos conectados",
   "connecting": "Conectando...",
   "connectingToRouter": "Conectando con el router...",

--- a/lib/l10n/app_es_ar.arb
+++ b/lib/l10n/app_es_ar.arb
@@ -473,6 +473,8 @@
   "confirmationRequired": "Se requiere confirmación",
   "confirmingNewFirmware": "Confirmando que el nuevo firmware está en ejecución…",
   "connect": "Conectar",
+  "duplicateMacAddress": "Esta dirección MAC ya está reservada",
+  "duplicateIpAddress": "Esta dirección IP ya está reservada",
   "connectedDevices": "Dispositivos conectados",
   "connecting": "Conectando...",
   "connectingToRouter": "Conectando al router...",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -471,6 +471,8 @@
   "confirmationRequired": "Vahvistus vaaditaan",
   "confirmingNewFirmware": "Vahvistetaan, että uusi laiteohjelmisto on käynnissä…",
   "connect": "Yhdistä",
+  "duplicateMacAddress": "Tämä MAC-osoite on jo varattu",
+  "duplicateIpAddress": "Tämä IP-osoite on jo varattu",
   "connectedDevices": "Yhdistetyt laitteet",
   "connecting": "Yhdistetään...",
   "connectingToRouter": "Yhdistetään reitittimeen...",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -473,6 +473,8 @@
   "confirmationRequired": "Confirmation requise",
   "confirmingNewFirmware": "Confirmation que le nouveau micrologiciel est en cours d'exécution…",
   "connect": "Connecter",
+  "duplicateMacAddress": "Cette adresse MAC est déjà réservée",
+  "duplicateIpAddress": "Cette adresse IP est déjà réservée",
   "connectedDevices": "Périphériques connectés",
   "connecting": "Connexion...",
   "connectingToRouter": "Connexion au routeur...",

--- a/lib/l10n/app_fr_ca.arb
+++ b/lib/l10n/app_fr_ca.arb
@@ -473,6 +473,8 @@
   "confirmationRequired": "Confirmation requise",
   "confirmingNewFirmware": "Confirmation de l'exécution du nouveau micrologiciel…",
   "connect": "Connecter",
+  "duplicateMacAddress": "Cette adresse MAC est déjà réservée",
+  "duplicateIpAddress": "Cette adresse IP est déjà réservée",
   "connectedDevices": "Appareils connectés",
   "connecting": "Connexion...",
   "connectingToRouter": "Connexion au routeur...",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -471,6 +471,8 @@
   "confirmationRequired": "Konfirmasi Diperlukan",
   "confirmingNewFirmware": "Mengonfirmasi firmware baru sedang berjalan…",
   "connect": "Sambungkan",
+  "duplicateMacAddress": "Alamat MAC ini sudah direservasi",
+  "duplicateIpAddress": "Alamat IP ini sudah direservasi",
   "connectedDevices": "Perangkat yang Tersambung",
   "connecting": "Menyambungkan...",
   "connectingToRouter": "Menyambungkan ke router...",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -473,6 +473,8 @@
   "confirmationRequired": "Conferma richiesta",
   "confirmingNewFirmware": "Verifica che il nuovo firmware sia in esecuzione…",
   "connect": "Connetti",
+  "duplicateMacAddress": "Questo indirizzo MAC è già prenotato",
+  "duplicateIpAddress": "Questo indirizzo IP è già prenotato",
   "connectedDevices": "Dispositivi connessi",
   "connecting": "Connessione in corso...",
   "connectingToRouter": "Connessione al router...",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -474,6 +474,8 @@
   "confirmationRequired": "確認が必要です",
   "confirmingNewFirmware": "新しいファームウェアが動作していることを確認中…",
   "connect": "接続",
+  "duplicateMacAddress": "この MAC アドレスはすでに予約されています",
+  "duplicateIpAddress": "この IP アドレスはすでに予約されています",
   "connectedDevices": "接続中のデバイス",
   "connecting": "接続中...",
   "connectingToRouter": "ルーターに接続中...",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -471,6 +471,8 @@
   "confirmationRequired": "확인 필요",
   "confirmingNewFirmware": "새 펌웨어가 실행 중인지 확인하는 중…",
   "connect": "연결",
+  "duplicateMacAddress": "이 MAC 주소는 이미 예약되어 있습니다",
+  "duplicateIpAddress": "이 IP 주소는 이미 예약되어 있습니다",
   "connectedDevices": "연결된 장치",
   "connecting": "연결 중...",
   "connectingToRouter": "라우터에 연결 중...",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -473,6 +473,8 @@
   "confirmationRequired": "Bekreftelse kreves",
   "confirmingNewFirmware": "Bekrefter at den nye fastvaren kjører…",
   "connect": "Koble til",
+  "duplicateMacAddress": "Denne MAC-adressen er allerede reservert",
+  "duplicateIpAddress": "Denne IP-adressen er allerede reservert",
   "connectedDevices": "Tilkoblede enheter",
   "connecting": "Kobler til...",
   "connectingToRouter": "Kobler til ruteren...",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -473,6 +473,8 @@
   "confirmationRequired": "Bevestiging vereist",
   "confirmingNewFirmware": "Bevestigen dat de nieuwe firmware draait…",
   "connect": "Verbinden",
+  "duplicateMacAddress": "Dit MAC-adres is al gereserveerd",
+  "duplicateIpAddress": "Dit IP-adres is al gereserveerd",
   "connectedDevices": "Verbonden apparaten",
   "connecting": "Verbinden...",
   "connectingToRouter": "Verbinden met router...",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -471,6 +471,8 @@
   "confirmationRequired": "Wymagane potwierdzenie",
   "confirmingNewFirmware": "Potwierdzanie działania nowego oprogramowania układowego…",
   "connect": "Połącz",
+  "duplicateMacAddress": "Ten adres MAC jest już zarezerwowany",
+  "duplicateIpAddress": "Ten adres IP jest już zarezerwowany",
   "connectedDevices": "Podłączone urządzenia",
   "connecting": "Łączenie...",
   "connectingToRouter": "Łączenie z routerem...",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -473,6 +473,8 @@
   "confirmationRequired": "Confirmação necessária",
   "confirmingNewFirmware": "Confirmando se o novo firmware está em execução…",
   "connect": "Conectar",
+  "duplicateMacAddress": "Este endereço MAC já está reservado",
+  "duplicateIpAddress": "Este endereço IP já está reservado",
   "connectedDevices": "Dispositivos conectados",
   "connecting": "Conectando...",
   "connectingToRouter": "Conectando ao roteador...",

--- a/lib/l10n/app_pt_pt.arb
+++ b/lib/l10n/app_pt_pt.arb
@@ -473,6 +473,8 @@
   "confirmationRequired": "Confirmação necessária",
   "confirmingNewFirmware": "A confirmar que o novo firmware está em execução…",
   "connect": "Ligar",
+  "duplicateMacAddress": "Este endereço MAC já está reservado",
+  "duplicateIpAddress": "Este endereço IP já está reservado",
   "connectedDevices": "Dispositivos ligados",
   "connecting": "A ligar...",
   "connectingToRouter": "A ligar ao router...",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -471,6 +471,8 @@
   "confirmationRequired": "Требуется подтверждение",
   "confirmingNewFirmware": "Подтверждение запуска новой прошивки…",
   "connect": "Подключить",
+  "duplicateMacAddress": "Этот MAC-адрес уже зарезервирован",
+  "duplicateIpAddress": "Этот IP-адрес уже зарезервирован",
   "connectedDevices": "Подключенные устройства",
   "connecting": "Подключение...",
   "connectingToRouter": "Подключение к маршрутизатору...",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -473,6 +473,8 @@
   "confirmationRequired": "Bekräftelse krävs",
   "confirmingNewFirmware": "Bekräftar att den nya fasta programvaran körs…",
   "connect": "Anslut",
+  "duplicateMacAddress": "Den här MAC-adressen är redan reserverad",
+  "duplicateIpAddress": "Den här IP-adressen är redan reserverad",
   "connectedDevices": "Anslutna enheter",
   "connecting": "Ansluter...",
   "connectingToRouter": "Ansluter till router...",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -471,6 +471,8 @@
   "confirmationRequired": "ต้องมีการยืนยัน",
   "confirmingNewFirmware": "กำลังยืนยันว่าเฟิร์มแวร์ใหม่กำลังทำงาน…",
   "connect": "เชื่อมต่อ",
+  "duplicateMacAddress": "ที่อยู่ MAC นี้ถูกสำรองไว้แล้ว",
+  "duplicateIpAddress": "ที่อยู่ IP นี้ถูกสำรองไว้แล้ว",
   "connectedDevices": "อุปกรณ์ที่เชื่อมต่อ",
   "connecting": "กำลังเชื่อมต่อ...",
   "connectingToRouter": "กำลังเชื่อมต่อกับเราเตอร์...",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -471,6 +471,8 @@
   "confirmationRequired": "Onay Gerekli",
   "confirmingNewFirmware": "Yeni bellenimin çalıştığı doğrulanıyor…",
   "connect": "Bağlan",
+  "duplicateMacAddress": "Bu MAC adresi zaten ayrılmış",
+  "duplicateIpAddress": "Bu IP adresi zaten ayrılmış",
   "connectedDevices": "Bağlı Cihazlar",
   "connecting": "Bağlanıyor...",
   "connectingToRouter": "Yönlendiriciye bağlanılıyor...",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -471,6 +471,8 @@
   "confirmationRequired": "Cần xác nhận",
   "confirmingNewFirmware": "Đang xác nhận firmware mới đang chạy…",
   "connect": "Kết nối",
+  "duplicateMacAddress": "Địa chỉ MAC này đã được dành riêng",
+  "duplicateIpAddress": "Địa chỉ IP này đã được dành riêng",
   "connectedDevices": "Thiết bị được kết nối",
   "connecting": "Đang kết nối...",
   "connectingToRouter": "Đang kết nối với router...",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -474,6 +474,8 @@
   "confirmationRequired": "需要确认",
   "confirmingNewFirmware": "正在确认新固件是否运行…",
   "connect": "连接",
+  "duplicateMacAddress": "此 MAC 地址已被保留",
+  "duplicateIpAddress": "此 IP 地址已被保留",
   "connectedDevices": "已连接的设备",
   "connecting": "连接中…",
   "connectingToRouter": "正在连接路由器…",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -474,6 +474,8 @@
   "confirmationRequired": "需要確認",
   "confirmingNewFirmware": "正在確認新韌體是否正在執行…",
   "connect": "連線",
+  "duplicateMacAddress": "此 MAC 位址已被保留",
+  "duplicateIpAddress": "此 IP 位址已被保留",
   "connectedDevices": "已連線的裝置",
   "connecting": "正在連線...",
   "connectingToRouter": "正在連線至路由器...",

--- a/lib/page/dhcp/providers/usp_dhcp_reservations_notifier.dart
+++ b/lib/page/dhcp/providers/usp_dhcp_reservations_notifier.dart
@@ -10,7 +10,17 @@ import 'package:privacy_gui/page/dhcp/models/dhcp_reservation_list.dart';
 import 'package:privacy_gui/page/dhcp/models/dhcp_reservations_feature_state.dart';
 import 'package:privacy_gui/page/dhcp/models/dhcp_reservations_status.dart';
 import 'package:privacy_gui/page/dhcp/services/usp_dhcp_service.dart';
+import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
 import 'package:privacy_gui/page/local_network/providers/dhcp_data_provider.dart';
+
+/// Pure-data snapshot of a client device offered as an autocomplete suggestion
+/// when adding or editing a reservation. The view maps this to UI options.
+typedef ReservationDeviceOption = ({
+  String name,
+  String mac,
+  String ip,
+  bool isActive,
+});
 
 // ---------------------------------------------------------------------------
 // Providers
@@ -162,6 +172,25 @@ class UspDhcpReservationsNotifier
       rethrow;
     }
     ref.invalidate(dhcpDataProvider);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Device suggestions (data source for reservation add/edit autocomplete)
+  // ---------------------------------------------------------------------------
+
+  /// Client devices offered as autocomplete suggestions when adding or editing
+  /// a reservation. Returns pure data — the view maps these to UI options.
+  List<ReservationDeviceOption> deviceOptions() {
+    final devices =
+        ref.read(devicesDataProvider).valueOrNull?.clientDevices ?? [];
+    return devices
+        .map((d) => (
+              name: d.displayName,
+              mac: d.mac,
+              ip: d.ip,
+              isActive: d.isActive,
+            ))
+        .toList();
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/page/dhcp/views/components/usp_dhcp_reservations_detail_card.dart
+++ b/lib/page/dhcp/views/components/usp_dhcp_reservations_detail_card.dart
@@ -6,7 +6,6 @@ import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/_shared/components/detail_widgets.dart';
 import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
 import 'package:privacy_gui/page/_shared/models/dhcp_reservation_ui_model.dart';
-import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
 import 'package:privacy_gui/page/dhcp/providers/usp_dhcp_reservations_notifier.dart';
 import 'package:privacy_gui/page/dhcp/views/dialogs/dhcp_reservation_edit_dialog.dart';
 import 'package:ui_kit_library/ui_kit.dart';
@@ -105,14 +104,16 @@ class UspDhcpReservationsDetailCard extends ConsumerWidget {
     );
   }
 
+  /// Maps device data from the notifier to autocomplete UI options for the
+  /// MAC and IP fields.
   ({List<AppAutoCompleteOption> mac, List<AppAutoCompleteOption> ip})
       _buildDeviceOptions(WidgetRef ref) {
     final devices =
-        ref.read(devicesDataProvider).valueOrNull?.clientDevices ?? [];
+        ref.read(uspDhcpReservationsProvider.notifier).deviceOptions();
     final macOptions = devices
         .where((d) => d.mac.isNotEmpty)
         .map((d) => AppAutoCompleteOption(
-              label: d.displayName,
+              label: d.name,
               value: d.mac,
               subtitle: d.ip,
               isActive: d.isActive,
@@ -121,7 +122,7 @@ class UspDhcpReservationsDetailCard extends ConsumerWidget {
     final ipOptions = devices
         .where((d) => d.ip.isNotEmpty)
         .map((d) => AppAutoCompleteOption(
-              label: d.displayName,
+              label: d.name,
               value: d.ip,
               subtitle: d.mac,
               isActive: d.isActive,

--- a/lib/page/local_network/cards/usp_dhcp_reservations_card.dart
+++ b/lib/page/local_network/cards/usp_dhcp_reservations_card.dart
@@ -125,9 +125,13 @@ class UspDhcpReservationsCard extends ConsumerWidget {
   }
 
   Future<void> _showAddDhcpDialog(BuildContext context, WidgetRef ref) async {
+    final options = _buildDeviceOptions(ref);
     final result = await showAppDialog<({String mac, String ip, bool enable})>(
       context: context,
-      builder: (_) => const DhcpReservationEditDialog(),
+      builder: (_) => DhcpReservationEditDialog(
+        macDeviceOptions: options.mac,
+        ipDeviceOptions: options.ip,
+      ),
     );
     if (result == null || !context.mounted) return;
     await performUspMutation(
@@ -142,6 +146,31 @@ class UspDhcpReservationsCard extends ConsumerWidget {
               ),
       successMessage: loc(context).reservationAdded,
     );
+  }
+
+  ({List<AppAutoCompleteOption> mac, List<AppAutoCompleteOption> ip})
+      _buildDeviceOptions(WidgetRef ref) {
+    final devices =
+        ref.read(uspDhcpReservationsProvider.notifier).deviceOptions();
+    final macOptions = devices
+        .where((d) => d.mac.isNotEmpty)
+        .map((d) => AppAutoCompleteOption(
+              label: d.name,
+              value: d.mac,
+              subtitle: d.ip,
+              isActive: d.isActive,
+            ))
+        .toList();
+    final ipOptions = devices
+        .where((d) => d.ip.isNotEmpty)
+        .map((d) => AppAutoCompleteOption(
+              label: d.name,
+              value: d.ip,
+              subtitle: d.mac,
+              isActive: d.isActive,
+            ))
+        .toList();
+    return (mac: macOptions, ip: ipOptions);
   }
 
   Future<void> _confirmDeleteDhcp(BuildContext context, WidgetRef ref,

--- a/test/page/dhcp/providers/usp_dhcp_reservations_notifier_test.dart
+++ b/test/page/dhcp/providers/usp_dhcp_reservations_notifier_test.dart
@@ -3,7 +3,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
+import 'package:privacy_gui/page/_shared/models/device_ui_model.dart';
 import 'package:privacy_gui/page/_shared/models/dhcp_reservation_ui_model.dart';
+import 'package:privacy_gui/page/devices/providers/devices_data_provider.dart';
 import 'package:privacy_gui/page/dhcp/providers/usp_dhcp_reservations_notifier.dart';
 import 'package:privacy_gui/page/dhcp/services/usp_dhcp_service.dart';
 import 'package:privacy_gui/page/local_network/providers/dhcp_data_provider.dart';
@@ -354,7 +356,139 @@ void main() {
       );
       container.dispose();
     });
+
+    // -------------------------------------------------------------------------
+    // deviceOptions (autocomplete data source)
+    // -------------------------------------------------------------------------
+
+    ProviderContainer createContainerWithDevices(DevicesData devicesData) {
+      final container = ProviderContainer(
+        overrides: [
+          uspDhcpServiceProvider.overrideWithValue(mockService),
+          uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+          devicesDataProvider
+              .overrideWith(() => _TestDevicesDataNotifier(devicesData)),
+        ],
+      );
+      container.listen(uspDhcpReservationsProvider, (_, __) {});
+      return container;
+    }
+
+    test('deviceOptions maps client devices to pure data', () async {
+      when(() => mockService.fetchReservations()).thenAnswer((_) async => []);
+      final container = createContainerWithDevices(DevicesData(
+        deviceModels: [
+          _device(
+            mac: 'AA:BB:CC:DD:EE:01',
+            ip: '192.168.1.10',
+            friendlyName: 'Laptop',
+            isActive: true,
+          ),
+        ],
+      ));
+      // Ensure devicesDataProvider resolves before reading.
+      await container.read(devicesDataProvider.future);
+      await Future.delayed(Duration.zero);
+
+      final options =
+          container.read(uspDhcpReservationsProvider.notifier).deviceOptions();
+
+      expect(options, hasLength(1));
+      expect(options[0].name, 'Laptop');
+      expect(options[0].mac, 'AA:BB:CC:DD:EE:01');
+      expect(options[0].ip, '192.168.1.10');
+      expect(options[0].isActive, isTrue);
+      container.dispose();
+    });
+
+    test('deviceOptions name falls back to hostName then mac', () async {
+      when(() => mockService.fetchReservations()).thenAnswer((_) async => []);
+      final container = createContainerWithDevices(DevicesData(
+        deviceModels: [
+          _device(mac: 'AA:BB:CC:DD:EE:01', ip: '192.168.1.10', hostName: 'pc'),
+          _device(mac: 'AA:BB:CC:DD:EE:02', ip: '192.168.1.11'),
+        ],
+      ));
+      await container.read(devicesDataProvider.future);
+      await Future.delayed(Duration.zero);
+
+      final options =
+          container.read(uspDhcpReservationsProvider.notifier).deviceOptions();
+
+      expect(options[0].name, 'pc');
+      expect(options[1].name, 'AA:BB:CC:DD:EE:02');
+      container.dispose();
+    });
+
+    test('deviceOptions excludes mesh nodes (master/slave)', () async {
+      when(() => mockService.fetchReservations()).thenAnswer((_) async => []);
+      final container = createContainerWithDevices(DevicesData(
+        deviceModels: [
+          _device(
+              mac: 'AA:BB:CC:DD:EE:01',
+              ip: '192.168.1.10',
+              deviceRole: 'client'),
+          _device(
+              mac: 'AA:BB:CC:DD:EE:02',
+              ip: '192.168.1.1',
+              deviceRole: 'master'),
+          _device(
+              mac: 'AA:BB:CC:DD:EE:03', ip: '192.168.1.2', deviceRole: 'slave'),
+        ],
+      ));
+      await container.read(devicesDataProvider.future);
+      await Future.delayed(Duration.zero);
+
+      final options =
+          container.read(uspDhcpReservationsProvider.notifier).deviceOptions();
+
+      expect(options, hasLength(1));
+      expect(options[0].mac, 'AA:BB:CC:DD:EE:01');
+      container.dispose();
+    });
+
+    test('deviceOptions returns empty when no devices', () async {
+      when(() => mockService.fetchReservations()).thenAnswer((_) async => []);
+      final container = createContainerWithDevices(const DevicesData());
+      await container.read(devicesDataProvider.future);
+      await Future.delayed(Duration.zero);
+
+      final options =
+          container.read(uspDhcpReservationsProvider.notifier).deviceOptions();
+
+      expect(options, isEmpty);
+      container.dispose();
+    });
   });
+}
+
+/// Test notifier that returns a fixed [DevicesData].
+class _TestDevicesDataNotifier extends DevicesDataNotifier {
+  final DevicesData _data;
+
+  _TestDevicesDataNotifier(this._data);
+
+  @override
+  Future<DevicesData> build() async => _data;
+}
+
+DeviceUIModel _device({
+  required String mac,
+  required String ip,
+  String hostName = '',
+  String? friendlyName,
+  bool isActive = true,
+  String? deviceRole,
+}) {
+  return DeviceUIModel(
+    mac: mac,
+    ip: ip,
+    hostName: hostName,
+    isActive: isActive,
+    isWifi: false,
+    friendlyName: friendlyName,
+    deviceRole: deviceRole,
+  );
 }
 
 /// Test notifier that tracks invalidation.


### PR DESCRIPTION
## Summary

Refactors the DHCP reservation cards so the client-device data lookup lives in
the notifier (data layer) rather than the views, and wires device autocomplete
options into the local-network add dialog. Also completes localization for two
duplicate-address validation strings and includes a small hooks fix.

## Changes

- **Data/UI split**: extract the cross-provider client-device read out of the
  reservation cards into `UspDhcpReservationsNotifier.deviceOptions()`, which
  returns pure data (`ReservationDeviceOption` records) instead of UI Kit types.
  The cards now map that data to `AppAutoCompleteOption` at the call site — the
  cross-provider read stays in the notifier, the UI projection stays in the view.
- **Local-network dialog**: pass device autocomplete options into the add
  reservation dialog (previously created without them).
- **l10n**: add `duplicateMacAddress` / `duplicateIpAddress` across all 26
  locales (previously only `en`).
- **Hooks**: use `$CLAUDE_PROJECT_DIR` absolute paths in the PreToolUse Bash
  hooks so they work regardless of the shell's working directory.

## Testing

- Added unit tests for `deviceOptions()`: mapping, name fallback
  (friendlyName → hostName → mac), mesh-node (master/slave) exclusion, empty case.
- `flutter analyze` clean on changed files.
- Affected functional tests pass (28 tests: notifier + dhcp_data_provider).
- `flutter gen-l10n` succeeds; generated getters verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)