### PR TITLE
fix(pnp): distinguish router read failure from no-internet (#1098)

### DIFF
--- a/lib/page/instant_setup/models/pnp_state.dart
+++ b/lib/page/instant_setup/models/pnp_state.dart
@@ -71,12 +71,22 @@ class AdminInternetConnected extends PnpPhase {
   List<Object?> get props => [];
 }
 
-/// Critical error in admin phase.
-class AdminError extends PnpPhase {
-  final String message;
-  const AdminError({required this.message});
+/// Router state could not be read (USP GET returned empty / missing fields).
+///
+/// Distinct from [NoInternet]: the router did not confirm "no internet" — the
+/// read itself failed, so we cannot tell the WAN state at all. The no-internet
+/// troubleshooter options (restart modem / enter ISP settings) are meaningless
+/// here, so this phase renders its own error card with a plain retry instead.
+///
+/// [code] / [detail] carry the underlying [ServiceError] diagnostics (e.g. the
+/// codegen 9998 "required fields missing" fault) for logging only — the UI
+/// derives its message from the phase itself.
+class AdminReadFailure extends PnpPhase {
+  final int? code;
+  final String? detail;
+  const AdminReadFailure({this.code, this.detail});
   @override
-  List<Object?> get props => [message];
+  List<Object?> get props => [code, detail];
 }
 
 /// No internet detected — route to troubleshooter.

--- a/lib/page/instant_setup/providers/pnp_notifier.dart
+++ b/lib/page/instant_setup/providers/pnp_notifier.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_auth_coordinator.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/core/session/providers/session_provider.dart';
@@ -46,10 +47,17 @@ class PnpNotifier extends Notifier<PnpState> {
       );
 
       await _checkInternet();
+    } on ServiceError catch (e) {
+      // Reading device info failed (e.g. USP GET returned empty). This is a
+      // read failure, not "no internet" — surface it as such.
+      logger.e('[PnP] startPostLoginFlow read failure: $e (code=${e.code})');
+      state = state.copyWith(
+        phase: AdminReadFailure(code: e.code, detail: '$e'),
+      );
     } catch (e) {
       logger.e('[PnP] startPostLoginFlow error: $e');
       state = state.copyWith(
-        phase: AdminError(message: '$e'),
+        phase: AdminReadFailure(detail: '$e'),
       );
     }
   }
@@ -71,9 +79,18 @@ class PnpNotifier extends Notifier<PnpState> {
           phase: NoInternet(ssid: ssid, currentWanSettings: wanSettings),
         );
       }
+    } on ServiceError catch (e) {
+      // The WAN read threw — we could NOT determine the WAN state (router
+      // unreachable / USP GET returned empty). This is distinct from the router
+      // confirming "no internet" (which returns false above, no throw), so we
+      // must not collapse it into NoInternet.
+      logger.e('[PnP] Internet check read failure: $e (code=${e.code})');
+      state = state.copyWith(
+        phase: AdminReadFailure(code: e.code, detail: '$e'),
+      );
     } catch (e) {
-      logger.e('[PnP] Internet check failed: $e');
-      state = state.copyWith(phase: const NoInternet());
+      logger.e('[PnP] Internet check unexpected error: $e');
+      state = state.copyWith(phase: AdminReadFailure(detail: '$e'));
     }
   }
 

