### PR TITLE
fix(dashboard): upgrade UI Kit to v2.28.0 to clamp traffic curve at baseline (#1113)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,11 +59,11 @@ dependencies:
   ui_kit_library:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.27.0
+      ref: v2.28.0
   generative_ui:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.27.0
+      ref: v2.28.0
       path: generative_ui
   flutter_blue_plus: ^1.4.0
   crypto: ^3.0.2


### PR DESCRIPTION
## Summary

Fixes #1113 — the Traffic Monitor card's upload/download curve could overshoot below the y=0 baseline (out of border) in near-zero troughs.

Upgrades `ui_kit_library` and `generative_ui` from **v2.27.0 → v2.28.0**. UI Kit v2.28.0 adds `AppLineChart.preventCurveOverShooting` (default `true`), which constrains the cubic-bezier smoothing of curved, filled lines so the line and its filled area cannot dip below the lowest data point / y=0 baseline.

## Related UI Kit issue

The root-cause fix lives in the UI Kit library — see linksys/privacyGUI-UI-kit#3 (*AppLineChart curved line dips below the y=0 baseline in near-zero troughs*), resolved in v2.28.0 (commit `49a0b044`).

## Why no app-side code change

`preventCurveOverShooting` defaults to `true`, so the fix takes effect automatically after the version bump. The Traffic Monitor card (`usp_traffic_analysis_card.dart`) uses `AppLineChart` with `filled: true`, which is exactly the case the UI Kit issue describes.

## Changes

- `pubspec.yaml`: bump `ui_kit_library` ref `v2.27.0` → `v2.28.0`
- `pubspec.yaml`: bump `generative_ui` ref `v2.27.0` → `v2.28.0`

## UI Kit v2.28.0 changelog reference

> **AppLineChart `preventCurveOverShooting`**: New parameter (default `true`) that constrains the cubic-bezier smoothing of curved lines so the line — and its filled area — cannot dip below the lowest data point.
>
> **Fixed — AppLineChart curve dipping below baseline**: Curved, filled line charts no longer overshoot below the y=0 baseline in near-zero troughs — e.g. a traffic monitor's upload/download line following a burst.

## Testing

- `flutter pub get` resolves `ui_kit_library` to v2.28.0
- `flutter analyze` on chart-using files: no new errors
- Verified on Dashboard: Traffic Monitor curve no longer goes out of border

Closes #1113