### PR TITLE
fix(dashboard): hide link-local IPv6 in LAN Information widget (#1129)

### DIFF
--- a/lib/page/local_network/cards/usp_lan_info_card.dart
+++ b/lib/page/local_network/cards/usp_lan_info_card.dart
@@ -108,7 +108,12 @@ class UspLanInfoCard extends ConsumerWidget {
                     copyable: true,
                   )
                 else if (info.ipv6Enabled)
-                  InfoGridItem(label: 'IPv6', value: 'Enabled'),
+                  // Issue #1129: IPv6 is enabled but no meaningful (global/ULA)
+                  // address is available (e.g. the interface holds only a
+                  // link-local fe80:: address). Render '-' consistent with how
+                  // the DNS field renders when unavailable, not the link-local
+                  // address and not a bare 'Enabled' label.
+                  InfoGridItem(label: 'IPv6', value: '-'),
               ],
             ),
           ],

--- a/lib/page/local_network/services/usp_lan_data_service.dart
+++ b/lib/page/local_network/services/usp_lan_data_service.dart
@@ -73,11 +73,29 @@ class UspLanDataService {
       final instances = resp.getInstances('Device.IP.Interface.1.IPv6Address.');
       return instances
           .map((i) => i.getString('IPAddress'))
-          .where((ip) => ip.isNotEmpty)
+          .where((ip) => ip.isNotEmpty && !_isLinkLocalIpv6(ip))
           .toList();
     } catch (e) {
       logger.w('[USP][LanData]: IPv6 addresses fetch failed: $e');
       return const <String>[];
     }
+  }
+
+  /// Returns true if [ip] is an IPv6 link-local address (`fe80::/10`).
+  ///
+  /// Issue #1129: when the LAN interface holds only a link-local address
+  /// (scope link, e.g. `fe80::7612:13ff:fe21:5394`) and no global/ULA prefix,
+  /// the widget must render empty rather than the link-local address, since a
+  /// link-local address is only valid on a single link and is not a meaningful
+  /// LAN IPv6 address. The `fe80::/10` block covers any address whose first
+  /// hextet, masked with `0xffc0`, equals `0xfe80` (i.e. `fe80`–`febf`).
+  static bool _isLinkLocalIpv6(String ip) {
+    // Drop any zone index (e.g. "fe80::1%eth0") before parsing.
+    final addr = ip.split('%').first.trim();
+    final firstHextet = addr.split(':').first;
+    if (firstHextet.isEmpty) return false;
+    final value = int.tryParse(firstHextet, radix: 16);
+    if (value == null) return false;
+    return (value & 0xffc0) == 0xfe80;
   }
 }

--- a/test/page/local_network/providers/lan_data_provider_test.dart
+++ b/test/page/local_network/providers/lan_data_provider_test.dart
@@ -120,6 +120,31 @@ void main() {
       container.dispose();
     });
 
