### PR TITLE
fix(dashboard/detail): unify IPv6 link-local display with a scope badge

### DIFF
--- a/lib/core/utils/ipv6_address.dart
+++ b/lib/core/utils/ipv6_address.dart
@@ -72,6 +72,16 @@ Ipv6Scope classifyIpv6Scope(String address) {
 bool isGlobalUnicastIpv6(String address) =>
     classifyIpv6Scope(address) == Ipv6Scope.global;
 
+/// Whether [address] is an IPv6 link-local address (`fe80::/10`).
+///
+/// Link-local addresses are only valid on a single link and are never a
+/// meaningful address to surface in the UI. The single source of truth for the
+/// `fe80::/10` range lives in `ipv6_ranges.dart`; this mirrors the public shape
+/// of [isGlobalUnicastIpv6] so callers can filter without re-implementing the
+/// scope test.
+bool isLinkLocalIpv6(String address) =>
+    classifyIpv6Scope(address) == Ipv6Scope.linkLocal;
+
 /// Returns [addresses] reordered so the most routable address comes first:
 /// global unicast, then ULA, then link-local, then anything else. The relative
 /// order of addresses that share a scope is preserved (stable sort), so the

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPV6",
   "ipv6Address": "عنوان IPv6",
+  "ipv6ScopeLinkLocal": "الرابط المحلي",
   "keepAlive": "استمرار النشاط",
   "l2tpPassthrough": "عبور من خلال L2TP",
   "labelInterface": "الواجهة",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPV6",
   "ipv6Address": "IPv6-adresse",
+  "ipv6ScopeLinkLocal": "Link-lokal",
   "keepAlive": "Bevar tilslutningen",
   "l2tpPassthrough": "L2TP Passthrough",
   "labelInterface": "Grænseflade",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "IPv6-Adresse",
+  "ipv6ScopeLinkLocal": "Link-lokal",
   "keepAlive": "Verbindung aufrecht halten",
   "l2tpPassthrough": "L2TP-Passthrough",
   "labelInterface": "Schnittstelle",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPV4",
   "ipv6": "IPv6",
   "ipv6Address": "Διεύθυνση IPv6",
+  "ipv6ScopeLinkLocal": "Τοπικό ζεύξης",
   "keepAlive": "Διατήρηση σε ενεργή κατάσταση",
   "l2tpPassthrough": "Διέλευση L2TP",
   "labelInterface": "Διασύνδεση",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -236,6 +236,7 @@
     "description": "Do not translate"
   },
   "ipv6Address": "IPv6 Address",
+  "ipv6ScopeLinkLocal": "Link-local",
   "keepAlive": "Keep alive",
   "l2tpPassthrough": "L2TP Passthrough",
   "labelInterface": "Interface",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "Dirección IPv6",
+  "ipv6ScopeLinkLocal": "Enlace local",
   "keepAlive": "Mantener activo",
   "l2tpPassthrough": "Paso a través de L2TP",
   "labelInterface": "Interfaz",

--- a/lib/l10n/app_es_ar.arb
+++ b/lib/l10n/app_es_ar.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "Dirección IPv6",
+  "ipv6ScopeLinkLocal": "Enlace local",
   "keepAlive": "Mantener activo",
   "l2tpPassthrough": "Paso a través de L2TP",
   "labelInterface": "Interfaz",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "IPv6-osoite",
+  "ipv6ScopeLinkLocal": "Linkkikohtainen",
   "keepAlive": "Aina käytössä",
   "l2tpPassthrough": "L2TP-läpiohjaus",
   "labelInterface": "Käyttöliittymä",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "Adresse IPv6",
+  "ipv6ScopeLinkLocal": "Lien-local",
   "keepAlive": "Maintenir la connexion",
   "l2tpPassthrough": "Passthrough L2TP",
   "labelInterface": "Interface",

--- a/lib/l10n/app_fr_ca.arb
+++ b/lib/l10n/app_fr_ca.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "Adresse IPv6",
+  "ipv6ScopeLinkLocal": "Lien-local",
   "keepAlive": "Maintenir la connexion",
   "l2tpPassthrough": "Intercommunication L2TP",
   "labelInterface": "Interface",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPV4",
   "ipv6": "IPv6",
   "ipv6Address": "Alamat IPv6",
+  "ipv6ScopeLinkLocal": "Link-local",
   "keepAlive": "Aktifkan terus",
   "l2tpPassthrough": "L2TP Passthrough",
   "labelInterface": "Antarmuka",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "Indirizzo IPv6",
+  "ipv6ScopeLinkLocal": "Link-local",
   "keepAlive": "Connessione sempre attiva",
   "l2tpPassthrough": "Passthrough L2TP",
   "labelInterface": "Interfaccia",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "IPv6 アドレス",
+  "ipv6ScopeLinkLocal": "リンクローカル",
   "keepAlive": "接続を維持",
   "l2tpPassthrough": "L2TP パススルー",
   "labelInterface": "インターフェイス",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "IPv6 주소",
