### PR TITLE
fix(golden): keep regional locale variants as distinct golden files

### DIFF
--- a/test/golden_test/golden_framework/golden_runner.dart
+++ b/test/golden_test/golden_framework/golden_runner.dart
@@ -27,7 +27,13 @@ List<Locale> _resolveLocales(GoldenTestConfig config) {
   if (envLocales.isEmpty) return config.locales;
   return envLocales.split(',').map((s) {
     final parts = s.trim().split('_');
-    return parts.length > 1 ? Locale(parts[0], parts[1]) : Locale(parts[0]);
+    // Normalize the country code to uppercase so it forms a standard locale
+    // (e.g. 'es_ar' -> Locale('es', 'AR')). Flutter's localizations assert on
+    // non-standard forms like 'es_ar', and this matches the generated
+    // supportedLocales (Locale('es', 'AR'), Locale('zh', 'TW'), ...).
+    return parts.length > 1
+        ? Locale(parts[0], parts[1].toUpperCase())
+        : Locale(parts[0]);
   }).toList();
 }
 
@@ -79,7 +85,7 @@ void runViewGoldenTests(GoldenTestConfig config) {
             );
 
             goldenTest(
-              '${config.viewName} - ${stateEntry.key} - ${device.name} - ${locale.languageCode}${theme == Brightness.dark ? ' - dark' : ''}',
+              '${config.viewName} - ${stateEntry.key} - ${device.name} - ${_localeTag(locale)}${theme == Brightness.dark ? ' - dark' : ''}',
               fileName: name,
               constraints: BoxConstraints.expand(
                 width: effectiveSize.width,
@@ -137,7 +143,7 @@ void runViewGoldenTests(GoldenTestConfig config) {
               );
 
               goldenTest(
-                '${config.viewName} - ${interactionEntry.key} - ${device.name} - ${locale.languageCode}${theme == Brightness.dark ? ' - dark' : ''}',
+                '${config.viewName} - ${interactionEntry.key} - ${device.name} - ${_localeTag(locale)}${theme == Brightness.dark ? ' - dark' : ''}',
                 fileName: name,
                 constraints: BoxConstraints.expand(
                   width: effectiveSize.width,
@@ -195,6 +201,19 @@ Future<void> _precacheIfNeeded(
   });
 }
 
+/// Builds the locale tag used in golden file names and test descriptions.
+///
+/// Regional variants keep their country code so they don't collide with the
+/// base language (e.g. 'es' vs 'es_AR', 'zh' vs 'zh_TW'). The country code is
+/// joined with '_' — never '-' — because the report parser splits file names
+/// on '-'. This matches Flutter's `Locale.toString()` and the ARB naming.
+String _localeTag(Locale locale) {
+  final country = locale.countryCode;
+  return country == null || country.isEmpty
+      ? locale.languageCode
+      : '${locale.languageCode}_$country';
+}
+
 /// Generates the golden file name.
 ///
 /// Format: {viewName}-{stateKey}-{device}-{locale}.png
@@ -206,7 +225,7 @@ String _goldenFileName(
   Locale locale,
   Brightness theme,
 ) {
-  final base = '$viewName-$stateKey-${device.name}-${locale.languageCode}';
+  final base = '$viewName-$stateKey-${device.name}-${_localeTag(locale)}';
   if (theme == Brightness.dark) {
     return '$base-dark';
   }

--- a/test_scripts/generate_gallery_report.dart
+++ b/test_scripts/generate_gallery_report.dart
@@ -98,7 +98,10 @@ _GoldenEntry? _parseGoldenFile(String fullPath) {
   // pattern: viewName matches the feature directory name (or a prefix of parts)
   // Simplest: split into viewName (first element) and state (rest joined by '-')
   // Actually viewName can span multiple '-' segments if it has underscores...
-  // The golden_runner uses: '$viewName-$stateKey-${device.name}-${locale.languageCode}'
+  // The golden_runner uses: '$viewName-$stateKey-${device.name}-$localeTag'
+  // where localeTag is the languageCode, or 'languageCode_COUNTRY' for regional
+  // variants (e.g. 'es_AR'). Every field uses '_' internally — never '-' — so
+  // the country code stays attached to the locale segment after the split.
   // Where viewName is snake_case (uses _ not -) and stateKey is snake_case (uses _ not -)
   // So the only '-' separators in the filename are between the 4 main fields!
   // Wait no — viewName like "unified_diagnostics" uses underscores, not dashes.


### PR DESCRIPTION
## Problem

Generating golden snapshots for all locales failed midway. Regional locale
variants were mishandled in two ways:

1. **Crash** — `_resolveLocales` built `Locale('es', 'ar')` from a lowercase
   `--dart-define=locales=es_ar`. Flutter's localizations assert on
   non-standard forms like `es_ar`, aborting the entire run (`set -e` in
   `run_generate_loc_snapshots.sh` then stopped all remaining locales).
2. **Collision** — golden file names used only `locale.languageCode`, so `es`
   and `es_AR` both wrote `...-es.png`. The regional variant silently
   overwrote the base language golden (same for `fr`/`fr_CA`, `pt`/`pt_PT`,
   `zh`/`zh_TW`).

## Changes

- Add `_localeTag()` helper: regional variants keep their country code in
  golden file names and test descriptions (`...-es_AR.png`), joined with `_`
  (never `-`) so the report parser's `-` split keeps the country code attached.
- Normalize the country code to uppercase in `_resolveLocales()`, so lowercase
  input like `es_ar` resolves to `Locale('es', 'AR')` — matching the generated
  `supportedLocales` and avoiding the assertion.
- Update `generate_gallery_report.dart` parser comments to document the new
  `languageCode_COUNTRY` locale tag format (parse logic already handled it).

## Verification

Regenerated all 26 locales via
`./run_generate_loc_snapshots.sh -l "ar,da,de,el,en,es,es_ar,fi,fr,fr_ca,id,it,ja,ko,nb,nl,pl,pt,pt_pt,ru,sv,th,tr,vi,zh,zh_TW"`:

- 26/26 locales passed (357 tests each), 0 failures, no locale assertion.
- Regional variants now produce distinct goldens: `es_AR`, `fr_CA`, `pt_PT`,
  `zh_TW` each have 357 files, no longer overwriting the base language.
- Gallery report generated successfully (9282 images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)