### PR TITLE
fix(dashboard/network-health): label Errors/Loss chart legend series (#1145)

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -415,8 +415,6 @@
   "avgRtt": "متوسط RTT",
   "avgShort": "المتوسط",
   "avgSignal": "متوسط الإشارة",
-  "avgValue": "المتوسط: {value}",
-  "avgValuePeakValue": "المتوسط: {avg}  الذروة: {peak}",
   "seriesAvgValuePeakValue": "{series}  المتوسط: {avg}  الذروة: {peak}",
   "seriesAvgValue": "{series}  المتوسط: {value}",
   "awsAccessKeyId": "معرّف مفتاح وصول AWS",

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -417,6 +417,8 @@
   "avgSignal": "متوسط الإشارة",
   "avgValue": "المتوسط: {value}",
   "avgValuePeakValue": "المتوسط: {avg}  الذروة: {peak}",
+  "seriesAvgValuePeakValue": "{series}  المتوسط: {avg}  الذروة: {peak}",
+  "seriesAvgValue": "{series}  المتوسط: {value}",
   "awsAccessKeyId": "معرّف مفتاح وصول AWS",
   "awsBedrockConfiguration": "تكوين AWS Bedrock",
   "awsSecretAccessKey": "مفتاح الوصول السري لـ AWS",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -414,8 +414,6 @@
   "avgRtt": "Gns. RTT",
   "avgShort": "Gns.",
   "avgSignal": "Gns. signal",
-  "avgValue": "Gns.: {value}",
-  "avgValuePeakValue": "Gns.: {avg}  Top: {peak}",
   "seriesAvgValuePeakValue": "{series}  Gns.: {avg}  Top: {peak}",
   "seriesAvgValue": "{series}  Gns.: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -416,6 +416,8 @@
   "avgSignal": "Gns. signal",
   "avgValue": "Gns.: {value}",
   "avgValuePeakValue": "Gns.: {avg}  Top: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Gns.: {avg}  Top: {peak}",
+  "seriesAvgValue": "{series}  Gns.: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "AWS Bedrock-konfiguration",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -416,6 +416,8 @@
   "avgSignal": "Durchschn. Signal",
   "avgValue": "Durchschn.: {value}",
   "avgValuePeakValue": "Durchschn.: {avg}  Spitze: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Durchschn.: {avg}  Spitze: {peak}",
+  "seriesAvgValue": "{series}  Durchschn.: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "AWS-Bedrock-Konfiguration",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -414,8 +414,6 @@
   "avgRtt": "Durchschn. RTT",
   "avgShort": "Durchschn.",
   "avgSignal": "Durchschn. Signal",
-  "avgValue": "Durchschn.: {value}",
-  "avgValuePeakValue": "Durchschn.: {avg}  Spitze: {peak}",
   "seriesAvgValuePeakValue": "{series}  Durchschn.: {avg}  Spitze: {peak}",
   "seriesAvgValue": "{series}  Durchschn.: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -412,8 +412,6 @@
   "avgRtt": "Μέσο RTT",
   "avgShort": "Μ.Ο.",
   "avgSignal": "Μέσο σήμα",
-  "avgValue": "Μ.Ο.: {value}",
-  "avgValuePeakValue": "Μ.Ο.: {avg}  Αιχμή: {peak}",
   "seriesAvgValuePeakValue": "{series}  Μ.Ο.: {avg}  Αιχμή: {peak}",
   "seriesAvgValue": "{series}  Μ.Ο.: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -414,6 +414,8 @@
   "avgSignal": "Μέσο σήμα",
   "avgValue": "Μ.Ο.: {value}",
   "avgValuePeakValue": "Μ.Ο.: {avg}  Αιχμή: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Μ.Ο.: {avg}  Αιχμή: {peak}",
+  "seriesAvgValue": "{series}  Μ.Ο.: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "Διαμόρφωση AWS Bedrock",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1186,6 +1186,31 @@
       }
     }
   },
+  "seriesAvgValuePeakValue": "{series}  Avg: {avg}  Peak: {peak}",
+  "@seriesAvgValuePeakValue": {
+    "placeholders": {
+      "series": {
+        "type": "String"
+      },
+      "avg": {
+        "type": "String"
+      },
+      "peak": {
+        "type": "String"
+      }
+    }
+  },
+  "seriesAvgValue": "{series}  Avg: {value}",
+  "@seriesAvgValue": {
+    "placeholders": {
+      "series": {
+        "type": "String"
+      },
+      "value": {
+        "type": "String"
+      }
+    }
+  },
   "releaseToRemove": "Release to Remove",
   "dragHereToRemove": "Drag Here to Remove",
   "traffic": "Traffic",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1167,25 +1167,6 @@
   },
   "networkHealth": "Network Health",
   "health": "Health",
-  "avgValuePeakValue": "Avg: {avg}  Peak: {peak}",
-  "@avgValuePeakValue": {
-    "placeholders": {
-      "avg": {
-        "type": "String"
-      },
-      "peak": {
-        "type": "String"
-      }
-    }
-  },
-  "avgValue": "Avg: {value}",
-  "@avgValue": {
-    "placeholders": {
-      "value": {
-        "type": "String"
-      }
-    }
-  },
   "seriesAvgValuePeakValue": "{series}  Avg: {avg}  Peak: {peak}",
   "@seriesAvgValuePeakValue": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -416,6 +416,8 @@
   "avgSignal": "Señal media",
   "avgValue": "Med.: {value}",
   "avgValuePeakValue": "Med.: {avg}  Máx.: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Med.: {avg}  Máx.: {peak}",
