### PR TITLE
feat(pnp): add "Log into router" bypass on no-internet page (#1104)

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -341,6 +341,7 @@
   "timezoneTurkeyIraqJordanKuwait": "تركيا، العراق، الأردن، الكويت",
   "traceroute": "تتبع المسار",
   "tryAgain": "حاول مجددًا",
+  "logIntoRouter": "تسجيل الدخول إلى جهاز التوجيه",
   "turnOff": "إيقاف",
   "turnOffInstantPrivacy": "هل ترغب في إيقاف خاصية  \r\nInstant-Privacy? ",
   "turnOffInstantPrivacyDesc": "سيسمح هذا للأجهزة الجديدة بالاتصال بالشبكة.",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -340,6 +340,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Tyrkiet, Irak, Jordan, Kuwait",
   "traceroute": "Traceroute",
   "tryAgain": "Prøv igen",
+  "logIntoRouter": "Log på routeren",
   "turnOff": "Sluk",
   "turnOffInstantPrivacy": "Deaktiver Instant-Databeskyttelse?",
   "turnOffInstantPrivacyDesc": "Dette giver nye enheder mulighed for at oprette forbindelse til netværket.",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -340,6 +340,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Turkei, Irak, Jordanien, Kuwait",
   "traceroute": "Traceroute",
   "tryAgain": "Versuchen Sie es erneut",
+  "logIntoRouter": "Am Router anmelden",
   "turnOff": "Deaktivieren",
   "turnOffInstantPrivacy": "Instant-Datenschutz deaktivieren?",
   "turnOffInstantPrivacyDesc": "Dadurch können sich neue Geräte mit dem Netzwerk verbinden.",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -338,6 +338,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Τουρκία, Ιράκ, Ιορδανία, Κουβέιτ",
   "traceroute": "Traceroute",
   "tryAgain": "Δοκιμάστε ξανά",
+  "logIntoRouter": "Σύνδεση στον δρομολογητή",
   "turnOff": "Απενεργοποίηση",
   "turnOffInstantPrivacy": "Απενεργοποίηση Άμεσου-απορρήτου;",
   "turnOffInstantPrivacyDesc": "Αυτό θα επιτρέψει σε νέες συσκευές να συνδεθούν στο δίκτυο.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -535,6 +535,7 @@
   "trend": "Trend",
   "trends": "Trends",
   "tryAgain": "Try again",
+  "logIntoRouter": "Log into router",
   "turnOff": "Turn Off",
   "type": "Type",
   "turnOffInstantPrivacy": "Turn off Instant-Privacy?",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -340,6 +340,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Turquía, Irak, Jordania, Kuwait",
   "traceroute": "Traceroute",
   "tryAgain": "Volver a intentarlo",
+  "logIntoRouter": "Iniciar sesión en el router",
   "turnOff": "Deshabilitar",
   "turnOffInstantPrivacy": "¿Desactivar la Instant-Privacidad?",
   "turnOffInstantPrivacyDesc": "Permitirá que nuevos dispositivos se conecten a la red.",

--- a/lib/l10n/app_es_ar.arb
+++ b/lib/l10n/app_es_ar.arb
@@ -340,6 +340,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Turquía, Irak, Jordania, Kuwait",
   "traceroute": "Traceroute",
   "tryAgain": "Vuelva a intentarlo",
+  "logIntoRouter": "Iniciar sesión en el router",
   "turnOff": "Desactivar",
   "turnOffInstantPrivacy": "¿Desactivar la Instant-Privacidad?",
   "turnOffInstantPrivacyDesc": "Permitirá que nuevos dispositivos se conecten a la red.",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -338,6 +338,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Turkki, Irak, Jordania, Kuwait",
   "traceroute": "Traceroute",
   "tryAgain": "Yritä uudelleen",
+  "logIntoRouter": "Kirjaudu reitittimeen",
   "turnOff": "Poista käytöstä",
   "turnOffInstantPrivacy": "Poistetaanko Pikayksityisyys käytöstä?",
   "turnOffInstantPrivacyDesc": "Tämä sallii uusien laitteiden yhdistämisen verkkoon.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -340,6 +340,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Turquie, Irak, Jordanie, Koweït",
   "traceroute": "Traceroute",
   "tryAgain": "Réessayez",
+  "logIntoRouter": "Se connecter au routeur",
   "turnOff": "Désactiver",
   "turnOffInstantPrivacy": "Désactiver la Instant-Confidentialité?",
   "turnOffInstantPrivacyDesc": "Les nouveaux appareils pourront se connecter au réseau.",

--- a/lib/l10n/app_fr_ca.arb
+++ b/lib/l10n/app_fr_ca.arb
@@ -340,6 +340,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Turquie, Iraq, Jordanie, Koweït",
   "traceroute": "Traceroute",
   "tryAgain": "Veuillez réessayer",
+  "logIntoRouter": "Se connecter au routeur",
   "turnOff": "Désactiver",
   "turnOffInstantPrivacy": "Désactiver la Instant-Confidentialité?",
   "turnOffInstantPrivacyDesc": "Les nouveaux appareils pourront se connecter au réseau.",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -338,6 +338,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Turki, Irak, Yordania, Kuwait",
   "traceroute": "Traceroute",
   "tryAgain": "Coba kembali",
+  "logIntoRouter": "Masuk ke router",
   "turnOff": "Matikan",
   "turnOffInstantPrivacy": "Matikan Privasi-Instan?",
   "turnOffInstantPrivacyDesc": "Ini akan mengizinkan perangkat baru untuk tersambung ke jaringan.",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -340,6 +340,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Turchia, Iraq, Giordania, Kuwait",
   "traceroute": "Traceroute",
   "tryAgain": "Riprova",
+  "logIntoRouter": "Accesso al router",
   "turnOff": "Disattiva",
   "turnOffInstantPrivacy": "Disattivare la Instant-Privacy?",
   "turnOffInstantPrivacyDesc": "Consente ai nuovi dispositivi di connettersi alla rete.",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -341,6 +341,7 @@
   "timezoneTurkeyIraqJordanKuwait": "トルコ、イラク、ヨルダン、クウェート",
   "traceroute": "トレースルート",
   "tryAgain": "もう一度試す",
+  "logIntoRouter": "ルーターにログインする",
   "turnOff": "オフにする",
   "turnOffInstantPrivacy": "Instant-プライバシーをオフにしますか？",
   "turnOffInstantPrivacyDesc": "これにより、新しいデバイスがネットワークに接続できるようになります。",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -338,6 +338,7 @@
   "timezoneTurkeyIraqJordanKuwait": "터키, 이라크, 요르단, 쿠웨이트",
   "traceroute": "트레이스라우트",
   "tryAgain": "다시 시도하십시오",
+  "logIntoRouter": "라우터에 로그인",
   "turnOff": "끄기",
   "turnOffInstantPrivacy": "즉시-개인정보를 끄시겠습니까?",
   "turnOffInstantPrivacyDesc": "이렇게 하면 새 장치가 네트워크에 연결할 수 있습니다.",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -340,6 +340,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Tyrkia, Irak, Jordan, Kuwait",
   "traceroute": "Traceroute",
   "tryAgain": "Prøv igjen",
+  "logIntoRouter": "Logg inn på ruteren",
   "turnOff": "Slå av",
   "turnOffInstantPrivacy": "Deaktivere Instant-Databeskyttelse?",
   "turnOffInstantPrivacyDesc": "Dette gjør det mulig for nye enheter å koble seg til nettverket.",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -340,6 +340,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Turkije, Irak, Jordanië, Koeweit",
   "traceroute": "Traceroute",
   "tryAgain": "Opnieuw proberen",
+  "logIntoRouter": "Log in op de router",
   "turnOff": "Uitschakelen",
   "turnOffInstantPrivacy": "Instant-privacy uitschakelen?",
   "turnOffInstantPrivacyDesc": "Hierdoor kunnen nieuwe apparaten verbinding maken met het netwerk.",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -338,6 +338,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Turcja, Irak, Jordania, Kuwejt",
   "traceroute": "Traceroute",
   "tryAgain": "Spróbuj ponownie",
+  "logIntoRouter": "Zaloguj się do routera",
   "turnOff": "Wyłącz",
   "turnOffInstantPrivacy": "Wyłączyć szybką prywatność?",
   "turnOffInstantPrivacyDesc": "To pozwoli nowym urządzeniom na łączenie się z siecią.",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -340,6 +340,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Turquia, Iraque, Jordânia, Kuwait",
   "traceroute": "Traceroute",
   "tryAgain": "Tente novamente",
+  "logIntoRouter": "Acesso ao roteador",
   "turnOff": "Desativar",
   "turnOffInstantPrivacy": "Desativar o Instant-Privacidade?",
   "turnOffInstantPrivacyDesc": "Permitir que novos dispositivos se conectem à rede.",

--- a/lib/l10n/app_pt_pt.arb
+++ b/lib/l10n/app_pt_pt.arb
@@ -340,6 +340,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Turquia, Iraque, Jordânia, Koweit",
   "traceroute": "Traceroute",
   "tryAgain": "Voltar a tentar",
+  "logIntoRouter": "Acesso ao roteador",
   "turnOff": "Desativar",
   "turnOffInstantPrivacy": "Desativar o Instant-Privacidade?",
   "turnOffInstantPrivacyDesc": "Permitir que novos dispositivos se conectem à rede.",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -338,6 +338,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Турция, Ирак, Иордания, Кувейт",
   "traceroute": "Трассировка маршрута",
   "tryAgain": "Повторить попытку",
+  "logIntoRouter": "Войти в маршрутизатор",
   "turnOff": "Отключить",
   "turnOffInstantPrivacy": "Отключить мгновенную конфиденциальность?",
   "turnOffInstantPrivacyDesc": "Это позволит новым устройствам подключаться к сети",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -340,6 +340,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Turkiet, Irak, Jordanien, Kuwait",
   "traceroute": "Traceroute",
   "tryAgain": "Försök igen",
+  "logIntoRouter": "Logga in på routern",
   "turnOff": "Slå av",
   "turnOffInstantPrivacy": "Avaktivera Instant-Dataskydd?",
   "turnOffInstantPrivacyDesc": "Detta gör att nya enheter kan ansluta till nätverket.",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -338,6 +338,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Turkey, Iraq, Jordan, Kuwait",
   "traceroute": "Traceroute",
   "tryAgain": "ลองอีกครั้ง",
+  "logIntoRouter": "ล็อกอินเข้าเราเตอร์",
   "turnOff": "ปิด",
   "turnOffInstantPrivacy": "ปิดความเป็นส่วนตัวทันที?",
   "turnOffInstantPrivacyDesc": "การดำเนินการนี้จะอนุญาตให้อุปกรณ์ใหม่เชื่อมต่อกับเครือข่าย",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -338,6 +338,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Türkiye, Irak, Ürdün, Kuveyt",
   "traceroute": "İz Rotası",
   "tryAgain": "Yeniden dene",
+  "logIntoRouter": "Yönlendiriciye giriş yap",
   "turnOff": "Kapat",
   "turnOffInstantPrivacy": "Anında-Gizlilik kapatılsın mı?",
   "turnOffInstantPrivacyDesc": "Bu, yeni cihazların ağa bağlanmasına izin verecektir.",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -338,6 +338,7 @@
   "timezoneTurkeyIraqJordanKuwait": "Thổ Nhĩ Kỳ, Iraq, Jordan, Kuwait",
   "traceroute": "Truy vết tuyến",
   "tryAgain": "Thử lại",
+  "logIntoRouter": "Đăng nhập vào bộ định tuyến",
   "turnOff": "Tắt",
   "turnOffInstantPrivacy": "Tắt Riêng tư tức thì",
   "turnOffInstantPrivacyDesc": "Tắt Riêng tư tức thì sẽ cho phép thiết bị mới kết nối với mạng của bạn",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -341,6 +341,7 @@
   "timezoneTurkeyIraqJordanKuwait": "土耳其、伊拉克、约旦、科威特",
   "traceroute": "路由跟踪",
   "tryAgain": "请重试",
+  "logIntoRouter": "登录路由器",
   "turnOff": "关闭",
   "turnOffInstantPrivacy": "是否关闭Instant隐私？",
   "turnOffInstantPrivacyDesc": "这将允许新设备连接到网络。",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -341,6 +341,7 @@
   "timezoneTurkeyIraqJordanKuwait": "土耳其、伊拉克、約旦、科威特",
   "traceroute": "路由追蹤",
   "tryAgain": "請重試",
+  "logIntoRouter": "登入路由器",
   "turnOff": "關閉",
   "turnOffInstantPrivacy": "是否關閉Instant隱私？",
   "turnOffInstantPrivacyDesc": "這將允許新裝置連接網絡。",

--- a/lib/page/instant_setup/providers/pnp_notifier.dart
+++ b/lib/page/instant_setup/providers/pnp_notifier.dart
@@ -259,7 +259,10 @@ class PnpNotifier extends Notifier<PnpState> {
         await _svc.saveWifi(phase.wifiConfig);
       });
 