+    test('fec0::1 is NOT link-local and must NOT be filtered (#1129)',
+        () async {
+      // fec0::1 is the first address just above the fe80::/10 range
+      // (link-local spans fe80::-febf::). It is a deprecated site-local
+      // address (RFC 3513), NOT link-local:
+      //   0xfec0 & 0xffc0 == 0xfec0 != 0xfe80
+      // The filter must keep it. This guards the upper boundary of fe80::/10.
+      when(() => mockUsp.get(any())).thenAnswer((_) async {
+        final paths = _.positionalArguments[0] as List;
+        if (paths.any((p) => p.toString().contains('IPv6Address'))) {
+          return <String, dynamic>{
+            'Device.IP.Interface.1.IPv6Enable': true,
+            'Device.IP.Interface.1.IPv6Address.1.IPAddress': 'fec0::1',
+          };
+        }
+        return lanInfoResponse;
+      });
+
+      final container = createContainer();
+      final data = await container.read(lanDataProvider.future);
+
+      expect(data.model.ipv6Addresses, ['fec0::1']);
+      container.dispose();
+    });
+
     test('build throws ServiceNotInitializedError when usp is null', () async {
       final container = ProviderContainer(
         overrides: [

--- a/test/page/local_network/providers/lan_data_provider_test.dart
+++ b/test/page/local_network/providers/lan_data_provider_test.dart
@@ -25,6 +25,8 @@ void main() {
   };
 
   /// IPv6 response from raw usp.get().
+  /// Includes a link-local (fe80::) address that must be filtered out (#1129)
+  /// and a global address that must be kept.
   final ipv6Response = <String, dynamic>{
     'Device.IP.Interface.1.IPv6Enable': true,
     'Device.IP.Interface.1.IPv6Address.1.IPAddress': 'fe80::1',
@@ -65,7 +67,56 @@ void main() {
       expect(data.model.dnsServers, '8.8.8.8,8.8.4.4');
       expect(data.model.hostName, 'LinksysRouter');
       expect(data.model.ipv6Enabled, isTrue);
-      expect(data.model.ipv6Addresses, ['fe80::1', '2001:db8::1']);
+      // #1129: link-local fe80:: is filtered out; only the global address remains.
+      expect(data.model.ipv6Addresses, ['2001:db8::1']);
+      container.dispose();
+    });
+
+    test('link-local-only IPv6 yields empty addresses (#1129)', () async {
+      // Reproduces the reported case: br-lan holds only a scope-link fe80::
+      // address and no global/ULA prefix. The link-local address must NOT be
+      // surfaced to the widget.
+      when(() => mockUsp.get(any())).thenAnswer((_) async {
+        final paths = _.positionalArguments[0] as List;
+        if (paths.any((p) => p.toString().contains('IPv6Address'))) {
+          return <String, dynamic>{
+            'Device.IP.Interface.1.IPv6Enable': true,
+            'Device.IP.Interface.1.IPv6Address.1.IPAddress':
+                'fe80::7612:13ff:fe21:5394',
+          };
+        }
+        return lanInfoResponse;
+      });
+
+      final container = createContainer();
+      final data = await container.read(lanDataProvider.future);
+
+      expect(data.model.ipv6Enabled, isTrue);
+      expect(data.model.ipv6Addresses, isEmpty);
+      container.dispose();
+    });
+
+    test('link-local with zone index is filtered, global kept (#1129)',
+        () async {
+      when(() => mockUsp.get(any())).thenAnswer((_) async {
+        final paths = _.positionalArguments[0] as List;
+        if (paths.any((p) => p.toString().contains('IPv6Address'))) {
+          return <String, dynamic>{
+            'Device.IP.Interface.1.IPv6Enable': true,
+            'Device.IP.Interface.1.IPv6Address.1.IPAddress': 'fe80::1%eth0',
+            'Device.IP.Interface.1.IPv6Address.2.IPAddress': 'febf::1',
+            'Device.IP.Interface.1.IPv6Address.3.IPAddress': '2001:db8:abcd::5',
+          };
+        }
+        return lanInfoResponse;
+      });
+
+      final container = createContainer();
+      final data = await container.read(lanDataProvider.future);
+
+      // fe80::1%eth0 (zone index) and febf::1 (top of fe80::/10) are link-local;
+      // only the global address survives.
+      expect(data.model.ipv6Addresses, ['2001:db8:abcd::5']);
       container.dispose();
     });
 


### PR DESCRIPTION
## Summary
Fixes the Dashboard **LAN Information** widget so it no longer shows the link-local IPv6 address (`fe80::…`, scope link) when the LAN interface has no global/ULA IPv6 address. `Refs #1129`.

## Root cause
`UspLanDataService._fetchLanIpv6Addresses()` collected every entry under `Device.IP.Interface.1.IPv6Address.` indiscriminately, and the card rendered `info.ipv6Addresses.first`. When `br-lan` holds only a link-local address (as confirmed by `ip -6 addr` in the report), that `fe80::` address became `.first` and was displayed. A link-local address is only valid on a single link and is not a meaningful LAN IPv6 address.

## Fix
- **Service layer (single source):** filter out `fe80::/10` link-local addresses in `_fetchLanIpv6Addresses()`. Detection masks the first hextet with `0xffc0` and compares to `0xfe80` (covers `fe80`–`febf`), stripping any zone index (`%eth0`) first. Filtering at the source keeps the dashboard card, PDF report, and AI LAN section consistent.
- **Card:** when IPv6 is enabled but no meaningful address remains, render `-` (consistent with how the DNS field renders when unavailable) instead of a bare `Enabled` label. If a global/ULA address later appears it is displayed normally.

Tier isolation preserved: filtering lives in the L1 Service, no codegen model leaks upward, view unchanged in structure.

## Acceptance (issue #1129)
| Expected | Result |
|---|---|
| Link-local-only LAN → IPv6 field shows `-`/empty | ✅ `_isLinkLocalIpv6` filters `fe80::/10`; card shows `-` |
| Global/ULA prefix present → show the global address | ✅ non-link-local addresses pass through unchanged |

## Changed files
```
 lib/page/local_network/cards/usp_lan_info_card.dart     |  7 ++-
 lib/page/local_network/services/usp_lan_data_service.dart | 20 +++++++-
 test/page/local_network/providers/lan_data_provider_test.dart | 53 +++++++++-
 3 files changed, 77 insertions(+), 3 deletions(-)
```

## Tests (real output)
White-box service/provider tests via `flutter test test/page/local_network/providers/lan_data_provider_test.dart`:
```
+1: link-local-only IPv6 yields empty addresses (#1129)
+2: link-local with zone index is filtered, global kept (#1129)
...
00:00 +9: All tests passed!
```
- New: link-local-only case (exact reported `fe80::7612:13ff:fe21:5394`) → empty.
- New: zone index (`fe80::1%eth0`) + `febf::1` filtered, global `2001:db8:abcd::5` kept.
- Updated existing `build fetches LAN info and IPv6`: `fe80::1` now filtered, only `2001:db8::1` remains.

`flutter analyze` on changed files: `No issues found!`
`dart format --set-exit-if-changed`: clean.
