### PR TITLE
fix(diagnostics): disable Speed Test across app pending FW support (#857)

### DIFF
--- a/lib/page/menu/views/usp_menu_view.dart
+++ b/lib/page/menu/views/usp_menu_view.dart
@@ -128,13 +128,13 @@ class UspMenuView extends ConsumerWidget {
         iconData: Icons.bar_chart,
         onTap: () => context.goNamed(RouteNamed.uspStatistics),
       ),
-      AppSectionItemData(
-        semanticLabel: 'menu-speed-test',
-        title: loc(context).speedTest,
-        description: loc(context).menuSpeedTestDesc,
-        iconData: Icons.speed,
-        onTap: () => context.goNamed(RouteNamed.uspSpeedTest),
-      ),
+      // AppSectionItemData(
+      //   semanticLabel: 'menu-speed-test',
+      //   title: loc(context).speedTest,
+      //   description: loc(context).menuSpeedTestDesc,
+      //   iconData: Icons.speed,
+      //   onTap: () => context.goNamed(RouteNamed.uspSpeedTest),
+      // ), // disabled: blocked by FW support (#857)
       AppSectionItemData(
         semanticLabel: 'menu-network-diagnostics',
         title: loc(context).networkDiagnostics,

--- a/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
+++ b/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
@@ -6,8 +6,9 @@ import 'package:privacy_gui/core/usp/models/operate_result.dart';
 import 'package:privacy_gui/core/usp/providers/sse_providers.dart';
 import 'package:privacy_gui/core/usp/services/network_diagnostics_executor.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
-import 'package:privacy_gui/page/unified_diagnostics/models/speed_test_state.dart';
-import 'package:privacy_gui/page/unified_diagnostics/providers/speed_test_notifier.dart';
+// Speed Test disabled: blocked by FW support (#857)
+// import 'package:privacy_gui/page/unified_diagnostics/models/speed_test_state.dart';
+// import 'package:privacy_gui/page/unified_diagnostics/providers/speed_test_notifier.dart';
 
 import '../models/diagnostic_result.dart';
 import '../models/diagnostic_state.dart';
@@ -371,24 +372,7 @@ class UnifiedDiagnosticsNotifier
       state = state.copyWith(results: List.from(results));
     }
 
-    // Step 5: Speed test
-    state = state.copyWith(step: DiagnosticStep.runningSpeedTest);
-    try {
-      final speedTestResult = await _runSharedSpeedTest();
-      if (speedTestResult != null) {
-        state = state.copyWith(speedTest: speedTestResult);
-        final speedResult = _evaluateSpeedTest(speedTestResult);
-        results.add(speedResult);
-        state = state.copyWith(results: List.from(results));
-      } else {
-        results.add(
-            _errorResult(DiagnosticStep.runningSpeedTest, 'Speed test failed'));
-        state = state.copyWith(results: List.from(results));
-      }
-    } catch (e) {
-      results.add(_errorResult(DiagnosticStep.runningSpeedTest, e));
-      state = state.copyWith(results: List.from(results));
-    }
+    // Speed test step disabled: blocked by FW support (#857)
 
     // Step 6: Check WiFi signal (per-radio RSSI)
     state = state.copyWith(step: DiagnosticStep.checkingWifiSignal);
@@ -457,7 +441,6 @@ class UnifiedDiagnosticsNotifier
     }
 
     final results = <DiagnosticStepUIModel>[];
-    bool connectivityOk = true;
 
     // Step 1: Check WAN status
     state = state.copyWith(step: DiagnosticStep.checkingWanStatus);
@@ -466,11 +449,9 @@ class UnifiedDiagnosticsNotifier
       final wanResult = _evaluateWanStatus(wan);
       results.add(wanResult);
       state = state.copyWith(results: List.from(results));
-      if (wanResult.isError) connectivityOk = false;
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.checkingWanStatus, e));
       state = state.copyWith(results: List.from(results));
-      connectivityOk = false;
     }
 
     // Step 1b: Check DHCP pool capacity / usage
@@ -498,11 +479,9 @@ class UnifiedDiagnosticsNotifier
       final pingResult = _evaluatePing(DiagnosticStep.pingGateway, ping);
       results.add(pingResult);
       state = state.copyWith(results: List.from(results));
-      if (pingResult.isError) connectivityOk = false;
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.pingGateway, e));
       state = state.copyWith(results: List.from(results));
-      connectivityOk = false;
     }
 
     // Step 3: Ping DNS
