### PR TITLE
fix(devices): show node display name in Node filter, not model (#1157)

### DIFF
--- a/lib/page/devices/providers/device_filter_provider.dart
+++ b/lib/page/devices/providers/device_filter_provider.dart
@@ -184,7 +184,7 @@ class DeviceFilterNotifier extends StateNotifier<DeviceFilterConfig> {
     var next = state;
 
     if (next.nodeIds.isNotEmpty) {
-      final validNodeIds = options.nodes.map((n) => n.deviceId).toSet();
+      final validNodeIds = options.nodes.map((n) => n.id).toSet();
       final filtered = next.nodeIds.intersection(validNodeIds);
       if (filtered.length != next.nodeIds.length) {
         next = next.copyWith(nodeIds: () => filtered);
@@ -227,8 +227,26 @@ final deviceFilterOptionsProvider = Provider<DeviceFilterOptions>((ref) {
   final data = ref.watch(devicesDataProvider).valueOrNull;
   if (data == null) return const DeviceFilterOptions();
   final devices = data.clientDevices;
+
+  // Node filter options. The selection key must stay the DataElements node ID
+  // (matches ClientDevice.parentNodeId), so we key off meshTopology.nodes.
+  // The user-facing label, however, lives on the fully-built mesh nodes
+  // (data.nodes), which carry the Hosts friendlyName/hostName that
+  // meshTopology.nodes lack — matched back via dataElementsId. Without this
+  // the label would fall back to the model name (issue #1157).
+  final labelByDataElementsId = {
+    for (final n in data.nodes)
+      if (n.dataElementsId != null) n.dataElementsId!: n.displayName,
+  };
+  final nodeOptions = data.meshTopology.nodes
+      .map((n) => NodeFilterOption(
+            id: n.deviceId,
+            label: labelByDataElementsId[n.deviceId] ?? n.displayName,
+          ))
+      .toList();
+
   return DeviceFilterOptions(
-    nodes: data.meshTopology.nodes,
+    nodes: nodeOptions,
     ssids: devices
         .map((d) => d.ssidName)
         .whereType<String>()

--- a/lib/page/devices/providers/device_filter_state.dart
+++ b/lib/page/devices/providers/device_filter_state.dart
@@ -1,6 +1,5 @@
 import 'package:equatable/equatable.dart';
 import 'package:privacy_gui/page/_shared/models/client_device.dart';
-import 'package:privacy_gui/page/_shared/models/node_entity.dart';
 import 'package:privacy_gui/page/_shared/utils/device_classifier.dart';
 
 enum DeviceStatusFilter { all, online, offline }
@@ -111,8 +110,26 @@ class DeviceFilterConfig extends Equatable {
       ];
 }
 
+/// Lightweight option for the Node filter dimension.
+///
+/// [id] is the DataElements node ID used to match `ClientDevice.parentNodeId`
+/// during filtering; [label] is the user-facing node name (friendlyName /
+/// hostName, falling back to model). Keeping this as a dedicated view model —
+/// rather than passing a full [NodeEntity] — mirrors the other filter
+/// dimensions (ssids/bands) and lets the provider resolve the display name
+/// once, so the view never has to know how a node name is derived.
+class NodeFilterOption extends Equatable {
+  final String id;
+  final String label;
+
+  const NodeFilterOption({required this.id, required this.label});
+
+  @override
+  List<Object?> get props => [id, label];
+}
+
 class DeviceFilterOptions extends Equatable {
-  final List<NodeEntity> nodes;
+  final List<NodeFilterOption> nodes;
   final List<String> ssids;
   final List<String> bands;
   final List<DeviceCategory> deviceCategories;

--- a/lib/page/devices/views/components/usp_device_filter_panel.dart
+++ b/lib/page/devices/views/components/usp_device_filter_panel.dart
@@ -127,17 +127,17 @@ class UspDeviceFilterPanel extends ConsumerWidget {
                     _ChipGroupRow(
                       label: loc(context).node,
                       chips: options.nodes
-                          .map((n) => ChipItem(label: n.model))
+                          .map((n) => ChipItem(label: n.label))
                           .toList(),
                       selectedIndices: _nodeIdsToIndices(
                         filter.nodeIds,
-                        options.nodes.map((n) => n.deviceId).toList(),
+                        options.nodes.map((n) => n.id).toList(),
                       ),
                       onSelectionChanged: (indices) => ref
                           .read(deviceFilterConfigProvider.notifier)
                           .setNodeIds(_indicesToNodeIds(
                             indices,
-                            options.nodes.map((n) => n.deviceId).toList(),
+                            options.nodes.map((n) => n.id).toList(),
                           )),
                     ),
                   ],
@@ -624,23 +624,19 @@ class UspDeviceFilterChipBar extends ConsumerWidget {
               ? loc(context).node
               : filter.nodeIds.length == 1
                   ? (options.nodes
-                          .where((n) => n.deviceId == filter.nodeIds.first)
+                          .where((n) => n.id == filter.nodeIds.first)
                           .firstOrNull
-                          ?.model ??
+                          ?.label ??
                       filter.nodeIds.first)
                   : '${loc(context).node} (${filter.nodeIds.length})',
           isActive: filter.nodeIds.isNotEmpty,
           onTap: () => _showMultiSelectPicker<String>(
             context: context,
             title: loc(context).node,
-            items: options.nodes.map((n) => n.deviceId).toList(),
+            items: options.nodes.map((n) => n.id).toList(),
             selected: filter.nodeIds,
             labelOf: (id) =>
-                options.nodes
-                    .where((n) => n.deviceId == id)
-                    .firstOrNull
-                    ?.model ??
-                id,
+                options.nodes.where((n) => n.id == id).firstOrNull?.label ?? id,
             onChanged: notifier.setNodeIds,
           ),
         ),

--- a/test/page/devices/providers/device_filter_provider_test.dart
+++ b/test/page/devices/providers/device_filter_provider_test.dart
@@ -681,6 +681,70 @@ void main() {
       container.dispose();
     });
 
+    test(
+        'node option uses the display name, not the model — id stays the '
+        'DataElements node id (#1157)', () async {
+      // meshTopology.nodes (DataElements) carry only model names and no
+      // user-assigned name. The fully-built mesh nodes (data.nodes) carry the
+      // Hosts friendlyName, matched back via dataElementsId. The Node filter
+      // must show the friendlyName while keeping the DataElements id as the
+      // selection key.
+      final data = DevicesData(
+        meshNetwork: MeshNetwork(
+          master: MasterNode(
+            deviceId: 'AA:BB:CC:DD:EE:01', // built node id = MAC
+            dataElementsId: 'NODE-01', // maps back to meshTopology node
+            friendlyName: 'Living Room',
+            model: 'MR7500',
+            connectedClients: const [],
+          ),
+          slaves: [
+            SlaveNode(
+              deviceId: 'AA:BB:CC:DD:EE:02',
+              dataElementsId: 'NODE-02',
+              friendlyName: 'Bedroom',
+              model: 'MX5500',
+              connectedClients: const [],
+              backhaul: const BackhaulInfo(mediaType: 'Wi-Fi'),
+            ),
+          ],
+        ),
+        meshTopology: MeshTopologyInfo(
+          nodes: [
+            MasterNode(deviceId: 'NODE-01', model: 'MR7500'),
+            SlaveNode(
+              deviceId: 'NODE-02',
+              model: 'MX5500',
+              backhaul: const BackhaulInfo(mediaType: 'Wi-Fi'),
+            ),
+          ],
+          clientToNodeMap: const {},
+        ),
+      );
+      final container = await createReadyContainer(data: data);
+
+      final nodes = container.read(deviceFilterOptionsProvider).nodes;
+
+      // Selection key stays the DataElements node id (matches parentNodeId).
+      expect(nodes.map((n) => n.id), ['NODE-01', 'NODE-02']);
+      // Label is the friendlyName, never the model.
+      expect(nodes.map((n) => n.label), ['Living Room', 'Bedroom']);
+      container.dispose();
+    });
+
+    test('node option falls back to model when no display name exists',
+        () async {
+      // Default test data: neither the built nodes nor meshTopology.nodes have
+      // a friendlyName/hostName, so the label falls back to the model.
+      final container = await createReadyContainer();
+
+      final nodes = container.read(deviceFilterOptionsProvider).nodes;
+
+      expect(nodes.map((n) => n.id), ['NODE-01', 'NODE-02']);
+      expect(nodes.map((n) => n.label), ['MR7500', 'MX5500']);
+      container.dispose();
+    });
+
     test('hasUnknownSignalDevices false when every WiFi device has RSSI',
         () async {
       final container = await createReadyContainer(


### PR DESCRIPTION
## Summary

The Node filter (device list page) showed the router **model name** (e.g. `MR7500`) instead of the user-assigned **display name** (e.g. `Living Room`). Fixes #1157.

## Root cause

The filter options were built directly from `meshTopology.nodes` (DataElements), whose `NodeEntity` entries carry **empty** `friendlyName`/`hostName` — so `displayName` fell back to `model`. The friendlyName only lives on the fully-built mesh nodes (`data.nodes`), sourced from the Hosts table.

An earlier attempt to swap `n.model` → `n.displayName` in the view alone did **not** work, because the underlying data source still had no name to resolve.

## Fix

- Introduce a dedicated `NodeFilterOption { id, label }` view model — mirroring the other filter dimensions (`ssids`/`bands`) so the view never needs to know how a node name is derived.
- In `deviceFilterOptionsProvider`, resolve the label by matching `meshTopology.nodes[i].deviceId` back to the built node's `displayName` via `dataElementsId`, falling back to `model` when no display name exists.
- The **selection key stays the DataElements node id** (`NodeFilterOption.id == meshTopology.nodes[i].deviceId`), which is exactly what `ClientDevice.parentNodeId` matches against. Only the display label changed — filtering behavior is unchanged.

## Testing

- `flutter analyze` on the 4 changed files — no issues.
- `fvm dart format` — no changes needed.
- Added 2 provider tests:
  - label resolves to `friendlyName` while `id` stays the DataElements node id.
  - label falls back to `model` when no display name exists.
- Full functional suite (`run_tests.sh`) — **3332 tests passed**.