-      // Acknowledge PnP completion and save serial number
+      // Acknowledge PnP completion and save serial number.
+      // NOTE: the same acknowledge + saveSelectedNetwork pair lives in
+      // bypassToDashboard(), but there errors are swallowed; here they
+      // propagate to the catch below so the user stays on the form to retry.
       logger.d(
           '[PnP] Saving setup completion, serialNumber=${state.serialNumber}');
       if (state.serialNumber != null) {
@@ -430,9 +433,15 @@ class PnpNotifier extends Notifier<PnpState> {
       return;
     }
     try {
+      // Same acknowledge + saveSelectedNetwork pair as saveChanges(), but the
+      // error handling is intentionally the opposite: saveChanges() lets errors
+      // propagate (a failed WiFi save should keep the user on the form to
+      // retry), whereas here we swallow them (an escape hatch must never block
+      // navigation). Keep the two in sync when changing this pair.
       await ref.read(pnpStatusServiceProvider).acknowledge(sn);
       // Persist selected network for session management, matching saveChanges().
       await ref.read(sessionProvider.notifier).saveSelectedNetwork(sn, '');
+      logger.i('[PnP] bypassToDashboard: acknowledged, entering dashboard');
     } catch (e) {
       // Do not block navigation — see method doc.
       logger

--- a/lib/page/instant_setup/providers/pnp_notifier.dart
+++ b/lib/page/instant_setup/providers/pnp_notifier.dart
@@ -402,6 +402,44 @@ class PnpNotifier extends Notifier<PnpState> {
     await _checkInternet();
   }
 
+  /// Bypass the no-internet page and let the user into the dashboard.
+  ///
+  /// Ports the dev-1.3.0 "Log into router" escape hatch. Unlike 1.3.0 — which
+  /// routed into a trimmed-down setup wizard — the USP flow goes straight to the
+  /// dashboard (the USP wizard is phase-driven and has no forceLogin branch, and
+  /// the dashboard does not depend on internet being up).
+  ///
+  /// We acknowledge PnP completion here so a later redirect through `/` does not
+  /// bounce the user back into PnP (`router_provider._prepare` re-checks
+  /// `needsPnp`; without acknowledging, a full-page reload would kick them out
+  /// again). This mirrors 1.3.0, where a configured router's save already sends
+  /// `SetUserAcknowledgedAutoConfig`. Acknowledge is fire-and-forget and does not
+  /// need WAN, so it succeeds while the router is offline.
+  ///
+  /// The caller performs the actual navigation once this completes.
+  ///
+  /// This never throws: an escape hatch must always let the user through. A
+  /// failed acknowledge / save is logged and swallowed — at worst the router
+  /// stays un-acknowledged and PnP is re-offered on the next `/` redirect, which
+  /// is strictly better than trapping the user on the no-internet page.
+  Future<void> bypassToDashboard() async {
+    final sn = state.serialNumber;
+    if (sn == null || sn.isEmpty) {
+      logger
+          .w('[PnP] bypassToDashboard: no serial number, skipping acknowledge');
+      return;
+    }
+    try {
+      await ref.read(pnpStatusServiceProvider).acknowledge(sn);
+      // Persist selected network for session management, matching saveChanges().
+      await ref.read(sessionProvider.notifier).saveSelectedNetwork(sn, '');
+    } catch (e) {
+      // Do not block navigation — see method doc.
+      logger
+          .w('[PnP] bypassToDashboard: acknowledge/save failed (ignored): $e');
+    }
+  }
+
   // ─── Modem Restart Flow ───────────────────────────────────
 
   /// Start the modem restart countdown (150s).

--- a/lib/page/instant_setup/views/pnp_no_internet_view.dart
+++ b/lib/page/instant_setup/views/pnp_no_internet_view.dart
@@ -18,6 +18,7 @@ class PnpNoInternetView extends ConsumerStatefulWidget {
 
 class _PnpNoInternetViewState extends ConsumerState<PnpNoInternetView> {
   bool _retrying = false;
+  bool _bypassing = false;
 
   Future<void> _onRetry() async {
     setState(() => _retrying = true);
@@ -25,6 +26,18 @@ class _PnpNoInternetViewState extends ConsumerState<PnpNoInternetView> {
       await ref.read(pnpProvider.notifier).retryInternetCheck();
     } finally {
       if (mounted) setState(() => _retrying = false);
+    }
+  }
+
+  /// "Log into router" escape hatch — acknowledge PnP and enter the dashboard
+  /// without waiting for internet. See [PnpNotifier.bypassToDashboard].
+  Future<void> _onLogIntoRouter() async {
+    setState(() => _bypassing = true);
+    try {
+      await ref.read(pnpProvider.notifier).bypassToDashboard();
+      if (mounted) context.go(RoutePath.uspDashboard);
+    } finally {
+      if (mounted) setState(() => _bypassing = false);
     }
   }
 
@@ -82,6 +95,14 @@ class _PnpNoInternetViewState extends ConsumerState<PnpNoInternetView> {
                         context.goNamed(RouteNamed.pnpIspTypeSelection),
                   ),
                   AppGap.xxxl(),
+                  Center(
+                    child: AppButton.text(
+                      label: loc(context).logIntoRouter,
+                      isLoading: _bypassing,
+                      onTap: _bypassing ? null : _onLogIntoRouter,
+                    ),
+                  ),
+                  AppGap.lg(),
                   Center(
                     child: AppButton.text(
                       label: loc(context).tryAgain,

--- a/lib/page/instant_setup/views/pnp_no_internet_view.dart
+++ b/lib/page/instant_setup/views/pnp_no_internet_view.dart
@@ -20,7 +20,12 @@ class _PnpNoInternetViewState extends ConsumerState<PnpNoInternetView> {
   bool _retrying = false;
   bool _bypassing = false;
 
+  /// True while either action is in flight. Both buttons guard on this so a
+  /// retry and a bypass can never run concurrently and race their navigation.
+  bool get _busy => _retrying || _bypassing;
+
   Future<void> _onRetry() async {
+    if (_busy) return;
     setState(() => _retrying = true);
     try {
       await ref.read(pnpProvider.notifier).retryInternetCheck();
@@ -32,6 +37,7 @@ class _PnpNoInternetViewState extends ConsumerState<PnpNoInternetView> {
   /// "Log into router" escape hatch — acknowledge PnP and enter the dashboard
   /// without waiting for internet. See [PnpNotifier.bypassToDashboard].
   Future<void> _onLogIntoRouter() async {
+    if (_busy) return;
     setState(() => _bypassing = true);
     try {
       await ref.read(pnpProvider.notifier).bypassToDashboard();
@@ -99,7 +105,7 @@ class _PnpNoInternetViewState extends ConsumerState<PnpNoInternetView> {
                     child: AppButton.text(
                       label: loc(context).logIntoRouter,
                       isLoading: _bypassing,
-                      onTap: _bypassing ? null : _onLogIntoRouter,
+                      onTap: _busy ? null : _onLogIntoRouter,
                     ),
                   ),
                   AppGap.lg(),
@@ -107,7 +113,7 @@ class _PnpNoInternetViewState extends ConsumerState<PnpNoInternetView> {
                     child: AppButton.text(
                       label: loc(context).tryAgain,
                       isLoading: _retrying,
-                      onTap: _retrying ? null : _onRetry,
+                      onTap: _busy ? null : _onRetry,
                     ),
                   ),
                 ],

--- a/test/page/instant_setup/providers/pnp_notifier_test.dart
+++ b/test/page/instant_setup/providers/pnp_notifier_test.dart
@@ -23,6 +23,27 @@ class MockPnpStatusService extends Mock implements PnpStatusService {}
 
 class MockSessionNotifier extends Mock implements SessionNotifier {}
 
+/// Mountable session notifier that records [saveSelectedNetwork] calls.
+///
+/// A plain mocktail mock cannot be mounted by Riverpod (it lacks the internal
+/// `_setElement` hook), so tests that actually invoke `sessionProvider.notifier`
+/// use this spy instead of [MockSessionNotifier].
+class SpySessionNotifier extends Notifier<SessionState>
+    implements SessionNotifier {
+  final List<({String sn, String networkId})> savedNetworks = [];
+
+  @override
+  SessionState build() => const SessionState();
+
+  @override
+  Future<void> saveSelectedNetwork(String sn, String networkId) async {
+    savedNetworks.add((sn: sn, networkId: networkId));
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 class FakePnpWifiConfig extends Fake implements PnpWifiConfig {}
 
 class FakePnpIspConfig extends Fake implements PnpIspConfig {}
@@ -242,6 +263,84 @@ void main() {
 
       final state = container.read(pnpProvider);
       expect(state.phase, isA<WizardConfiguring>());
+      container.dispose();
+    });
+  });
+
+  group('PnpNotifier — bypassToDashboard', () {
+    test('acknowledges PnP and saves selected network when SN is present',
+        () async {
+      when(() => mockPnpService.checkFactoryDefault())
+          .thenAnswer((_) async => testFactoryResult);
+      when(() => mockPnpService.checkInternetConnected())
+          .thenAnswer((_) async => false);
+      when(() => mockPnpService.fetchCurrentSsid())
+          .thenAnswer((_) async => 'Test');
+      when(() => mockPnpStatusService.acknowledge(any()))
+          .thenAnswer((_) async {});
+
+      // Use the mountable spy so sessionProvider.notifier can be read.
+      final spySession = SpySessionNotifier();
+      final container = ProviderContainer(
+        overrides: [
+          uspClientProvider.overrideWithValue(mockUsp),
+          pnpServiceProvider.overrideWithValue(mockPnpService),
+          pnpStatusServiceProvider.overrideWithValue(mockPnpStatusService),
+          uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+          sessionProvider.overrideWith(() => spySession),
+        ],
+      );
+      final notifier = container.read(pnpProvider.notifier);
+
+      // Populate serialNumber via the normal entry flow (lands on NoInternet).
+      await notifier.startPostLoginFlow();
+      expect(container.read(pnpProvider).phase, isA<NoInternet>());
+
+      await notifier.bypassToDashboard();
+
+      verify(() => mockPnpStatusService.acknowledge('SN123')).called(1);
+      expect(spySession.savedNetworks, [(sn: 'SN123', networkId: '')]);
+      container.dispose();
+    });
+
+    test('skips acknowledge when serial number is missing', () async {
+      final container = createContainer();
+      final notifier = container.read(pnpProvider.notifier);
+
+      // No startPostLoginFlow → serialNumber stays null.
+      await notifier.bypassToDashboard();
+
+      verifyNever(() => mockPnpStatusService.acknowledge(any()));
+      container.dispose();
+    });
+
+    // The escape hatch must never throw — a failed acknowledge/save must not
+    // trap the user on the no-internet page. The view navigates regardless.
+    test('does not throw when acknowledge fails', () async {
+      when(() => mockPnpService.checkFactoryDefault())
+          .thenAnswer((_) async => testFactoryResult);
+      when(() => mockPnpService.checkInternetConnected())
+          .thenAnswer((_) async => false);
+      when(() => mockPnpService.fetchCurrentSsid())
+          .thenAnswer((_) async => 'Test');
+      when(() => mockPnpStatusService.acknowledge(any()))
+          .thenThrow(Exception('TR-181 write failed'));
+
+      final spySession = SpySessionNotifier();
+      final container = ProviderContainer(
+        overrides: [
+          uspClientProvider.overrideWithValue(mockUsp),
+          pnpServiceProvider.overrideWithValue(mockPnpService),
+          pnpStatusServiceProvider.overrideWithValue(mockPnpStatusService),
+          uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+          sessionProvider.overrideWith(() => spySession),
+        ],
+      );
+      final notifier = container.read(pnpProvider.notifier);
+      await notifier.startPostLoginFlow();
+
+      // Must complete normally (no throw) despite acknowledge failing.
+      await expectLater(notifier.bypassToDashboard(), completes);
       container.dispose();
     });
   });

--- a/test/page/instant_setup/views/pnp_no_internet_view_test.dart
+++ b/test/page/instant_setup/views/pnp_no_internet_view_test.dart
@@ -1,0 +1,150 @@
+@Tags(['ui'])
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/instant_setup/models/pnp_state.dart';
+import 'package:privacy_gui/page/instant_setup/providers/pnp_notifier.dart';
+import 'package:privacy_gui/page/instant_setup/providers/pnp_providers.dart';
+import 'package:privacy_gui/page/instant_setup/views/pnp_no_internet_view.dart';
+import 'package:privacy_gui/route/constants.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+import 'package:flutter_portal/flutter_portal.dart';
+
+import '../../../golden_test/golden_framework/mocks/mock_common.dart';
+
+final _testTheme = AppTheme.create(
+  brightness: Brightness.light,
+  seedColor: Colors.blue,
+  designThemeBuilder: (c) => CustomDesignTheme.fromJson({'style': 'flat'}),
+);
+
+/// Fake notifier that starts on [NoInternet] and records bypass calls, so the
+/// view test never touches real USP services.
+class _FakePnpNotifier extends PnpNotifier {
+  int bypassCalls = 0;
+  int retryCalls = 0;
+
+  @override
+  PnpState build() => const PnpState(
+        phase: NoInternet(ssid: 'Linksys-Test'),
+        serialNumber: 'SN-TEST',
+      );
+
+  @override
+  Future<void> bypassToDashboard() async {
+    bypassCalls++;
+  }
+
+  @override
+  Future<void> retryInternetCheck() async {
+    retryCalls++;
+  }
+}
+
+void main() {
+  late _FakePnpNotifier fakeNotifier;
+  late String currentLocation;
+
+  // The view is taller than the default 800x600 test surface; enlarge it so
+  // the bottom buttons are on-screen and tappable.
+  void enlargeSurface(WidgetTester tester) {
+    tester.view.physicalSize = const Size(1200, 2000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+  }
+
+  Widget host() {
+    fakeNotifier = _FakePnpNotifier();
+    final router = GoRouter(
+      initialLocation: RoutePath.pnpNoInternetConnection,
+      routes: [
+        GoRoute(
+          path: RoutePath.pnpNoInternetConnection,
+          builder: (_, __) => const PnpNoInternetView(),
+        ),
+        GoRoute(
+          path: RoutePath.uspDashboard,
+          builder: (_, __) => const Scaffold(body: Text('DASHBOARD_STUB')),
+        ),
+        GoRoute(
+          path: RoutePath.pnp,
+          builder: (_, __) => const Scaffold(body: Text('PNP_STUB')),
+        ),
+      ],
+    );
+    router.routerDelegate.addListener(() {
+      currentLocation =
+          router.routerDelegate.currentConfiguration.uri.toString();
+    });
+    return ProviderScope(
+      overrides: [
+        ...commonOverrides(),
+        pnpProvider.overrideWith(() => fakeNotifier),
+      ],
+      child: Portal(
+        child: MaterialApp.router(
+          theme: _testTheme,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          // Freeze looping animations (e.g. AppLoader) so pump() settles;
+          // otherwise pumpAndSettle never returns.
+          builder: (context, child) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(disableAnimations: true),
+            child: child ?? const SizedBox.shrink(),
+          ),
+          routerConfig: router,
+        ),
+      ),
+    );
+  }
+
+  testWidgets('shows both Log into router and Try again buttons',
+      (tester) async {
+    enlargeSurface(tester);
+    await tester.pumpWidget(host());
+    await _settle(tester);
+
+    expect(find.text('Log into router'), findsOneWidget);
+    expect(find.text('Try again'), findsOneWidget);
+  });
+
+  testWidgets('tapping Log into router bypasses and navigates to dashboard',
+      (tester) async {
+    enlargeSurface(tester);
+    await tester.pumpWidget(host());
+    await _settle(tester);
+
+    await tester.tap(find.text('Log into router'));
+    await _settle(tester);
+
+    expect(fakeNotifier.bypassCalls, 1);
+    expect(currentLocation, RoutePath.uspDashboard);
+    expect(find.text('DASHBOARD_STUB'), findsOneWidget);
+  });
+
+  testWidgets('bypass navigates even when notifier skips acknowledge (no SN)',
+      (tester) async {
+    // The fake's bypassToDashboard is a no-op (mirrors the SN-null early return
+    // in production, which also completes without throwing). The view must
+    // still navigate — proving the SN-null path is a deliberate, safe bypass.
+    enlargeSurface(tester);
+    await tester.pumpWidget(host());
+    await _settle(tester);
+
+    await tester.tap(find.text('Log into router'));
+    await _settle(tester);
+
+    expect(currentLocation, RoutePath.uspDashboard);
+  });
+}
+
+/// Bounded pump — the view contains an [AppLoader] whose animation never fully
+/// settles even with disableAnimations, so pumpAndSettle would time out. A few
+/// fixed frames are enough for navigation + rebuilds to flush.
+Future<void> _settle(WidgetTester tester) async {
+  for (var i = 0; i < 5; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a **"Log into router"** button to the PnP no-internet page, giving users an exit when the router is online but has no WAN (a node paired behind an upstream router, or a factory-default box with no cable). Previously they were trapped with only Restart modem / Enter ISP / Try again. Addresses #1104 (Problem A).
- Ports the dev-1.3.0 escape hatch, with two deliberate differences from 1.3.0.

## Decision 1 — Bypass acknowledges PnP completion
Tapping "Log into router" calls `pnpStatusService.acknowledge()` (TR-181 `SetUserAcknowledgedAutoConfig`) before navigating.

**Why:** the USP router redirect only re-checks `needsPnp` when it passes through `/` or `/localLoginPassword` (`router_provider._prepare`). Without acknowledging, a full-page reload back to `/` would bounce the user right back into PnP. Acknowledging mirrors 1.3.0, where a configured router's save already sends `SetUserAcknowledgedAutoConfig`.

**Trade-off:** the user bypasses without configuring anything, yet we mark the router "PnP done" — slightly different from 1.3.0 (which acknowledges only after a WiFi step's save). Accepted because the USP flow has no unconfigured/configured split (`checkFactoryDefault` always returns false), and keeping the user stably in the dashboard matters more.

## Decision 2 — Bypass goes straight to the dashboard (no mini-wizard)
Unlike 1.3.0 (which routed into a trimmed-down `forceLogin` wizard), the USP bypass navigates directly to the dashboard.

**Why:** the USP wizard is phase-driven and has no `forceLogin` branch; grafting one on would fight the architecture and carry a large surface (new wizard path, save, post-WiFi-change reconnect). The core complaint in #1104 is "router is online but I can't reach the UI" — going straight to the dashboard addresses that directly.

**Trade-off:** a first-time-setup user with no WAN lands on the dashboard without being guided to set WiFi (stays at factory defaults; changeable later in settings). A future "show the wizard only for a true factory default" needs `checkFactoryDefault` fixed first (tied to #1104 Problem B/C).

## Known limitation
`acknowledge` is fire-and-forget (best-effort): a silent TR-181 write failure would leave the router un-acknowledged, so a later reload could re-offer PnP once. This is benign, needs no WAN (normally succeeds while offline), and is the same acknowledge the normal wizard path uses. `bypassToDashboard()` deliberately swallows any error and still navigates — an escape hatch must never trap the user.

## Testing
- Manual: on a real device with the WAN cable unplugged, "Log into router" successfully enters the dashboard.
- Unit tests: acknowledge + saveSelectedNetwork on SN-present; skip on SN-missing; no-throw on acknowledge failure (16 tests pass).
- Adds `logIntoRouter` l10n key (26 locales, values from dev-1.3.0).