--- a/lib/page/instant_setup/providers/pnp_notifier.dart
+++ b/lib/page/instant_setup/providers/pnp_notifier.dart
@@ -396,27 +396,6 @@ class PnpNotifier extends Notifier<PnpState> {
 
   // ─── No Internet Flow ───────────────────────────────────
 
-  /// Save ISP settings and re-check internet.
-  Future<void> saveIspSettingsAndCheck(PnpIspConfig config) async {
-    try {
-      await ref.read(uspMutationLockProvider).withLock(() async {
-        await _svc.saveIspSettings(config);
-      });
-
-      // Wait for WAN interface to come up
-      await Future.delayed(const Duration(seconds: 5));
-
-      state = state.copyWith(phase: const AdminCheckingInternet());
-      await _checkInternet();
-    } catch (e) {
-      logger.e('[PnP] ISP save failed: $e');
-      state = state.copyWith(
-        phase: const NoInternet(),
-        errorMessage: '$e',
-      );
-    }
-  }
-
   /// Retry internet check after modem restart flow.
   Future<void> retryInternetCheck() async {
     state = state.copyWith(phase: const AdminCheckingInternet());

--- a/lib/page/instant_setup/views/pnp_entry_view.dart
+++ b/lib/page/instant_setup/views/pnp_entry_view.dart
@@ -60,7 +60,7 @@ class _PnpEntryViewState extends ConsumerState<PnpEntryView> {
             child: switch (pnpState.phase) {
               AdminCheckingInternet() => _buildCheckingInternet(context),
               AdminInternetConnected() => _buildLoading(context),
-              AdminError(message: final msg) => _buildErrorCard(context, msg),
+              AdminReadFailure() => _buildErrorCard(context),
               WizardInitializing() => _buildLoading(context),
               _ => _buildLoading(context),
             },
@@ -93,7 +93,7 @@ class _PnpEntryViewState extends ConsumerState<PnpEntryView> {
     );
   }
 
-  Widget _buildErrorCard(BuildContext context, String message) {
+  Widget _buildErrorCard(BuildContext context) {
     return AppCard(
       child: Padding(
         padding: const EdgeInsets.all(AppSpacing.lg),
@@ -102,7 +102,10 @@ class _PnpEntryViewState extends ConsumerState<PnpEntryView> {
           children: [
             AppIcon.font(Icons.error_outline, size: 48, color: Colors.red),
             AppGap.lg(),
-            AppText.bodyMedium(message),
+            AppText.bodyMedium(
+              loc(context).unableToGatherDeviceInfo,
+              textAlign: TextAlign.center,
+            ),
             AppGap.xl(),
             AppButton.text(
               label: loc(context).tryAgain,

--- a/lib/page/instant_setup/views/pnp_isp_settings_view.dart
+++ b/lib/page/instant_setup/views/pnp_isp_settings_view.dart
@@ -39,6 +39,11 @@ class _PnpIspSettingsViewState extends ConsumerState<PnpIspSettingsView> {
     final phase = state.phase;
     if (phase is WizardConfiguring || phase is WizardInitializing) {
       context.go(RoutePath.pnp);
+    } else if (phase is AdminReadFailure) {
+      // Save succeeded but the trailing internet check could not read router
+      // state. Route back to the entry view, which re-runs the flow (implicit
+      // retry) and renders the read-failure card if it still fails.
+      context.go(RoutePath.pnp);
     } else if (state.errorMessage != null) {
       showFailedSnackBar(context, state.errorMessage!);
     }

--- a/lib/page/instant_setup/views/pnp_no_internet_view.dart
+++ b/lib/page/instant_setup/views/pnp_no_internet_view.dart
@@ -34,6 +34,11 @@ class _PnpNoInternetViewState extends ConsumerState<PnpNoInternetView> {
     ref.listen(pnpProvider, (prev, next) {
       if (next.phase is WizardConfiguring || next.phase is WizardInitializing) {
         context.go(RoutePath.pnp);
+      } else if (next.phase is AdminReadFailure) {
+        // "Try again" hit a read failure (router state unreadable) rather than a
+        // confirmed no-internet. Route back to the entry view, which re-runs the
+        // flow (implicit retry) and renders the read-failure card if it persists.
+        context.go(RoutePath.pnp);
       }
     });
 

--- a/lib/page/instant_setup/views/pnp_pppoe_view.dart
+++ b/lib/page/instant_setup/views/pnp_pppoe_view.dart
@@ -58,6 +58,11 @@ class _PnpPppoeViewState extends ConsumerState<PnpPppoeView> {
     ref.listen(pnpProvider, (prev, next) {
       if (next.phase is WizardConfiguring || next.phase is WizardInitializing) {
         context.go(RoutePath.pnp);
+      } else if (next.phase is AdminReadFailure) {
+        // Save succeeded but the trailing internet check could not read router
+        // state. Route back to the entry view, which re-runs the flow (implicit
+        // retry) and renders the read-failure card if it still fails.
+        context.go(RoutePath.pnp);
       } else if (prev?.phase is IspSaving &&
           next.phase is NoInternet &&
           next.errorMessage != null) {

--- a/lib/page/instant_setup/views/pnp_static_ip_view.dart
+++ b/lib/page/instant_setup/views/pnp_static_ip_view.dart
@@ -64,6 +64,11 @@ class _PnpStaticIpViewState extends ConsumerState<PnpStaticIpView> {
     ref.listen(pnpProvider, (prev, next) {
       if (next.phase is WizardConfiguring || next.phase is WizardInitializing) {
         context.go(RoutePath.pnp);
+      } else if (next.phase is AdminReadFailure) {
+        // Save succeeded but the trailing internet check could not read router
+        // state. Route back to the entry view, which re-runs the flow (implicit
+        // retry) and renders the read-failure card if it still fails.
+        context.go(RoutePath.pnp);
       } else if (prev?.phase is IspSaving &&
           next.phase is NoInternet &&
           next.errorMessage != null) {

--- a/test/page/instant_setup/providers/pnp_notifier_test.dart
+++ b/test/page/instant_setup/providers/pnp_notifier_test.dart
@@ -364,7 +364,8 @@ void main() {
     // AdminReadFailure (read failure), NOT NoInternet — distinct from a genuine
     // no-internet (checkInternetConnected returns false) and from a save write
     // failure (which stays on NoInternet + errorMessage, tested above).
-    test('ISP save success but check read failure → AdminReadFailure', () async {
+    test('ISP save success but check read failure → AdminReadFailure',
+        () async {
       when(() => mockPnpService.saveIspSettings(any()))
           .thenAnswer((_) async {});
       when(() => mockPnpService.checkInternetConnected())

--- a/test/page/instant_setup/providers/pnp_notifier_test.dart
+++ b/test/page/instant_setup/providers/pnp_notifier_test.dart
@@ -358,5 +358,37 @@ void main() {
       expect(state.phase, isA<NoInternet>());
       container.dispose();
     });
+
+    // Regression for #1098: the ISP save WRITE succeeds, but the trailing
+    // internet check READ fails (USP GET returned empty). This must land in
+    // AdminReadFailure (read failure), NOT NoInternet — distinct from a genuine
+    // no-internet (checkInternetConnected returns false) and from a save write
+    // failure (which stays on NoInternet + errorMessage, tested above).
+    test('ISP save success but check read failure → AdminReadFailure', () async {
+      when(() => mockPnpService.saveIspSettings(any()))
+          .thenAnswer((_) async {});
+      when(() => mockPnpService.checkInternetConnected())
+          .thenThrow(const InvalidInputError(code: 9998, detail: 'missing'));
+
+      final container = createContainer();
+      final notifier = container.read(pnpProvider.notifier);
+
+      notifier.setDemoPhase(const NoInternet(ssid: 'Test'));
+
+      const config = PnpIspConfig(
+        type: IspConnectionType.staticIp,
+        staticIpAddress: '10.0.0.5',
+        subnetMask: '255.255.255.0',
+        defaultGateway: '10.0.0.1',
+      );
+
+      await notifier.saveIspWithProgress(config);
+
+      verify(() => mockPnpService.saveIspSettings(any())).called(1);
+      final state = container.read(pnpProvider);
+      expect(state.phase, isA<AdminReadFailure>());
+      expect((state.phase as AdminReadFailure).code, 9998);
+      container.dispose();
+    });
   });
 }

--- a/test/page/instant_setup/providers/pnp_notifier_test.dart
+++ b/test/page/instant_setup/providers/pnp_notifier_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/core/usp/providers/usp_client_provider.dart';
 import 'package:privacy_gui/core/usp/services/usp_client.dart';
@@ -127,9 +128,10 @@ void main() {
       container.dispose();
     });
 
-    test('error transitions to AdminError phase', () async {
+    test('device info read failure transitions to AdminReadFailure phase',
+        () async {
       when(() => mockPnpService.checkFactoryDefault())
-          .thenThrow(Exception('Network error'));
+          .thenThrow(const NetworkError(detail: 'Network error'));
 
       final container = createContainer();
       final notifier = container.read(pnpProvider.notifier);
@@ -137,8 +139,30 @@ void main() {
       await notifier.startPostLoginFlow();
 
       final state = container.read(pnpProvider);
-      expect(state.phase, isA<AdminError>());
-      expect((state.phase as AdminError).message, contains('Network error'));
+      expect(state.phase, isA<AdminReadFailure>());
+      expect(
+          (state.phase as AdminReadFailure).detail, contains('Network error'));
+      container.dispose();
+    });
+
+    // Regression for #1098: a WAN read FAILURE (USP GET returned empty →
+    // WanStatus.fetch throws) must NOT collapse into NoInternet. That state is
+    // reserved for the router *confirming* no internet (returns false, no throw).
+    test('WAN read failure transitions to AdminReadFailure, not NoInternet',
+        () async {
+      when(() => mockPnpService.checkFactoryDefault())
+          .thenAnswer((_) async => testFactoryResult);
+      when(() => mockPnpService.checkInternetConnected())
+          .thenThrow(const InvalidInputError(code: 9998, detail: 'missing'));
+
+      final container = createContainer();
+      final notifier = container.read(pnpProvider.notifier);
+
+      await notifier.startPostLoginFlow();
+
+      final state = container.read(pnpProvider);
+      expect(state.phase, isA<AdminReadFailure>());
+      expect((state.phase as AdminReadFailure).code, 9998);
       container.dispose();
     });
   });


### PR DESCRIPTION
Fixes #1098

## Background / Root cause

During PnP first-time setup, the app runs an internet check after login. In the reported session the device returned an **empty `{}` payload for every USP GET** (396/396 empty), so the WAN read failed. The user saw a brief spinner, landed on the **no-internet page**, and **"Try again" could never recover** — even after the WAN cable was reconnected and the internet was genuinely back.

The internet check conflated **two distinct outcomes** into a single `NoInternet` state. They are already separated by control flow — the code just discarded that distinction:

- **Path A — genuine no-internet.** `WanStatus.fetch` succeeds, WAN `Status != 'Up'` → `checkInternetConnected()` **returns `false`** (no throw).
- **Path B — read failure.** The USP GET returns empty / missing fields → `WanStatus.fetch` throws (codegen fault `9998`) → mapped to a `ServiceError` and rethrown.

`PnpNotifier._checkInternet()` had the `else` branch (path A) **and** the `catch` block (path B) both produce `NoInternet`. So a read failure — where we genuinely cannot tell the WAN state — was reported as the router *confirming* there is no internet, and "Try again" just looped.

> Note: the fix keys off the **control-flow boundary** (`fetch` threw = read failure), not the `9998` code alone — the code is carried only as diagnostic detail. The reported session is unambiguous (396/396 GETs empty, incl. `DeviceInfo`): the whole data plane was unreadable.

## Affected paths

`_checkInternet()` is **not** only triggered by the entry view — it has multiple callers, each in a different view context. It also **does not rethrow**: it writes the resulting phase itself and returns.

| # | Trigger | View | Gap before this PR |
|---|---------|------|--------------------|
| 1 | `startPostLoginFlow()` | entry view | none — `switch(phase)` renders it |
| 2 | `retryInternetCheck()` | no-internet view | `ref.listen` only; read failure → spinner ends, stuck |
| 3a/3b | `saveIspWithProgress()` | PPPoE / Static IP | listener misses `AdminReadFailure` → stuck on saving / blank |
| 3c | `saveIspWithProgress()` (DHCP) | ISP settings | `_onDhcpTap` misses it → silently does nothing |
| 4 | `saveIspSettingsAndCheck()` | — | dead code, zero callers |

### The save-vs-read distinction inside `saveIspWithProgress`

Two different failure points must **not** share a fate:

1. **`saveIspSettings()` write fails** (bad value, PPP instance fail) → not a read failure. Stay on the ISP form + errorMessage snackbar so the user can fix it.
2. **Save succeeds, trailing `_checkInternet()` read-fails** → real read failure → `AdminReadFailure`.

Because `_checkInternet()` doesn't rethrow, case 2 is handled inside it and never reaches the `saveIspWithProgress` catch. Only case 1 reaches that catch — so it **stays `NoInternet` + snackbar, unchanged**.

## Solution

Introduce a dedicated `AdminReadFailure` phase (replacing the former `AdminError`, whose only job was an error card + retry — a strict superset, so no orphan is left), carrying the `ServiceError` code/detail for diagnostics.

**Provider**
- `startPostLoginFlow()` + `_checkInternet()` catch: `on ServiceError` → `AdminReadFailure` (covers a read failure at either the `SystemInfo` or `WanStatus` step).
- `saveIspWithProgress()` catch: **unchanged** (`NoInternet` + errorMessage — write-failure path).
- Deleted dead code `saveIspSettingsAndCheck()`.

**Views** — every read-failure path converges on the entry view (`RoutePath.pnp`): no-internet / PPPoE / Static IP listeners + DHCP `_onDhcpTap` each route to it on `AdminReadFailure`.

### Why "navigate to entry" = implicit retry (important — non-obvious)

`/pnp` (PnpEntryView) and `/pnpNoInternetConnection` (+ its isp/pppoe/static-ip children) are **two independent top-level route trees** — the no-internet subtree is *not* nested under `/pnp`. The entry view reaches the no-internet subtree via `context.go(...)`, which replaces the stack, so PnpEntryView is already **unmounted** by the time the user is there.

Therefore `go(RoutePath.pnp)` from paths #2/#3 is a **cross-tree switch that mounts a fresh PnpEntryView**, whose `initState` re-runs `startPostLoginFlow()`. Since `pnpProvider` is **not autoDispose**, the phase persists; `startPostLoginFlow` overwrites the lingering `AdminReadFailure` with `AdminCheckingInternet` and re-checks.

Net effect: back to entry → re-run the whole flow → **only if it still fails** does it settle on `AdminReadFailure` and render the error card (no infinite loop). If the transient condition cleared (e.g. FW warm-up finished), it proceeds straight into the wizard. Cost: one redundant check (a few seconds), which is the intended retry.

> Two recovery behaviors coexist: the **entry view** renders the read-failure card **in place** (manual retry via the button); the **other views** navigate to entry (**implicit retry**).

## Expected behavior after the fix

| Scenario | Before | After |
|----------|--------|-------|
| WAN read succeeds, `Status != 'Up'` | `NoInternet` | `NoInternet` (unchanged) |
| WAN read fails at entry | `NoInternet`, retry loops forever | `AdminReadFailure` → entry error card + retry |
| Read fails at `SystemInfo` step (reported session) | `AdminError` | `AdminReadFailure` (consistent) |
| "Try again" on no-internet page hits a read failure | stuck | navigate to entry → implicit retry → card if still failing |
| ISP save → trailing check read-fails | stuck / silent | navigate to entry → implicit retry |
| ISP save **write** fails | `NoInternet` + snackbar | `NoInternet` + snackbar (unchanged — stay on form) |

## Tests

- Read failure → `AdminReadFailure`, not `NoInternet` (regression for this bug).
- Read at `SystemInfo` fails → `AdminReadFailure`.
- `saveIspWithProgress` where save succeeds but trailing check read-fails → `AdminReadFailure`.
- Existing: save write failure stays `NoInternet` + errorMessage; genuine no-internet stays `NoInternet`.

No widget tests: the added navigation is a thin `if (phase is AdminReadFailure) go(pnp)` branch, and this feature's test suite is provider/service/model only. Core logic is covered by the provider tests above.

## Scope note

The firmware-side trigger (why every USP GET returns empty after a successful login) still needs FW confirmation (`need-fw-confirm`). This PR is the UI-resilience fix, which also hardens against any future transient read failure.