+  "ipv6ScopeLinkLocal": "링크-로컬",
   "keepAlive": "상태 유지",
   "l2tpPassthrough": "L2TP 패스스루",
   "labelInterface": "인터페이스",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPV4",
   "ipv6": "IPV6",
   "ipv6Address": "IPv6-adresse",
+  "ipv6ScopeLinkLocal": "Lenkelokal",
   "keepAlive": "Oppretthold",
   "l2tpPassthrough": "L2TP-passasje",
   "labelInterface": "Grensesnitt",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "IPv6-adres",
+  "ipv6ScopeLinkLocal": "Link-lokaal",
   "keepAlive": "Continu verbinding houden",
   "l2tpPassthrough": "L2TP-doorvoer",
   "labelInterface": "Interface",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "Adres IPv6",
+  "ipv6ScopeLinkLocal": "Link-local",
   "keepAlive": "Utrzymywanie aktywności",
   "l2tpPassthrough": "L2TP Passthrough",
   "labelInterface": "Interfejs",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "Endereço IPv6",
+  "ipv6ScopeLinkLocal": "Link-local",
   "keepAlive": "Funcionamento",
   "l2tpPassthrough": "Passagem L2TP",
   "labelInterface": "Interface",

--- a/lib/l10n/app_pt_pt.arb
+++ b/lib/l10n/app_pt_pt.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "Endereço IPv6",
+  "ipv6ScopeLinkLocal": "Link-local",
   "keepAlive": "Manter ligado",
   "l2tpPassthrough": "Passagem L2TP",
   "labelInterface": "Interface",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "IPv6-адрес",
+  "ipv6ScopeLinkLocal": "Локальный для канала",
   "keepAlive": "Проверка активности",
   "l2tpPassthrough": "L2TP-туннель",
   "labelInterface": "Интерфейс",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "IPv6-adress",
+  "ipv6ScopeLinkLocal": "Länklokal",
   "keepAlive": "Behåll anslutning",
   "l2tpPassthrough": "L2TP-vidarekoppling",
   "labelInterface": "Gränssnitt",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "IPv6 แอดเดรส",
+  "ipv6ScopeLinkLocal": "ลิงก์-โลคัล",
   "keepAlive": "คงการเชื่อมต่อ",
   "l2tpPassthrough": "L2TP Passthrough",
   "labelInterface": "อินเตอร์เฟซ",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "IPv6 Adresi",
+  "ipv6ScopeLinkLocal": "Bağlantı yerel",
   "keepAlive": "Bağlı tut",
   "l2tpPassthrough": "L2TP Geçiş İzni",
   "labelInterface": "Arabirim",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "Địa chỉ IPv6",
+  "ipv6ScopeLinkLocal": "Link-local",
   "keepAlive": "Giữ hoạt động",
   "l2tpPassthrough": "L2TP Truyền qua",
   "labelInterface": "Giao diện",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "IPv6地址",
+  "ipv6ScopeLinkLocal": "链路本地",
   "keepAlive": "保持活跃",
   "l2tpPassthrough": "L2TP通道",
   "labelInterface": "接口",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -136,6 +136,7 @@
   "ipv4": "IPv4",
   "ipv6": "IPv6",
   "ipv6Address": "IPv6 位址",
+  "ipv6ScopeLinkLocal": "連結本地",
   "keepAlive": "保持活躍",
   "l2tpPassthrough": "L2TP 穿透",
   "labelInterface": "介面",

