### PR TITLE
fix(diagnostics): honor Cancel mid-flow by guarding step boundaries (`#1148`)

### DIFF
--- a/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
+++ b/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
@@ -303,6 +303,30 @@ class UnifiedDiagnosticsNotifier
         // to — or launching an unsolicited flow via selectFlow on WAN-down.
         // Mirrors [cancel] and the running case below.
         ++_generation;
+        // [startWithPreQualifier] acquires [_scope] (via [_ensureScope]) before
+        // its pingInternet step, so a Back from preQualifying can leave a live
+        // scope with an in-flight op. Capture it, null the live field so a new
+        // runner's [_ensureScope] acquires a fresh scope instead of reusing this
+        // one, then drain + release off the critical path and track it via
+        // [_teardownFuture] so [teardownDone] reflects the real completion.
+        final scope = _scope;
+        _scope = null;
+        _teardownFuture = () async {
+          final inFlight = _runFuture;
+          if (inFlight != null) {
+            try {
+              await inFlight;
+            } catch (_) {}
+          }
+          if (scope != null) {
+            try {
+              await scope.release();
+            } catch (e) {
+              logger.w('[Diagnostics] Failed to release scope on back: $e');
+            }
+          }
+        }();
+        unawaited(_teardownFuture!);
         state = const UnifiedDiagnosticsState();
         return true;
       case DiagnosticStep.showingResults:

--- a/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
+++ b/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
@@ -84,7 +84,7 @@ class UnifiedDiagnosticsNotifier
 
   /// Acquire (or reuse) the shared diagnostic scope. Lifecycle is bound to
   /// this notifier — released automatically on dispose.
-  Future<DiagnosticScope> _ensureScope() async {
+  Future<DiagnosticScope> _ensureScope(int gen) async {
     final existing = _scope;
     if (existing != null && !existing.isReleased) return existing;
 
@@ -94,6 +94,19 @@ class UnifiedDiagnosticsNotifier
           detail: 'NetworkDiagnosticsExecutor not available');
     }
     final scope = await executor.acquireScope();
+    // Guard this post-await mutation like every other state write. If the run
+    // was invalidated (cancel/back/newer run) while [acquireScope] was in
+    // flight, release the scope we just took instead of clobbering [_scope] —
+    // otherwise a newer run's scope is orphaned and never released (the
+    // acquire-side mirror of the release-side guard).
+    if (!_isCurrent(gen)) {
+      try {
+        await scope.release();
+      } catch (e) {
+        logger.w('[Diagnostics] Failed to release scope for stale run: $e');
+      }
+      return scope;
+    }
     _scope = scope;
     _svc?.attachScope(scope);
     return scope;
@@ -133,6 +146,21 @@ class UnifiedDiagnosticsNotifier
     logger.i('[Diagnostics] Starting with pre-qualifier');
     state = const UnifiedDiagnosticsState(step: DiagnosticStep.preQualifying);
 