+  "seriesAvgValue": "{series}  Med.: {value}",
   "awsAccessKeyId": "ID de clave de acceso de AWS",
   "awsBedrockConfiguration": "Configuración de AWS Bedrock",
   "awsSecretAccessKey": "Clave de acceso secreta de AWS",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -414,8 +414,6 @@
   "avgRtt": "RTT medio",
   "avgShort": "Med.",
   "avgSignal": "Señal media",
-  "avgValue": "Med.: {value}",
-  "avgValuePeakValue": "Med.: {avg}  Máx.: {peak}",
   "seriesAvgValuePeakValue": "{series}  Med.: {avg}  Máx.: {peak}",
   "seriesAvgValue": "{series}  Med.: {value}",
   "awsAccessKeyId": "ID de clave de acceso de AWS",

--- a/lib/l10n/app_es_ar.arb
+++ b/lib/l10n/app_es_ar.arb
@@ -414,8 +414,6 @@
   "avgRtt": "RTT prom.",
   "avgShort": "Prom.",
   "avgSignal": "Señal prom.",
-  "avgValue": "Prom.: {value}",
-  "avgValuePeakValue": "Prom.: {avg}  Máx.: {peak}",
   "seriesAvgValuePeakValue": "{series}  Prom.: {avg}  Máx.: {peak}",
   "seriesAvgValue": "{series}  Prom.: {value}",
   "awsAccessKeyId": "ID de clave de acceso de AWS",

--- a/lib/l10n/app_es_ar.arb
+++ b/lib/l10n/app_es_ar.arb
@@ -416,6 +416,8 @@
   "avgSignal": "Señal prom.",
   "avgValue": "Prom.: {value}",
   "avgValuePeakValue": "Prom.: {avg}  Máx.: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Prom.: {avg}  Máx.: {peak}",
+  "seriesAvgValue": "{series}  Prom.: {value}",
   "awsAccessKeyId": "ID de clave de acceso de AWS",
   "awsBedrockConfiguration": "Configuración de AWS Bedrock",
   "awsSecretAccessKey": "Clave de acceso secreta de AWS",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -412,8 +412,6 @@
   "avgRtt": "Keskim. RTT",
   "avgShort": "Keskiarvo",
   "avgSignal": "Keskim. signaali",
-  "avgValue": "Keskiarvo: {value}",
-  "avgValuePeakValue": "Keskiarvo: {avg}  Huippu: {peak}",
   "seriesAvgValuePeakValue": "{series}  Keskiarvo: {avg}  Huippu: {peak}",
   "seriesAvgValue": "{series}  Keskiarvo: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -414,6 +414,8 @@
   "avgSignal": "Keskim. signaali",
   "avgValue": "Keskiarvo: {value}",
   "avgValuePeakValue": "Keskiarvo: {avg}  Huippu: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Keskiarvo: {avg}  Huippu: {peak}",
+  "seriesAvgValue": "{series}  Keskiarvo: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "AWS Bedrock -määritykset",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -414,8 +414,6 @@
   "avgRtt": "RTT moy.",
   "avgShort": "Moy.",
   "avgSignal": "Signal moy.",
-  "avgValue": "Moy. : {value}",
-  "avgValuePeakValue": "Moy. : {avg}  Pic : {peak}",
   "seriesAvgValuePeakValue": "{series}  Moy. : {avg}  Pic : {peak}",
   "seriesAvgValue": "{series}  Moy. : {value}",
   "awsAccessKeyId": "ID de clé d'accès AWS",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -416,6 +416,8 @@
   "avgSignal": "Signal moy.",
   "avgValue": "Moy. : {value}",
   "avgValuePeakValue": "Moy. : {avg}  Pic : {peak}",
+  "seriesAvgValuePeakValue": "{series}  Moy. : {avg}  Pic : {peak}",
+  "seriesAvgValue": "{series}  Moy. : {value}",
   "awsAccessKeyId": "ID de clé d'accès AWS",
   "awsBedrockConfiguration": "Configuration AWS Bedrock",
   "awsSecretAccessKey": "Clé d'accès secrète AWS",

--- a/lib/l10n/app_fr_ca.arb
+++ b/lib/l10n/app_fr_ca.arb
@@ -416,6 +416,8 @@
   "avgSignal": "Signal moy.",
   "avgValue": "Moy. : {value}",
   "avgValuePeakValue": "Moy. : {avg}  Crête : {peak}",
+  "seriesAvgValuePeakValue": "{series}  Moy. : {avg}  Crête : {peak}",
+  "seriesAvgValue": "{series}  Moy. : {value}",
   "awsAccessKeyId": "ID de clé d'accès AWS",
   "awsBedrockConfiguration": "Configuration AWS Bedrock",
   "awsSecretAccessKey": "Clé d'accès secrète AWS",

--- a/lib/l10n/app_fr_ca.arb
+++ b/lib/l10n/app_fr_ca.arb
@@ -414,8 +414,6 @@
   "avgRtt": "RTT moy.",
   "avgShort": "Moy.",
   "avgSignal": "Signal moy.",
-  "avgValue": "Moy. : {value}",
-  "avgValuePeakValue": "Moy. : {avg}  Crête : {peak}",
   "seriesAvgValuePeakValue": "{series}  Moy. : {avg}  Crête : {peak}",
   "seriesAvgValue": "{series}  Moy. : {value}",
   "awsAccessKeyId": "ID de clé d'accès AWS",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -412,8 +412,6 @@
   "avgRtt": "RTT Rata-rata",
   "avgShort": "Rata-rata",
   "avgSignal": "Sinyal Rata-rata",