--- a/lib/page/_shared/components/detail_widgets.dart
+++ b/lib/page/_shared/components/detail_widgets.dart
@@ -183,11 +183,16 @@ class DetailCopyableTile extends StatelessWidget {
   final String label;
   final String value;
 
+  /// Optional widget that replaces the default leading [Icon] (e.g. an
+  /// [Ipv6ScopeBadge] carrying its own tooltip/semantics).
+  final Widget? leading;
+
   const DetailCopyableTile({
     super.key,
     required this.icon,
     required this.label,
     required this.value,
+    this.leading,
   });
 
   @override
@@ -196,7 +201,7 @@ class DetailCopyableTile extends StatelessWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Icon(icon, size: 16, color: colorScheme.onSurfaceVariant),
+        leading ?? Icon(icon, size: 16, color: colorScheme.onSurfaceVariant),
         AppGap.sm(),
         Expanded(
           child: Column(

--- a/lib/page/_shared/components/layout_blocks/list_blocks.dart
+++ b/lib/page/_shared/components/layout_blocks/list_blocks.dart
@@ -158,12 +158,44 @@ class InfoGridItem {
   final bool fullWidth;
   final bool copyable;
 
+  /// Optional widget rendered next to the label (e.g. an [Ipv6ScopeBadge]).
+  final Widget? labelTrailing;
+
   const InfoGridItem({
     required this.label,
     required this.value,
     this.fullWidth = false,
     this.copyable = false,
+    this.labelTrailing,
   });
+}
+
+/// Icon-only marker for an IPv6 link-local (`fe80::/10`) address.
+///
+/// Link-local addresses are only valid on a single link and are not routable.
+/// Wherever an IPv6 address is surfaced (dashboard cards and the device/node
+/// detail views), a link-local address is shown but tagged with this compact
+/// icon (`public_off` — mirroring the routable `public` icon used for WAN
+/// addresses) rather than hidden. The tooltip provides discoverability and
+/// doubles as the semantic label for screen readers, since the icon alone
+/// carries no text.
+class Ipv6ScopeBadge extends StatelessWidget {
+  final double? size;
+
+  const Ipv6ScopeBadge({super.key, this.size});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Tooltip(
+      message: loc(context).ipv6ScopeLinkLocal,
+      child: Icon(
+        Icons.public_off,
+        size: size ?? BlockConstants.iconSm,
+        color: colorScheme.onSurfaceVariant,
+      ),
+    );
+  }
 }
 
 class _InfoGridTile extends StatelessWidget {
@@ -179,10 +211,23 @@ class _InfoGridTile extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          AppText.labelSmall(
-            item.label.toUpperCase(),
-            color: colorScheme.onSurfaceVariant,
-          ),
+          if (item.labelTrailing != null)
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AppText.labelSmall(
+                  item.label.toUpperCase(),
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                AppGap.xs(),
+                item.labelTrailing!,
+              ],
+            )
+          else
+            AppText.labelSmall(
+              item.label.toUpperCase(),
+              color: colorScheme.onSurfaceVariant,
+            ),
           AppGap.xs(),
           item.copyable
               ? _CopyableText(text: item.value)

--- a/lib/page/devices/views/usp_device_detail_view.dart
+++ b/lib/page/devices/views/usp_device_detail_view.dart
@@ -4,6 +4,7 @@ import 'package:privacy_gui/route/navigation_extensions.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/_shared/utils/device_classifier.dart';
+import 'package:privacy_gui/core/utils/ipv6_address.dart';
 import 'package:privacy_gui/core/utils/oui_lookup.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/_shared/models/client_device.dart'
@@ -720,14 +721,26 @@ class _UspDeviceDetailViewState extends ConsumerState<UspDeviceDetailView> {
   // IPv6 Section
   // ===========================================================================
 
-  Widget _buildIpv6Section(BuildContext context, List<String> addresses) {
+  Widget _buildIpv6Section(BuildContext context, List<String> rawAddresses) {
     final colorScheme = Theme.of(context).colorScheme;
+    // Surface globally routable addresses first so the collapsed view (which
+    // shows only the first entry) never leads with a link-local address, while
+    // still enumerating every address when expanded. See #1128/#1129.
+    final addresses = preferGlobalIpv6First(rawAddresses);
     final displayCount = _ipv6Expanded ? addresses.length : 1;
+    // When the representative (first) address is link-local, the leading icon
+    // itself signals the scope (public_off + tooltip) instead of a duplicate
+    // trailing badge. See #1128/#1129.
+    final leadingIsLinkLocal =
+        addresses.isNotEmpty && isLinkLocalIpv6(addresses.first);
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Icon(Icons.language, size: 16, color: colorScheme.onSurfaceVariant),
+        if (leadingIsLinkLocal)
+          const Ipv6ScopeBadge(size: 16)
+        else
+          Icon(Icons.language, size: 16, color: colorScheme.onSurfaceVariant),
         AppGap.sm(),
         Expanded(
           child: Column(

--- a/lib/page/internet_settings/cards/usp_network_status_card.dart
+++ b/lib/page/internet_settings/cards/usp_network_status_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/utils/ipv6_address.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/_shared/models/wan_status_ui_model.dart';
 import 'package:privacy_gui/page/_shared/components/dashboard_card_template.dart';
@@ -102,6 +103,12 @@ class UspNetworkStatusCard extends ConsumerWidget {
                   label: 'IPv6',
                   value: wan.ipv6Addresses.first,
                   copyable: true,
+                  // The representative address prefers global unicast; when only
+                  // a link-local (fe80::/10) address exists it is still shown,
+                  // tagged with a scope badge rather than hidden. See #1128.
+                  labelTrailing: isLinkLocalIpv6(wan.ipv6Addresses.first)
+                      ? const Ipv6ScopeBadge()
+                      : null,
                 )
               else if (wan.ipv6Enabled)
                 InfoGridItem(label: 'IPv6', value: 'Enabled'),

--- a/lib/page/internet_settings/services/usp_wan_data_service.dart
+++ b/lib/page/internet_settings/services/usp_wan_data_service.dart
@@ -92,16 +92,18 @@ class UspWanDataService {
         }
       }
 
+      // TR-181 returns IPv6 addresses in instance order, which frequently puts
+      // the link-local (fe80::/10) address first. The WAN widget shows a single
+      // representative address (ipv6Addresses.first), which must prefer the
+      // globally routable one. We keep every address (including link-local) and
+      // only reorder so global unicast wins; the UI marks a link-local address
+      // with a scope badge rather than hiding it, so a WAN with no global/ULA
+      // prefix still shows its link-local address instead of nothing.
+      // See linksys/PrivacyGUI#1128.
       final ipv6Addresses = ipv6.items
           .map((addr) => addr.ipAddress)
           .where((ip) => ip.isNotEmpty)
           .toList();
-
-      // TR-181 returns IPv6 addresses in instance order, which frequently puts
-      // the link-local (fe80::/10) address first. The WAN widget shows a single
-      // representative address (ipv6Addresses.first), which must be the globally
-      // routable one — not the link-local. Reorder so global unicast wins.
-      // See linksys/PrivacyGUI#1128.
       final orderedIpv6Addresses = preferGlobalIpv6First(ipv6Addresses);
 
       return (gateway: gateway, ipv6Addresses: orderedIpv6Addresses);

--- a/lib/page/local_network/cards/usp_lan_info_card.dart
+++ b/lib/page/local_network/cards/usp_lan_info_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/utils/ipv6_address.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/_shared/models/lan_info_ui_model.dart';
 import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
@@ -106,14 +107,16 @@ class UspLanInfoCard extends ConsumerWidget {
                     label: 'IPv6',
                     value: info.ipv6Addresses.first,
                     copyable: true,
+                    // The representative address prefers global unicast; when
+                    // only a link-local (fe80::/10) address exists it is still
+                    // shown, tagged with a scope badge rather than hidden.
+                    // See #1129.
+                    labelTrailing: isLinkLocalIpv6(info.ipv6Addresses.first)
+                        ? const Ipv6ScopeBadge()
+                        : null,
                   )
                 else if (info.ipv6Enabled)
-                  // Issue #1129: IPv6 is enabled but no meaningful (global/ULA)
-                  // address is available (e.g. the interface holds only a
-                  // link-local fe80:: address). Render '-' consistent with how
-                  // the DNS field renders when unavailable, not the link-local
-                  // address and not a bare 'Enabled' label.
-                  InfoGridItem(label: 'IPv6', value: '-'),
+                  InfoGridItem(label: 'IPv6', value: 'Enabled'),
               ],
             ),
           ],

--- a/lib/page/local_network/services/usp_lan_data_service.dart
+++ b/lib/page/local_network/services/usp_lan_data_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/errors/service_error.dart';
+import 'package:privacy_gui/core/utils/ipv6_address.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/errors/usp_error.dart';
 import 'package:privacy_gui/core/usp/services/usp_client.dart';
@@ -70,32 +71,21 @@ class UspLanDataService {
         'Device.IP.Interface.1.IPv6Address.',
       ]).timeout(const Duration(seconds: 20));
 
+      // Issue #1129: keep every LAN IPv6 address (including link-local) and let
+      // the UI mark a link-local (fe80::/10) address with a scope badge rather
+      // than hiding it. Reorder so a globally routable address is preferred as
+      // the representative value; when the interface holds only a link-local
+      // address it is still shown, tagged as link-local. Ordering is shared with
+      // the WAN path via `preferGlobalIpv6First`.
       final instances = resp.getInstances('Device.IP.Interface.1.IPv6Address.');
-      return instances
+      final addresses = instances
           .map((i) => i.getString('IPAddress'))
-          .where((ip) => ip.isNotEmpty && !_isLinkLocalIpv6(ip))
+          .where((ip) => ip.isNotEmpty)
           .toList();
+      return preferGlobalIpv6First(addresses);
     } catch (e) {
       logger.w('[USP][LanData]: IPv6 addresses fetch failed: $e');
       return const <String>[];
     }
-  }
-
-  /// Returns true if [ip] is an IPv6 link-local address (`fe80::/10`).
-  ///
-  /// Issue #1129: when the LAN interface holds only a link-local address
-  /// (scope link, e.g. `fe80::7612:13ff:fe21:5394`) and no global/ULA prefix,
-  /// the widget must render empty rather than the link-local address, since a
-  /// link-local address is only valid on a single link and is not a meaningful
-  /// LAN IPv6 address. The `fe80::/10` block covers any address whose first
-  /// hextet, masked with `0xffc0`, equals `0xfe80` (i.e. `fe80`–`febf`).
-  static bool _isLinkLocalIpv6(String ip) {
-    // Drop any zone index (e.g. "fe80::1%eth0") before parsing.
-    final addr = ip.split('%').first.trim();
-    final firstHextet = addr.split(':').first;
-    if (firstHextet.isEmpty) return false;
-    final value = int.tryParse(firstHextet, radix: 16);
-    if (value == null) return false;
-    return (value & 0xffc0) == 0xfe80;
   }
 }