@@ -512,11 +491,9 @@ class UnifiedDiagnosticsNotifier
       final pingResult = _evaluatePing(DiagnosticStep.pingDns, ping);
       results.add(pingResult);
       state = state.copyWith(results: List.from(results));
-      if (pingResult.isError) connectivityOk = false;
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.pingDns, e));
       state = state.copyWith(results: List.from(results));
-      connectivityOk = false;
     }
 
     // Step 3b: DNS lookup — verify name resolution actually works
@@ -525,11 +502,9 @@ class UnifiedDiagnosticsNotifier
       final dnsResult = await _runDnsLookup(svc);
       results.add(dnsResult);
       state = state.copyWith(results: List.from(results));
-      if (dnsResult.isError) connectivityOk = false;
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.dnsLookup, e));
       state = state.copyWith(results: List.from(results));
-      connectivityOk = false;
     }
 
     // Step 4: Ping internet
@@ -539,33 +514,12 @@ class UnifiedDiagnosticsNotifier
       final pingResult = _evaluatePing(DiagnosticStep.pingInternet, ping);
       results.add(pingResult);
       state = state.copyWith(results: List.from(results));
-      if (pingResult.isError) connectivityOk = false;
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.pingInternet, e));
       state = state.copyWith(results: List.from(results));
-      connectivityOk = false;
     }
 
-    // Step 5: Speed test (only if connectivity is OK)
-    if (connectivityOk) {
-      state = state.copyWith(step: DiagnosticStep.runningSpeedTest);
-      try {
-        final speedTestResult = await _runSharedSpeedTest();
-        if (speedTestResult != null) {
-          state = state.copyWith(speedTest: speedTestResult);
-          final speedResult = _evaluateSpeedTest(speedTestResult);
-          results.add(speedResult);
-          state = state.copyWith(results: List.from(results));
-        } else {
-          results.add(_errorResult(
-              DiagnosticStep.runningSpeedTest, 'Speed test failed'));
-          state = state.copyWith(results: List.from(results));
-        }
-      } catch (e) {
-        results.add(_errorResult(DiagnosticStep.runningSpeedTest, e));
-        state = state.copyWith(results: List.from(results));
-      }
-    }
+    // Speed test step disabled: blocked by FW support (#857)
 
     await _analyzeAndShowResults(results);
   }
@@ -804,70 +758,6 @@ class UnifiedDiagnosticsNotifier
   }
 
   // ══════════════════════════════════════════════════════════════════════════
-  // Shared Speed Test
-  // ══════════════════════════════════════════════════════════════════════════
-
-  /// Run speed test using shared [speedTestProvider] and wait for completion.
-  Future<SpeedTestResult?> _runSharedSpeedTest() async {
-    logger.d('[Diagnostics] Starting shared speed test');
-
-    // Wait for provider to be ready
-    final asyncState = ref.read(speedTestProvider);
-    if (asyncState.isLoading) {
-      logger.d('[Diagnostics] Waiting for speedTestProvider to initialize');
-      await ref.read(speedTestProvider.future);
-    }
-
-    // Now start the speed test
-    final notifier = ref.read(speedTestProvider.notifier);
-    logger.d('[Diagnostics] Calling runSpeedTest()');
-
-    // Don't await - runSpeedTest updates state asynchronously
-    unawaited(notifier.runSpeedTest());
-
-    // Wait for completion by polling the provider state
-    final completer = Completer<SpeedTestResult?>();
-
-    void checkState() {
-      final speedState = ref.read(speedTestProvider).valueOrNull;
-      if (speedState == null) return;
-
-      logger.d('[Diagnostics] SpeedTest state: step=${speedState.step}');
-
-      if (speedState.step == SpeedTestStep.completed &&
-          speedState.result != null) {
-        if (!completer.isCompleted) {
-          logger.d('[Diagnostics] SpeedTest completed');
-          completer.complete(speedState.result);
-        }
-      } else if (speedState.step == SpeedTestStep.error) {
-        if (!completer.isCompleted) {
-          logger.w('[Diagnostics] SpeedTest error: ${speedState.error}');
-          completer.complete(null);
-        }
-      }
-    }
-
-    // Listen for state changes
-    final sub = ref.listen(speedTestProvider, (_, __) => checkState());
-
-    // Also check immediately in case it's already done
-    checkState();
-
-    // Timeout after 3 minutes
-    final result = await completer.future.timeout(
-      const Duration(minutes: 3),
-      onTimeout: () {
-        logger.w('[Diagnostics] Speed test timed out');
-        return null;
-      },
-    );
-
-    sub.close();
-    return result;
-  }
-
-  // ══════════════════════════════════════════════════════════════════════════
   // Analysis & Recommendations
   // ══════════════════════════════════════════════════════════════════════════
 