-  "avgValue": "Rata-rata: {value}",
-  "avgValuePeakValue": "Rata-rata: {avg}  Puncak: {peak}",
   "seriesAvgValuePeakValue": "{series}  Rata-rata: {avg}  Puncak: {peak}",
   "seriesAvgValue": "{series}  Rata-rata: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -414,6 +414,8 @@
   "avgSignal": "Sinyal Rata-rata",
   "avgValue": "Rata-rata: {value}",
   "avgValuePeakValue": "Rata-rata: {avg}  Puncak: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Rata-rata: {avg}  Puncak: {peak}",
+  "seriesAvgValue": "{series}  Rata-rata: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "Konfigurasi AWS Bedrock",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -414,8 +414,6 @@
   "avgRtt": "RTT medio",
   "avgShort": "Media",
   "avgSignal": "Segnale medio",
-  "avgValue": "Media: {value}",
-  "avgValuePeakValue": "Media: {avg}  Picco: {peak}",
   "seriesAvgValuePeakValue": "{series}  Media: {avg}  Picco: {peak}",
   "seriesAvgValue": "{series}  Media: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -416,6 +416,8 @@
   "avgSignal": "Segnale medio",
   "avgValue": "Media: {value}",
   "avgValuePeakValue": "Media: {avg}  Picco: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Media: {avg}  Picco: {peak}",
+  "seriesAvgValue": "{series}  Media: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "Configurazione AWS Bedrock",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -415,8 +415,6 @@
   "avgRtt": "平均 RTT",
   "avgShort": "平均",
   "avgSignal": "平均信号",
-  "avgValue": "平均: {value}",
-  "avgValuePeakValue": "平均: {avg}  ピーク: {peak}",
   "seriesAvgValuePeakValue": "{series}  平均: {avg}  ピーク: {peak}",
   "seriesAvgValue": "{series}  平均: {value}",
   "awsAccessKeyId": "AWS アクセスキー ID",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -417,6 +417,8 @@
   "avgSignal": "平均信号",
   "avgValue": "平均: {value}",
   "avgValuePeakValue": "平均: {avg}  ピーク: {peak}",
+  "seriesAvgValuePeakValue": "{series}  平均: {avg}  ピーク: {peak}",
+  "seriesAvgValue": "{series}  平均: {value}",
   "awsAccessKeyId": "AWS アクセスキー ID",
   "awsBedrockConfiguration": "AWS Bedrock 設定",
   "awsSecretAccessKey": "AWS シークレットアクセスキー",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -414,6 +414,8 @@
   "avgSignal": "평균 신호",
   "avgValue": "평균: {value}",
   "avgValuePeakValue": "평균: {avg}  최고: {peak}",
+  "seriesAvgValuePeakValue": "{series}  평균: {avg}  최고: {peak}",
+  "seriesAvgValue": "{series}  평균: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "AWS Bedrock 구성",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -412,8 +412,6 @@
   "avgRtt": "평균 RTT",
   "avgShort": "평균",
   "avgSignal": "평균 신호",
-  "avgValue": "평균: {value}",
-  "avgValuePeakValue": "평균: {avg}  최고: {peak}",
   "seriesAvgValuePeakValue": "{series}  평균: {avg}  최고: {peak}",
   "seriesAvgValue": "{series}  평균: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -414,8 +414,6 @@
   "avgRtt": "Gj.snittlig RTT",
   "avgShort": "Gj.snitt",
   "avgSignal": "Gj.snittlig signal",
-  "avgValue": "Gj.snitt: {value}",
-  "avgValuePeakValue": "Gj.snitt: {avg}  Topp: {peak}",
   "seriesAvgValuePeakValue": "{series}  Gj.snitt: {avg}  Topp: {peak}",
   "seriesAvgValue": "{series}  Gj.snitt: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -416,6 +416,8 @@
   "avgSignal": "Gj.snittlig signal",
   "avgValue": "Gj.snitt: {value}",
   "avgValuePeakValue": "Gj.snitt: {avg}  Topp: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Gj.snitt: {avg}  Topp: {peak}",
+  "seriesAvgValue": "{series}  Gj.snitt: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "AWS Bedrock-konfigurasjon",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -416,6 +416,8 @@
   "avgSignal": "Gem. signaal",
   "avgValue": "Gem.: {value}",
   "avgValuePeakValue": "Gem.: {avg}  Piek: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Gem.: {avg}  Piek: {peak}",
+  "seriesAvgValue": "{series}  Gem.: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "AWS Bedrock-configuratie",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -414,8 +414,6 @@
   "avgRtt": "Gem. RTT",
   "avgShort": "Gem.",
   "avgSignal": "Gem. signaal",
-  "avgValue": "Gem.: {value}",
-  "avgValuePeakValue": "Gem.: {avg}  Piek: {peak}",
   "seriesAvgValuePeakValue": "{series}  Gem.: {avg}  Piek: {peak}",
   "seriesAvgValue": "{series}  Gem.: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -412,8 +412,6 @@
   "avgRtt": "Śr. RTT",
   "avgShort": "Śr.",
   "avgSignal": "Śr. sygnał",
-  "avgValue": "Śr.: {value}",
-  "avgValuePeakValue": "Śr.: {avg}  Szczyt: {peak}",
   "seriesAvgValuePeakValue": "{series}  Śr.: {avg}  Szczyt: {peak}",
   "seriesAvgValue": "{series}  Śr.: {value}",
   "awsAccessKeyId": "Identyfikator klucza dostępu AWS",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -414,6 +414,8 @@
   "avgSignal": "Śr. sygnał",
   "avgValue": "Śr.: {value}",
   "avgValuePeakValue": "Śr.: {avg}  Szczyt: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Śr.: {avg}  Szczyt: {peak}",