--- a/lib/page/topology/views/usp_node_detail_view.dart
+++ b/lib/page/topology/views/usp_node_detail_view.dart
@@ -5,6 +5,7 @@ import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/route/navigation_extensions.dart';
 import 'package:privacy_gui/core/utils/device_image_helper.dart';
 import 'package:privacy_gui/core/utils/icon_rules.dart';
+import 'package:privacy_gui/core/utils/ipv6_address.dart';
 import 'package:privacy_gui/components/ui_kit_page_view.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/page/_shared/components/detail_widgets.dart';
@@ -234,12 +235,17 @@ class UspNodeDetailView extends ConsumerWidget {
                   label: loc(context).lanIp,
                   value: node.ipAddress!,
                 ),
-              // LAN IPv6 (from Hosts)
-              for (final ipv6 in node.ipv6Addresses)
+              // LAN IPv6 (from Hosts) — routable addresses first; a link-local
+              // address swaps its leading icon for a scope badge (see
+              // #1128/#1129).
+              for (final ipv6 in preferGlobalIpv6First(node.ipv6Addresses))
                 DetailCopyableTile(
                   icon: Icons.language,
                   label: loc(context).lanIpv6,
                   value: ipv6,
+                  leading: isLinkLocalIpv6(ipv6)
+                      ? const Ipv6ScopeBadge(size: 16)
+                      : null,
                 ),
               // WAN IPv4 (master only)
               if (wanIp != null && wanIp.isNotEmpty)