+    // Register the run future exactly as [runFullDiagnostic] and [selectFlow]
+    // do, so cancel()/goBack() teardown can drain the in-flight pingInternet
+    // before releasing the scope this flow acquires — otherwise the scope is
+    // released while the ping is still in flight (DELETE/POST overlap risk).
+    final future = _preQualifierFlow(gen);
+    _runFuture = future;
+    try {
+      await future;
+    } finally {
+      if (identical(_runFuture, future)) _runFuture = null;
+    }
+  }
+
+  Future<void> _preQualifierFlow(int gen) async {
+    if (!_isCurrent(gen)) return;
     final svc = _svc;
     if (svc == null) {
       logger
@@ -165,7 +193,7 @@ class UnifiedDiagnosticsNotifier
 
       // Step 2: Quick ping to check internet connectivity
       try {
-        await _ensureScope();
+        await _ensureScope(gen);
         final pingResult = await svc.pingInternet(repeatCount: 1);
         if (!_isCurrent(gen)) return;
 
@@ -429,7 +457,7 @@ class UnifiedDiagnosticsNotifier
     // Acquire shared scope for all ping and speed test operations.
     // Released on notifier dispose / cancel / back navigation.
     try {
-      await _ensureScope();
+      await _ensureScope(gen);
     } catch (e) {
       logger.e('[Diagnostics] Failed to acquire scope: $e');
     }
@@ -586,7 +614,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     try {
-      await _ensureScope();
+      await _ensureScope(gen);
     } catch (e) {
       logger.e('[Diagnostics] Failed to acquire scope: $e');
     }
@@ -846,7 +874,7 @@ class UnifiedDiagnosticsNotifier
     final results = <DiagnosticStepUIModel>[];
 
     try {
-      await _ensureScope();
+      await _ensureScope(gen);
     } catch (e) {
       logger.e('[Diagnostics] Failed to acquire scope: $e');
     }

--- a/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
+++ b/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
@@ -792,6 +792,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 1: Check intermittent issues (uptime + jitter)
+    if (!_isCurrent(gen)) return;
     state = state.copyWith(step: DiagnosticStep.pingInternet);
     try {
       final intermittent = await svc.checkIntermittent();

--- a/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
+++ b/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
@@ -200,18 +200,28 @@ class UnifiedDiagnosticsNotifier
     }
   }
 
-  /// Cancel and reset to idle. Awaits any in-flight diagnostic future before
-  /// releasing the scope so we don't race with operations still completing.
+  /// Cancel and reset to idle. Tears down the in-flight future and scope off
+  /// the critical path (mirrors [goBack]'s running case) so the UI resets
+  /// immediately. Awaiting the in-flight future here would block the state
+  /// reset for up to the speed test's 3-minute timeout, making the Cancel
+  /// button appear ignored during [DiagnosticStep.runningSpeedTest].
   Future<void> cancel() async {
     logger.d('[Diagnostics] Cancelled');
     _cancelled = true;
-    final inFlight = _runFuture;
-    if (inFlight != null) {
+    unawaited(() async {
+      // Actively stop the shared speed test so its polling future observes the
+      // cancellation and completes promptly instead of lingering to timeout.
       try {
-        await inFlight;
+        await ref.read(speedTestProvider.notifier).cancel();
       } catch (_) {}
-    }
-    await _releaseScope();
+      final inFlight = _runFuture;
+      if (inFlight != null) {
+        try {
+          await inFlight;
+        } catch (_) {}
+      }
+      await _releaseScope();
+    }());
     state = const UnifiedDiagnosticsState();
   }
 
@@ -846,6 +856,16 @@ class UnifiedDiagnosticsNotifier
     final completer = Completer<SpeedTestResult?>();
 
     void checkState() {
+      // Honor cancellation: if the flow was cancelled, resolve immediately so
+      // the in-flight future does not linger until the 3-minute timeout.
+      if (_cancelled) {
+        if (!completer.isCompleted) {
+          logger.d('[Diagnostics] SpeedTest cancelled');
+          completer.complete(null);
+        }
+        return;
+      }
+
       final speedState = ref.read(speedTestProvider).valueOrNull;
       if (speedState == null) return;
 

--- a/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
+++ b/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
@@ -31,7 +31,26 @@ class UnifiedDiagnosticsNotifier
 
   DiagnosticScope? _scope;
   Future<void>? _runFuture;
-  bool _cancelled = false;
+
+  /// Monotonic run-identity token. Every run entry point ([runFullDiagnostic],
+  /// [startWithPreQualifier], [selectFlow]) claims a fresh generation by
+  /// pre-incrementing this counter and capturing the value locally. Step guards
+  /// and all post-`await` state writes are gated on the captured generation via
+  /// [_isCurrent] / [_publish], so a stale runner that revives after a long
+  /// `await` cannot clobber a newer run's state. [cancel] / [goBack] bump the
+  /// counter to invalidate any in-flight run — this replaces the old shared
+  /// `_cancelled` bool, which the next run reset to `false`, leaving no
+  /// per-run identity and allowing the cancel→restart clobber race.
+  int _generation = 0;
+
+  bool _isCurrent(int gen) => _generation == gen;
+
+  /// Write [next] only if [gen] is still the active run. Prevents a stale
+  /// runner from overwriting a newer run's state after resuming from an await.
+  void _publish(int gen, UnifiedDiagnosticsState next) {
+    if (_generation != gen) return;
+    state = next;
+  }
 
   @override
   UnifiedDiagnosticsState build() {
@@ -66,26 +85,13 @@ class UnifiedDiagnosticsNotifier
     return scope;
   }
 
-  /// Release the active scope (if any). Used by [cancel] and [goBack] when
-  /// the user leaves mid-flow without disposing the notifier.
-  Future<void> _releaseScope() async {
-    final scope = _scope;
-    _scope = null;
-    if (scope == null) return;
-    try {
-      await scope.release();
-    } catch (e) {
-      logger.w('[Diagnostics] Failed to release scope: $e');
-    }
-  }
-
   /// Run full diagnostic — auto-run all checks without user selection.
   Future<void> runFullDiagnostic() async {
     logger.i('[Diagnostics] Running full diagnostic (auto-run)');
-    _cancelled = false;
+    final gen = ++_generation;
     state =
         const UnifiedDiagnosticsState(step: DiagnosticStep.checkingWanStatus);
-    final future = _runFullDiagnosticFlow();
+    final future = _runFullDiagnosticFlow(gen);
     _runFuture = future;
     try {
       await future;
@@ -103,7 +109,7 @@ class UnifiedDiagnosticsNotifier
   /// Start diagnostic flow with pre-qualifier check.
   /// Runs a quick WAN + ping check, then shows flow menu or auto-selects flow.
   Future<void> startWithPreQualifier() async {
-    _cancelled = false;
+    final gen = ++_generation;
     logger.i('[Diagnostics] Starting with pre-qualifier');
     state = const UnifiedDiagnosticsState(step: DiagnosticStep.preQualifying);
 
@@ -111,22 +117,27 @@ class UnifiedDiagnosticsNotifier
     if (svc == null) {
       logger
           .w('[Diagnostics] Service not available, falling back to flow menu');
-      state = state.copyWith(
-        step: DiagnosticStep.selectFlow,
-        preQualifierResult: PreQualifierResult.internetOk,
-      );
+      _publish(
+          gen,
+          state.copyWith(
+            step: DiagnosticStep.selectFlow,
+            preQualifierResult: PreQualifierResult.internetOk,
+          ));
       return;
     }
 
     try {
       // Step 1: Check WAN status
       final wan = await svc.checkWanStatus();
+      if (!_isCurrent(gen)) return;
       if (!wan.isUp || !wan.hasIp) {
         logger.i('[Diagnostics] Pre-qualifier: WAN down or no IP');
-        state = state.copyWith(
-          step: DiagnosticStep.selectFlow,
-          preQualifierResult: PreQualifierResult.wanDownNoIp,
-        );
+        _publish(
+            gen,
+            state.copyWith(
+              step: DiagnosticStep.selectFlow,
+              preQualifierResult: PreQualifierResult.wanDownNoIp,
+            ));
         // Auto-select No Internet flow for critical issues
         await selectFlow(DiagnosticFlow.internet);
         return;
@@ -136,50 +147,61 @@ class UnifiedDiagnosticsNotifier
       try {
         await _ensureScope();
         final pingResult = await svc.pingInternet(repeatCount: 1);
+        if (!_isCurrent(gen)) return;
 
         if (pingResult.successCount == 0) {
           // Ping failed — could be DNS or internet issue
           logger.i('[Diagnostics] Pre-qualifier: Internet ping failed');
-          state = state.copyWith(
-            step: DiagnosticStep.selectFlow,
-            preQualifierResult: PreQualifierResult.dnsFailure,
-          );
+          _publish(
+              gen,
+              state.copyWith(
+                step: DiagnosticStep.selectFlow,
+                preQualifierResult: PreQualifierResult.dnsFailure,
+              ));
         } else if (pingResult.avgResponseTime > 500) {
           // High latency
           logger.i(
               '[Diagnostics] Pre-qualifier: High latency (${pingResult.avgResponseTime}ms)');
-          state = state.copyWith(
-            step: DiagnosticStep.selectFlow,
-            preQualifierResult: PreQualifierResult.internetSlow,
-          );
+          _publish(
+              gen,
+              state.copyWith(
+                step: DiagnosticStep.selectFlow,
+                preQualifierResult: PreQualifierResult.internetSlow,
+              ));
         } else {
           // Internet OK
           logger.i('[Diagnostics] Pre-qualifier: Internet OK');
-          state = state.copyWith(
-            step: DiagnosticStep.selectFlow,
-            preQualifierResult: PreQualifierResult.internetOk,
-          );
+          _publish(
+              gen,
+              state.copyWith(
+                step: DiagnosticStep.selectFlow,
+                preQualifierResult: PreQualifierResult.internetOk,
+              ));
         }
       } catch (e) {
         logger.w('[Diagnostics] Pre-qualifier ping failed: $e');
-        state = state.copyWith(
-          step: DiagnosticStep.selectFlow,
-          preQualifierResult: PreQualifierResult.dnsFailure,
-        );
+        _publish(
+            gen,
+            state.copyWith(
+              step: DiagnosticStep.selectFlow,
+              preQualifierResult: PreQualifierResult.dnsFailure,
+            ));
       }
     } catch (e) {
       logger.w('[Diagnostics] Pre-qualifier failed: $e');
-      state = state.copyWith(
-        step: DiagnosticStep.selectFlow,
-        preQualifierResult: PreQualifierResult.internetOk,
-      );
+      _publish(
+          gen,
+          state.copyWith(
+            step: DiagnosticStep.selectFlow,
+            preQualifierResult: PreQualifierResult.internetOk,
+          ));
     }
   }
 
   /// User selects diagnostic flow from menu.
   Future<void> selectFlow(DiagnosticFlow flow) async {
     logger.i('[Diagnostics] Flow selected: $flow');
-    _cancelled = false;
+    final gen = ++_generation;
     state = state.copyWith(
       flow: flow,
       results: [],
@@ -188,11 +210,11 @@ class UnifiedDiagnosticsNotifier
     );
 
     final future = switch (flow) {
-      DiagnosticFlow.internet => _runInternetDiagnostics(),
-      DiagnosticFlow.deviceIssues => _runDeviceIssuesDiagnostics(),
-      DiagnosticFlow.wifiCoverage => _runWifiCoverageDiagnostics(),
-      DiagnosticFlow.meshBackhaul => _runMeshBackhaulDiagnostics(),
-      DiagnosticFlow.intermittent => _runIntermittentDiagnostics(),
+      DiagnosticFlow.internet => _runInternetDiagnostics(gen),
+      DiagnosticFlow.deviceIssues => _runDeviceIssuesDiagnostics(gen),
+      DiagnosticFlow.wifiCoverage => _runWifiCoverageDiagnostics(gen),
+      DiagnosticFlow.meshBackhaul => _runMeshBackhaulDiagnostics(gen),
+      DiagnosticFlow.intermittent => _runIntermittentDiagnostics(gen),
     };
     _runFuture = future;
     try {
@@ -204,12 +226,19 @@ class UnifiedDiagnosticsNotifier
 
   /// Cancel and reset to idle. Tears down the in-flight future and scope off
   /// the critical path (mirrors [goBack]'s running case) so the UI resets
-  /// immediately instead of waiting for the in-flight step to drain. The
-  /// [_cancelled] flag makes each runner short-circuit at its next step
-  /// boundary.
+  /// immediately instead of waiting for the in-flight step to drain. Bumping
+  /// [_generation] makes each runner short-circuit at its next generation
+  /// guard.
   Future<void> cancel() async {
     logger.d('[Diagnostics] Cancelled');
-    _cancelled = true;
+    // Invalidate the in-flight run so any suspended runner short-circuits at
+    // its next generation guard instead of clobbering the reset state.
+    ++_generation;
+    // Capture the scope this cancel owns and null the live field immediately,
+    // so a subsequent run's [_ensureScope] acquires a fresh scope rather than
+    // reusing (and having torn out from under it) the one released below.
+    final scope = _scope;
+    _scope = null;
     unawaited(() async {
       final inFlight = _runFuture;
       if (inFlight != null) {
@@ -217,7 +246,13 @@ class UnifiedDiagnosticsNotifier
           await inFlight;
         } catch (_) {}
       }
-      await _releaseScope();
+      if (scope != null) {
+        try {
+          await scope.release();
+        } catch (e) {
+          logger.w('[Diagnostics] Failed to release scope on cancel: $e');
+        }
+      }
     }());
     state = const UnifiedDiagnosticsState();
   }
@@ -266,10 +301,12 @@ class UnifiedDiagnosticsNotifier
         }
         return true;
       default:
-        // Running — mark cancelled, await the in-flight future, then release
-        // the scope. Sequencing prevents the linger window from re-entering
-        // with a stale scope.
-        _cancelled = true;
+        // Running — invalidate the in-flight run, await it, then release the
+        // scope this back-nav owns. Bumping the generation prevents a suspended
+        // runner from re-entering with a stale scope or clobbering state.
+        ++_generation;
+        final scope = _scope;
+        _scope = null;
         unawaited(() async {
           final inFlight = _runFuture;
           if (inFlight != null) {
@@ -277,7 +314,13 @@ class UnifiedDiagnosticsNotifier
               await inFlight;
             } catch (_) {}
           }
-          await _releaseScope();
+          if (scope != null) {
+            try {
+              await scope.release();
+            } catch (e) {
+              logger.w('[Diagnostics] Failed to release scope on back: $e');
+            }
+          }
         }());
         if (state.flow != null) {
           state = state.copyWith(
@@ -299,8 +342,8 @@ class UnifiedDiagnosticsNotifier
   // Full Diagnostic (Auto-run all checks)
   // ══════════════════════════════════════════════════════════════════════════
 
-  Future<void> _runFullDiagnosticFlow() async {
-    if (_cancelled) return;
+  Future<void> _runFullDiagnosticFlow(int gen) async {
+    if (!_isCurrent(gen)) return;
     final svc = _svc;
     if (svc == null) {
       _setError(const ServiceNotInitializedError(
@@ -317,10 +360,10 @@ class UnifiedDiagnosticsNotifier
       final wan = await svc.checkWanStatus();
       wanResult = _evaluateWanStatus(wan);
       results.add(wanResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.checkingWanStatus, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
     // Acquire shared scope for all ping and speed test operations.
@@ -332,113 +375,113 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 2: Ping gateway
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     state = state.copyWith(step: DiagnosticStep.pingGateway);
     try {
       final ping = await svc.pingGateway();
       final pingResult = _evaluatePing(DiagnosticStep.pingGateway, ping);
       results.add(pingResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.pingGateway, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
     // Step 3: Ping DNS
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     state = state.copyWith(step: DiagnosticStep.pingDns);
     try {
       final ping = await svc.pingDns();
       final pingResult = _evaluatePing(DiagnosticStep.pingDns, ping);
       results.add(pingResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.pingDns, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
     // Step 3b: DNS lookup
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     state = state.copyWith(step: DiagnosticStep.dnsLookup);
     try {
       final dnsResult = await _runDnsLookup(svc);
       results.add(dnsResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.dnsLookup, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
     // Step 4: Ping internet
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     state = state.copyWith(step: DiagnosticStep.pingInternet);
     try {
       final ping = await svc.pingInternet();
       final pingResult = _evaluatePing(DiagnosticStep.pingInternet, ping);
       results.add(pingResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.pingInternet, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
     // Speed test step disabled: blocked by FW support (#857)
 
     // Step 6: Check WiFi signal (per-radio RSSI)
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     state = state.copyWith(step: DiagnosticStep.checkingWifiSignal);
     try {
       final perRadio = await svc.analyzeWifiSignalPerRadio();
       final wifiResult = _evaluateWifiSignal(perRadio);
       results.add(wifiResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.checkingWifiSignal, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
     // Step 6b: Check DHCP pool usage
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     state = state.copyWith(step: DiagnosticStep.checkingDhcpPool);
     try {
       final pool = await svc.checkDhcpPool();
       final poolResult = _evaluateDhcpPool(pool);
       results.add(poolResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.checkingDhcpPool, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
     // Step 6c: Mesh / Backhaul (LAN-only GET — runs even without internet).
     // Skipped silently when only one node exists.
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     state = state.copyWith(step: DiagnosticStep.checkingMeshBackhaul);
     try {
       final meshResult = _buildMeshBackhaulResult(
         await svc.checkMeshBackhaul(),
       );
       results.add(meshResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.checkingMeshBackhaul, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
     // Step 7: Check connected devices
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     state = state.copyWith(step: DiagnosticStep.checkingConnectedDevices);
     try {
       final devices = await svc.checkConnectedDevices();
       final devicesResult = _evaluateConnectedDevices(devices);
       results.add(devicesResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.checkingConnectedDevices, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     await _analyzeAndShowResults(results);
   }
 
@@ -446,8 +489,8 @@ class UnifiedDiagnosticsNotifier
   // Flow 1: Internet (combined connectivity + speed)
   // ══════════════════════════════════════════════════════════════════════════
 
-  Future<void> _runInternetDiagnostics() async {
-    if (_cancelled) return;
+  Future<void> _runInternetDiagnostics(int gen) async {
+    if (!_isCurrent(gen)) return;
     final svc = _svc;
     if (svc == null) {
       _setError(const ServiceNotInitializedError(
@@ -463,23 +506,23 @@ class UnifiedDiagnosticsNotifier
       final wan = await svc.checkWanStatus();
       final wanResult = _evaluateWanStatus(wan);
       results.add(wanResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.checkingWanStatus, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
     // Step 1b: Check DHCP pool capacity / usage
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     state = state.copyWith(step: DiagnosticStep.checkingDhcpPool);
     try {
       final pool = await svc.checkDhcpPool();
       final poolResult = _evaluateDhcpPool(pool);
       results.add(poolResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.checkingDhcpPool, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
     try {
@@ -489,59 +532,59 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 2: Ping gateway
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     state = state.copyWith(step: DiagnosticStep.pingGateway);
     try {
       final ping = await svc.pingGateway();
       final pingResult = _evaluatePing(DiagnosticStep.pingGateway, ping);
       results.add(pingResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.pingGateway, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
     // Step 3: Ping DNS
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     state = state.copyWith(step: DiagnosticStep.pingDns);
     try {
       final ping = await svc.pingDns();
       final pingResult = _evaluatePing(DiagnosticStep.pingDns, ping);
       results.add(pingResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.pingDns, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
     // Step 3b: DNS lookup — verify name resolution actually works
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     state = state.copyWith(step: DiagnosticStep.dnsLookup);
     try {
       final dnsResult = await _runDnsLookup(svc);
       results.add(dnsResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.dnsLookup, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
     // Step 4: Ping internet
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     state = state.copyWith(step: DiagnosticStep.pingInternet);
     try {
       final ping = await svc.pingInternet();
       final pingResult = _evaluatePing(DiagnosticStep.pingInternet, ping);
       results.add(pingResult);
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.pingInternet, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
     // Speed test step disabled: blocked by FW support (#857)
 
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     await _analyzeAndShowResults(results);
   }
 
@@ -549,8 +592,8 @@ class UnifiedDiagnosticsNotifier
   // Flow 2: Device Issues
   // ══════════════════════════════════════════════════════════════════════════
 
-  Future<void> _runDeviceIssuesDiagnostics() async {
-    if (_cancelled) return;
+  Future<void> _runDeviceIssuesDiagnostics(int gen) async {
+    if (!_isCurrent(gen)) return;
     final svc = _svc;
     if (svc == null) {
       _setError(const ServiceNotInitializedError(
@@ -589,13 +632,13 @@ class UnifiedDiagnosticsNotifier
         titleKey: 'diagnostics_device_issues',
         descriptionKey: 'diagnostics_device_issues_desc',
       ));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.checkingConnectedDevices, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     await _analyzeAndShowResults(results);
   }
 
@@ -603,8 +646,8 @@ class UnifiedDiagnosticsNotifier
   // Flow 3: WiFi Coverage
   // ══════════════════════════════════════════════════════════════════════════
 
-  Future<void> _runWifiCoverageDiagnostics() async {
-    if (_cancelled) return;
+  Future<void> _runWifiCoverageDiagnostics(int gen) async {
+    if (!_isCurrent(gen)) return;
     final svc = _svc;
     if (svc == null) {
       _setError(const ServiceNotInitializedError(
@@ -637,13 +680,13 @@ class UnifiedDiagnosticsNotifier
         titleKey: 'diagnostics_wifi_coverage',
         descriptionKey: 'diagnostics_wifi_coverage_desc',
       ));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.checkingWifiSignal, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     await _analyzeAndShowResults(results);
   }
 
@@ -651,8 +694,8 @@ class UnifiedDiagnosticsNotifier
   // Flow: Mesh / Backhaul
   // ══════════════════════════════════════════════════════════════════════════
 
-  Future<void> _runMeshBackhaulDiagnostics() async {
-    if (_cancelled) return;
+  Future<void> _runMeshBackhaulDiagnostics(int gen) async {
+    if (!_isCurrent(gen)) return;
     final svc = _svc;
     if (svc == null) {
       _setError(const ServiceNotInitializedError(
@@ -667,13 +710,13 @@ class UnifiedDiagnosticsNotifier
     try {
       final records = await svc.checkMeshBackhaul();
       results.add(_buildMeshBackhaulResult(records));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.checkingMeshBackhaul, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     await _analyzeAndShowResults(results);
   }
 
@@ -730,8 +773,8 @@ class UnifiedDiagnosticsNotifier
   // Flow 4: Intermittent
   // ══════════════════════════════════════════════════════════════════════════
 
-  Future<void> _runIntermittentDiagnostics() async {
-    if (_cancelled) return;
+  Future<void> _runIntermittentDiagnostics(int gen) async {
+    if (!_isCurrent(gen)) return;
     final svc = _svc;
     if (svc == null) {
       _setError(const ServiceNotInitializedError(
@@ -772,13 +815,13 @@ class UnifiedDiagnosticsNotifier
         titleKey: 'diagnostics_intermittent',
         descriptionKey: 'diagnostics_intermittent_desc',
       ));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     } catch (e) {
       results.add(_errorResult(DiagnosticStep.pingInternet, e));
-      state = state.copyWith(results: List.from(results));
+      _publish(gen, state.copyWith(results: List.from(results)));
     }
 
-    if (_cancelled) return;
+    if (!_isCurrent(gen)) return;
     await _analyzeAndShowResults(results);
   }
 

--- a/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
+++ b/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
@@ -325,6 +325,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 2: Ping gateway
+    if (_cancelled) return;
     state = state.copyWith(step: DiagnosticStep.pingGateway);
     try {
       final ping = await svc.pingGateway();
@@ -337,6 +338,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 3: Ping DNS
+    if (_cancelled) return;
     state = state.copyWith(step: DiagnosticStep.pingDns);
     try {
       final ping = await svc.pingDns();
@@ -349,6 +351,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 3b: DNS lookup
+    if (_cancelled) return;
     state = state.copyWith(step: DiagnosticStep.dnsLookup);
     try {
       final dnsResult = await _runDnsLookup(svc);
@@ -360,6 +363,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 4: Ping internet
+    if (_cancelled) return;
     state = state.copyWith(step: DiagnosticStep.pingInternet);
     try {
       final ping = await svc.pingInternet();
@@ -372,6 +376,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 5: Speed test
+    if (_cancelled) return;
     state = state.copyWith(step: DiagnosticStep.runningSpeedTest);
     try {
       final speedTestResult = await _runSharedSpeedTest();
@@ -391,6 +396,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 6: Check WiFi signal (per-radio RSSI)
+    if (_cancelled) return;
     state = state.copyWith(step: DiagnosticStep.checkingWifiSignal);
     try {
       final perRadio = await svc.analyzeWifiSignalPerRadio();
@@ -403,6 +409,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 6b: Check DHCP pool usage
+    if (_cancelled) return;
     state = state.copyWith(step: DiagnosticStep.checkingDhcpPool);
     try {
       final pool = await svc.checkDhcpPool();
@@ -416,6 +423,7 @@ class UnifiedDiagnosticsNotifier
 
     // Step 6c: Mesh / Backhaul (LAN-only GET — runs even without internet).
     // Skipped silently when only one node exists.
+    if (_cancelled) return;
     state = state.copyWith(step: DiagnosticStep.checkingMeshBackhaul);
     try {
       final meshResult = _buildMeshBackhaulResult(
@@ -429,6 +437,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 7: Check connected devices
+    if (_cancelled) return;
     state = state.copyWith(step: DiagnosticStep.checkingConnectedDevices);
     try {
       final devices = await svc.checkConnectedDevices();
@@ -440,6 +449,7 @@ class UnifiedDiagnosticsNotifier
       state = state.copyWith(results: List.from(results));
     }
 
+    if (_cancelled) return;
     await _analyzeAndShowResults(results);
   }
 
@@ -474,6 +484,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 1b: Check DHCP pool capacity / usage
+    if (_cancelled) return;
     state = state.copyWith(step: DiagnosticStep.checkingDhcpPool);
     try {
       final pool = await svc.checkDhcpPool();
@@ -492,6 +503,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 2: Ping gateway
+    if (_cancelled) return;
     state = state.copyWith(step: DiagnosticStep.pingGateway);
     try {
       final ping = await svc.pingGateway();
@@ -506,6 +518,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 3: Ping DNS
+    if (_cancelled) return;
     state = state.copyWith(step: DiagnosticStep.pingDns);
     try {
       final ping = await svc.pingDns();
@@ -520,6 +533,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 3b: DNS lookup — verify name resolution actually works
+    if (_cancelled) return;
     state = state.copyWith(step: DiagnosticStep.dnsLookup);
     try {
       final dnsResult = await _runDnsLookup(svc);
@@ -533,6 +547,7 @@ class UnifiedDiagnosticsNotifier
     }
 
     // Step 4: Ping internet
+    if (_cancelled) return;
     state = state.copyWith(step: DiagnosticStep.pingInternet);
     try {
       final ping = await svc.pingInternet();
@@ -548,6 +563,7 @@ class UnifiedDiagnosticsNotifier
 
     // Step 5: Speed test (only if connectivity is OK)
     if (connectivityOk) {
+      if (_cancelled) return;
       state = state.copyWith(step: DiagnosticStep.runningSpeedTest);
       try {
         final speedTestResult = await _runSharedSpeedTest();
@@ -567,6 +583,7 @@ class UnifiedDiagnosticsNotifier
       }
     }
 
+    if (_cancelled) return;
     await _analyzeAndShowResults(results);
   }
 

--- a/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
+++ b/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
@@ -103,6 +103,9 @@ class UnifiedDiagnosticsNotifier
   Future<void> runFullDiagnostic() async {
     logger.i('[Diagnostics] Running full diagnostic (auto-run)');
     final gen = ++_generation;
+    // Clear any completed prior teardown so [teardownDone] reflects THIS run's
+    // lifecycle, not a stale cancel()/goBack() future that already resolved.
+    _teardownFuture = null;
     state =
         const UnifiedDiagnosticsState(step: DiagnosticStep.checkingWanStatus);
     final future = _runFullDiagnosticFlow(gen);
@@ -124,6 +127,9 @@ class UnifiedDiagnosticsNotifier
   /// Runs a quick WAN + ping check, then shows flow menu or auto-selects flow.
   Future<void> startWithPreQualifier() async {
     final gen = ++_generation;
+    // Clear any completed prior teardown so [teardownDone] reflects THIS run's
+    // lifecycle, not a stale cancel()/goBack() future that already resolved.
+    _teardownFuture = null;
     logger.i('[Diagnostics] Starting with pre-qualifier');
     state = const UnifiedDiagnosticsState(step: DiagnosticStep.preQualifying);
 
@@ -216,6 +222,9 @@ class UnifiedDiagnosticsNotifier
   Future<void> selectFlow(DiagnosticFlow flow) async {
     logger.i('[Diagnostics] Flow selected: $flow');
     final gen = ++_generation;
+    // Clear any completed prior teardown so [teardownDone] reflects THIS run's
+    // lifecycle, not a stale cancel()/goBack() future that already resolved.
+    _teardownFuture = null;
     state = state.copyWith(
       flow: flow,
       results: [],
@@ -352,7 +361,12 @@ class UnifiedDiagnosticsNotifier
         ++_generation;
         final scope = _scope;
         _scope = null;
-        unawaited(() async {
+        // Track the teardown via [_teardownFuture] (mirrors [cancel] and the
+        // preQualifying case above) so [teardownDone] reflects THIS back-nav's
+        // drain + scope release. A bare unawaited() here would leave
+        // [_teardownFuture] pointing at a stale prior teardown, so
+        // [teardownDone] would resolve early on the wrong future.
+        _teardownFuture = () async {
           final inFlight = _runFuture;
           if (inFlight != null) {
             try {
@@ -366,7 +380,8 @@ class UnifiedDiagnosticsNotifier
               logger.w('[Diagnostics] Failed to release scope on back: $e');
             }
           }
-        }());
+        }();
+        unawaited(_teardownFuture!);
         if (state.flow != null) {
           state = state.copyWith(
             step: DiagnosticStep.selectFlow,

--- a/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
+++ b/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
@@ -102,6 +102,7 @@ class UnifiedDiagnosticsNotifier
   /// Start diagnostic flow with pre-qualifier check.
   /// Runs a quick WAN + ping check, then shows flow menu or auto-selects flow.
   Future<void> startWithPreQualifier() async {
+    _cancelled = false;
     logger.i('[Diagnostics] Starting with pre-qualifier');
     state = const UnifiedDiagnosticsState(step: DiagnosticStep.preQualifying);
 
@@ -208,11 +209,17 @@ class UnifiedDiagnosticsNotifier
   Future<void> cancel() async {
     logger.d('[Diagnostics] Cancelled');
     _cancelled = true;
+    // Capture the notifier synchronously before the async gap. This
+    // AutoDisposeNotifier can be disposed (e.g. route popped right after the
+    // Cancel tap) before the unawaited closure runs, at which point a deferred
+    // `ref.read` would throw StateError and the speed test would never be told
+    // to stop. Reading it now guarantees the cancellation is delivered.
+    final speedTestNotifier = ref.read(speedTestProvider.notifier);
     unawaited(() async {
       // Actively stop the shared speed test so its polling future observes the
       // cancellation and completes promptly instead of lingering to timeout.
       try {
-        await ref.read(speedTestProvider.notifier).cancel();
+        await speedTestNotifier.cancel();
       } catch (_) {}
       final inFlight = _runFuture;
       if (inFlight != null) {
@@ -647,6 +654,7 @@ class UnifiedDiagnosticsNotifier
       state = state.copyWith(results: List.from(results));
     }
 
+    if (_cancelled) return;
     await _analyzeAndShowResults(results);
   }
 
@@ -694,6 +702,7 @@ class UnifiedDiagnosticsNotifier
       state = state.copyWith(results: List.from(results));
     }
 
+    if (_cancelled) return;
     await _analyzeAndShowResults(results);
   }
 
@@ -723,6 +732,7 @@ class UnifiedDiagnosticsNotifier
       state = state.copyWith(results: List.from(results));
     }
 
+    if (_cancelled) return;
     await _analyzeAndShowResults(results);
   }
 
@@ -827,6 +837,7 @@ class UnifiedDiagnosticsNotifier
       state = state.copyWith(results: List.from(results));
     }
 
+    if (_cancelled) return;
     await _analyzeAndShowResults(results);
   }
 

--- a/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
+++ b/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
@@ -281,7 +281,13 @@ class UnifiedDiagnosticsNotifier
       case DiagnosticStep.preQualifying:
       case DiagnosticStep.selectFlow:
       case DiagnosticStep.manualTools:
-        // Back to start screen
+        // Back to start screen. Bump the generation first so any in-flight
+        // runner (e.g. a [startWithPreQualifier] suspended on checkWanStatus /
+        // pingInternet) short-circuits at its next [_isCurrent] / [_publish]
+        // guard instead of clobbering the idle screen the user just navigated
+        // to — or launching an unsolicited flow via selectFlow on WAN-down.
+        // Mirrors [cancel] and the running case below.
+        ++_generation;
         state = const UnifiedDiagnosticsState();
         return true;
       case DiagnosticStep.showingResults:

--- a/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
+++ b/lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart
@@ -32,6 +32,20 @@ class UnifiedDiagnosticsNotifier
   DiagnosticScope? _scope;
   Future<void>? _runFuture;
 
+  /// Completion of the most recent off-critical-path teardown started by
+  /// [cancel] / [goBack]. [cancel] resets state synchronously and releases the
+  /// scope in an `unawaited` background task for UI responsiveness, so awaiting
+  /// [cancel] alone no longer guarantees the scope is released. Callers that
+  /// need the shared scope actually released before proceeding (e.g. navigating
+  /// away so the notifier auto-disposes, then quickly re-entering) must await
+  /// [teardownDone] after [cancel]. Resolves immediately when no teardown is
+  /// in flight.
+  Future<void>? _teardownFuture;
+
+  /// Resolves when the last [cancel]/[goBack] teardown (in-flight drain +
+  /// scope release) has completed. See [_teardownFuture].
+  Future<void> get teardownDone => _teardownFuture ?? Future.value();
+
   /// Monotonic run-identity token. Every run entry point ([runFullDiagnostic],
   /// [startWithPreQualifier], [selectFlow]) claims a fresh generation by
   /// pre-incrementing this counter and capturing the value locally. Step guards
@@ -239,7 +253,7 @@ class UnifiedDiagnosticsNotifier
     // reusing (and having torn out from under it) the one released below.
     final scope = _scope;
     _scope = null;
-    unawaited(() async {
+    _teardownFuture = () async {
       final inFlight = _runFuture;
       if (inFlight != null) {
         try {
@@ -253,7 +267,8 @@ class UnifiedDiagnosticsNotifier
           logger.w('[Diagnostics] Failed to release scope on cancel: $e');
         }
       }
-    }());
+    }();
+    unawaited(_teardownFuture!);
     state = const UnifiedDiagnosticsState();
   }
 

--- a/lib/page/unified_diagnostics/views/unified_diagnostics_view.dart
+++ b/lib/page/unified_diagnostics/views/unified_diagnostics_view.dart
@@ -121,20 +121,27 @@ class _UnifiedDiagnosticsViewState
     );
   }
 
-  void _handleBack(
+  Future<void> _handleBack(
     BuildContext context,
     WidgetRef ref,
     UnifiedDiagnosticsState state,
-  ) {
+  ) async {
     final notifier = ref.read(unifiedDiagnosticsProvider.notifier);
     final handledInternally = notifier.goBack();
     if (!handledInternally) {
-      _returnToMenu(context, ref);
+      await _returnToMenu(context, ref);
     }
   }
 
-  void _returnToMenu(BuildContext context, WidgetRef ref) {
-    ref.read(unifiedDiagnosticsProvider.notifier).cancel();
+  Future<void> _returnToMenu(BuildContext context, WidgetRef ref) async {
+    // Await the full teardown (in-flight drain + scope release) before
+    // navigating, mirroring _returnToDashboard. cancel() tears the scope down
+    // off the critical path, so awaiting cancel() alone races the unsubscribe
+    // DELETE against a quick re-entry's subscribe POST.
+    final notifier = ref.read(unifiedDiagnosticsProvider.notifier);
+    await notifier.cancel();
+    await notifier.teardownDone;
+    if (!context.mounted) return;
     if (context.canPop()) {
       context.pop();
     } else {

--- a/lib/page/unified_diagnostics/views/unified_diagnostics_view.dart
+++ b/lib/page/unified_diagnostics/views/unified_diagnostics_view.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -121,16 +123,40 @@ class _UnifiedDiagnosticsViewState
     );
   }
 
-  Future<void> _handleBack(
+  // Single-flight guard for the app-bar back tap. onBackTap is a plain
+  // VoidCallback slot, so a Future-returning handler would have its Future
+  // silently discarded — leaving no guard against a second back-tap firing a
+  // concurrent cancel()/teardown that clobbers _teardownFuture. Keeping
+  // _handleBack synchronous and gating on this flag prevents that race.
+  bool _isBackNavigating = false;
+
+  void _handleBack(
     BuildContext context,
     WidgetRef ref,
     UnifiedDiagnosticsState state,
-  ) async {
+  ) {
+    if (_isBackNavigating) return;
     final notifier = ref.read(unifiedDiagnosticsProvider.notifier);
     final handledInternally = notifier.goBack();
-    if (!handledInternally) {
-      await _returnToMenu(context, ref);
-    }
+    if (handledInternally) return;
+
+    // Leaving the page: capture the router before any state change, cancel the
+    // in-flight run, then navigate only after the full teardown (in-flight
+    // drain + scope release) completes — mirroring _returnToMenu. Awaiting
+    // cancel() alone would race the unsubscribe DELETE against a quick
+    // re-entry's subscribe POST.
+    _isBackNavigating = true;
+    final router = GoRouter.of(context);
+    notifier.cancel();
+    unawaited(notifier.teardownDone.then((_) {
+      _isBackNavigating = false;
+      if (!mounted) return;
+      if (router.canPop()) {
+        router.pop();
+      } else {
+        router.goNamed(RouteNamed.uspMenu);
+      }
+    }));
   }
 
   Future<void> _returnToMenu(BuildContext context, WidgetRef ref) async {

--- a/lib/page/unified_diagnostics/views/unified_diagnostics_view.dart
+++ b/lib/page/unified_diagnostics/views/unified_diagnostics_view.dart
@@ -148,15 +148,21 @@ class _UnifiedDiagnosticsViewState
     _isBackNavigating = true;
     final router = GoRouter.of(context);
     notifier.cancel();
-    unawaited(notifier.teardownDone.then((_) {
-      _isBackNavigating = false;
-      if (!mounted) return;
-      if (router.canPop()) {
-        router.pop();
-      } else {
-        router.goNamed(RouteNamed.uspMenu);
-      }
-    }));
+    unawaited(
+      notifier.teardownDone
+          // Release the single-flight guard unconditionally — even if teardown
+          // completes with an error — so the app-bar back button can never get
+          // permanently stuck disabled.
+          .whenComplete(() => _isBackNavigating = false)
+          .then((_) {
+        if (!mounted) return;
+        if (router.canPop()) {
+          router.pop();
+        } else {
+          router.goNamed(RouteNamed.uspMenu);
+        }
+      }),
+    );
   }
 
   Future<void> _returnToMenu(BuildContext context, WidgetRef ref) async {

--- a/lib/page/unified_diagnostics/views/widgets/diagnostic_results_view.dart
+++ b/lib/page/unified_diagnostics/views/widgets/diagnostic_results_view.dart
@@ -73,11 +73,16 @@ class DiagnosticResultsView extends ConsumerWidget {
     // critical path (unawaited), so awaiting cancel() alone is not enough —
     // we must also await teardownDone. Without this, a quick re-entry races
     // the unsubscribe DELETE against the next acquire's subscribe POST.
+    //
+    // cancel() resets state to UnifiedDiagnosticsState(), which rebuilds and
+    // unmounts THIS widget. Since the awaits cross frame boundaries,
+    // context.mounted is false afterward and a context-based navigation would
+    // be silently dropped — so capture the router up front.
+    final router = GoRouter.of(context);
     final notifier = ref.read(unifiedDiagnosticsProvider.notifier);
     await notifier.cancel();
     await notifier.teardownDone;
-    if (!context.mounted) return;
-    context.goNamed(RouteNamed.uspDashboard);
+    router.goNamed(RouteNamed.uspDashboard);
   }
 }
 

--- a/lib/page/unified_diagnostics/views/widgets/diagnostic_results_view.dart
+++ b/lib/page/unified_diagnostics/views/widgets/diagnostic_results_view.dart
@@ -68,10 +68,14 @@ class DiagnosticResultsView extends ConsumerWidget {
   }
 
   Future<void> _returnToDashboard(BuildContext context, WidgetRef ref) async {
-    // Await cancel so the shared diagnostic scope is released before the
-    // notifier auto-disposes — without this, a quick re-entry races the
-    // unsubscribe DELETE against the next acquire's subscribe POST.
-    await ref.read(unifiedDiagnosticsProvider.notifier).cancel();
+    // Release the shared diagnostic scope before the notifier auto-disposes.
+    // cancel() resets state synchronously and tears the scope down off the
+    // critical path (unawaited), so awaiting cancel() alone is not enough —
+    // we must also await teardownDone. Without this, a quick re-entry races
+    // the unsubscribe DELETE against the next acquire's subscribe POST.
+    final notifier = ref.read(unifiedDiagnosticsProvider.notifier);
+    await notifier.cancel();
+    await notifier.teardownDone;
     if (!context.mounted) return;
     context.goNamed(RouteNamed.uspDashboard);
   }

--- a/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
+++ b/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
@@ -951,6 +951,70 @@ void main() {
             reason: 'revived Run A (WAN Down) must not clobber Run B (WAN Up)');
         container.dispose();
       });
+
+      // Regression for the residual clobber race on the Intermittent flow
+      // (PR #1175 review). Unlike the Internet flow above, this runner suspends
+      // on the *scope acquisition* await (`_ensureScope()`), and the bare
+      // `state = copyWith(step: pingInternet)` write that follows it was the one
+      // flow missing an `_isCurrent(gen)` recheck. We hang Run A on
+      // acquireScope, cancel (resetting to idle), let Run B finish, then revive
+      // Run A: without the guard it re-stamps step=pingInternet over Run B's
+      // showingResults, stranding the view on a spinner. The guard makes the
+      // stale write a no-op.
+      test(
+          'revived intermittent run after cancel+restart does not clobber step (#1175)',
+          () async {
+        final container = createContainer();
+        final notifier = container.read(unifiedDiagnosticsProvider.notifier);
+
+        // First scope acquisition (Run A) hangs; later calls (Run B, after
+        // cancel nulls the cached scope) resolve immediately.
+        final runAScope = Completer<DiagnosticScope>();
+        var acquireCalls = 0;
+        when(() => mockExecutor.acquireScope(
+              referencePaths: any(named: 'referencePaths'),
+            )).thenAnswer((_) {
+          acquireCalls++;
+          return acquireCalls == 1 ? runAScope.future : Future.value(mockScope);
+        });
+        when(() => mockService.checkIntermittent())
+            .thenAnswer((_) async => const IntermittentUIModel(
+                  uptimeSeconds: 86400,
+                  pingSuccessRate: 1.0,
+                  averageLatencyMs: 12,
+                  jitterMs: 2,
+                  hasHighJitter: false,
+                  hasPacketLoss: false,
+                  recentReboot: false,
+                ));
+
+        // Run A — suspends inside _ensureScope on the hung acquireScope.
+        final runAFuture = notifier.selectFlow(DiagnosticFlow.intermittent);
+        await Future.delayed(Duration.zero);
+
+        // Cancel Run A (resets state to idle), then start Run B and let it
+        // complete while A is still suspended on scope acquisition.
+        final cancelFuture = notifier.cancel();
+        final runBFuture = notifier.selectFlow(DiagnosticFlow.intermittent);
+        await runBFuture;
+        await Future.delayed(Duration.zero);
+
+        final afterB = container.read(unifiedDiagnosticsProvider);
+        expect(afterB.step, DiagnosticStep.showingResults);
+
+        // Revive Run A: its post-await `step=pingInternet` write must be
+        // rejected by the generation guard, leaving Run B's terminal state.
+        runAScope.complete(mockScope);
+        await runAFuture;
+        await cancelFuture;
+        await Future.delayed(Duration.zero);
+
+        final finalState = container.read(unifiedDiagnosticsProvider);
+        expect(finalState.step, DiagnosticStep.showingResults,
+            reason:
+                'revived Run A must not re-stamp step=pingInternet over Run B');
+        container.dispose();
+      });
     });
 
     group('Restart', () {

--- a/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
+++ b/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
@@ -1147,6 +1147,136 @@ void main() {
         verify(() => mockScope.release()).called(1);
         container.dispose();
       });
+
+      // Regression for H-1 (PR #1175 review). startWithPreQualifier acquires the
+      // scope before its pingInternet step but — unlike runFullDiagnostic and
+      // selectFlow — used to assign no _runFuture. cancel()'s teardown drains
+      // `_runFuture` before calling scope.release(), so a null _runFuture made
+      // it release the scope WHILE the ping was still in flight (the
+      // unsubscribe-DELETE vs next-subscribe-POST overlap the PR exists to
+      // prevent). With the fix, startWithPreQualifier registers its future, so
+      // cancel() drains the in-flight ping before releasing the scope. We assert
+      // the scope is NOT released until the hung ping completes.
+      test(
+          'cancel during preQualifier ping drains it before scope release '
+          '(#1175 H-1)', () async {
+        final container = createContainer();
+        final notifier = container.read(unifiedDiagnosticsProvider.notifier);
+
+        // WAN up so the runner acquires the scope, then suspends on the hung
+        // internet ping.
+        when(() => mockService.checkWanStatus()).thenAnswer(
+          (_) async => const WanStatusUIModel(
+            status: 'Up',
+            ipAddress: '192.168.1.100',
+            subnetMask: '255.255.255.0',
+            addressingType: 'DHCP',
+          ),
+        );
+        final pingCompleter = Completer<PingResult>();
+        when(() => mockService.pingInternet(
+              host: any(named: 'host'),
+              repeatCount: any(named: 'repeatCount'),
+            )).thenAnswer((_) => pingCompleter.future);
+
+        final preQualFuture = notifier.startWithPreQualifier();
+        await Future.delayed(Duration.zero);
+        expect(container.read(unifiedDiagnosticsProvider).step,
+            DiagnosticStep.preQualifying);
+        verify(() => mockExecutor.acquireScope(
+              referencePaths: any(named: 'referencePaths'),
+            )).called(1);
+
+        // Cancel while the ping is in flight. State resets immediately, but the
+        // scope must NOT be released yet — the teardown has to drain the
+        // in-flight ping first (which requires _runFuture to be registered).
+        final cancelFuture = notifier.cancel();
+        await Future.delayed(Duration.zero);
+        expect(container.read(unifiedDiagnosticsProvider).step,
+            DiagnosticStep.idle);
+        verifyNever(() => mockScope.release());
+
+        // Complete the ping — only now may the scope be released.
+        pingCompleter.complete(_createPingResult('1.1.1.1'));
+        await preQualFuture;
+        await cancelFuture;
+        await notifier.teardownDone;
+        await Future.delayed(Duration.zero);
+        verify(() => mockScope.release()).called(1);
+        container.dispose();
+      });
+
+      // Regression for H-3 (PR #1175 review). _ensureScope() was the only
+      // post-await mutation without a generation guard: after `await
+      // acquireScope()` it unconditionally wrote `_scope = scope`. A stale
+      // runner revived inside acquireScope would therefore overwrite the live
+      // run's _scope with its own, orphaning the live scope (nothing releases
+      // it → the shared SSE ref-count never returns to 0). This is the acquire
+      // -side mirror of the release-side sink fixed in 37d28891. Here Run A
+      // hangs inside acquireScope (returning a DISTINCT scopeA); we cancel, let
+      // Run B acquire scopeB and finish, then revive Run A. The guard must make
+      // Run A release scopeA and leave scopeB as the live _scope.
+      test(
+          'revived run releases its own scope instead of orphaning the live '
+          "run's (#1175 H-3)", () async {
+        final container = createContainer();
+        final notifier = container.read(unifiedDiagnosticsProvider.notifier);
+
+        final scopeA = _MockScope();
+        when(() => scopeA.isReleased).thenReturn(false);
+        when(() => scopeA.release()).thenAnswer((_) async {});
+
+        // Run A's scope acquisition hangs and yields a distinct scopeA; Run B
+        // (after cancel nulls the cached scope) gets the default mockScope.
+        final runAScope = Completer<DiagnosticScope>();
+        var acquireCalls = 0;
+        when(() => mockExecutor.acquireScope(
+              referencePaths: any(named: 'referencePaths'),
+            )).thenAnswer((_) {
+          acquireCalls++;
+          return acquireCalls == 1 ? runAScope.future : Future.value(mockScope);
+        });
+        when(() => mockService.checkIntermittent())
+            .thenAnswer((_) async => const IntermittentUIModel(
+                  uptimeSeconds: 86400,
+                  pingSuccessRate: 1.0,
+                  averageLatencyMs: 12,
+                  jitterMs: 2,
+                  hasHighJitter: false,
+                  hasPacketLoss: false,
+                  recentReboot: false,
+                ));
+
+        // Run A — suspends inside _ensureScope on the hung acquireScope.
+        final runAFuture = notifier.selectFlow(DiagnosticFlow.intermittent);
+        await Future.delayed(Duration.zero);
+
+        // Cancel Run A, then start Run B (acquires scopeB) and let it finish.
+        final cancelFuture = notifier.cancel();
+        final runBFuture = notifier.selectFlow(DiagnosticFlow.intermittent);
+        await runBFuture;
+        await Future.delayed(Duration.zero);
+        expect(container.read(unifiedDiagnosticsProvider).step,
+            DiagnosticStep.showingResults);
+
+        // Revive Run A: _ensureScope resumes and sees the run is stale, so it
+        // must release scopeA (the scope it just acquired) and NOT overwrite
+        // the live _scope. Without the fix, `_scope = scopeA` orphans scopeB.
+        runAScope.complete(scopeA);
+        await runAFuture;
+        await cancelFuture;
+        await Future.delayed(Duration.zero);
+
+        // Stale Run A released its own scope immediately.
+        verify(() => scopeA.release()).called(1);
+
+        // The live run's scope (scopeB == mockScope) must still be the one held
+        // by the notifier — proven by it being released on dispose. Without the
+        // fix it was orphaned by scopeA and would never be released.
+        container.dispose();
+        await Future.delayed(Duration.zero);
+        verify(() => mockScope.release()).called(1);
+      });
     });
 
     group('Restart', () {

--- a/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
+++ b/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
@@ -861,6 +861,96 @@ void main() {
         expect(state.step, DiagnosticStep.idle);
         container.dispose();
       });
+
+      // Regression for the cancel→restart clobber race (PR #1175 review):
+      // a runner suspended on a long await must NOT overwrite a *newer* run's
+      // state when it revives. Run A hangs on the gateway ping; we cancel, then
+      // start Run B which completes fully; only then do we release Run A's ping.
+      // With the old shared `_cancelled` bool (reset to false by Run B), the
+      // revived Run A saw _cancelled==false and clobbered B's state. The
+      // per-run generation guard must make A's post-await writes no-ops.
+      test('revived run after cancel+restart does not clobber new run (#1175)',
+          () async {
+        final container = createContainer();
+        final notifier = container.read(unifiedDiagnosticsProvider.notifier);
+
+        // Fingerprint the two runs so a clobber is detectable: Run A's WAN
+        // check reports Down (error), Run B's reports Up (ok). If revived Run A
+        // clobbers state, the final WAN result would be an error and the
+        // results list would collapse to Run A's short accumulation.
+        var wanCalls = 0;
+        when(() => mockService.checkWanStatus()).thenAnswer((_) async {
+          wanCalls++;
+          return wanCalls == 1
+              ? const WanStatusUIModel(
+                  status: 'Down',
+                  ipAddress: '',
+                  subnetMask: '',
+                  addressingType: 'DHCP',
+                )
+              : const WanStatusUIModel(
+                  status: 'Up',
+                  ipAddress: '192.168.1.100',
+                  subnetMask: '255.255.255.0',
+                  addressingType: 'DHCP',
+                );
+        });
+        // First gateway ping (Run A) hangs; every later call (Run B) resolves
+        // immediately so B can run to completion while A is suspended.
+        final runAGateway = Completer<PingResult>();
+        var gatewayCalls = 0;
+        when(() =>
+                mockService.pingGateway(repeatCount: any(named: 'repeatCount')))
+            .thenAnswer((_) {
+          gatewayCalls++;
+          return gatewayCalls == 1
+              ? runAGateway.future
+              : Future.value(_createPingResult('192.168.1.1'));
+        });
+        when(() => mockService.pingDns(
+              host: any(named: 'host'),
+              repeatCount: any(named: 'repeatCount'),
+            )).thenAnswer((_) async => _createPingResult('8.8.8.8'));
+        when(() => mockService.pingInternet(
+              host: any(named: 'host'),
+              repeatCount: any(named: 'repeatCount'),
+            )).thenAnswer((_) async => _createPingResult('1.1.1.1'));
+
+        // Run A — suspends at the hung gateway ping.
+        final runAFuture = notifier.selectFlow(DiagnosticFlow.internet);
+        await Future.delayed(Duration.zero);
+
+        // Cancel Run A, then immediately start Run B and let it finish.
+        final cancelFuture = notifier.cancel();
+        final runBFuture = notifier.selectFlow(DiagnosticFlow.internet);
+        await runBFuture;
+        await Future.delayed(Duration.zero);
+
+        // Snapshot Run B's completed state before reviving A.
+        final afterB = container.read(unifiedDiagnosticsProvider);
+        expect(afterB.step, DiagnosticStep.showingResults);
+        expect(afterB.results.length, 6);
+        final wanB = afterB.results
+            .firstWhere((r) => r.step == DiagnosticStep.checkingWanStatus);
+        expect(wanB.isError, isFalse); // Run B saw WAN Up.
+
+        // Revive Run A — its post-await writes must be rejected by the
+        // generation guard and leave Run B's state untouched.
+        runAGateway.complete(_createPingResult('192.168.1.1'));
+        await runAFuture;
+        await cancelFuture;
+        await Future.delayed(Duration.zero);
+
+        final finalState = container.read(unifiedDiagnosticsProvider);
+        expect(finalState.step, DiagnosticStep.showingResults);
+        // Run A must NOT have clobbered: length and WAN verdict stay Run B's.
+        expect(finalState.results.length, 6);
+        final finalWan = finalState.results
+            .firstWhere((r) => r.step == DiagnosticStep.checkingWanStatus);
+        expect(finalWan.isError, isFalse,
+            reason: 'revived Run A (WAN Down) must not clobber Run B (WAN Up)');
+        container.dispose();
+      });
     });
 
     group('Restart', () {

--- a/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
+++ b/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
@@ -1087,6 +1087,66 @@ void main() {
             mockService.pingGateway(repeatCount: any(named: 'repeatCount')));
         container.dispose();
       });
+
+      // Regression for the preQualifying-back scope-release gap (PR #1175
+      // review, W-6). startWithPreQualifier acquires the scope via
+      // _ensureScope() right before its pingInternet step; if the user presses
+      // Back while that ping is in flight, goBack()'s preQualifying case must
+      // run the full teardown invariant like cancel() and the running case:
+      // null the live _scope (so a re-entry acquires a fresh one instead of
+      // reusing a scope with an in-flight op) and drain + release it via
+      // _teardownFuture (so teardownDone reflects real completion). Before the
+      // fix this branch only bumped the generation, leaking the scope. Here we
+      // pass WAN, hang on pingInternet, press Back, then release the ping and
+      // assert the captured scope was released and teardownDone resolves.
+      test('back during preQualifying releases the acquired scope (#1175)',
+          () async {
+        final container = createContainer();
+        final notifier = container.read(unifiedDiagnosticsProvider.notifier);
+
+        // WAN passes so the runner proceeds to acquire the scope and then
+        // suspends on the hung pingInternet.
+        when(() => mockService.checkWanStatus()).thenAnswer(
+          (_) async => const WanStatusUIModel(
+            status: 'Up',
+            ipAddress: '192.168.1.100',
+            subnetMask: '255.255.255.0',
+            addressingType: 'DHCP',
+          ),
+        );
+        final pingCompleter = Completer<PingResult>();
+        when(() => mockService.pingInternet(
+              host: any(named: 'host'),
+              repeatCount: any(named: 'repeatCount'),
+            )).thenAnswer((_) => pingCompleter.future);
+
+        // Start the pre-qualifier; it acquires the scope, then suspends on the
+        // hung internet ping.
+        final preQualFuture = notifier.startWithPreQualifier();
+        await Future.delayed(Duration.zero);
+        expect(container.read(unifiedDiagnosticsProvider).step,
+            DiagnosticStep.preQualifying);
+        verify(() => mockExecutor.acquireScope(
+              referencePaths: any(named: 'referencePaths'),
+            )).called(1);
+
+        // User presses Back while the scope is live with an in-flight ping.
+        final handled = notifier.goBack();
+        expect(handled, isTrue);
+        expect(container.read(unifiedDiagnosticsProvider).step,
+            DiagnosticStep.idle);
+
+        // Release the in-flight ping so the teardown drain can complete.
+        pingCompleter.complete(_createPingResult('1.1.1.1'));
+        await preQualFuture;
+        await notifier.teardownDone;
+        await Future.delayed(Duration.zero);
+
+        // The scope captured by goBack() must have been released, and the
+        // teardown future must resolve (not report a misleading "already done").
+        verify(() => mockScope.release()).called(1);
+        container.dispose();
+      });
     });
 
     group('Restart', () {

--- a/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
+++ b/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
@@ -802,6 +802,64 @@ void main() {
         verify(() => mockScope.release()).called(1);
         container.dispose();
       });
+
+      // Regression for #1148: pressing "Cancel Diagnostics" mid-flow must
+      // short-circuit the remaining sequential steps at the next step
+      // boundary, not run every check to completion first. We hang the
+      // gateway ping, fire cancel() while it's in-flight, then release the
+      // ping — the subsequent steps (DNS ping, DNS lookup, internet ping,
+      // speed test) must NOT be invoked.
+      test('cancel mid-flow skips subsequent diagnostic steps (#1148)',
+          () async {
+        final container = createContainer();
+        final notifier = container.read(unifiedDiagnosticsProvider.notifier);
+
+        when(() => mockService.checkWanStatus())
+            .thenAnswer((_) async => const WanStatusUIModel(
+                  status: 'Up',
+                  ipAddress: '192.168.1.100',
+                  subnetMask: '255.255.255.0',
+                  addressingType: 'DHCP',
+                ));
+        // Hang the gateway ping so we can interleave a cancel() before the
+        // remaining steps run.
+        final gatewayCompleter = Completer<PingResult>();
+        when(() =>
+                mockService.pingGateway(repeatCount: any(named: 'repeatCount')))
+            .thenAnswer((_) => gatewayCompleter.future);
+        when(() => mockService.pingDns(
+              host: any(named: 'host'),
+              repeatCount: any(named: 'repeatCount'),
+            )).thenAnswer((_) async => _createPingResult('8.8.8.8'));
+        when(() => mockService.pingInternet(
+              host: any(named: 'host'),
+              repeatCount: any(named: 'repeatCount'),
+            )).thenAnswer((_) async => _createPingResult('1.1.1.1'));
+
+        final runFuture = notifier.selectFlow(DiagnosticFlow.internet);
+        await Future.delayed(Duration.zero);
+
+        // Cancel while the gateway ping is still in-flight, then let it
+        // resolve. The next step boundary must observe _cancelled and bail.
+        final cancelFuture = notifier.cancel();
+        gatewayCompleter.complete(_createPingResult('192.168.1.1'));
+        await runFuture;
+        await cancelFuture;
+
+        // Steps after the cancelled gateway ping must never have executed.
+        verifyNever(() => mockService.pingDns(
+              host: any(named: 'host'),
+              repeatCount: any(named: 'repeatCount'),
+            ));
+        verifyNever(() => mockService.pingInternet(
+              host: any(named: 'host'),
+              repeatCount: any(named: 'repeatCount'),
+            ));
+
+        final state = container.read(unifiedDiagnosticsProvider);
+        expect(state.step, DiagnosticStep.idle);
+        container.dispose();
+      });
     });
 
     group('Restart', () {

--- a/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
+++ b/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
@@ -1015,6 +1015,78 @@ void main() {
                 'revived Run A must not re-stamp step=pingInternet over Run B');
         container.dispose();
       });
+
+      // Regression for the preQualifying-back state-clobber (PR #1175 review).
+      // Back is a live affordance during preQualifying: the spinner view wires
+      // onBackTap -> goBack(), which returns handledInternally==true so the
+      // AutoDispose notifier survives with the same generation. Before the fix,
+      // goBack()'s preQualifying case reset state to idle WITHOUT bumping
+      // _generation (unlike cancel() and the running case), so a
+      // startWithPreQualifier runner suspended on checkWanStatus would revive,
+      // still pass _isCurrent(gen), and either _publish stale selectFlow state
+      // over the idle start screen or fire an unsolicited selectFlow on
+      // WAN-down. Here Run A's WAN check hangs and reports Down; we press Back,
+      // then release the WAN check. The generation bump in goBack must make the
+      // revived runner's post-await writes no-ops, leaving the idle screen and
+      // NOT auto-launching the internet flow.
+      test('back during preQualifying does not clobber idle screen (#1175)',
+          () async {
+        final container = createContainer();
+        final notifier = container.read(unifiedDiagnosticsProvider.notifier);
+
+        // Hang the WAN check so we can interleave a goBack() while the
+        // pre-qualifier runner is suspended on it.
+        final wanCompleter = Completer<WanStatusUIModel>();
+        when(() => mockService.checkWanStatus())
+            .thenAnswer((_) => wanCompleter.future);
+        when(() =>
+                mockService.pingGateway(repeatCount: any(named: 'repeatCount')))
+            .thenAnswer((_) async => _createPingResult('192.168.1.1'));
+        when(() => mockService.pingDns(
+              host: any(named: 'host'),
+              repeatCount: any(named: 'repeatCount'),
+            )).thenAnswer((_) async => _createPingResult('8.8.8.8'));
+        when(() => mockService.pingInternet(
+              host: any(named: 'host'),
+              repeatCount: any(named: 'repeatCount'),
+            )).thenAnswer((_) async => _createPingResult('1.1.1.1'));
+
+        // Start the pre-qualifier; it suspends on the hung WAN check.
+        final preQualFuture = notifier.startWithPreQualifier();
+        await Future.delayed(Duration.zero);
+        expect(container.read(unifiedDiagnosticsProvider).step,
+            DiagnosticStep.preQualifying);
+
+        // User presses Back — handled internally, state resets to idle.
+        final handled = notifier.goBack();
+        expect(handled, isTrue);
+        expect(container.read(unifiedDiagnosticsProvider).step,
+            DiagnosticStep.idle);
+
+        // Revive the suspended WAN check with a WAN-down result. Without the
+        // generation bump this would _publish selectFlow(wanDownNoIp) over the
+        // idle screen AND auto-launch selectFlow(DiagnosticFlow.internet).
+        wanCompleter.complete(const WanStatusUIModel(
+          status: 'Down',
+          ipAddress: '',
+          subnetMask: '',
+          addressingType: 'DHCP',
+        ));
+        await preQualFuture;
+        await Future.delayed(Duration.zero);
+
+        final finalState = container.read(unifiedDiagnosticsProvider);
+        expect(finalState.step, DiagnosticStep.idle,
+            reason:
+                'revived pre-qualifier must not clobber the idle start screen');
+        expect(finalState.flow, isNull,
+            reason: 'no unsolicited flow may be launched after Back');
+        // The auto-select internet flow (which would ping the gateway) must
+        // never have fired.
+        verifyNever(() =>
+            mockService.pingGateway(repeatCount: any(named: 'repeatCount')));
+        container.dispose();
+      });
     });
 
     group('Restart', () {

--- a/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
+++ b/test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart
@@ -860,6 +860,65 @@ void main() {
         expect(state.step, DiagnosticStep.idle);
         container.dispose();
       });
+
+      // Regression for #1148: pressing Cancel while the shared speed test is
+      // in-flight must reset the unified state to idle IMMEDIATELY (not block
+      // on the speed test's 3-minute timeout) AND actively cancel the shared
+      // speed-test notifier so its polling future stops promptly.
+      test(
+          'cancel during speed-test step resets immediately and stops the '
+          'speed test (#1148)', () async {
+        final hangingSpeedTest = _HangingSpeedTestNotifier();
+        final container = ProviderContainer(
+          overrides: [
+            unifiedDiagnosticsServiceProvider.overrideWithValue(mockService),
+            networkDiagnosticsExecutorProvider.overrideWithValue(mockExecutor),
+            speedTestProvider.overrideWith(() => hangingSpeedTest),
+          ],
+        );
+        container.listen(unifiedDiagnosticsProvider, (_, __) {});
+        final notifier = container.read(unifiedDiagnosticsProvider.notifier);
+
+        when(() => mockService.checkWanStatus())
+            .thenAnswer((_) async => const WanStatusUIModel(
+                  status: 'Up',
+                  ipAddress: '192.168.1.100',
+                  subnetMask: '255.255.255.0',
+                  addressingType: 'DHCP',
+                ));
+        when(() =>
+                mockService.pingGateway(repeatCount: any(named: 'repeatCount')))
+            .thenAnswer((_) async => _createPingResult('192.168.1.1'));
+        when(() => mockService.pingDns(
+              host: any(named: 'host'),
+              repeatCount: any(named: 'repeatCount'),
+            )).thenAnswer((_) async => _createPingResult('8.8.8.8'));
+        when(() => mockService.pingInternet(
+              host: any(named: 'host'),
+              repeatCount: any(named: 'repeatCount'),
+            )).thenAnswer((_) async => _createPingResult('1.1.1.1'));
+
+        // Kick off the flow; it will run up to the speed-test step and hang
+        // there because _HangingSpeedTestNotifier.runSpeedTest blocks.
+        final runFuture = notifier.selectFlow(DiagnosticFlow.internet);
+        await Future.delayed(Duration.zero);
+
+        // Cancel while the speed test is still in-flight. The state reset must
+        // be synchronous — no need to release the hanging speed test first.
+        await notifier.cancel();
+
+        final state = container.read(unifiedDiagnosticsProvider);
+        expect(state.step, DiagnosticStep.idle,
+            reason: 'cancel() must reset state without blocking on the '
+                'in-flight speed test');
+        expect(hangingSpeedTest.cancelCalled, isTrue,
+            reason: 'cancel() must actively cancel the shared speed test');
+
+        // Let the (now released) in-flight future unwind cleanly.
+        hangingSpeedTest.release();
+        await runFuture;
+        container.dispose();
+      });
     });
 
     group('Restart', () {
@@ -959,6 +1018,49 @@ class _MockSpeedTestNotifier extends AutoDisposeAsyncNotifier<SpeedTestState>
 
   @override
   Future<void> cancel() async {
+    state = const AsyncData(SpeedTestState());
+  }
+}
+
+/// Speed-test notifier whose [runSpeedTest] hangs until [release] is called,
+/// and which records whether [cancel] was invoked. Used to reproduce the
+/// #1148 finding: pressing Cancel during the speed-test step must reset the
+/// unified state immediately AND actively cancel the shared speed test,
+/// instead of blocking on the speed test's timeout.
+class _HangingSpeedTestNotifier extends AutoDisposeAsyncNotifier<SpeedTestState>
+    implements SpeedTestNotifier {
+  final Completer<void> _runGate = Completer<void>();
+  bool cancelCalled = false;
+
+  void release() {
+    if (!_runGate.isCompleted) _runGate.complete();
+  }
+
+  @override
+  Future<SpeedTestState> build() async => const SpeedTestState();
+
+  @override
+  void selectServer(SpeedTestServer server) {}
+
+  @override
+  Future<void> runSpeedTest() async {
+    state = AsyncData(state.requireValue.copyWith(
+      step: SpeedTestStep.testingDownload,
+    ));
+    // Block until the test explicitly releases us (simulates the long-running
+    // speed test that previously pinned cancel() to its 3-minute timeout).
+    await _runGate.future;
+  }
+
+  @override
+  void reset() {
+    state = const AsyncData(SpeedTestState());
+  }
+
+  @override
+  Future<void> cancel() async {
+    cancelCalled = true;
+    release();
     state = const AsyncData(SpeedTestState());
   }
 }


### PR DESCRIPTION
## Summary
Fixes #1148 — pressing **Cancel Diagnostics** (or Back) mid-run had no effect until the entire diagnostic flow finished.

> **Scope note (read before reviewing).** This PR grew well beyond the original one-line fix. #1148 itself is closed by the very first commit (`61400455`, +17). The remaining commits replace the shared `_cancelled` bool with a **per-run generation-token** mechanism to close a family of cancel→restart / back concurrency races that the naïve step-boundary guard exposed, plus a `teardownDone` lifecycle so navigation can wait for the shared USP scope to release. This is deliberately larger than #1148 requires. If reviewing for scope, see the "Why this grew" section and the discussion on the PR thread.

## Root cause (#1148)
`_runFullDiagnosticFlow` / `_runInternetDiagnostics` checked cancellation **only once at the top**, then ran ~10 sequential awaited steps with no interleaved guards. `cancel()` set a flag but `await`ed the in-flight run future, so once past the entry check the flow ran every remaining step to completion before the cancel could take effect. Confirmed from the attached UI log: cancel fired right after DNS lookup, yet the pipeline kept running the speed test and every remaining check. All USP ops returned `Complete` — a UI/state gap, not firmware.

## What this PR does now (head)
The fix evolved through review into a **run-identity model** rather than a shared bool:

- **`_generation` / `_isCurrent(gen)` / `_publish(gen, …)`** — every run entry point (`runFullDiagnostic`, `startWithPreQualifier`, `selectFlow`) claims a fresh generation; every step guard checks `_isCurrent(gen)`, every post-`await` state write goes through `_publish(gen, …)`. A revived stale runner can neither advance the step machine nor clobber a newer run's state.
- **Non-blocking `cancel()` / `goBack()`** — state resets synchronously (UI leaves the running view on the next frame); the in-flight drain + shared-scope release run off the critical path.
- **`teardownDone`** — exposes the off-critical-path teardown future so navigation paths (`_returnToDashboard` / `_returnToMenu`) can wait for the shared USP scope's unsubscribe DELETE to complete before the next acquire's subscribe POST, avoiding a firmware subscription drop on quick re-entry.
- **`_ensureScope(gen)`** — scope acquisition is generation-guarded on both the release side (cancel/back capture-then-null) and the acquire side (a stale runner releases the scope it just acquired instead of orphaning the live run's).

## Changed files
- `lib/page/unified_diagnostics/providers/unified_diagnostics_notifier.dart` — generation model, scope lifecycle, `teardownDone`
- `lib/page/unified_diagnostics/views/unified_diagnostics_view.dart` — single-flight back-nav guard, `teardownDone` await
- `lib/page/unified_diagnostics/views/widgets/diagnostic_results_view.dart` — captured router + `teardownDone` await
- `test/page/unified_diagnostics/providers/unified_diagnostics_notifier_test.dart` — regression tests (30 total; every #1175 fix has a load-bearing test)

## Why this grew (commit map)
| Commit | Fixes |
|---|---|
| `61400455` | **#1148 — Cancel ignored mid-flow ✅** (closes the reported bug) |
| `89955b47` | `cancel()` blocking on the speed-test await |
| `e0384884` | 4 runners missing tail guards; `startWithPreQualifier` missing flag reset |
| `37d28891` | cancel→restart clobber race — replaces the bool with `_generation` |
| `0f75a2be` | intermittent flow missing post-scope generation recheck |
| `c76634bb` | `goBack` from preQualifying missing `++_generation` |
| `82453ed6`…`8f9daeb0` | `teardownDone` lifecycle + view-layer navigation (dashboard/menu/back) |
| `e8f566ac` | **H-1 / H-3** — `_runFuture` in preQualifier + generation-guard the scope acquire |

## Verification
- `flutter analyze` (changed files): No issues found (3 pre-existing `curly_braces` infos remain in untouched `unified_diagnostics_service.dart` / `diagnostic_running_view.dart`).
- `dart format --set-exit-if-changed`: clean.
- `flutter test unified_diagnostics_notifier_test.dart`: **30/30 pass**, including load-bearing regression tests for #1148 and every #1175 race (cancel→restart clobber, intermittent post-scope, preQualifying back clobber + scope release, H-1 drain-before-release, H-3 stale-acquire orphan).

## Follow-ups (tracked separately, not in this PR)
Carried-over 🟡 warnings from the approval — deferred so they get their own review budget rather than extending this loop:
- Collapse the ~3 byte-identical teardown closures into one helper (root cause of the repeated "missed a guard" rounds).
- Promote "teardown in progress" to an observable notifier state field so the back-nav single-flight guard becomes testable.
- Unify the three "leave diagnostics" navigation paths (`_handleBack` / `_returnToMenu` / `onDone`).

Refs #1148