+  "seriesAvgValue": "{series}  Śr.: {value}",
   "awsAccessKeyId": "Identyfikator klucza dostępu AWS",
   "awsBedrockConfiguration": "Konfiguracja AWS Bedrock",
   "awsSecretAccessKey": "Tajny klucz dostępu AWS",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -416,6 +416,8 @@
   "avgSignal": "Sinal médio",
   "avgValue": "Méd: {value}",
   "avgValuePeakValue": "Méd: {avg}  Pico: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Méd: {avg}  Pico: {peak}",
+  "seriesAvgValue": "{series}  Méd: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "Configuração do AWS Bedrock",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -414,8 +414,6 @@
   "avgRtt": "RTT médio",
   "avgShort": "Méd",
   "avgSignal": "Sinal médio",
-  "avgValue": "Méd: {value}",
-  "avgValuePeakValue": "Méd: {avg}  Pico: {peak}",
   "seriesAvgValuePeakValue": "{series}  Méd: {avg}  Pico: {peak}",
   "seriesAvgValue": "{series}  Méd: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_pt_pt.arb
+++ b/lib/l10n/app_pt_pt.arb
@@ -416,6 +416,8 @@
   "avgSignal": "Sinal médio",
   "avgValue": "Média: {value}",
   "avgValuePeakValue": "Média: {avg}  Pico: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Média: {avg}  Pico: {peak}",
+  "seriesAvgValue": "{series}  Média: {value}",
   "awsAccessKeyId": "ID da chave de acesso AWS",
   "awsBedrockConfiguration": "Configuração do AWS Bedrock",
   "awsSecretAccessKey": "Chave de acesso secreta AWS",

--- a/lib/l10n/app_pt_pt.arb
+++ b/lib/l10n/app_pt_pt.arb
@@ -414,8 +414,6 @@
   "avgRtt": "RTT médio",
   "avgShort": "Méd.",
   "avgSignal": "Sinal médio",
-  "avgValue": "Média: {value}",
-  "avgValuePeakValue": "Média: {avg}  Pico: {peak}",
   "seriesAvgValuePeakValue": "{series}  Média: {avg}  Pico: {peak}",
   "seriesAvgValue": "{series}  Média: {value}",
   "awsAccessKeyId": "ID da chave de acesso AWS",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -414,6 +414,8 @@
   "avgSignal": "Сред. сигнал",
   "avgValue": "Сред.: {value}",
   "avgValuePeakValue": "Сред.: {avg}  Пик: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Сред.: {avg}  Пик: {peak}",
+  "seriesAvgValue": "{series}  Сред.: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "Конфигурация AWS Bedrock",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -412,8 +412,6 @@
   "avgRtt": "Сред. RTT",
   "avgShort": "Сред.",
   "avgSignal": "Сред. сигнал",
-  "avgValue": "Сред.: {value}",
-  "avgValuePeakValue": "Сред.: {avg}  Пик: {peak}",
   "seriesAvgValuePeakValue": "{series}  Сред.: {avg}  Пик: {peak}",
   "seriesAvgValue": "{series}  Сред.: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -414,8 +414,6 @@
   "avgRtt": "Genomsnittlig RTT",
   "avgShort": "Snitt",
   "avgSignal": "Genomsnittlig signal",
-  "avgValue": "Snitt: {value}",
-  "avgValuePeakValue": "Snitt: {avg}  Topp: {peak}",
   "seriesAvgValuePeakValue": "{series}  Snitt: {avg}  Topp: {peak}",
   "seriesAvgValue": "{series}  Snitt: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -416,6 +416,8 @@
   "avgSignal": "Genomsnittlig signal",
   "avgValue": "Snitt: {value}",
   "avgValuePeakValue": "Snitt: {avg}  Topp: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Snitt: {avg}  Topp: {peak}",
+  "seriesAvgValue": "{series}  Snitt: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "AWS Bedrock-konfiguration",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -412,8 +412,6 @@
   "avgRtt": "RTT เฉลี่ย",
   "avgShort": "เฉลี่ย",
   "avgSignal": "สัญญาณเฉลี่ย",
-  "avgValue": "เฉลี่ย: {value}",
-  "avgValuePeakValue": "เฉลี่ย: {avg}  สูงสุด: {peak}",
   "seriesAvgValuePeakValue": "{series}  เฉลี่ย: {avg}  สูงสุด: {peak}",
   "seriesAvgValue": "{series}  เฉลี่ย: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -414,6 +414,8 @@
   "avgSignal": "สัญญาณเฉลี่ย",
   "avgValue": "เฉลี่ย: {value}",
   "avgValuePeakValue": "เฉลี่ย: {avg}  สูงสุด: {peak}",
+  "seriesAvgValuePeakValue": "{series}  เฉลี่ย: {avg}  สูงสุด: {peak}",
+  "seriesAvgValue": "{series}  เฉลี่ย: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "การกำหนดค่า AWS Bedrock",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -414,6 +414,8 @@
   "avgSignal": "Ort. Sinyal",
   "avgValue": "Ort: {value}",
   "avgValuePeakValue": "Ort: {avg}  Tepe: {peak}",