@@ -248,12 +254,17 @@ class UspNodeDetailView extends ConsumerWidget {
                   label: loc(context).wanIp,
                   value: wanIp,
                 ),
-              // WAN IPv6 (master only)
-              for (final ipv6 in wanIpv6Addresses)
+              // WAN IPv6 (master only) — routable addresses first; a link-local
+              // address swaps its leading icon for a scope badge (see
+              // #1128/#1129).
+              for (final ipv6 in preferGlobalIpv6First(wanIpv6Addresses))
                 DetailCopyableTile(
                   icon: Icons.public,
                   label: loc(context).wanIpv6,
                   value: ipv6,
+                  leading: isLinkLocalIpv6(ipv6)
+                      ? const Ipv6ScopeBadge(size: 16)
+                      : null,
                 ),
             ],
           ),

--- a/test/golden_test/page/dashboard/cards/fixtures/cards_test_data.dart
+++ b/test/golden_test/page/dashboard/cards/fixtures/cards_test_data.dart
@@ -99,8 +99,22 @@ const testWanOffline = WanStatusUIModel(
   mtu: 1500,
 );
 
+// WAN whose upstream assigns no global/ULA prefix — only a link-local
+// (fe80::/10) address. The card still shows it, tagged with a scope badge.
+const testWanLinkLocalOnly = WanStatusUIModel(
+  isUp: true,
+  ipAddress: '10.92.12.87',
+  subnetMask: '255.255.255.0',
+  addressingType: 'DHCP',
+  mtu: 1500,
+  gateway: '10.92.12.1',
+  ipv6Enabled: true,
+  ipv6Addresses: ['fe80::7612:13ff:fe21:5502'],
+);
+
 final testWanOnlineData = WanData(model: testWanOnline);
 final testWanOfflineData = WanData(model: testWanOffline);
+final testWanLinkLocalOnlyData = WanData(model: testWanLinkLocalOnly);
 
 // ---------------------------------------------------------------------------
 // LAN Info
@@ -118,7 +132,22 @@ const testLanDhcpEnabled = LanInfoUIModel(
   ipv6Addresses: ['fd00::1'],
 );
 
+// LAN whose bridge holds only a link-local (fe80::/10) address — no global/ULA
+// prefix. The card still shows it, tagged with a scope badge.
+const testLanLinkLocalOnly = LanInfoUIModel(
+  ipAddress: '192.168.1.1',
+  subnetMask: '255.255.255.0',
+  dhcpEnabled: true,
+  minAddress: '192.168.1.100',
+  maxAddress: '192.168.1.200',
+  leaseTimeMinutes: 1440,
+  dnsServers: '8.8.8.8, 8.8.4.4',
+  ipv6Enabled: true,
+  ipv6Addresses: ['fe80::7612:13ff:fe21:5502'],
+);
+
 final testLanData = LanData(model: testLanDhcpEnabled);
