### PR TITLE
feat(dashboard): show spinner on card toggle during mutation (#1055)

### DIFF
--- a/lib/page/_shared/components/layout_blocks/row_blocks.dart
+++ b/lib/page/_shared/components/layout_blocks/row_blocks.dart
@@ -167,13 +167,9 @@ class ToggleRow extends StatelessWidget {
         width: 44,
         child: Center(
           child: isLoading
-              ? SizedBox(
-                  width: 26,
-                  height: 26,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    semanticsLabel: 'Loading',
-                  ),
+              ? SizedBox.square(
+                  dimension: 26,
+                  child: AppLoader(strokeWidth: 2),
                 )
               : AppSwitch(
                   value: value,
@@ -278,7 +274,7 @@ class NetworkRow extends StatelessWidget {
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (isEnabled && onShareTap != null) ...[
+            if (!isLoading && isEnabled && onShareTap != null) ...[
               _ShareButton(onTap: onShareTap!),
               AppGap.sm(),
             ],
@@ -287,13 +283,9 @@ class NetworkRow extends StatelessWidget {
                     width: 52,
                     height: 32,
                     child: Center(
-                      child: SizedBox(
-                        width: 24,
-                        height: 24,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          semanticsLabel: 'Loading',
-                        ),
+                      child: SizedBox.square(
+                        dimension: 24,
+                        child: AppLoader(strokeWidth: 2),
                       ),
                     ),
                   )

--- a/lib/page/_shared/components/layout_blocks/row_blocks.dart
+++ b/lib/page/_shared/components/layout_blocks/row_blocks.dart
@@ -134,6 +134,8 @@ class NetworkBadgeWidget extends StatelessWidget {
 ///
 /// Uses [AppListTile] from UI Kit for consistent styling.
 /// Use for DHCP reservations, port forwarding rules, etc.
+///
+/// When [isLoading] is true, displays a spinner in place of the switch.
 class ToggleRow extends StatelessWidget {
   final bool value;
   final ValueChanged<bool>? onChanged;
@@ -141,6 +143,7 @@ class ToggleRow extends StatelessWidget {
   final String? subtitle;
   final Widget? trailing;
   final VoidCallback? onTap;
+  final bool isLoading;
 
   const ToggleRow({
     super.key,
@@ -150,6 +153,7 @@ class ToggleRow extends StatelessWidget {
     this.subtitle,
     this.trailing,
     this.onTap,
+    this.isLoading = false,
   });
 
   @override
@@ -162,11 +166,20 @@ class ToggleRow extends StatelessWidget {
       leading: SizedBox(
         width: 44,
         child: Center(
-          child: AppSwitch(
-            value: value,
-            onChanged: onChanged,
-            scale: 0.8,
-          ),
+          child: isLoading
+              ? SizedBox(
+                  width: 26,
+                  height: 26,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    semanticsLabel: 'Loading',
+                  ),
+                )
+              : AppSwitch(
+                  value: value,
+                  onChanged: onChanged,
+                  scale: 0.8,
+                ),
         ),
       ),
       title: AppText.bodyMedium(
@@ -195,6 +208,8 @@ class ToggleRow extends StatelessWidget {
 /// Network row block for WiFi networks with band badges, client count, and toggle.
 ///
 /// Uses [AppListTile] from UI Kit for consistent styling.
+///
+/// When [isLoading] is true, displays a spinner in place of the switch.
 class NetworkRow extends StatelessWidget {
   final String ssidName;
   final List<String> bands;
@@ -203,6 +218,7 @@ class NetworkRow extends StatelessWidget {
   final int clientCount;
   final ValueChanged<bool>? onChanged;
   final VoidCallback? onShareTap;
+  final bool isLoading;
 
   const NetworkRow({
     super.key,
@@ -213,6 +229,7 @@ class NetworkRow extends StatelessWidget {
     required this.clientCount,
     this.onChanged,
     this.onShareTap,
+    this.isLoading = false,
   });
 
   @override
@@ -265,10 +282,25 @@ class NetworkRow extends StatelessWidget {
               _ShareButton(onTap: onShareTap!),
               AppGap.sm(),
             ],
-            AppSwitch(
-              value: isEnabled,
-              onChanged: onChanged,
-            ),
+            isLoading
+                ? SizedBox(
+                    width: 52,
+                    height: 32,
+                    child: Center(
+                      child: SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          semanticsLabel: 'Loading',
+                        ),
+                      ),
+                    ),
+                  )
+                : AppSwitch(
+                    value: isEnabled,
+                    onChanged: onChanged,
+                  ),
           ],
         ),
       ),

--- a/lib/page/dashboard/models/usp_dashboard_preset.dart
+++ b/lib/page/dashboard/models/usp_dashboard_preset.dart
@@ -81,6 +81,7 @@ extension UspDashboardPresetX on UspDashboardPreset {
             'system_status',
             'connected_devices',
             'wifi_status',
+            'wifi_networks',
             'time_settings',
             'dhcp_reservations',
             'port_forwarding',
@@ -176,7 +177,7 @@ List<LayoutItem> _standardLayout() => [
       _item('firewall_overview', x: 6, y: 23, w: 6, h: 4),
     ];
 
-/// Professional: all 17 cards — full feature set.
+/// Professional: all 18 cards — full feature set.
 ///
 /// ```
 /// y=0:  StatsPanel (12×1)
@@ -185,9 +186,10 @@ List<LayoutItem> _standardLayout() => [
 /// y=9:  TrafficAnalysis (6×5)     | LanInfo (6×3)
 /// y=14: EthernetPorts (6×3)       | ConnectedDevices (6×4)
 /// y=18: Topology (6×5)            | DeviceAnalytics (6×5)
-/// y=23: WiFiStatus (6×6)          | WiFiPerformance (6×5)
-/// y=29: FirewallOverview (6×4)    | TimeSettings (6×3)
-/// y=33: DhcpReservations (6×4)    | PortForwarding (6×4)
+/// y=23: WiFiStatus (6×4)          | WiFiPerformance (6×5)
+/// y=28: WiFiNetworks (6×4)        | FirewallOverview (6×4)
+/// y=32: TimeSettings (6×3)        | DhcpReservations (6×4)
+/// y=36: PortForwarding (6×4)
 /// ```
 List<LayoutItem> _professionalLayout() => [
       _item('stats_panel', x: 0, y: 0, w: 12, h: 1),
@@ -203,10 +205,11 @@ List<LayoutItem> _professionalLayout() => [
       _item('device_analytics', x: 6, y: 18, w: 6, h: 5),
       _item('wifi_status', x: 0, y: 23, w: 6, h: 4),
       _item('wifi_performance', x: 6, y: 23, w: 6, h: 5),
-      _item('firewall_overview', x: 0, y: 29, w: 6, h: 4),
-      _item('time_settings', x: 6, y: 29, w: 6, h: 3),
-      _item('dhcp_reservations', x: 0, y: 33, w: 6, h: 4),
-      _item('port_forwarding', x: 6, y: 33, w: 6, h: 4),
+      _item('wifi_networks', x: 0, y: 28, w: 6, h: 4),
+      _item('firewall_overview', x: 6, y: 28, w: 6, h: 4),
+      _item('time_settings', x: 0, y: 32, w: 6, h: 3),
+      _item('dhcp_reservations', x: 6, y: 32, w: 6, h: 4),
+      _item('port_forwarding', x: 0, y: 36, w: 6, h: 4),
     ];
 
 /// Monitoring: 8 cards — performance & analytics prominent.

--- a/lib/page/local_network/cards/usp_dhcp_reservations_card.dart
+++ b/lib/page/local_network/cards/usp_dhcp_reservations_card.dart
@@ -88,7 +88,7 @@ class UspDhcpReservationsCard extends ConsumerWidget {
       subtitle: reservation.ip,
       trailing: AppIconButton(
         icon: AppIcon.font(Icons.delete_outline, size: 18),
-        onTap: isLoading
+        onTap: isLoading || reservation.instancePath == null
             ? null
             : () => _confirmDeleteDhcp(context, ref, reservation),
       ),

--- a/lib/page/local_network/cards/usp_dhcp_reservations_card.dart
+++ b/lib/page/local_network/cards/usp_dhcp_reservations_card.dart
@@ -73,6 +73,7 @@ class UspDhcpReservationsCard extends ConsumerWidget {
       DhcpReservationUIModel reservation, bool isLoading) {
     return ToggleRow(
       value: reservation.enable,
+      isLoading: isLoading,
       onChanged: isLoading || reservation.instancePath == null
           ? null
           : (value) => performUspMutation(

--- a/lib/page/port_forwarding/cards/usp_port_forwarding_card.dart
+++ b/lib/page/port_forwarding/cards/usp_port_forwarding_card.dart
@@ -76,7 +76,7 @@ class UspPortForwardingCard extends ConsumerWidget {
     return ToggleRow(
       value: rule.enabled,
       isLoading: isLoading,
-      onChanged: isLoading
+      onChanged: isLoading || rule.instancePath == null
           ? null
           : (value) => performUspMutation(
                 context,
@@ -97,7 +97,7 @@ class UspPortForwardingCard extends ConsumerWidget {
     return ToggleRow(
       value: trigger.enabled,
       isLoading: isLoading,
-      onChanged: isLoading
+      onChanged: isLoading || trigger.instancePath == null
           ? null
           : (value) => performUspMutation(
                 context,

--- a/lib/page/port_forwarding/cards/usp_port_forwarding_card.dart
+++ b/lib/page/port_forwarding/cards/usp_port_forwarding_card.dart
@@ -75,6 +75,7 @@ class UspPortForwardingCard extends ConsumerWidget {
       PortForwardingRuleUIModel rule, bool isLoading) {
     return ToggleRow(
       value: rule.enabled,
+      isLoading: isLoading,
       onChanged: isLoading
           ? null
           : (value) => performUspMutation(
@@ -95,6 +96,7 @@ class UspPortForwardingCard extends ConsumerWidget {
       PortTriggeringRuleUIModel trigger, bool isLoading) {
     return ToggleRow(
       value: trigger.enabled,
+      isLoading: isLoading,
       onChanged: isLoading
           ? null
           : (value) => performUspMutation(

--- a/lib/page/wifi_settings/cards/usp_wifi_networks_card.dart
+++ b/lib/page/wifi_settings/cards/usp_wifi_networks_card.dart
@@ -102,6 +102,7 @@ class UspWifiNetworksCard extends ConsumerWidget {
       isGuest: network.isGuest,
       isEnabled: network.isEnabled,
       clientCount: network.clientCount,
+      isLoading: isLoading,
       onChanged: isLoading
           ? null
           : (value) => _confirmToggleNetwork(context, ref, network, value),

--- a/lib/page/wifi_settings/cards/usp_wifi_networks_card.dart
+++ b/lib/page/wifi_settings/cards/usp_wifi_networks_card.dart
@@ -54,6 +54,7 @@ class UspWifiNetworksCard extends ConsumerWidget {
     final data = wifiData ?? ref.watch(wifiDataProvider).valueOrNull;
     if (data == null) return const CardSkeleton.list(rows: 3);
 
+    final isLoading = ref.watch(uspMutationLoadingProvider) == 'wifi_network';
     final networks = _aggregateBySSID(
       data.radioModels,
       data.connectionDetailMap,
@@ -69,7 +70,7 @@ class UspWifiNetworksCard extends ConsumerWidget {
           : Column(
               children: [
                 for (var i = 0; i < networks.length; i++) ...[
-                  _buildNetworkRow(context, ref, networks[i]),
+                  _buildNetworkRow(context, ref, networks[i], isLoading),
                   if (i < networks.length - 1) AppGap.sm(),
                 ],
               ],
@@ -93,9 +94,8 @@ class UspWifiNetworksCard extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     _WifiNetworkEntry network,
+    bool isLoading,
   ) {
-    final isLoading = ref.watch(uspMutationLoadingProvider) == 'wifi_network';
-
     return NetworkRow(
       ssidName: network.ssidName,
       bands: network.bands,

--- a/test/page/dashboard/models/usp_dashboard_preset_test.dart
+++ b/test/page/dashboard/models/usp_dashboard_preset_test.dart
@@ -57,8 +57,8 @@ void main() {
       expect(UspDashboardPreset.standard.cardIds.length, 12);
     });
 
-    test('professional has 17 cards (all)', () {
-      expect(UspDashboardPreset.professional.cardIds.length, 17);
+    test('professional has 18 cards (all)', () {
+      expect(UspDashboardPreset.professional.cardIds.length, 18);
     });
 
     test('monitoring has 8 cards', () {

--- a/test/page/dashboard/providers/usp_layout_controller_test.dart
+++ b/test/page/dashboard/providers/usp_layout_controller_test.dart
@@ -583,7 +583,7 @@ void main() {
       expect(layout.length, 8);
     });
 
-    test('professional → 17 items', () async {
+    test('professional → 18 items', () async {
       final container = await createInitializedContainer();
       addTearDown(container.dispose);
 
@@ -593,7 +593,7 @@ void main() {
 
       final layout =
           container.read(uspSliverDashboardControllerProvider).exportLayout();
-      expect(layout.length, 17);
+      expect(layout.length, 18);
     });
 
     test('saves preset layout to prefs', () async {


### PR DESCRIPTION
## Summary

- Add loading spinner to dashboard card toggles during mutation, replacing the previous "disabled with no feedback" behavior
- Fix Professional preset missing the WiFi Networks card

## Changes

### Toggle Spinner
Added `isLoading` parameter to `ToggleRow` and `NetworkRow` components. When `true`, displays a `CircularProgressIndicator` in place of the switch, providing clear visual feedback that an operation is in progress.

### Professional Preset Fix
Added missing `wifi_networks` card to the Professional preset. The preset description says "all cards enabled" but was missing this card (17 → 18 cards).

## Affected Toggles

| Dashboard Card | Toggle Location |
|---|---|
| **WiFi Networks** | Each SSID network |
| **DHCP Reservations** | Each reservation entry |
| **Port Forwarding** | Each forwarding rule |
| **Port Triggering** | Each triggering rule |

## Test Plan

- [ ] Toggle WiFi network on/off → spinner appears during mutation
- [ ] Toggle DHCP reservation on/off → spinner appears during mutation
- [ ] Toggle port forwarding rule on/off → spinner appears during mutation
- [ ] Toggle port triggering rule on/off → spinner appears during mutation
- [ ] Switch to Professional preset → WiFi Networks card is now visible

## Notes

1. **Existing loadable switch components in this project**
   - `AppSwitchTriggerTile` at `lib/components/composed/app_switch_trigger_tile.dart` — self-manages `_isLoading`, replaces `AppSwitch` with `CircularProgressIndicator` when loading. 
   **Currently unused.**
   - `AppLoadableWidget.appSwitch` at `lib/components/composed/app_loadable_widget.dart` — same as above but more generic, includes controller.
   **Currently unused.**

2. **UI Kit status**
   - UI Kit (`ui_kit_library`) only provides the atomic `AppSwitch` component
   - `AppSwitch` has no built-in `loading` parameter (pure `StatelessWidget`)
   - UI Kit has no equivalent loadable-switch composite component