+  "seriesAvgValuePeakValue": "{series}  Ort: {avg}  Tepe: {peak}",
+  "seriesAvgValue": "{series}  Ort: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "AWS Bedrock Yapılandırması",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -412,8 +412,6 @@
   "avgRtt": "Ort. RTT",
   "avgShort": "Ort",
   "avgSignal": "Ort. Sinyal",
-  "avgValue": "Ort: {value}",
-  "avgValuePeakValue": "Ort: {avg}  Tepe: {peak}",
   "seriesAvgValuePeakValue": "{series}  Ort: {avg}  Tepe: {peak}",
   "seriesAvgValue": "{series}  Ort: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -412,8 +412,6 @@
   "avgRtt": "RTT TB",
   "avgShort": "TB",
   "avgSignal": "Tín hiệu TB",
-  "avgValue": "TB: {value}",
-  "avgValuePeakValue": "TB: {avg}  Đỉnh: {peak}",
   "seriesAvgValuePeakValue": "{series}  TB: {avg}  Đỉnh: {peak}",
   "seriesAvgValue": "{series}  TB: {value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -414,6 +414,8 @@
   "avgSignal": "Tín hiệu TB",
   "avgValue": "TB: {value}",
   "avgValuePeakValue": "TB: {avg}  Đỉnh: {peak}",
+  "seriesAvgValuePeakValue": "{series}  TB: {avg}  Đỉnh: {peak}",
+  "seriesAvgValue": "{series}  TB: {value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "Cấu hình AWS Bedrock",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -415,8 +415,6 @@
   "avgRtt": "平均 RTT",
   "avgShort": "平均",
   "avgSignal": "平均信号",
-  "avgValue": "平均：{value}",
-  "avgValuePeakValue": "平均：{avg}  峰值：{peak}",
   "seriesAvgValuePeakValue": "{series}  平均：{avg}  峰值：{peak}",
   "seriesAvgValue": "{series}  平均：{value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -417,6 +417,8 @@
   "avgSignal": "平均信号",
   "avgValue": "平均：{value}",
   "avgValuePeakValue": "平均：{avg}  峰值：{peak}",
+  "seriesAvgValuePeakValue": "{series}  平均：{avg}  峰值：{peak}",
+  "seriesAvgValue": "{series}  平均：{value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "AWS Bedrock 配置",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -417,6 +417,8 @@
   "avgSignal": "平均訊號",
   "avgValue": "平均：{value}",
   "avgValuePeakValue": "平均：{avg}  尖峰：{peak}",
+  "seriesAvgValuePeakValue": "{series}  平均：{avg}  尖峰：{peak}",
+  "seriesAvgValue": "{series}  平均：{value}",
   "awsAccessKeyId": "AWS Access Key ID",
   "awsBedrockConfiguration": "AWS Bedrock 設定",
   "awsSecretAccessKey": "AWS Secret Access Key",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -415,8 +415,6 @@
   "avgRtt": "平均 RTT",
   "avgShort": "平均",
   "avgSignal": "平均訊號",
-  "avgValue": "平均：{value}",
-  "avgValuePeakValue": "平均：{avg}  尖峰：{peak}",
   "seriesAvgValuePeakValue": "{series}  平均：{avg}  尖峰：{peak}",
   "seriesAvgValue": "{series}  平均：{value}",
   "awsAccessKeyId": "AWS Access Key ID",

--- a/lib/page/dashboard/views/components/usp_network_health_card.dart
+++ b/lib/page/dashboard/views/components/usp_network_health_card.dart
@@ -292,7 +292,7 @@ class _ErrorsChart extends StatelessWidget {
                 AppChartSeries(
                   label: loc(parentContext).discards,
                   data: discardData,
-                  color: Colors.orange,
+                  color: colorScheme.tertiary,
                 ),
               ],
               yAxis: AppChartAxis(min: 0, max: yMax),
@@ -317,7 +317,7 @@ class _ErrorsChart extends StatelessWidget {
               ),
             ),
             _LegendEntry(
-              color: Colors.orange,
+              color: colorScheme.tertiary,
               label: loc(parentContext).seriesAvgValue(
                 loc(parentContext).discards,
                 NetworkHealthHelpers.formatFaultRate(avgDisc),
@@ -385,8 +385,8 @@ class _LossChart extends StatelessWidget {
               color: colorScheme.error,
               label: loc(parentContext).seriesAvgValuePeakValue(
                 loc(parentContext).loss,
-                '${avgLoss.toStringAsFixed(3)}%',
-                '${peakLoss.toStringAsFixed(3)}%',
+                '${avgLoss.toStringAsFixed(2)}%',
+                '${peakLoss.toStringAsFixed(2)}%',
               ),
             ),
           ],

--- a/lib/page/dashboard/views/components/usp_network_health_card.dart
+++ b/lib/page/dashboard/views/components/usp_network_health_card.dart
@@ -302,23 +302,38 @@ class _ErrorsChart extends StatelessWidget {
           ),
         ),
         AppGap.sm(),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