+final testLanLinkLocalOnlyData = LanData(model: testLanLinkLocalOnly);
 
 const testLanDhcpDisabled = LanInfoUIModel(
   ipAddress: '192.168.1.1',

--- a/test/golden_test/page/dashboard/cards/localizations/usp_info_cards_test.dart
+++ b/test/golden_test/page/dashboard/cards/localizations/usp_info_cards_test.dart
@@ -61,6 +61,10 @@ void main() {
         'online_dhcp': (overrides) => overrides.addAll(
               cardOverrides(wanData: testWanOnlineData),
             ),
+        // WAN with only a link-local IPv6 — address shown with a scope badge.
+        'link_local_ipv6': (overrides) => overrides.addAll(
+              cardOverrides(wanData: testWanLinkLocalOnlyData),
+            ),
         'offline': (overrides) => overrides.addAll(
               cardOverrides(wanData: testWanOfflineData),
             ),
@@ -80,6 +84,10 @@ void main() {
       states: {
         'dhcp_enabled': (overrides) => overrides.addAll(
               cardOverrides(lanData: testLanData),
+            ),
+        // LAN with only a link-local IPv6 — address shown with a scope badge.
+        'link_local_ipv6': (overrides) => overrides.addAll(
+              cardOverrides(lanData: testLanLinkLocalOnlyData),
             ),
         'dhcp_disabled': (overrides) => overrides.addAll(
               cardOverrides(lanData: testLanDisabledData),

--- a/test/golden_test/page/devices/fixtures/devices_test_data.dart
+++ b/test/golden_test/page/devices/fixtures/devices_test_data.dart
@@ -122,4 +122,51 @@ DeviceDetailState get offlineDetail => DeviceDetailState(
       device: offlineDevice,
     );
 
+// Device with a global (routable) IPv6 address — shown without a scope badge.
+final wifiDeviceGlobalIpv6 = ClientDevice(
+  mac: 'AA:BB:CC:DD:EE:06',
+  ip: '192.168.1.106',
+  hostName: 'Desktop-PC',
+  isActive: true,
+  connectionType: ConnectionType.wifi,
+  wifi: WifiConnectionInfo(
+    signalStrength: -42,
+    downlinkRate: 866000,
+    uplinkRate: 433000,
+    band: '5GHz',
+    ssidName: 'MyNetwork',
+  ),
+  ipv6Addresses: const ['2401:e180:8801:d79d::5'],
+  parentNodeId: 'node-1',
+  parentNodeName: 'Living Room',
+);
+
+// Device whose only IPv6 address is link-local (fe80::/10) — shown with a
+// scope badge in place of the leading icon.
+final wifiDeviceLinkLocalIpv6 = ClientDevice(
+  mac: 'AA:BB:CC:DD:EE:07',
+  ip: '192.168.1.107',
+  hostName: 'Laptop',
+  isActive: true,
+  connectionType: ConnectionType.wifi,
+  wifi: WifiConnectionInfo(
+    signalStrength: -42,
+    downlinkRate: 866000,
+    uplinkRate: 433000,
+    band: '5GHz',
+    ssidName: 'MyNetwork',
+  ),
+  ipv6Addresses: const ['fe80::cd3:70da:d0a0:49cf'],
+  parentNodeId: 'node-1',
+  parentNodeName: 'Living Room',
+);
+
 DeviceDetailState get deviceNotFound => DeviceDetailState.empty();
+
+DeviceDetailState get wifiDetailGlobalIpv6 => DeviceDetailState(
+      device: wifiDeviceGlobalIpv6,
+    );
+
+DeviceDetailState get wifiDetailLinkLocalIpv6 => DeviceDetailState(
+      device: wifiDeviceLinkLocalIpv6,
+    );

--- a/test/golden_test/page/devices/localizations/usp_device_detail_view_test.dart
+++ b/test/golden_test/page/devices/localizations/usp_device_detail_view_test.dart
@@ -25,6 +25,14 @@ void main() {
         'wired_device': (overrides) => overrides.addAll(
               deviceDetailOverrides(detail: wiredDetail),
             ),
+        // IPv6 global address — rendered without a scope badge.
+        'global_ipv6': (overrides) => overrides.addAll(
+              deviceDetailOverrides(detail: wifiDetailGlobalIpv6),
+            ),
+        // IPv6 link-local only — leading icon swapped for a scope badge.
+        'link_local_ipv6': (overrides) => overrides.addAll(
+              deviceDetailOverrides(detail: wifiDetailLinkLocalIpv6),
+            ),
         'offline_device': (overrides) => overrides.addAll(
               deviceDetailOverrides(detail: offlineDetail),
             ),

--- a/test/golden_test/page/topology/fixtures/topology_test_data.dart
+++ b/test/golden_test/page/topology/fixtures/topology_test_data.dart
@@ -170,4 +170,35 @@ final masterNodeEmptyDevices = UspNodeDetailState(
   connectedClients: [],
 );
 
+// Slave node with a global (routable) LAN IPv6 — shown without a scope badge.
+final slaveNodeGlobalIpv6 = UspNodeDetailState(
+  node: SlaveNode(
+    deviceId: 'AA:BB:CC:DD:FF:02',
+    model: 'MX2000',
+    manufacturer: 'Linksys',
+    serialNumber: 'DEF789013',
+    softwareVersion: '1.0.10.200000',
+    ipv6Addresses: const ['2401:e180:8801:d79d::5'],
+    connectedClients: _meshSlaveClients,
+    backhaul: BackhaulInfo(mediaType: 'Wi-Fi', signalStrength: -50),
+  ),
+  connectedClients: _meshSlaveClients,
+);
+
+// Slave node whose only LAN IPv6 is link-local (fe80::/10) — shown with a
+// scope badge in place of the leading icon.
+final slaveNodeLinkLocalIpv6 = UspNodeDetailState(
+  node: SlaveNode(
+    deviceId: 'AA:BB:CC:DD:FF:03',
+    model: 'MX2000',
+    manufacturer: 'Linksys',
+    serialNumber: 'DEF789014',
+    softwareVersion: '1.0.10.200000',
+    ipv6Addresses: const ['fe80::7612:13ff:fe21:5503'],
+    connectedClients: _meshSlaveClients,
+    backhaul: BackhaulInfo(mediaType: 'Wi-Fi', signalStrength: -50),
+  ),
+  connectedClients: _meshSlaveClients,
+);
+
 const nodeNotFoundState = UspNodeDetailState();

--- a/test/golden_test/page/topology/localizations/usp_node_detail_view_test.dart
+++ b/test/golden_test/page/topology/localizations/usp_node_detail_view_test.dart
@@ -18,6 +18,14 @@ void main() {
         'slave_with_devices': (overrides) => overrides.addAll(
               nodeDetailOverrides(slaveNodeWithDevices),
             ),
+        // LAN IPv6 global address — rendered without a scope badge.
+        'global_ipv6': (overrides) => overrides.addAll(
+              nodeDetailOverrides(slaveNodeGlobalIpv6),
+            ),
+        // LAN IPv6 link-local only — leading icon swapped for a scope badge.
+        'link_local_ipv6': (overrides) => overrides.addAll(
+              nodeDetailOverrides(slaveNodeLinkLocalIpv6),
+            ),
         'empty_devices': (overrides) => overrides.addAll(
               nodeDetailOverrides(masterNodeEmptyDevices),
             ),

--- a/test/page/internet_settings/services/usp_wan_data_service_test.dart
+++ b/test/page/internet_settings/services/usp_wan_data_service_test.dart
@@ -138,7 +138,8 @@ void main() {
       expect(result.ipv6Addresses, contains('2001:db8::2'));
     });
 
-    test('global IPv6 surfaces before link-local (issue #1128)', () async {
+    test('global IPv6 surfaces first, link-local kept at end (issue #1128)',
+        () async {
       // Instance order as reported by the router in the #1128 diagnostic log:
       // instance 1 is the link-local fe80:: address.
       stubWanStatus(
@@ -153,11 +154,28 @@ void main() {
 
       final result = await svc.fetch();
 
-      // The widget shows ipv6Addresses.first, which must now be a global
-      // unicast address rather than the link-local fe80::.
+      // The widget shows ipv6Addresses.first, which must be a global unicast
+      // address. Link-local is not filtered — every address is kept and merely
+      // reordered so global unicast wins; the UI tags the link-local one with a
+      // scope badge. So all 4 remain and the link-local sinks to the end.
       expect(result.ipv6Addresses, hasLength(4));
       expect(result.ipv6Addresses.first, '2401:e180:8831:505f::1');
       expect(result.ipv6Addresses.last, 'fe80::7612:13ff:fe21:5394');
+    });
+
+    test('link-local-only WAN keeps the link-local address (issue #1128)',
+        () async {
+      // Real case observed on an M60TB whose upstream assigns no IPv6 prefix:
+      // the WAN interface (eth0) holds only a scope-link fe80:: address. It is
+      // still surfaced (tagged with a scope badge by the UI), not hidden.
+      stubWanStatus(
+        ipv6Enabled: true,
+        ipv6Addresses: const ['fe80::7612:13ff:fe21:5502'],
+      );
+
+      final result = await svc.fetch();
+
+      expect(result.ipv6Addresses, ['fe80::7612:13ff:fe21:5502']);
     });
   });
 

--- a/test/page/local_network/providers/lan_data_provider_test.dart
+++ b/test/page/local_network/providers/lan_data_provider_test.dart
@@ -25,8 +25,8 @@ void main() {
   };
 
   /// IPv6 response from raw usp.get().
-  /// Includes a link-local (fe80::) address that must be filtered out (#1129)
-  /// and a global address that must be kept.
+  /// Includes a link-local (fe80::) address (kept but reordered after global,
+  /// tagged by the UI) and a global address that must be preferred first (#1129).
   final ipv6Response = <String, dynamic>{
     'Device.IP.Interface.1.IPv6Enable': true,
     'Device.IP.Interface.1.IPv6Address.1.IPAddress': 'fe80::1',
@@ -67,15 +67,16 @@ void main() {
       expect(data.model.dnsServers, '8.8.8.8,8.8.4.4');
       expect(data.model.hostName, 'LinksysRouter');
       expect(data.model.ipv6Enabled, isTrue);
-      // #1129: link-local fe80:: is filtered out; only the global address remains.
-      expect(data.model.ipv6Addresses, ['2001:db8::1']);
+      // #1129: link-local fe80:: is kept but reordered after the global address
+      // (the UI tags it with a scope badge rather than hiding it).
+      expect(data.model.ipv6Addresses, ['2001:db8::1', 'fe80::1']);
       container.dispose();
     });
 
-    test('link-local-only IPv6 yields empty addresses (#1129)', () async {
+    test('link-local-only IPv6 keeps the link-local address (#1129)', () async {
       // Reproduces the reported case: br-lan holds only a scope-link fe80::
-      // address and no global/ULA prefix. The link-local address must NOT be
-      // surfaced to the widget.
+      // address and no global/ULA prefix. It is still surfaced (tagged with a
+      // scope badge by the UI), not hidden.
       when(() => mockUsp.get(any())).thenAnswer((_) async {
         final paths = _.positionalArguments[0] as List;
         if (paths.any((p) => p.toString().contains('IPv6Address'))) {
@@ -92,12 +93,11 @@ void main() {
       final data = await container.read(lanDataProvider.future);
 
       expect(data.model.ipv6Enabled, isTrue);
-      expect(data.model.ipv6Addresses, isEmpty);
+      expect(data.model.ipv6Addresses, ['fe80::7612:13ff:fe21:5394']);
       container.dispose();
     });
 
-    test('link-local with zone index is filtered, global kept (#1129)',
-        () async {
+    test('link-local reordered after global, all kept (#1129)', () async {
       when(() => mockUsp.get(any())).thenAnswer((_) async {
         final paths = _.positionalArguments[0] as List;
         if (paths.any((p) => p.toString().contains('IPv6Address'))) {
@@ -115,18 +115,18 @@ void main() {
       final data = await container.read(lanDataProvider.future);
 
       // fe80::1%eth0 (zone index) and febf::1 (top of fe80::/10) are link-local;
-      // only the global address survives.
-      expect(data.model.ipv6Addresses, ['2001:db8:abcd::5']);
+      // all addresses are kept, with the global one surfaced first.
+      expect(data.model.ipv6Addresses,
+          ['2001:db8:abcd::5', 'fe80::1%eth0', 'febf::1']);
       container.dispose();
     });
 
-    test('fec0::1 is NOT link-local and must NOT be filtered (#1129)',
-        () async {
+    test('fec0::1 is NOT link-local (#1129)', () async {
       // fec0::1 is the first address just above the fe80::/10 range
       // (link-local spans fe80::-febf::). It is a deprecated site-local
       // address (RFC 3513), NOT link-local:
       //   0xfec0 & 0xffc0 == 0xfec0 != 0xfe80
-      // The filter must keep it. This guards the upper boundary of fe80::/10.
+      // It is kept and, not being link-local, is not tagged as such by the UI.
       when(() => mockUsp.get(any())).thenAnswer((_) async {
         final paths = _.positionalArguments[0] as List;
         if (paths.any((p) => p.toString().contains('IPv6Address'))) {


### PR DESCRIPTION
## Summary

Unifies how an IPv6 **link-local (`fe80::/10`)** address is presented across
every view that surfaces an IPv6 address. A link-local address is now **always
shown but tagged** with a scope badge (`public_off` icon + tooltip) rather than
hidden or dropped.

Data services keep **every** address and reorder so a globally routable address
is preferred as the representative value; the UI marks link-local instead of
filtering it. One consistent rule everywhere:

> Prefer a global/ULA address; when only a link-local exists, show it — tagged
> as link-local — never a bare `-` or a misleading unmarked `fe80::`.

## Behavior change (supersedes prior fixes)

This **replaces the earlier filter / `-` behavior** shipped in:
- #1128 → #1139 (WAN: was "reorder, keep link-local at end")
- #1129 → #1138 (LAN: was "filter link-local, render `-` when none global")

A WAN/LAN with no global/ULA prefix (e.g. an upstream that assigns no IPv6
prefix — observed on M60TB) now shows its link-local address **with the badge**
instead of a bare `-`. Reviewers: this is intentional, not a regression of
#1138/#1129.

## Views covered

| View | Field | Link-local rendering |
|------|-------|----------------------|
| Dashboard → Network Status (WAN) | `IPv6` | representative address + badge next to label |
| Dashboard → LAN Information | `IPv6` | representative address + badge next to label |
| Device Detail → WiFi Connection | `IPv6 Address` | leading icon swapped for badge |
| Node Detail → Network | `LAN IPv6` / `WAN IPv6` | per-row leading icon swapped for badge |

The Detail views swap the row's **leading icon** for the badge (avoids a
duplicate globe icon); the Dashboard cards tag the **label** since `InfoGridItem`
has no leading icon.

## Changes

- `ipv6_address.dart`: add public `isLinkLocalIpv6()` (shared classifier; single
  source of truth in `ipv6_ranges.dart`)
- WAN/LAN data services: keep all addresses + `preferGlobalIpv6First()`; removed
  the LAN private link-local helper
- `Ipv6ScopeBadge` (moved to `list_blocks.dart`, shared by cards + detail),
  `InfoGridItem.labelTrailing`, `DetailCopyableTile.leading`
- `ipv6ScopeLinkLocal` string added across **all 26 locales** (translated)
- updated WAN/LAN service tests for the keep-and-reorder behavior
- **golden (screenshot) states** for both a global (no badge) and a link-local
  (badge) IPv6 case in each of the four views (see below)

## Screenshot test coverage

Each view now generates screenshots for both scope cases, confirming the badge
renders only in the link-local state:

| View | Global (no badge) | Link-local (badge) |
|------|-------------------|--------------------|
| Network Status card | `online_dhcp` (existing) | `link_local_ipv6` (new) |
| LAN Information card | `dhcp_enabled` (existing, ULA) | `link_local_ipv6` (new) |
| Device Detail | `global_ipv6` (new) | `link_local_ipv6` (new) |
| Node Detail | `global_ipv6` (new) | `link_local_ipv6` (new) |

Note: golden baselines are screenshot-generation tests — the PNG baselines are
gitignored and regenerated by the suite, so only the `.dart` state/fixture
changes are committed. This pass also refreshes the `node_detail`
`slave_with_devices` screenshot, whose on-disk baseline predated the backhaul
card.

## Verification

- `dart format`: clean
- `flutter analyze`: 0 error / 0 warning on changed files
- `./run_tests.sh`: **3313 tests passed**
- golden screenshot suite (info_cards + device_detail + node_detail): **36 tests passed**

Refs #1128 #1129