@@ -975,26 +865,7 @@ class UnifiedDiagnosticsNotifier
             priority: 4,
             actionId: 'contactIsp',
           ));
-        case DiagnosticStep.runningSpeedTest:
-          final speedTest = state.speedTest;
-          if (speedTest != null) {
-            if (speedTest.isSlowDownload) {
-              recommendations.add(RecommendationUIModel(
-                id: 'slow_download',
-                titleKey: 'diagnostics_rec_slow_download_title',
-                descriptionKey: 'diagnostics_rec_slow_download_desc',
-                priority: 5,
-              ));
-            }
-            if (speedTest.isSlowUpload) {
-              recommendations.add(RecommendationUIModel(
-                id: 'slow_upload',
-                titleKey: 'diagnostics_rec_slow_upload_title',
-                descriptionKey: 'diagnostics_rec_slow_upload_desc',
-                priority: 6,
-              ));
-            }
-          }
+        // Speed test recommendations disabled: blocked by FW support (#857)
         case DiagnosticStep.checkingWifiSignal:
           if (result is WifiSignalCheckUIModel && result.isWeakSignal) {
             recommendations.add(RecommendationUIModel(
@@ -1189,40 +1060,6 @@ class UnifiedDiagnosticsNotifier
       severity: severity,
       titleKey: titleKey,
       descriptionKey: descriptionKey,
-    );
-  }
-
-  DiagnosticStepUIModel _evaluateSpeedTest(SpeedTestResult speedTest) {
-    DiagnosticSeverity severity;
-    String titleKey;
-    String descriptionKey;
-
-    if (speedTest.isSlowDownload && speedTest.isSlowUpload) {
-      severity = DiagnosticSeverity.error;
-      titleKey = 'diagnostics_speed_slow';
-      descriptionKey = 'diagnostics_speed_slow_desc';
-    } else if (speedTest.isSlowDownload || speedTest.isSlowUpload) {
-      severity = DiagnosticSeverity.warning;
-      titleKey = 'diagnostics_speed_partial';
-      descriptionKey = 'diagnostics_speed_partial_desc';
-    } else {
-      severity = DiagnosticSeverity.ok;
-      titleKey = 'diagnostics_speed_ok';
-      descriptionKey = 'diagnostics_speed_ok_desc';
-    }
-
-    return DiagnosticStepUIModel(
-      step: DiagnosticStep.runningSpeedTest,
-      severity: severity,
-      titleKey: titleKey,
-      descriptionKey: descriptionKey,
-      rawData: {
-        'downloadMbps': speedTest.downloadMbps,
-        'uploadMbps': speedTest.uploadMbps,
-        'hasUpload': speedTest.hasUpload,
-        if (speedTest.hasLatency) 'latencyMs': speedTest.latencyMs!,
-        if (speedTest.serverHost != null) 'serverHost': speedTest.serverHost!,
-      },
     );
   }
 

--- a/lib/page/unified_diagnostics/views/widgets/diagnostic_running_view.dart
+++ b/lib/page/unified_diagnostics/views/widgets/diagnostic_running_view.dart
@@ -109,7 +109,7 @@ class DiagnosticRunningView extends ConsumerWidget {
           DiagnosticStep.pingDns,
           DiagnosticStep.dnsLookup,
           DiagnosticStep.pingInternet,
-          DiagnosticStep.runningSpeedTest,
+          // Speed test disabled: blocked by FW support (#857)
         ],
       DiagnosticFlow.deviceIssues => [
           DiagnosticStep.checkingConnectedDevices,
@@ -130,7 +130,7 @@ class DiagnosticRunningView extends ConsumerWidget {
           DiagnosticStep.pingDns,
           DiagnosticStep.dnsLookup,
           DiagnosticStep.pingInternet,
-          DiagnosticStep.runningSpeedTest,
+          // Speed test disabled: blocked by FW support (#857)
           DiagnosticStep.checkingWifiSignal,
           DiagnosticStep.checkingDhcpPool,
           DiagnosticStep.checkingMeshBackhaul,
@@ -145,7 +145,7 @@ class DiagnosticRunningView extends ConsumerWidget {
       DiagnosticFlow.internet => (
           Icons.language,
           loc(context).internetDiagnostics,
-          7
+          6
         ),
       DiagnosticFlow.deviceIssues => (
           Icons.devices,
@@ -167,7 +167,7 @@ class DiagnosticRunningView extends ConsumerWidget {
           loc(context).intermittentConnectionDiagnostics,
           1,
         ),
-      null => (Icons.network_check, loc(context).fullDiagnostic, 10),
+      null => (Icons.network_check, loc(context).fullDiagnostic, 9),
     };
   }
 

--- a/lib/route/route_usp_dashboard.dart
+++ b/lib/route/route_usp_dashboard.dart
@@ -216,11 +216,12 @@ final uspDashboardRoute = ShellRoute(
       path: RoutePath.uspApps,
       builder: (context, state) => const UspAppsView(),
     ),
-    LinksysRoute(
-      name: RouteNamed.uspSpeedTest,
-      path: RoutePath.uspSpeedTest,
-      builder: (context, state) => const SpeedTestView(),
-    ),
+    // Speed Test route disabled: blocked by FW support (#857)
+    // LinksysRoute(
+    //   name: RouteNamed.uspSpeedTest,
+    //   path: RoutePath.uspSpeedTest,
+    //   builder: (context, state) => const SpeedTestView(),
+    // ),
     LinksysRoute(
       name: RouteNamed.uspAiAssistant,
       path: RoutePath.uspAiAssistant,

--- a/lib/route/router_provider.dart
+++ b/lib/route/router_provider.dart
@@ -64,7 +64,8 @@ import 'package:privacy_gui/page/wifi_settings/providers/usp_wifi_settings_provi
 import 'package:privacy_gui/page/wifi_settings/views/usp_wifi_settings_view.dart';
 import 'package:privacy_gui/page/apps/views/usp_apps_view.dart';
 import 'package:privacy_gui/page/unified_diagnostics/views/unified_diagnostics_view.dart';
-import 'package:privacy_gui/page/unified_diagnostics/views/speed_test_view.dart';
+// Speed Test disabled: blocked by FW support (#857)
+// import 'package:privacy_gui/page/unified_diagnostics/views/speed_test_view.dart';
 import 'package:privacy_gui/page/ai_assistant/views/router_assistant_view.dart';
 import 'package:privacy_gui/page/instant_setup/services/pnp_status_service.dart';
 

--- a/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
+++ b/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
@@ -168,8 +168,9 @@ void main() {
 
         final state = container.read(unifiedDiagnosticsProvider);
         expect(state.step, DiagnosticStep.showingResults);
-        // WAN, DHCP Pool, Gateway, DNS Ping, DNS Lookup, Internet, SpeedTest
-        expect(state.results.length, 7);
+        // WAN, DHCP Pool, Gateway, DNS Ping, DNS Lookup, Internet.
+        // Speed test disabled: blocked by FW support (#857).
+        expect(state.results.length, 6);
         expect(state.results.every((r) => r.isOk), isTrue);
         container.dispose();
       });


### PR DESCRIPTION
## Summary

Speed Test relies on TR-181 `IP.Diagnostics` paths that firmware does not support (#857). The dashboard card was already disabled, but three user-facing entry points remained live:

- the **Speed Test menu entry**,
- the standalone **`uspSpeedTest` route** (still reachable by direct URL on web), and
- the **speed-test step inside the Network Diagnostics flow**.

This PR disables all remaining entry points and removes the speed-test step from the diagnostics flow, bringing the whole app in line with the already-disabled dashboard card.

## Changes

- **menu** (`usp_menu_view.dart`): comment out the Speed Test menu entry
- **route** (`route_usp_dashboard.dart`, `router_provider.dart`): comment out the `uspSpeedTest` route + `SpeedTestView` import
- **diagnostics notifier** (`unified_diagnostics_notifier.dart`): remove the speed-test blocks from both the full and internet flows; drop the now write-only `connectivityOk` tracking; remove the unused `_runSharedSpeedTest` / `_evaluateSpeedTest` helpers, the speed-test recommendation case, and speed-test imports
- **running view** (`diagnostic_running_view.dart`): remove speed-test checklist entries and adjust the (discarded) step counts (7 to 6, 10 to 9)
- **test** (`unified_diagnostics_notifier_test.dart`): update internet-flow result count (7 to 6)

## Kept for future restore

The `DiagnosticStep.runningSpeedTest` enum value, `SpeedTestView`, `speedTestProvider`/notifier, and the speed-test models are intentionally left in place (as dead code) so the feature can be restored once FW supports it — no test edits or enum-removal blast radius required.

## Test plan

- [x] `./run_tests.sh` — **3,327 / 3,327 passed**, 0 fail, 0 skip
- [x] `flutter analyze` on changed files — no new issues (only pre-existing `curly_braces` info lints)
- [x] `dart format` — clean (0 changed)
- [x] menu golden localization test — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)