+        Wrap(
+          alignment: WrapAlignment.center,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          spacing: 16,
+          runSpacing: 4,
           children: [
-            _LegendDot(color: colorScheme.error),
-            AppGap.xs(),
-            AppText.labelSmall(
-              loc(parentContext).avgValuePeakValue(
-                NetworkHealthHelpers.formatFaultRate(avgErr),
-                NetworkHealthHelpers.formatFaultRate(peakErr),
-              ),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _LegendDot(color: colorScheme.error),
+                AppGap.xs(),
+                AppText.labelSmall(
+                  loc(parentContext).seriesAvgValuePeakValue(
+                    loc(parentContext).errors,
+                    NetworkHealthHelpers.formatFaultRate(avgErr),
+                    NetworkHealthHelpers.formatFaultRate(peakErr),
+                  ),
+                ),
+              ],
             ),
-            AppGap.lg(),
-            _LegendDot(color: Colors.orange),
-            AppGap.xs(),
-            AppText.labelSmall(
-              loc(parentContext)
-                  .avgValue(NetworkHealthHelpers.formatFaultRate(avgDisc)),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _LegendDot(color: Colors.orange),
+                AppGap.xs(),
+                AppText.labelSmall(
+                  loc(parentContext).seriesAvgValue(
+                    loc(parentContext).discards,
+                    NetworkHealthHelpers.formatFaultRate(avgDisc),
+                  ),
+                ),
+              ],
             ),
           ],
         ),
@@ -381,7 +396,8 @@ class _LossChart extends StatelessWidget {
             _LegendDot(color: colorScheme.error),
             AppGap.xs(),
             AppText.labelSmall(
-              loc(parentContext).avgValuePeakValue(
+              loc(parentContext).seriesAvgValuePeakValue(
+                loc(parentContext).loss,
                 '${avgLoss.toStringAsFixed(3)}%',
                 '${peakLoss.toStringAsFixed(3)}%',
               ),

--- a/lib/page/dashboard/views/components/usp_network_health_card.dart
+++ b/lib/page/dashboard/views/components/usp_network_health_card.dart
@@ -308,32 +308,20 @@ class _ErrorsChart extends StatelessWidget {
           spacing: 16,
           runSpacing: 4,
           children: [
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                _LegendDot(color: colorScheme.error),
-                AppGap.xs(),
-                AppText.labelSmall(
-                  loc(parentContext).seriesAvgValuePeakValue(
-                    loc(parentContext).errors,
-                    NetworkHealthHelpers.formatFaultRate(avgErr),
-                    NetworkHealthHelpers.formatFaultRate(peakErr),
-                  ),
-                ),
-              ],
+            _LegendEntry(
+              color: colorScheme.error,
+              label: loc(parentContext).seriesAvgValuePeakValue(
+                loc(parentContext).errors,
+                NetworkHealthHelpers.formatFaultRate(avgErr),
+                NetworkHealthHelpers.formatFaultRate(peakErr),
+              ),
             ),
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                _LegendDot(color: Colors.orange),
-                AppGap.xs(),
-                AppText.labelSmall(
-                  loc(parentContext).seriesAvgValue(
-                    loc(parentContext).discards,
-                    NetworkHealthHelpers.formatFaultRate(avgDisc),
-                  ),
-                ),
-              ],
+            _LegendEntry(
+              color: Colors.orange,
+              label: loc(parentContext).seriesAvgValue(
+                loc(parentContext).discards,
+                NetworkHealthHelpers.formatFaultRate(avgDisc),
+              ),
             ),
           ],
         ),
@@ -393,10 +381,9 @@ class _LossChart extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            _LegendDot(color: colorScheme.error),
-            AppGap.xs(),
-            AppText.labelSmall(
-              loc(parentContext).seriesAvgValuePeakValue(
+            _LegendEntry(
+              color: colorScheme.error,
+              label: loc(parentContext).seriesAvgValuePeakValue(
                 loc(parentContext).loss,
                 '${avgLoss.toStringAsFixed(3)}%',
                 '${peakLoss.toStringAsFixed(3)}%',
@@ -423,6 +410,24 @@ class _LegendDot extends StatelessWidget {
       width: 8,
       height: 8,
       decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+    );
+  }
+}
+
+class _LegendEntry extends StatelessWidget {
+  final Color color;
+  final String label;
+  const _LegendEntry({required this.color, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _LegendDot(color: color),
+        AppGap.xs(),
+        AppText.labelSmall(label),
+      ],
     );
   }
 }

--- a/test/golden_test/page/dashboard/cards/fixtures/cards_test_data.dart
+++ b/test/golden_test/page/dashboard/cards/fixtures/cards_test_data.dart
@@ -713,6 +713,36 @@ final testTrafficWithHistory = TrafficAnalysisState(
 
 const testTrafficEmpty = TrafficAnalysisState();
 
+/// Variant of [testTrafficWithHistory] that carries a constant, non-zero WAN
+/// discard rate so the Errors-tab "Discards" legend renders a formatted value
+/// (avg 3.0/s) rather than the default 0. Used to cover the non-zero discards
+/// path, which the base fixture leaves at 0 (#1145 review-fix).
+final testTrafficWithDiscards = TrafficAnalysisState(
+  history: List.generate(
+    10,
+    (i) => MultiInterfaceSnapshot(
+      timestamp: _baseTime.add(Duration(seconds: i * 5)),
+      interfaces: {
+        TrafficInterface.wan: InterfaceTrafficSnapshot(
+          uploadBytesPerSec: 50000.0 + i * 10000,
+          downloadBytesPerSec: 200000.0 + i * 30000,
+          totalBytesSent: 5000000 + i * 50000,
+          totalBytesReceived: 20000000 + i * 200000,
+          totalPacketsSent: 5000 + i * 50,
+          totalPacketsReceived: 20000 + i * 200,
+          uploadPacketsPerSec: 50.0 + i * 5,
+          downloadPacketsPerSec: 200.0 + i * 20,
+          errorsSentPerSec: i * 0.05,
+          errorsReceivedPerSec: i * 0.05,
+          discardsSentPerSec: 1.5,
+          discardsReceivedPerSec: 1.5,
+        ),
+      },
+    ),
+  ),
+  refreshInterval: Duration(seconds: 5),
+);
+
 // ---------------------------------------------------------------------------
 // Device Analytics
 // ---------------------------------------------------------------------------

--- a/test/page/dashboard/views/components/usp_network_health_card_legend_test.dart
+++ b/test/page/dashboard/views/components/usp_network_health_card_legend_test.dart
@@ -1,0 +1,91 @@
+@Tags(['ui'])
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/dashboard/views/components/usp_network_health_card.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import '../../../../golden_test/golden_framework/mocks/mock_dashboard_cards.dart';
+import '../../../../golden_test/page/dashboard/cards/fixtures/cards_test_data.dart';
+
+final _testTheme = AppTheme.create(
+  brightness: Brightness.light,
+  seedColor: Colors.blue,
+  designThemeBuilder: (c) => CustomDesignTheme.fromJson({'style': 'flat'}),
+);
+
+/// White-box widget tests for the [UspNetworkHealthCard] chart legends (#1145).
+///
+/// Regression coverage for the Errors and Loss tabs: each legend entry must be
+/// prefixed with its series name (Errors / Discards / Loss), so the two "Avg"
+/// values are distinguishable — consistent with the labeled charts elsewhere
+/// (System Status card labels CPU / Memory next to each legend dot).
+void main() {
+  Future<void> pumpCard(WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: cardOverrides(trafficAnalysisState: testTrafficWithHistory),
+        child: MaterialApp(
+          theme: _testTheme,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const Scaffold(
+            body: SizedBox(
+              width: 500,
+              height: 400,
+              child: UspNetworkHealthCard(),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  AppLocalizations locOf(WidgetTester tester) =>
+      AppLocalizations.of(tester.element(find.byType(UspNetworkHealthCard)))!;
+
+  /// Finds a Text/AppText whose rendered data contains [substring].
+  Finder textContaining(String substring) => find.byWidgetPredicate(
+        (w) => w is Text && (w.data?.contains(substring) ?? false),
+      );
+
+  testWidgets('Errors tab legend labels both series (Errors + Discards)',
+      (tester) async {
+    await pumpCard(tester);
+    final l = locOf(tester);
+
+    // Switch to the Errors tab.
+    await tester.tap(find.text(l.errors).first);
+    await tester.pumpAndSettle();
+
+    // Errors series: "Errors  Avg: ...  Peak: ..." (single string, prefixed).
+    expect(
+      textContaining('${l.errors}  Avg:'),
+      findsOneWidget,
+      reason: 'Errors legend entry must be prefixed with its series name',
+    );
+    // Discards series: "Discards  Avg: ..." (single string, prefixed).
+    expect(
+      textContaining('${l.discards}  Avg:'),
+      findsOneWidget,
+      reason: 'Discards legend entry must be prefixed with its series name',
+    );
+  });
+
+  testWidgets('Loss tab legend labels the series (Loss)', (tester) async {
+    await pumpCard(tester);
+    final l = locOf(tester);
+
+    // Switch to the Loss tab.
+    await tester.tap(find.text(l.loss).first);
+    await tester.pumpAndSettle();
+
+    expect(
+      textContaining('${l.loss}  Avg:'),
+      findsOneWidget,
+      reason: 'Loss legend entry must be prefixed with its series name',
+    );
+  });
+}

--- a/test/page/dashboard/views/components/usp_network_health_card_legend_test.dart
+++ b/test/page/dashboard/views/components/usp_network_health_card_legend_test.dart
@@ -121,7 +121,7 @@ void main() {
     // Discards series carries a real, formatted rate — not the default 0.
     // avg = (1.5 + 1.5)/s constant across snapshots => formatFaultRate => "3.0/s".
     expect(
-      textContaining('${l.discards}  Avg: 3.0/s'),
+      textContaining(l.seriesAvgValue(l.discards, '3.0/s')),
       findsOneWidget,
       reason: 'Discards legend must render the formatted non-zero avg value',
     );

--- a/test/page/dashboard/views/components/usp_network_health_card_legend_test.dart
+++ b/test/page/dashboard/views/components/usp_network_health_card_legend_test.dart
@@ -62,13 +62,13 @@ void main() {
 
     // Errors series: "Errors  Avg: ...  Peak: ..." (single string, prefixed).
     expect(
-      textContaining('${l.errors}  Avg:'),
+      textContaining('${l.errors}  '),
       findsOneWidget,
       reason: 'Errors legend entry must be prefixed with its series name',
     );
     // Discards series: "Discards  Avg: ..." (single string, prefixed).
     expect(
-      textContaining('${l.discards}  Avg:'),
+      textContaining('${l.discards}  '),
       findsOneWidget,
       reason: 'Discards legend entry must be prefixed with its series name',
     );
@@ -83,7 +83,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      textContaining('${l.loss}  Avg:'),
+      textContaining('${l.loss}  '),
       findsOneWidget,
       reason: 'Loss legend entry must be prefixed with its series name',
     );

--- a/test/page/dashboard/views/components/usp_network_health_card_legend_test.dart
+++ b/test/page/dashboard/views/components/usp_network_health_card_legend_test.dart
@@ -88,4 +88,42 @@ void main() {
       reason: 'Loss legend entry must be prefixed with its series name',
     );
   });
+
+  testWidgets(
+      'Errors tab Discards legend renders the formatted non-zero avg value',
+      (tester) async {
+    // Base fixture leaves discards at 0; this variant supplies a constant
+    // 3.0/s WAN discard rate so the formatted value path is exercised.
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: cardOverrides(trafficAnalysisState: testTrafficWithDiscards),
+        child: MaterialApp(
+          theme: _testTheme,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const Scaffold(
+            body: SizedBox(
+              width: 500,
+              height: 400,
+              child: UspNetworkHealthCard(),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final l = locOf(tester);
+
+    // Switch to the Errors tab.
+    await tester.tap(find.text(l.errors).first);
+    await tester.pumpAndSettle();
+
+    // Discards series carries a real, formatted rate — not the default 0.
+    // avg = (1.5 + 1.5)/s constant across snapshots => formatFaultRate => "3.0/s".
+    expect(
+      textContaining('${l.discards}  Avg: 3.0/s'),
+      findsOneWidget,
+      reason: 'Discards legend must render the formatted non-zero avg value',
+    );
+  });
 }

--- a/test/page/dashboard/views/components/usp_network_health_card_legend_test.dart
+++ b/test/page/dashboard/views/components/usp_network_health_card_legend_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/_shared/models/traffic_analysis_state.dart';
 import 'package:privacy_gui/page/dashboard/views/components/usp_network_health_card.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
@@ -22,10 +23,15 @@ final _testTheme = AppTheme.create(
 /// values are distinguishable — consistent with the labeled charts elsewhere
 /// (System Status card labels CPU / Memory next to each legend dot).
 void main() {
-  Future<void> pumpCard(WidgetTester tester) async {
+  Future<void> pumpCard(
+    WidgetTester tester, {
+    TrafficAnalysisState? state,
+  }) async {
     await tester.pumpWidget(
       ProviderScope(
-        overrides: cardOverrides(trafficAnalysisState: testTrafficWithHistory),
+        overrides: cardOverrides(
+          trafficAnalysisState: state ?? testTrafficWithHistory,
+        ),
         child: MaterialApp(
           theme: _testTheme,
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -94,24 +100,7 @@ void main() {
       (tester) async {
     // Base fixture leaves discards at 0; this variant supplies a constant
     // 3.0/s WAN discard rate so the formatted value path is exercised.
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: cardOverrides(trafficAnalysisState: testTrafficWithDiscards),
-        child: MaterialApp(
-          theme: _testTheme,
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: const Scaffold(
-            body: SizedBox(
-              width: 500,
-              height: 400,
-              child: UspNetworkHealthCard(),
-            ),
-          ),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
+    await pumpCard(tester, state: testTrafficWithDiscards);
     final l = locOf(tester);
 
     // Switch to the Errors tab.

--- a/tools/check_l10n.dart
+++ b/tools/check_l10n.dart
@@ -45,7 +45,6 @@ const String dartSourceDir = 'lib';
 // A key that is genuinely unreferenced must be DELETED from the ARB files,
 // not added here. Each entry notes the file that contains the real usage.
 const Set<String> allowedUnusedKeys = {
-  'avgValue', // usp_network_health_card.dart
   'copyRight', // bottom_bar.dart
   'addedWidgetNamed', // usp_layout_settings_panel.dart
   'nOnlineOfTotal', // usp_network_topology_card.dart


### PR DESCRIPTION
## Summary

Fixes `#1145`. On the **Network Health** card's **Errors** and **Loss** tabs, the chart legend showed two "Avg" values in different colors with **no series name** — the user couldn't tell which colored line was which. This was inconsistent with the labeled charts elsewhere (the System Status card labels CPU / Memory next to each legend dot, and this card's own `AppChartSeries` already carries `label:` values).

## Root cause

In `lib/page/dashboard/views/components/usp_network_health_card.dart`, the `_ErrorsChart` and `_LossChart` legend rows rendered only the aggregate values via `avgValuePeakValue` / `avgValue` — the series name was never included in the legend text (only in the chart's internal `AppChartSeries.label`, which is not surfaced in this legend row).

## Change

- Added two l10n keys that fold the series name into the legend text: `seriesAvgValuePeakValue` (`{series}  Avg: {avg}  Peak: {peak}`) and `seriesAvgValue` (`{series}  Avg: {value}`).
- Errors tab: `Errors  Avg/Peak` + `Discards  Avg`. Loss tab: `Loss  Avg/Peak`. Series names reuse existing keys (`errors` / `discards` / `loss`) — the same strings already used as the chart series labels.
- Because the Errors legend now carries two longer labeled entries, its `Row` is converted to a centered `Wrap` so entries flow onto a second line instead of overflowing the card width (a RenderFlex overflow was reproduced by the new test before the `Wrap` change).

## Files

| File | Change |
|---|---|
| `lib/l10n/app_en.arb` | +2 l10n keys (`seriesAvgValuePeakValue`, `seriesAvgValue`) |
| `lib/page/dashboard/views/components/usp_network_health_card.dart` | legend entries prefixed with series name; Errors legend `Row`→`Wrap` |
| `test/page/dashboard/views/components/usp_network_health_card_legend_test.dart` | new white-box widget tests |

## Verification (real output)

- `flutter analyze lib/...usp_network_health_card.dart test/...legend_test.dart` → `No issues found!`
- `dart format --output=none --set-exit-if-changed .` → `Formatted 1109 files (0 changed)` (CI Quality gate clean)
- `flutter test .../usp_network_health_card_legend_test.dart` → `All tests passed!` (2/2)
  - `Errors tab legend labels both series (Errors + Discards)` ✅
  - `Loss tab legend labels the series (Loss)` ✅

`git diff --stat origin/dev-2.6.0...HEAD`: 3 files changed, 148 insertions(+), 16 deletions(-).

Refs `#1145`
