### PR TITLE
fix: PnP Auto Master — earlier detection, no CGI lockout, correct landing (#1180)

### DIFF
--- a/docs/pnp-auto-master-cgi-lockout-fix.md
+++ b/docs/pnp-auto-master-cgi-lockout-fix.md
@@ -4,10 +4,16 @@
 > [LinksysWRT#449](https://github.com/linksys/LinksysWRT/issues/449)
 > 目標分支：`fix/pnp-pppoe-auto-master-wan-up-1180`（base `dev-1.3.1`）· PR [#1181](https://github.com/linksys/PrivacyGUI/pull/1181)
 
-> **本文件已於 review 後改寫。** 初版的修法是「poll 收到第一個 401 就終止串流」
-> （commit `371dbbf8`）。該機制在 `05d2529a` 被**移除並取代**為「Auto Master 狀態讀取一律
-> 不送憑證（`auth: false`）」。本文件描述的是**現行**設計；被取代的設計及其理由記錄在 §8,
-> 以免未來維護者從 git log 讀到 `371dbbf8` 時誤以為它還在。
+> **本文件已改寫三次,描述的都是現行設計。**
+> ① 初版修法為「poll 收到第一個 401 就終止串流」（commit `371dbbf8`）,在 `05d2529a` 被
+> **移除並取代**為「Auto Master 狀態讀取一律不送憑證（`auth: false`）」;被取代的設計
+> 及其理由記錄在 §8,以免未來維護者從 git log 讀到 `371dbbf8` 時誤以為它還在。
+> ② QA 實機 log 顯示還有第二個放棄得太早的機制:「連續 N 個 null 就判定路由器不見了」。
+> 該門檻與其 probe 已**整組移除**,改為有界時間預算 + 單一連線裁判,見 **§2.4**
+> （該節原本記錄的 F1 修法建立在門檻之上,已隨之作廢）。
+> ③ 同一份 QA log 還顯示 reconnect 後被導到 `localLoginPassword`。該落點屬於
+> **已完成**的 PnP(`userAcknowledgedAutoConfiguration == true`),用在未完成的流程上是錯的;
+> 三處硬編已改為一律回 PnP,見 **§2.7**（§3.2 原本把此不一致判為「刻意保留」,該判斷已作廢）。
 
 ---
 
@@ -47,7 +53,8 @@ WAN 是在使用者送出 ISP 帳密**之後**才起來。WAN-up 觸發韌體 Au
    當成 yielded result（不是 exception）。
 2. `condition` 只認 `running/complete/idle/failed`,401 → 回 `false`
    → 每 5 秒**繼續用失效的 `admin:admin` 重打**。
-3. `.map()` 又把 401 壓平成 `null`;消費端要**累積 3 個 null** 才會 probe。
+3. `.map()` 又把 401 壓平成 `null`;消費端當時要**累積 3 個 null** 才會 probe
+   （該門檻機制後來因另一個原因整組移除,見 §2.4）。
 
 結果:**還沒等使用者輸入任何東西,poll 就燒光 5 次額度**。計數器只在「登入成功」時由 HDK
 `AuthFn_Default` 自動清零（Vinh 確認),但鎖定後正確密碼也回 401 →「成功登入」永遠無法發生 →
@@ -126,27 +133,84 @@ WAN 是在使用者送出 ISP 帳密**之後**才起來。WAN-up 觸發韌體 Au
 `on ExceptionAutoMasterUnauthorized` 包裝、`pnp_setup_view` 一處 try/catch、
 `pnp_admin_view` 四處 `.catchError(test: e is ExceptionAutoMasterUnauthorized)`。
 
-### 2.4 Phase A 的 null probe 改判 `proceed`（review F1）
+### 2.4 放棄「數 null」,改用**有界時間預算**（QA log 實測後改寫）
 
-mixin 的 `_waitForRunning`（Phase A）累積 3 個 null 後會 `_probe()` 一次。
-probe 回 `null`（狀態無法判定）時,舊碼一律映射成 `connectionError`。
+> 本節取代初版的「Phase A null probe 改判 `proceed`（review F1）」。
+> 該修法建立在「累積 N 個 null 就 probe 一次」的門檻機制上,而**門檻機制本身已被移除**,
+> 因此 F1 的修法連同 `_probe()` 一併刪除。理由如下。
 
-在**不支援 no-auth 的韌體**上,每一次 poll 與 probe 都會落在 null,
-於是 Phase A 必然回 `connectionError` → 使用者在「ISP 設定剛存成功、internet check 剛通過」
-之後,看到「找不到路由器」。
+#### 症狀
 
-Phase A 的前提是**session 剛被 internet check 證明活著**,所以「狀態讀不到」不該解讀為連線問題:
+QA 在 PPPoE 設定完成後看到:internet connected → **Router Not Found** → 重連路由器後
+被丟回 login 畫面。前半段（偵測 `running`、進等待畫面）都對,錯在**提早放棄**。
+
+#### 根因：把雜訊當訊號
+
+舊碼在 `_waitForRunning` / `_waitForCompletion` 都用
+`consecutiveNullThreshold`（3 個 null）作為「路由器可能不見了」的判準。但 make-Master
+**會把路由器的 HTTP 服務整段拿掉**,而這正是 null 的來源。從 QA log 對時間軸:
+
+| 時間點 | 事件 |
+|-------|------|
+| T+0s | make-Master 開始,HTTP 服務中斷 |
+| ~T+50s | 連續 3 個 null 達標 → 舊碼判定 router not found |
+| ~T+65s | 路由器 HTTP 服務**才真正回來** |
+| ~T+115s | Auto Master 全程結束 |
+
+也就是說,舊碼在服務恢復前約 **15 秒**就宣告失敗。中斷期間路由器可能 timeout、
+拒連、或回一個無法解析的東西 —— 全部壓平成 `null`。**數 null 等於數雜訊**,
+而且愈是正常的 make-Master,null 愈多。
+
+#### 修法：讓「串流自己的長度」成為唯一的放棄條件
+
+null 一律**繼續等**。放棄與否改由 poll 的**總時長**決定,而總時長靠三個參數釘死
+（`pnp_provider.dart`）:
 
 ```dart
-if (probe == AutoMasterFlowResult.connectionError) {
-  logger.w('[PnP]: Auto Master wait-for-running undetermined, proceed');
-  return AutoMasterFlowResult.proceed;
+maxRetry: 24,                  // 24 輪
+requestTimeoutOverride: 3000,  // 每次請求最多 3s（local web,3s 已相當寬鬆）
+retryDelayInMilliSec: 5000,    // 每輪間隔 5s
+```
+
+24 × (3s + 5s) = **192s**,對照上表的 ~65s 中斷與 ~115s 全程,餘裕充足。
+關鍵是**上界可預測**：沒有 request timeout 時,單一次慢回應就能讓整段等待失控。
+
+串流耗盡而仍無終局狀態時,才問唯一能被可靠回答的問題 —— **路由器在不在**：
+
+```dart
+logger.w('[PnP]: Auto Master polling budget spent, verifying connection');
+try {
+  await ref.read(pnpProvider.notifier).testConnectionReconnected();
+  return AutoMasterFlowResult.budgetExhausted;  // 活著,但 Auto Master 結果未知
+} catch (_) {
+  return AutoMasterFlowResult.connectionError;  // 真的不見了
 }
 ```
 
-Phase B（`_waitForCompletion`）**維持** `connectionError`：它的前提不同 —— 已經觀察到
-`running`,狀態突然讀不到確實可能是路由器不見了,且該路徑末端還有
-`testConnectionReconnected()` 收尾。因此 `_probe()` 自身回傳「未判定」,由各 phase 決定意義。
+`testConnectionReconnected` 因此成為「router not found」的**唯一裁判**,並強化為
+`retries: 2, timeoutMs: 5000` —— 它不該押在單一個封包上,還在重啟收尾的路由器
+常常是第二、三次才回應。
+
+#### 新增 `budgetExhausted`：用 IoC 換掉三份重複實作
+
+「時間到了但路由器活著」與「Auto Master 明確沒動作」是**不同的事實**,舊碼把兩者都
+壓成 `proceed`,所以每個呼叫端只能自己寫一份 poll loop 來拿到足夠資訊。
+`AutoMasterFlowResult` 因此增加第四個值,讓 mixin 只負責**陳述發生了什麼**,
+由呼叫端決定意義:
+
+| 呼叫端 | 對 `budgetExhausted` 的處置 | 為什麼 |
+|-------|---------------------------|-------|
+| `pnp_admin_view` | 當 `proceed` 繼續 | 手上沒有待辦;後續 internet check / `pnpConfig` 都會重讀即時狀態,密碼真被輪替就走既有錯誤路徑 |
+| ISP-save pre-save | 照樣存檔 | 已等滿整個預算;若存檔時密碼被輪替,會以 `JNAPError` 落到既有錯誤處理 |
+| ISP-save post-WAN-up | 進 PnP,交給 entry precheck | 設定已存好,沒有待辦 |
+| `pnp_setup_view` | **從頭重查一次**（上限 2 次） | **唯一有客製流程者**:手上有一個待存的 save,一旦密碼被輪替就會 401 |
+
+`pnp_setup_view` 的計數器語意也隨之改變 —— 一次「等待」現在要價約 192s,
+所以必須**在花掉時就記帳**（先加再比),而非事後才檢查:
+`_maxAutoMasterSaveAttempts` → `_maxAutoMasterWaits`。
+
+三份 bespoke poll loop（admin_view ~85 行、setup_view ~75 行、mixin 自己一份）
+因此收斂為一份實作。
 
 ### 2.5 ISP-save pre-save 檢查的 null 早退
 
@@ -188,6 +252,64 @@ static AutoMasterStatus? fromValue(Object? value) {
 
 放寬型別而非在 5 個點各加一道 guard：一次改動消除全部呼叫點的風險,且非字串值自然
 miss 掉所有 case、回 `null` —— 正是呼叫端已經在處理的「狀態無法取得」。
+
+### 2.7 Auto Master 完成後的落點:一律回 PnP,不再去 `localLoginPassword`（QA log 實測後新增）
+
+#### 症狀
+
+QA log(18:29–18:30)在 ISP 重連後出現:
+
+```
+18:30:45  [PnP]: Start PNP setup without admin password
+18:30:57  [PnP]: Interrupted and go to: localLoginPassword
+```
+
+reconnect 後**應該回到 PnP 輸入新密碼**,實際卻被丟到 local login 密碼頁。
+
+#### 根因:把「PnP 沒跑完」當成「PnP 跑完了」
+
+`localLoginPassword` 是 **`userAcknowledgedAutoConfiguration == true`** —— 也就是
+**PnP 確實走完**才會到的畫面。Auto Master 完成確實會改密碼、確實需要重新登入,
+但在 PnP **還沒走完**的情況下,使用者必須回到 **PnP admin**、用 **PnP 自己的**登入輸入密碼。
+硬編去 local login 等於宣告「這輪 setup 已完成」,把使用者留在一個他還沒走完的流程之外。
+
+這個硬編是 #980 時期的慣例,在 §2.4 的 mixin 重構中被原封不動沿用 —— 諷刺的是
+`pnp_auto_master_flow.dart` 的檔頭註解**當時就寫對了**設計意圖
+（「pnp-vs-login 的決定留給 router 的 `userAcknowledgedAutoConfiguration`,不在此硬編 redirect」),
+是呼叫端做了它警告的事。
+
+第二個缺陷同源:`case completed` 這條分支**也會被剛進入的 view 打到** —— 它只是
+「發現 Auto Master 已經是 `complete`」（正是 log 中 reconnect 後的情境,`Start PNP setup
+without admin password` 就在前 12 秒）。這種 view 從來沒有 session 可失去,但它同樣
+不可能知道現在的密碼,所以該去的地方也是同一個密碼輸入提示。
+
+#### 修法
+
+| 位置 | 原本 | 現在 |
+|------|------|------|
+| `pnp_admin_view.dart` `case completed` | `throw ExceptionInterruptAndExit(route: localLoginPassword)` | `throw ExceptionAutoMasterRotatedPassword()` → `_promptForRotatedPassword()` |
+| `pnp_setup_view.dart` `case completed` | `goNamed(localLoginPassword)` | `goNamed(RouteNamed.pnp)` |
+| `pnp_setup_view.dart` idle-on-entry → `complete` 邊緣 | `goNamed(localLoginPassword)` | `goNamed(RouteNamed.pnp)` |
+
+新增 `ExceptionAutoMasterRotatedPassword`(`pnp_exception.dart`),
+**刻意不是** 帶 route 的 `ExceptionInterruptAndExit` —— 去向不該由拋出點決定。
+`pnp_admin_view` 的 4 條 `.catchError` 鏈(initState / `_unconfiguredView` / `_doLogin` /
+`_retryAutoMasterCheck`)各加一個分支接它。
+
+`_promptForRotatedPassword()` **不導航**:這裡就是 PnP 的入口 view,提示只差一次 `setState`。
+真正關鍵的是**清掉 `_password`** —— 它存的是我們帶進來的憑證（route 參數 `p`,或原廠預設值）,
+而輪替剛剛讓它失效。不清掉,下一輪 precheck 會拿它再試一次,白燒一次 CGI 額度
+（§3 額度表那唯一的 1 次就是這條;留著會變 2 次）。同時 `pnp.setAttachedPassword(null)`,
+避免 provider 端的殘留值繞過這道清除。
+
+`goNamed(RouteNamed.pnp)` 這個落點不是新發明的:`pnp_setup_view.dart` 的
+「存檔時 401」handler **本來就**這樣做。這次是把另外三條路徑收斂到同一個既有落點。
+
+#### 順帶查清:log 中重複的 `Auto Master polling status`
+
+同一則 log 出現兩次,**不是**遞迴或重複訂閱:舊版 `pnp_admin_view` 的 bespoke poll loop
+在自己的 `await for` 裡也印一次,與 `pnp_provider.dart:814` 的 `.map` 各印一次 ——
+一個事件兩個 log 敘述。該 loop 已在 §2.4 隨 mixin 重構刪除,**現行程式碼已無此重複**。
 
 ---
 
@@ -234,27 +356,30 @@ ISP-save 導航時 `deviceInfo` 早已填好 —— **被走的就是這個繞�
   → `PnpAdminView._examineAdminPassword` 會用它試一次,燒掉 1 次額度。
   這就是 §3 表中那一列的來源。實際總計約 **2**,仍 < 5,死結結論不變,只是餘裕比初版所述少一格。
 
-### 3.2 落點不一致 —— 已知、刻意保留
+### 3.2 落點已收斂 —— 全部回 PnP
 
-Auto Master 完成後三條路徑落在不同地方,且**去向由不同機制決定**:
+Auto Master 完成後,**四條路徑落在同一個地方**（§2.7）:
 
 | 路徑 | `goNamed(...)` | redirect 分支 | 實際決定去向者 |
 |------|---------------|--------------|--------------|
 | ISP-save（mixin,#449 主場景） | `pnp` | L139 `startsWith('/pnp')` → `_goPnpPath` | **`_goPnpPath` 自己**:`deviceInfo != null` → 原路放行,直接落在 `PnpAdminView`,由該 view 自己的 precheck 鏈決定後續 |
-| setup view | `localLoginPassword` | L127 → `_redirectLogic`（L138） | 停在 local login 密碼頁 |
-| admin view | `localLoginPassword` | 同上 | 停在 local login 密碼頁 |
+| setup view（`completed` / idle-on-entry 邊緣） | `pnp` | 同上 | 同上 |
+| setup view（存檔時 401） | `pnp` | 同上 | 同上（此路徑**本來就**如此,是收斂的目標） |
+| admin view | **不導航** | — | 就地 `setState` 回到 PnP 自己的密碼提示（§2.7） |
 
-- 初版文件在此處寫 ISP-save 的 pnp-vs-login「由 router 依
-  `userAcknowledgedAutoConfiguration` 判斷」—— **對這條路徑不成立**（同 §3.1,
-  `_autoConfigurationLogic` 不會被呼叫)。實際是落進 `PnpAdminView`,由 view 自己判斷。
-- 此不一致**非本次引入**：mixin 路徑（#1180）刻意不硬編 redirect;setup/admin（#980）
-  早已硬編去 login。
-- **維持現狀**。理由:各自沿用該路徑既有且經測試的慣例,回歸面最小;
-  三條路徑最終都讓使用者回到「用新密碼登入」,差別僅中間多繞一跳。
+- 前一版此節記載 setup / admin 兩條路徑硬編去 `localLoginPassword`,並判斷為
+  「已知、刻意保留」的不一致 —— **該判斷是錯的,已於 §2.7 修掉**。
+  那個落點屬於 `userAcknowledgedAutoConfiguration == true`(PnP 已完成)的情境,
+  用在未完成的 PnP 上會把使用者留在流程之外,正是 QA 回報的症狀。
+- 「pnp-vs-login 由 router 依 `userAcknowledgedAutoConfiguration` 判斷」這句話,
+  現在對四條路徑**都成立**:呼叫端一律回 PnP,不自行判讀 ack 旗標。
+  （注意這與 §3.1 不衝突:`_goPnpPath` 繞過 `_autoConfigurationLogic` 而原路放行,
+  最終仍是落進 `PnpAdminView` 由它的 precheck 鏈決定,而非呼叫端硬編。)
+- `grep localLoginPassword lib/page/instant_setup/` 現在**只剩註解**,無任何硬編 redirect。
 
 > 註:`10b7881e` 已修掉 `localLoginPassword` 分支原本 fire-and-forget 呼叫
 > `_autoConfigurationLogic` 造成的 pnp ↔ login 迴圈。該分支現在只走 `_redirectLogic`,
-> 原因見 `router_provider.dart:128-137` 的註解。
+> 原因見 `router_provider.dart:128-137` 的註解。本次修法讓 PnP 不再進入該分支。
 
 ---
 
@@ -262,15 +387,19 @@ Auto Master 完成後三條路徑落在不同地方,且**去向由不同機制�
 
 | # | 情境 | 修法後行為 | 判斷 |
 |---|------|-----------|------|
-| E1 | **韌體已開放 no-auth**（目標狀態) | 全程 unauthed 讀到真實狀態;`running` → 等待畫面 → `complete` → 依路徑導向 | ✅ 主要場景 |
-| E2 | **韌體尚未開放 no-auth** | 每次 poll 與 probe 都回 401 → 全部壓平成 `null` → Auto Master 偵測**完全失效** | ⚠️ **見 §4.1** |
+| E1 | **韌體已開放 no-auth**（目標狀態) | 全程 unauthed 讀到真實狀態;`running` → 等待畫面 → `complete` → 回 PnP 要新密碼（§2.7) | ✅ 主要場景 |
+| E2 | **韌體尚未開放 no-auth** | 每次 poll 都回 401 → 全部壓平成 `null` → 等滿預算 → 連線測試通過 → `budgetExhausted` → 各呼叫端繼續（見 §2.4 表）→ Auto Master 偵測**完全失效但不擋路** | ⚠️ **見 §4.1** |
 | E3 | **老韌體不支援 GetAutoMasterStatus** | 同 E2（`_ErrorUnknownAction` → `null`) | ⚠️ 同 §4.1 |
-| E4 | **真連線中斷** | poll 回 `null` → null-threshold → probe 也 `null` → Phase A `proceed`、Phase B `connectionError` | ✅ Phase B 末端另有 `testConnectionReconnected()` 把關 |
+| E4 | **真連線中斷** | poll 全程 `null` → 等滿 192s 預算 → `testConnectionReconnected` 失敗 → `connectionError` | ✅ 唯一裁判是連線測試,不是 null 的個數（§2.4） |
+| E4b | **make-Master 期間的正常中斷** | 同樣全程 `null`,但預算耗盡時服務已恢復 → 連線測試通過 → `budgetExhausted` | ✅ **這正是 #1180 的回歸點**:舊碼在此判 `connectionError` |
+| E4c | **路由器卡在 `running` 不動** | 等滿預算 → 活著 → `budgetExhausted`;`setup_view` 最多重查 2 次後顯示錯誤畫面 | ✅ 有界,不會無限迴圈 |
 | E5 | **make-Master 極快,錯過 running 邊緣** | `condition` 仍認 `complete/failed` → 提早停;Phase A 直接看到 `complete` → `completed` | ✅ 既有行為保留 |
 | E6 | **make-Master 在等待期間輪替密碼** | poll 不帶憑證,**不受影響**;狀態照常走到 `Complete` | ✅ 這正是本修法要達成的 |
 | E7 | **非字串 `autoMasterStatus` payload** | `fromValue(Object?)` → `null`,串流存活 | ✅ §2.6 |
 | E8 | **view 在 make-Master 期間被 dispose** | mixin 每個 `await` 後都檢查 `mounted`;`_checkAutoMasterStatus` 每個 `setState` 都有 guard（`c4b7acc4`) | ✅ |
 | E9 | **非 local 模式重用這三個方法** | `auth: false` 被靜默忽略,憑證照送,§1.3 的保證失效 | ⚠️ **見 §2.2**;目前無此呼叫端 |
+| E10 | **reconnect 後剛進 view,Auto Master 已是 `complete`** | 走 `case completed` → 回 PnP 密碼提示,`_password` 清空 | ✅ **#1180 QA log 的落點**:舊碼在此跳 `localLoginPassword`（§2.7) |
+| E11 | **使用者輸入舊密碼的瞬間 Auto Master 完成** | `_doLogin` 的 gate 攔下 → 剛打的密碼已作廢 → 同樣回密碼提示,不落進 WiFi 表單 | ✅ 否則會落到 catch-all 顯示假的「密碼錯誤」 |
 
 ### 4.1 韌體未開放 no-auth 時的降級行為（必須與 FW/QA 對齊）
 
@@ -282,8 +411,10 @@ E2 / E3 下,Auto Master 偵測**靜默失效**,PnP 退回它原本的**兩趟流
 - 這是**已知且可接受**的降級（Jamie 已認可兩趟流程作為 fallback),不是回歸。
 - 但**它與修法前的症狀長得一樣** —— 差別在於現在**不會**再燒 CGI 額度、不會鎖死登入。
   也就是說:**#1180 的死結解除了,#449 的「填兩次」在這種韌體上仍會出現。**
-- 因此 §2.4 的 Phase A `proceed` 是必要的:沒有它,這種韌體上使用者會在 ISP 設定成功後
-  看到「找不到路由器」,比兩趟流程更糟。
+- 因此 §2.4 的「null 不作為判準」是必要的:沒有它,這種韌體上每一次 poll 都是 null,
+  使用者會在 ISP 設定成功後看到「找不到路由器」,比兩趟流程更糟。
+  現在這種韌體只會安靜地等滿預算、連線測試通過、以 `budgetExhausted` 放行 ——
+  代價是多等一段時間,而非一個假的錯誤畫面。
 
 > **待確認項**：測試韌體 `FW_Pinnacle2.0_v1.2.4.26080716_PW` 是否包含 dennisnltran 的
 > `GetAutoMasterStatus` no-auth 改動。若否,這一輪 QA 會落在 E2,量測到的行為即為上述降級。
@@ -292,7 +423,7 @@ E2 / E3 下,Auto Master 偵測**靜默失效**,PnP 退回它原本的**兩趟流
 
 ## 5. 測試
 
-### 5.1 `test/page/instant_setup/data/pnp_provider_auto_master_test.dart`（20 案例,全綠）
+### 5.1 `test/page/instant_setup/data/pnp_provider_auto_master_test.dart`（23 案例,全綠）
 
 以 `ProviderContainer` + `MockRouterRepository` 驅動**真的** `PnpNotifier`,
 是唯一直接驗證「JNAP result → status」映射的地方。
@@ -306,6 +437,14 @@ E2 / E3 下,Auto Master 偵測**靜默失效**,PnP 退回它原本的**兩趟流
 | `a Running before a 401 keeps both in the stream` | 401 不會吃掉先前已 yield 的狀態 |
 | `non-String status payload maps to null instead of throwing` | §2.6,payload 餵 `42` |
 | `non-String status payload flattens to null, stream survives` | §2.6 的**真正後果**:`[42, 'Complete']` → `[null, complete]`,串流沒有被 TypeError 打斷 |
+| `bounds its own duration: 24 rounds of 3s request + 5s delay` | **§2.4 的三個數字**。門檻機制拿掉之後,這串流的長度**就是**放棄條件,任一參數被改小就會重現 #1180 |
+| `bounds its own duration, shorter than the wait-for-completion poll` | `pollAutoMasterUntilRunning` 的 `maxRetry: 18` + 同樣的 3s/5s 上限 |
+| `retries before condemning the connection` | `testConnectionReconnected` 送 `retries: 2, timeoutMs: 5000` —— 它是 router-not-found 的唯一裁判,不能押在單一封包上 |
+
+> 這三個參數斷言改用**讀取 mock 收到的 `Invocation` 具名引數**（`lastScheduled` / `lastSend`
+> 搭配 `sendArg` / `scheduledArg`),而非 `captureAnyNamed`。原因:`captured` 的順序跟著
+> **呼叫端實際的具名引數順序**跑,對這種「數字本身就是設計」的斷言太隱晦 ——
+> 參數順序一改,斷言會靜靜地比錯對象。
 
 ### 5.2 `test/page/instant_setup/widgets/pnp_auto_master_flow_test.dart`（14 案例,全綠）
 
@@ -313,13 +452,21 @@ E2 / E3 下,Auto Master 偵測**靜默失效**,PnP 退回它原本的**兩趟流
 
 | 案例 | 鎖住什麼 |
 |------|---------|
-| `Phase A: 3 nulls then probe null (undetermined) -> proceed` | **§2.4 的 F1 修正**;同時 `verifyNever(pollAutoMasterStatus())` 確認 Phase A 就地解決 |
-| `Phase B: 3 nulls then probe null (undetermined) -> connectionError` | Phase B **不**跟著改,兩者前提不同 |
+| `nulls during the make-Master outage`（3 案例) | **§2.4 的核心**:①nulls 後 `Complete` → `completed`;②nulls 到底 + 路由器活著 → `budgetExhausted`（**#1180 的回歸鎖**);③nulls 到底 + 路由器不見 → `connectionError` |
+| `Budget spent with router alive -> budgetExhausted` / `Budget spent with reconnect failure -> connectionError` | 預算耗盡後的分岔,唯一裁判是連線測試 |
+| `Phase A: nulls only then stream closes (budget spent) -> proceed` | Phase A 就地解決,`verifyNever(pollAutoMasterStatus())` + `verifyNever(checkAutoMasterStatus())` |
 | `Phase A Running, then rotation mid-completion -> completed` | 取代舊的 3 個「stream 拋 401」案例:輪替現在是**普通路徑**（狀態走到 `Complete`),不再是 exception |
 
-**刪除**的案例及理由:舊有 3 個 `Stream.error(ExceptionAutoMasterUnauthorized())` 案例
-與 1 個 `probe unauthorized -> completed` 案例,其前提（poll 會因輪替而 error）
-在 `auth: false` 之後**不可能發生**,該 exception 型別亦已刪除。
+**刪除**的案例及理由:
+
+- 舊有 3 個 `Stream.error(ExceptionAutoMasterUnauthorized())` 案例與 1 個
+  `probe unauthorized -> completed`:前提（poll 會因輪替而 error）在 `auth: false`
+  之後**不可能發生**,該 exception 型別亦已刪除。
+- 4 個 null-threshold / probe 案例（`3 nulls then probe Complete -> completed`、
+  `Phase B: 3 nulls then probe null -> connectionError`、
+  `Phase A: 3 nulls then probe null -> proceed`、
+  `probe Running resets counter, then Complete -> completed`）：
+  門檻與 `_probe()` 皆已移除（§2.4),前提消失。
 
 ### 5.3 View 層 loc 測試
 
@@ -333,27 +480,63 @@ E2 / E3 下,Auto Master 偵測**靜默失效**,PnP 退回它原本的**兩趟流
 同樣刪除 3 個 `unauthorized → login` 的 golden 案例（前提已不存在）。
 `test/**/goldens/*` 在 `.gitignore:89`,無 orphan golden 需清理。
 
+§2.4 之後另有三處調整:
+
+- 兩個 `Auto Master connection error` 案例改 stub `testConnectionReconnected` 拋
+  `ExceptionNeedToReconnect`。3 個 null 不再能產生那個畫面 —— 連線測試失敗才行。
+- `Auto Master poll complete before save redirects to pnp` 的收尾從 `pumpAndSettle()`
+  改為 `runAsync(Future.delayed(100ms))` + 兩次 `pump()`。這類測試同時存在**兩個時鐘**:
+  mock 的 future/stream 在**真** microtask 上解析,動畫與 delay 在 fake timer 上;
+  串流訂閱的取消只在真事件迴圈的 turn 上完成,`pumpAndSettle` 推不動它。
+- 三個 retry 分支案例改以預算機制與 `_maxAutoMasterWaits` 命名
+  （`Auto Master budget spent then reconnect re-checks and saves` 等)。
+
+**修掉一個既有的 golden 檔名衝突。** `pnp_admin_view_test.dart` 與
+`pnp_setup_view_test.dart` 都叫 `Instant Setup - PnP: Auto Master connection error` ——
+而 golden 路徑**只由描述字串決定**,兩者共用 `localizations/goldens/`。
+兩個同名案例會互相覆蓋截圖,後跑的那個必定比對失敗(130 個 variant 全滅,
+差異僅頁面底色 `#FFFFFF` vs `#F9F9F9`)。setup 的那個依同檔慣例改名為
+`... connection error before save`。此衝突由本分支自己引入（兩案例都是本分支新增的)。
+
+§2.7 之後的落點測試改動（4 個案例、2 個 helper）:
+
+| 案例 | 改為鎖住什麼 |
+|------|------------|
+| admin view `Tap Login with Auto Master complete asks for the new password`（原 `... redirects to login`) | **不導航**:`PnpAdminView` + `AppPasswordField` 仍在、`PnpAutoMasterWaitingView` 已離開、沒進 `pnpConfigStub`,且 `verify(setAttachedPassword(null))` 釘住輪替憑證被丟棄 |
+| setup view `Auto Master poll complete before save redirects to pnp`（原 `... to login`) | 落在 `pnpStub` |
+| setup view `Auto Master idle on entry but complete during config redirects to pnp`（原 `... to login`) | 同上 |
+| setup view `Auto Master status unavailable before save continues to save` | `findsNothing` 的對象由 `loginStub` 改為 `pnpStub` |
+
+兩檔的 `_loginStubRoute()` helper 一併處理:admin 檔**整個刪除**(已無任何路徑導向 login),
+setup 檔改名為 `_pnpStubRoute()`,並吸收原本「存檔時 401」案例裡**行內重複**的同一份 stub。
+
+admin view 那個案例特意保留 `expect(find.byKey(Key('pnpConfigStub')), findsNothing)` 之外
+**不再註冊 login stub** —— 若未來有人把 redirect 加回去,harness 會直接拋
+"unknown route name" 而不是安靜地通過。
+
 ### 5.4 測試結果
 
 | 範圍 | 結果 |
 |------|------|
-| `pnp_provider_auto_master_test.dart` | **20/20** |
+| `pnp_provider_auto_master_test.dart` | **23/23** |
 | `pnp_auto_master_flow_test.dart` | **14/14** |
-| `test/page/instant_setup/ --exclude-tags loc` | **47/47** |
-| 全專案 `--exclude-tags loc` | **560 passed**（baseline 557,新增 3) |
-| `fvm flutter analyze` | 淨新增 **0** 個 issue（stash 前後對照皆 60） |
-| `test/page/instant_setup/ --tags loc --update-goldens` | **6107 passed / 3 failed — 未查清** |
+| `test/page/instant_setup/ --exclude-tags loc` | **50/50** |
+| 全專案 `--exclude-tags loc` | **563 passed**（baseline 557,新增 6) |
+| `fvm flutter analyze` | 淨新增 **0** 個 issue（改動 5 檔共 19 issue,全為既有的 deprecated `background` / unused import / `use_build_context_synchronously`,且不在本次 diff 的行上）|
+| loc 兩檔 `--tags loc --update-goldens` | **3247 passed / 3 failed（既有,已查清 — 見下）** |
 
-> **`--tags loc` 的 3 個失敗未查清。** compact reporter 以 `\r` 覆蓋同一行,輸出檔僅存
-> 1153 bytes,失敗案例名與斷言訊息均已遺失。已排除 `pnp_waiting_modem_view_test.dart`
-> （單獨跑全綠）。尚未逐檔確認的候選為本分支動過的 3 個 loc 檔:
-> `pnp_admin_view_test.dart`、`pnp_setup_view_test.dart`、
-> `troubleshooter/localizations/pnp_auto_master_waiting_view_test.dart`。
+> **前一版記錄的「3 個失敗未查清」已查清,與本修法無關。**
+> 用 `--reporter json` 取代 compact reporter（後者以 `\r` 覆蓋同一行,失敗案例名會遺失)
+> 後可定位到:`Instant Setup - PnP: Wifi ready (split SSID)` 在 da / de 三個 variant 失敗,
+> 原因是 `pnp_setup_view.dart:538` 的 `Row`(Print / Download QR 兩顆按鈕)
+> `RenderFlex overflowed by 16 pixels` —— 長字語系在窄版面下擠不下。
+> 該 `Row` 不在本分支的 diff 內（本分支只動 27 / 67 / 730+ 行),屬既有版面問題,**未處理**。
 >
-> 判讀準則（供後續查證）：`testLocalizations` 每案例跑遍 device × locale 矩陣,
-> 因此**邏輯壞掉會讓同一案例的整組 variant（20+）一起失敗**。只有 3 個更像是少數 variant
-> 的 timing 抖動 —— 這類測試同時存在兩個時鐘（mock future 走 `runAsync` 的真 microtask、
-> 內部 1 秒動畫走 fake timer),特定尺寸/語系下容易差一個 pump。此推論**尚未驗證**。
+> 另外釘住一項判讀準則:此 loc suite **沒有 baseline** ——
+> `test/**/goldens/*` 在 `.gitignore`,repo 內不存在任何 golden 圖檔,
+> 這套測試實際用途是**產生截圖**。因此在乾淨 checkout 上首跑必定全綠(檔案不存在即寫入),
+> 而本機殘留的舊截圖會讓比對失敗看起來像回歸。判斷有無回歸要看**例外內容**
+> （layout / assertion）而非 pixel diff 百分比。
 
 ---
 
@@ -361,13 +544,13 @@ E2 / E3 下,Auto Master 偵測**靜默失效**,PnP 退回它原本的**兩趟流
 
 | 檔案 | 改動 |
 |------|------|
-| `lib/page/instant_setup/data/pnp_provider.dart` | 三處 `auth: true` → `false`;兩處 `.map` 的 401→throw 刪除;`checkAutoMasterStatus` 的 401 分支併入通用 catch;4 處解析改用 `fromValue`（§2.1 / §2.3 / §2.6） |
+| `lib/page/instant_setup/data/pnp_provider.dart` | 三處 `auth: true` → `false`;兩處 `.map` 的 401→throw 刪除;`checkAutoMasterStatus` 的 401 分支併入通用 catch;4 處解析改用 `fromValue`（§2.1 / §2.3 / §2.6）;兩個 poll 加上有界預算參數、`testConnectionReconnected` 改 `retries: 2, timeoutMs: 5000`（§2.4） |
 | `lib/core/jnap/models/auto_master_status.dart` | `fromValue` 參數 `String?` → `Object?`（§2.6） |
-| `lib/page/instant_setup/widgets/pnp_auto_master_flow.dart` | 移除兩處 `on ExceptionAutoMasterUnauthorized`;`_probeUnauthorized` → `_probe`（去掉 unauthorized 分支);Phase A 的 undetermined → `proceed`（§2.4） |
-| `lib/page/instant_setup/pnp_admin_view.dart` | 移除 4 處 `.catchError(test: e is ExceptionAutoMasterUnauthorized)`（§2.3） |
-| `lib/page/instant_setup/pnp_setup_view.dart` | 移除 pre-check 與 `await for` 外層的 `on ExceptionAutoMasterUnauthorized`（§2.3） |
-| `lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart` | `_checkAndWaitForAutoMaster` 增加 `status == null` 顯式早退（§2.5） |
-| `lib/page/instant_setup/data/pnp_exception.dart` | 刪除 `ExceptionAutoMasterUnauthorized`（§2.3） |
+| `lib/page/instant_setup/widgets/pnp_auto_master_flow.dart` | 移除兩處 `on ExceptionAutoMasterUnauthorized`;**刪除 `consecutiveNullThreshold` 與 `_probe()`**;新增 `AutoMasterFlowResult.budgetExhausted`（§2.4) |
+| `lib/page/instant_setup/pnp_admin_view.dart` | 移除 4 處 `.catchError(test: e is ExceptionAutoMasterUnauthorized)`（§2.3);**改用 mixin**,~85 行 bespoke poll loop 刪除（§2.4);`case completed` 改拋 `ExceptionAutoMasterRotatedPassword`,新增 `_promptForRotatedPassword()`,4 條 `.catchError` 鏈各加一個分支（§2.7) |
+| `lib/page/instant_setup/pnp_setup_view.dart` | 移除 pre-check 與 `await for` 外層的 `on ExceptionAutoMasterUnauthorized`（§2.3);**改用 mixin**,~75 行 bespoke poll loop 刪除;計數器改為 `_maxAutoMasterWaits`(先加再比)（§2.4);兩處 `localLoginPassword` → `RouteNamed.pnp`（§2.7) |
+| `lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart` | `_checkAndWaitForAutoMaster` 增加 `status == null` 顯式早退（§2.5);兩處呼叫點處理 `budgetExhausted`（§2.4) |
+| `lib/page/instant_setup/data/pnp_exception.dart` | 刪除 `ExceptionAutoMasterUnauthorized`（§2.3);新增 `ExceptionAutoMasterRotatedPassword`（§2.7） |
 | 測試 4 檔 | 見 §5 |
 
 > 韌體側:`GetAutoMasterStatus` 需開放 no-auth（dennisnltran)。**這是本修法的前置依賴**,
@@ -382,6 +565,8 @@ E2 / E3 下,Auto Master 偵測**靜默失效**,PnP 退回它原本的**兩趟流
 | 項目 | 為何延後 |
 |------|---------|
 | `pollAutoMasterStatus` / `pollAutoMasterUntilRunning` 高度重複 | 兩者僅 `condition` 與 `maxRetry` 不同,可合併。屬重構,不在 hotfix 範圍 |
+| `pnp_setup_view.dart:538` 的 `Row` 在 da / de 窄版面 overflow 16px | 既有版面問題,與 Auto Master 無關（見 §5.4） |
+| 三個 view 的呼叫端各自的 `budgetExhausted` 處置 | §2.4 表中四種處置**刻意不同**,是 IoC 的目的而非重複。不需再收斂 |
 | `fromValue(result.output['autoMasterStatus'])` 在 4 處重複 | 同上 |
 | mixin 放在 `widgets/` 目錄 | 它不是 widget。搬移會動到 import 面,延後 |
 | `_autoMasterPostWanUp` 這個暫態欄位 | 可用參數傳遞取代。延後 |
@@ -439,8 +624,9 @@ poll 的 `.map` 在遇到 401 時 throw `ExceptionAutoMasterUnauthorized`,
 
 | 方案 | 當時不採用的理由 |
 |------|-----------|
-| null-threshold 降為 1,首個 null 就 probe | probe 當時是 authed call（再燒 1 次);且對 transient null 過度反應 |
+| null-threshold 降為 1,首個 null 就 probe | probe 當時是 authed call（再燒 1 次);且對 transient null 過度反應 —— 後者正是 §2.4 最終把整個門檻機制移除的原因,只是當時低估了它的嚴重性 |
 | 新增 `AutoMasterStatus.unauthorized` enum 值,用 yield sentinel 取代 throw | 比 throw 更侵入（改 enum + 全 switch);且無法被 admin_view 既有的 `.catchError` 接住 |
 | poll 加 `terminateOnUnauthorized` 參數（只限 ISP 路徑) | 已選共用改法;setup_view 當時對串流 401 無防護,本就是隱性 bug |
 
-> 三者在現行設計下均已無意義:probe 現在是 unauthed;已無 unauthorized 訊號需要表達。
+> 三者在現行設計下均已無意義:`_probe()` 與 null-threshold 已整組移除（§2.4);
+> 已無 unauthorized 訊號需要表達。

--- a/docs/pnp-auto-master-cgi-lockout-fix.md
+++ b/docs/pnp-auto-master-cgi-lockout-fix.md
@@ -4,7 +4,7 @@
 > [LinksysWRT#449](https://github.com/linksys/LinksysWRT/issues/449)
 > 目標分支：`fix/pnp-pppoe-auto-master-wan-up-1180`（base `dev-1.3.1`）· PR [#1181](https://github.com/linksys/PrivacyGUI/pull/1181)
 
-> **本文件已改寫三次,描述的都是現行設計。**
+> **本文件已改寫四次,描述的都是現行設計。**
 > ① 初版修法為「poll 收到第一個 401 就終止串流」（commit `371dbbf8`）,在 `05d2529a` 被
 > **移除並取代**為「Auto Master 狀態讀取一律不送憑證（`auth: false`）」;被取代的設計
 > 及其理由記錄在 §8,以免未來維護者從 git log 讀到 `371dbbf8` 時誤以為它還在。
@@ -14,6 +14,10 @@
 > ③ 同一份 QA log 還顯示 reconnect 後被導到 `localLoginPassword`。該落點屬於
 > **已完成**的 PnP(`userAcknowledgedAutoConfiguration == true`),用在未完成的流程上是錯的;
 > 三處硬編已改為一律回 PnP,見 **§2.7**（§3.2 原本把此不一致判為「刻意保留」,該判斷已作廢）。
+> ④ 第二份 QA log(`PnP-Check-Auto-Master2.txt`)同時**證實 ②③ 在真機上生效**,並暴露下一層:
+> gate 讀到 `complete` 卻直接放過（§2.7 寫的「`case completed` 也會接到它」是**錯的前提**）,
+> 舊憑證因此被帶進 internet check,其 401 又被讀成「沒網路」而跳 troubleshooter。
+> 見 **§2.8**。
 
 ---
 
@@ -278,10 +282,11 @@ reconnect 後**應該回到 PnP 輸入新密碼**,實際卻被丟到 local login
 （「pnp-vs-login 的決定留給 router 的 `userAcknowledgedAutoConfiguration`,不在此硬編 redirect」),
 是呼叫端做了它警告的事。
 
-第二個缺陷同源:`case completed` 這條分支**也會被剛進入的 view 打到** —— 它只是
-「發現 Auto Master 已經是 `complete`」（正是 log 中 reconnect 後的情境,`Start PNP setup
-without admin password` 就在前 12 秒）。這種 view 從來沒有 session 可失去,但它同樣
-不可能知道現在的密碼,所以該去的地方也是同一個密碼輸入提示。
+> **⚠️ 本段原有一個錯誤前提,已於 §2.8 更正。**
+> 原文寫「`case completed` 這條分支**也會被剛進入的 view 打到**」—— **這是錯的**。
+> `runAutoMasterFlow` 只在狀態為 `running` 時才會被呼叫,所以「進來就看到 `complete`」
+> 永遠到不了 `case completed`。第二份 QA log 證實了這點:gate 讀到 `complete`、
+> 直接 `return`,`_promptForRotatedPassword` 一次都沒被呼叫。修法見 **§2.8**。
 
 #### 修法
 
@@ -310,6 +315,88 @@ without admin password` 就在前 12 秒）。這種 view 從來沒有 session �
 同一則 log 出現兩次,**不是**遞迴或重複訂閱:舊版 `pnp_admin_view` 的 bespoke poll loop
 在自己的 `await for` 裡也印一次,與 `pnp_provider.dart:814` 的 `.map` 各印一次 ——
 一個事件兩個 log 敘述。該 loop 已在 §2.4 隨 mixin 重構刪除,**現行程式碼已無此重複**。
+
+### 2.8 進來就是 `complete` 的落點 + 401 不再等於「沒網路」（第二份 QA log 實測後新增）
+
+#### 這份 log 先證實了兩件事是對的
+
+`PnP-Check-Auto-Master2.txt`(2026-08-13 11:41–11:46)在同一份記錄裡驗證了 §2.4 與 §2.7:
+
+| 證據 | 對應修法 |
+|------|----------|
+| `11:45:09`→`11:46:06` **連續 8 次** `TimeoutException after 0-00-03-000000`(≈57s),之後恢復並續輪到 `complete` | §2.4 有界預算。舊的 3-null 門檻會在這段誤判 router-not-found;`3s` 也確認 `requestTimeoutOverride` 生效 |
+| `11:46:18.829` `polling status: complete` → `11:46:18.832` `[RouteChanged]:<pnp>` | §2.7 落點。**不再**是 `localLoginPassword` |
+
+#### 症狀
+
+```
+11:46:22.471  [PnP]: Auto Master status check result: AutoMasterStatus.complete
+11:46:22.471  [PnP]: Check internet connections MAX retries <1>, i=0
+11:46:22.514  REQUEST GetInternetConnectionStatus ... X-JNAP-Authorization: Basic ************
+11:46:23.007  RESPONSE: 200, {"result": "_ErrorUnauthorized",
+               "error": "Invalid authorization credentials 'Basic YWRtaW46YWRtaW4='"}
+11:46:26.009  [PnP Troubleshooter]: Internet connection failed - initiate the troubleshooter
+11:46:26.012  [RouteChanged]:<noInternetConnection>
+```
+
+回到 PnP 之後,**仍用舊憑證**(`admin:admin`,make-Master 輪替前的原廠預設)去打 internet check,
+401 被讀成「沒網路」,於是使用者在 ISP 設定**成功之後**被丟進 troubleshooter。
+
+#### 三個獨立根因
+
+**① gate 漏接 `complete`。** `_checkAutoMasterStatus()` 原本是:
+
+```dart
+if (status != AutoMasterStatus.running) return;   // complete 從這裡直接 return
+```
+
+`complete` 被認出來、印進 log,然後當成「沒事」放過去。§2.7 的 `case completed` 接不到它 ——
+`runAutoMasterFlow` 只在 `running` 時才被呼叫。log 中 `_promptForRotatedPassword` 的
+訊息出現 **0 次**,實證了這條路徑從未被走到。
+
+那行 `Check internet connections` 夾在兩行 Auto Master log 中間只是 logger 的 `[D]`/`[I]`
+緩衝順序（`[D]` 時戳 `470`、`[I]` 是 `471`）,不是兩條並行的 chain。
+
+**② 401 被壓成「沒網路」。** `checkInternetConnection` 原本 `onError` 吞掉一切 →
+`isConnected = false` → `throw ExceptionNoInternetConnection()`。這是同一個主題第三次出現:
+**憑證輪替後被重用,它的 401 被誤讀**。
+
+**③ auth header 不看 pnp state。** header 由 `router_repository.dart:373` 從 auth session 的
+`getLocalPassword()` 組出,`loginType == none` 時 fallback 到 `defaultAdminPassword`。
+`_promptForRotatedPassword()` 清的 `_password` / `setAttachedPassword(null)` **都不影響它**。
+更關鍵的是殘留的 `LoginType.local` 讓 `isLoggedIn()` 回 true,於是 initState 的
+`_examineAdminPassword` 被**整段跳過** —— log 中 `11:46` 期間確實沒有任何 `CheckAdminPassword`。
+
+#### 修法
+
+| # | 位置 | 修法 |
+|---|------|------|
+| ① | `pnp_admin_view.dart` `_checkAutoMasterStatus` | 在 `!= running` 早退**之前**加 `if (status == complete) throw ExceptionAutoMasterRotatedPassword();`。既有的 4 條 `.catchError` 鏈已能接住 |
+| ② | `pnp_provider.dart` `checkInternetConnection` | 改用 `try/catch`:401 → `ExceptionInvalidAdminPassword` 並**立即中止**（不重試,見下）;其餘錯誤照舊進重試迴圈 |
+| ② | `pnp_admin_view.dart` `_checkInternetConnection` | 新增一條 `ExceptionInvalidAdminPassword` 分支:清 spinner 後 rethrow,交給呼叫端的密碼提示,**不去 troubleshooter** |
+| ② | `pnp_isp_save_settings_view.dart` / `pnp_waiting_modem_view.dart` | 同一個例外會逃出這兩處（原本只 catch `ExceptionNoInternetConnection`）。兩處都改為 `goNamed(pnp)` —— 這兩個呼叫是 `checkInternetConnection(30)`(≈90s 視窗),Auto Master 從 WAN-up 起算約 115s,輪替落在視窗內是**成功**而非設定失敗 |
+| ② | `pnp_admin_view.dart` `_retryAutoMasterCheck` | 該鏈**只有**這條沒有 catch-all,新例外會逃逸成 unhandled error。其 `ExceptionAutoMasterRotatedPassword` 分支的 `test` 改為同時接 `ExceptionInvalidAdminPassword` —— 兩者落點相同 |
+| ③ | `pnp_admin_view.dart` `_promptForRotatedPassword` | 加 `ref.read(authProvider.notifier).logout()` |
+
+**為何另外三條鏈不比照併入:** initState / `_unconfiguredView` / `_doLogin` 都先呼叫
+`_examineAdminPassword`,而它在**密碼真的錯**時也拋 `ExceptionInvalidAdminPassword`。
+把兩者併在同一個 `test` 裡,會讓真正的密碼錯誤跳過「顯示密碼錯誤」而靜靜地重置輸入框。
+這三條鏈的 catch-all 已經是正確處置。`_retryAutoMasterCheck` 不呼叫
+`_examineAdminPassword`,所以那裡併入是安全的。
+
+**為何 401 不重試:** 密碼不會因為再送一次就變正確,而每一輪都燒掉路由器 5 次 CGI 額度中的一次
+—— 正是 §2.3 在別處修掉的那個鎖定。第一個 401 必須是終局。
+
+**為何 `logout()` 從這裡呼叫是安全的（已查證）:** `/pnp*` 走 `router_provider.dart` 的
+`_goPnpPath`,該分支**不 watch `authProvider`**,且 `deviceInfo != null` 時回傳原 URI（原地不動）;
+`logout()` 也不清 `pnpProvider`,所以 `deviceInfo` 還在。這正是 §2.7 header 註解裡
+「`localLoginPassword` 分支刻意不重跑 `_autoConfigurationLogic`」所防的那個 redirect 迴圈 ——
+這裡不觸發它。
+
+**`logout()` 並不會讓 header 消失。** `loginType == none` 時 header fallback 到
+`defaultAdminPassword` = `'admin'`,恰好就是 log 中那個失效憑證。所以 ③ 的價值不是
+「停止送舊 header」,而是讓 `isLoggedIn()` 回 false,使下一輪 precheck **真的會驗密碼**。
+真正的安全網是 ②:任何路徑帶著死憑證走到 authed 呼叫,401 都會被正確歸類。
 
 ---
 
@@ -398,8 +485,11 @@ Auto Master 完成後,**四條路徑落在同一個地方**（§2.7）:
 | E7 | **非字串 `autoMasterStatus` payload** | `fromValue(Object?)` → `null`,串流存活 | ✅ §2.6 |
 | E8 | **view 在 make-Master 期間被 dispose** | mixin 每個 `await` 後都檢查 `mounted`;`_checkAutoMasterStatus` 每個 `setState` 都有 guard（`c4b7acc4`) | ✅ |
 | E9 | **非 local 模式重用這三個方法** | `auth: false` 被靜默忽略,憑證照送,§1.3 的保證失效 | ⚠️ **見 §2.2**;目前無此呼叫端 |
-| E10 | **reconnect 後剛進 view,Auto Master 已是 `complete`** | 走 `case completed` → 回 PnP 密碼提示,`_password` 清空 | ✅ **#1180 QA log 的落點**:舊碼在此跳 `localLoginPassword`（§2.7) |
+| E10 | **reconnect 後剛進 view,Auto Master 已是 `complete`** | **gate 自己**拋 `ExceptionAutoMasterRotatedPassword` → 回 PnP 密碼提示,`_password` 清空 + `logout()`;poll 完全不啟動 | ✅ §2.8 ①。本列原寫「走 `case completed`」是**錯的**:該分支只在 `running → complete` 時走到,第二份 QA log 證實 gate 讀到 `complete` 後直接放過 |
 | E11 | **使用者輸入舊密碼的瞬間 Auto Master 完成** | `_doLogin` 的 gate 攔下 → 剛打的密碼已作廢 → 同樣回密碼提示,不落進 WiFi 表單 | ✅ 否則會落到 catch-all 顯示假的「密碼錯誤」 |
+| E12 | **authed 呼叫拿到 401,但 WAN 其實正常** | `checkInternetConnection` 區分兩者:401 → `ExceptionInvalidAdminPassword`(**不重試**,不燒 CGI 額度);非 401 → 照舊重試,耗盡才判 `ExceptionNoInternetConnection` | ✅ §2.8 ②。舊碼把兩者壓平成「沒網路」,在 ISP 設定**成功後**把使用者丟進 troubleshooter |
+| E13 | **輪替發生在 troubleshooter 的 90s 檢查視窗內** | ISP-save / waiting-modem 兩處接住 `ExceptionInvalidAdminPassword` → `goNamed(pnp)`,而非 pop ISP 錯誤 / 跳無網路頁 | ✅ §2.8 ②。Auto Master 從 WAN-up 起算 ≈115s,`checkInternetConnection(30)` ≈90s,重疊是常態 |
+| E14 | **輪替後殘留的 `LoginType.local` 讓 `isLoggedIn()` 回 true** | `_promptForRotatedPassword` 內 `logout()`,下一輪 precheck 會真的驗密碼 | ✅ §2.8 ③。log 中 `11:46` 全程**沒有** `CheckAdminPassword`,驗證被整段跳過 |
 
 ### 4.1 韌體未開放 no-auth 時的降級行為（必須與 FW/QA 對齊）
 
@@ -423,7 +513,7 @@ E2 / E3 下,Auto Master 偵測**靜默失效**,PnP 退回它原本的**兩趟流
 
 ## 5. 測試
 
-### 5.1 `test/page/instant_setup/data/pnp_provider_auto_master_test.dart`（23 案例,全綠）
+### 5.1 `test/page/instant_setup/data/pnp_provider_auto_master_test.dart`（28 案例,全綠）
 
 以 `ProviderContainer` + `MockRouterRepository` 驅動**真的** `PnpNotifier`,
 是唯一直接驗證「JNAP result → status」映射的地方。
@@ -440,6 +530,10 @@ E2 / E3 下,Auto Master 偵測**靜默失效**,PnP 退回它原本的**兩趟流
 | `bounds its own duration: 24 rounds of 3s request + 5s delay` | **§2.4 的三個數字**。門檻機制拿掉之後,這串流的長度**就是**放棄條件,任一參數被改小就會重現 #1180 |
 | `bounds its own duration, shorter than the wait-for-completion poll` | `pollAutoMasterUntilRunning` 的 `maxRetry: 18` + 同樣的 3s/5s 上限 |
 | `retries before condemning the connection` | `testConnectionReconnected` 送 `retries: 2, timeoutMs: 5000` —— 它是 router-not-found 的唯一裁判,不能押在單一封包上 |
+| `checkInternetConnection unauthorized -> ExceptionInvalidAdminPassword, not NoInternet` | **§2.8 ② 的核心**:401 與「WAN 真的斷了」不再同義 |
+| `checkInternetConnection unauthorized does not retry` | 401 是終局。斷言只送了 **1** 次(`retries` 傳 30) —— 每輪重試都燒一次 CGI 額度,正是 §2.3 修掉的鎖定 |
+| `checkInternetConnection a transient failure still retries` | 只有 401 終局:timeout 照舊重試（第 3 次成功) |
+| `checkInternetConnection InternetConnected -> completes` / `a non-connected status -> ExceptionNoInternetConnection` | 原有語意未被新分支破壞 |
 
 > 這三個參數斷言改用**讀取 mock 收到的 `Invocation` 具名引數**（`lastScheduled` / `lastSend`
 > 搭配 `sendArg` / `scheduledArg`),而非 `captureAnyNamed`。原因:`captured` 的順序跟著
@@ -514,15 +608,22 @@ admin view 那個案例特意保留 `expect(find.byKey(Key('pnpConfigStub')), fi
 **不再註冊 login stub** —— 若未來有人把 redirect 加回去,harness 會直接拋
 "unknown route name" 而不是安靜地通過。
 
+§2.8 之後新增 2 個 admin view 案例:
+
+| 案例 | 鎖住什麼 |
+|------|---------|
+| `Auto Master already complete on entry asks for the new password` | **§2.8 ① 的回歸鎖**。與既有的 `Tap Login with Auto Master complete ...` 是**不同分支**:那個先看到 `running` 再輪到 `complete`,這個進來就是 `complete` —— 故 `verifyNever(pollAutoMasterStatus())`,並且 `verifyNever(checkInternetConnection())` 釘住「不再帶著死憑證去打 internet check」 |
+| `Unauthorized internet check does not go to the troubleshooter` | **§2.8 ② 的 view 層安全網**。`checkInternetConnection` 拋 `ExceptionInvalidAdminPassword` 時停在 PnP;此案例**刻意不註冊** troubleshooter 路由,導過去就會拋 "unknown route name" |
+
 ### 5.4 測試結果
 
 | 範圍 | 結果 |
 |------|------|
-| `pnp_provider_auto_master_test.dart` | **23/23** |
+| `pnp_provider_auto_master_test.dart` | **28/28**（原 23 + §2.8 新增 5) |
 | `pnp_auto_master_flow_test.dart` | **14/14** |
-| `test/page/instant_setup/ --exclude-tags loc` | **50/50** |
-| 全專案 `--exclude-tags loc` | **563 passed**（baseline 557,新增 6) |
-| `fvm flutter analyze` | 淨新增 **0** 個 issue（改動 5 檔共 19 issue,全為既有的 deprecated `background` / unused import / `use_build_context_synchronously`,且不在本次 diff 的行上）|
+| `test/page/instant_setup/ --exclude-tags loc` | **52/52**（原 50 + §2.8 新增 2) |
+| 全專案 `--exclude-tags loc` | **570 passed / 0 failed**（baseline 557;以 `--reporter json` 逐案清點:635 個 testDone、0 失敗) |
+| `flutter analyze lib/ test/` | **564**,對 §2.7 的 563 淨增 **1**:`pnp_waiting_modem_view.dart:132` 新增的 `goNamed` 帶一個 `use_build_context_synchronously` info。已加 `if (mounted)` 保護,但 `context` 是跨 `Future.delayed().then()` 從外層 closure 捕獲,分析器追不到（同檔既有的 119 / 123 兩行是同一情形)|
 | loc 兩檔 `--tags loc --update-goldens` | **3247 passed / 3 failed（既有,已查清 — 見下）** |
 
 > **前一版記錄的「3 個失敗未查清」已查清,與本修法無關。**
@@ -544,12 +645,13 @@ admin view 那個案例特意保留 `expect(find.byKey(Key('pnpConfigStub')), fi
 
 | 檔案 | 改動 |
 |------|------|
-| `lib/page/instant_setup/data/pnp_provider.dart` | 三處 `auth: true` → `false`;兩處 `.map` 的 401→throw 刪除;`checkAutoMasterStatus` 的 401 分支併入通用 catch;4 處解析改用 `fromValue`（§2.1 / §2.3 / §2.6）;兩個 poll 加上有界預算參數、`testConnectionReconnected` 改 `retries: 2, timeoutMs: 5000`（§2.4） |
+| `lib/page/instant_setup/data/pnp_provider.dart` | 三處 `auth: true` → `false`;兩處 `.map` 的 401→throw 刪除;`checkAutoMasterStatus` 的 401 分支併入通用 catch;4 處解析改用 `fromValue`（§2.1 / §2.3 / §2.6）;兩個 poll 加上有界預算參數、`testConnectionReconnected` 改 `retries: 2, timeoutMs: 5000`（§2.4）;`checkInternetConnection` 改 `try/catch`,401 → `ExceptionInvalidAdminPassword` 且不重試（§2.8 ②) |
 | `lib/core/jnap/models/auto_master_status.dart` | `fromValue` 參數 `String?` → `Object?`（§2.6） |
 | `lib/page/instant_setup/widgets/pnp_auto_master_flow.dart` | 移除兩處 `on ExceptionAutoMasterUnauthorized`;**刪除 `consecutiveNullThreshold` 與 `_probe()`**;新增 `AutoMasterFlowResult.budgetExhausted`（§2.4) |
-| `lib/page/instant_setup/pnp_admin_view.dart` | 移除 4 處 `.catchError(test: e is ExceptionAutoMasterUnauthorized)`（§2.3);**改用 mixin**,~85 行 bespoke poll loop 刪除（§2.4);`case completed` 改拋 `ExceptionAutoMasterRotatedPassword`,新增 `_promptForRotatedPassword()`,4 條 `.catchError` 鏈各加一個分支（§2.7) |
+| `lib/page/instant_setup/pnp_admin_view.dart` | 移除 4 處 `.catchError(test: e is ExceptionAutoMasterUnauthorized)`（§2.3);**改用 mixin**,~85 行 bespoke poll loop 刪除（§2.4);`case completed` 改拋 `ExceptionAutoMasterRotatedPassword`,新增 `_promptForRotatedPassword()`,4 條 `.catchError` 鏈各加一個分支（§2.7);gate 加 `complete` 分支、`_promptForRotatedPassword` 加 `logout()`、`_checkInternetConnection` 加 `ExceptionInvalidAdminPassword` 分支（§2.8) |
 | `lib/page/instant_setup/pnp_setup_view.dart` | 移除 pre-check 與 `await for` 外層的 `on ExceptionAutoMasterUnauthorized`（§2.3);**改用 mixin**,~75 行 bespoke poll loop 刪除;計數器改為 `_maxAutoMasterWaits`(先加再比)（§2.4);兩處 `localLoginPassword` → `RouteNamed.pnp`（§2.7) |
-| `lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart` | `_checkAndWaitForAutoMaster` 增加 `status == null` 顯式早退（§2.5);兩處呼叫點處理 `budgetExhausted`（§2.4) |
+| `lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart` | `_checkAndWaitForAutoMaster` 增加 `status == null` 顯式早退（§2.5);兩處呼叫點處理 `budgetExhausted`（§2.4);接住 `ExceptionInvalidAdminPassword` → `goNamed(pnp)`（§2.8 ②) |
+| `lib/page/instant_setup/troubleshooter/views/pnp_waiting_modem_view.dart` | 接住 `ExceptionInvalidAdminPassword` → `goNamed(pnp)`（§2.8 ②) |
 | `lib/page/instant_setup/data/pnp_exception.dart` | 刪除 `ExceptionAutoMasterUnauthorized`（§2.3);新增 `ExceptionAutoMasterRotatedPassword`（§2.7） |
 | 測試 4 檔 | 見 §5 |
 
@@ -574,6 +676,7 @@ admin view 那個案例特意保留 `expect(find.byKey(Key('pnpConfigStub')), fi
 | `_isAuthFailure` / `_isRouterTemporarilyUnreachable` 缺單元測試 | 純 predicate,可加 `@visibleForTesting` 直接測。另開 issue |
 | `behind` / `others` 分支不尊重 `needAuth` | 見 §2.2:共用路徑,blast radius 遠大於 #1180 |
 | `docs/` 與 `doc/` 兩個目錄並存 | 與本議題無關 |
+| **PnP 之外**的 authed 呼叫在 make-Master 視窗內帶著 stale 憑證 | §2.8 只處理了 PnP 流程內的 `checkInternetConnection`(②)與 session 殘留(③)。核心 polling 已由 `polling_provider.dart` 的「只有憑證被拒才登出」擋住最糟的後果,但**其他** authed 呼叫仍可能在該視窗吃到 401。要普遍解決需在 `router_repository` 層區辨,blast radius 遠大於 #1180 |
 
 ---
 

--- a/docs/pnp-auto-master-cgi-lockout-fix.md
+++ b/docs/pnp-auto-master-cgi-lockout-fix.md
@@ -1,0 +1,257 @@
+# PnP Auto Master — CGI 認證鎖定死結修復設計
+
+> 追蹤：[PrivacyGUI#1180](https://github.com/linksys/PrivacyGUI/issues/1180) ·
+> [LinksysWRT#449](https://github.com/linksys/LinksysWRT/issues/449)
+> 前置修復：#980 / #1006 / #1180（`85f39a74` — WAN-up 早期偵測）
+
+---
+
+## 1. 背景與問題
+
+#1180 的「WAN-up 早期偵測」在真機（FW `v1.2.3.26072823_CF`）驗證**運作正確**：
+
+- `pollAutoMasterUntilRunning` 正確接手（log：`Auto Master wait-for-running status: running`）
+- `_probeUnauthorized` 的 `unauthorized → completed (recover)` 分類正確觸發
+
+但驗證中浮現一層**更底層的死結**，位於 JNAP CGI 的 5 次認證失敗鎖定計數器（`jnap_auth_failed_attempts`）。
+
+### 1.1 失敗時序（QA log 摘錄）
+
+```
+11:21:01  console  Auto Master「makes Master」→ 輪替 admin 密碼
+11:21:02  console  admin password rotated
+11:21:06  GUI      pollAutoMasterStatus 仍用 STALE admin:admin → 401（燒 attempt 1）
+11:21:12  GUI      poll → 401（attempt 2）
+11:21:17  GUI      poll → 401（attempt 3）
+11:21:18  GUI      poll → 401（attempt 4）
+11:21:20  GUI      poll → 401（attempt 5 — 額度用盡）
+11:21:21  GUI      redirect to login
+11:22:07  user     輸入「正確的新密碼」→ CheckAdminPassword2 回 invalid ×5（LED 恆亮白，無法登入）
+```
+
+### 1.2 根因
+
+`pollAutoMasterStatus` / `pollAutoMasterUntilRunning` 走
+`scheduledCommand(auth: true, retryDelayInMilliSec: 5000, ...)`。
+
+1. 在 `router_repository.dart:259` 401（`JNAPError`）被吞進 yielded result。
+2. `condition` 只認 `running/complete/idle/failed`，401 → 回 `false`
+   → 每 5 秒**繼續用失效的 `admin:admin` 重打**。
+3. `.map()` 又把 401 壓平成 `null`；消費端要**累積 3 個 null** 才會 `_probeUnauthorized`。
+
+結果：**還沒等使用者輸入任何東西，poll 就燒光 5 次額度**。計數器只在「登入成功」時由 HDK
+`AuthFn_Default` 自動清零（Vinh 確認），但鎖定後正確密碼也回 401 →「成功登入」永遠無法發生 →
+**死結**。（Auto Master 走 `platform.setAdminPassword` 繞過 JNAP，亦不觸碰計數器。）
+
+### 1.3 修復目標
+
+在 poll 串流收到**第一個 401** 時就終止，而不是壓平成 null 繼續重打。
+淨效果：make-Master 後 poll **最多只花 1 次 CGI 額度**（原本 4–5 次），把使用者的重登額度完整留住。
+
+---
+
+## 2. 修法
+
+訊號分離其實**早已存在**：`checkAutoMasterStatus`（`pnp_provider.dart:751`）對 401 已丟
+`ExceptionAutoMasterUnauthorized`，對不支援/逾時才 `return null`。只是兩個**串流**方法沒這麼做。
+本修法讓串流也採用同一套語意。
+
+### 2.1 核心改動 — `pnp_provider.dart`（兩個 poll 方法）
+
+`pollAutoMasterStatus`（L765）與 `pollAutoMasterUntilRunning`（L809）的 `.map` 段：
+
+```dart
+.map((result) {
+  // NEW: 把 401 當串流錯誤丟出，消費端 await-for 立即中斷（1 次額度）
+  if (result is JNAPError && result.result == errorJNAPUnauthorized) {
+    throw ExceptionAutoMasterUnauthorized();
+  }
+  if (result is JNAPSuccess) { /* 既有：running/complete/idle/failed → 回 status */ }
+  return null; // 真正的連線失敗/不支援 仍走 null（不受影響）
+});
+```
+
+> `errorJNAPUnauthorized` 與 `ExceptionAutoMasterUnauthorized` 在此檔已 import（L305 / L752），無需新增依賴。
+
+**為什麼「throw」足以停止重打（不需改 `condition`）— 見 §5.1。** 這是本設計刻意避免 over-design 的關鍵決定。
+
+### 2.2 消費端影響（共用改法 → 3 個消費端全數盤點）
+
+| # | 消費端 | 是否需改 | 401 落點 | 說明 |
+|---|--------|---------|---------|------|
+| 1 | **ISP-save**（mixin，#449 主路徑）<br>`pnp_auto_master_flow.dart` + `pnp_isp_save_settings_view.dart` | **需改**（mixin 加 try/catch） | **`goNamed(pnp)`** | `_waitForRunning` / `_waitForCompletion` 的 `await for` 包 try/catch → 回 `AutoMasterFlowResult.completed`；view 端 `completed → goNamed(pnp)` **已存在**（L99）。符合「router 決定 pnp-vs-login」的既定原則。 |
+| 2 | **pnp_setup_view** `pnp_setup_view.dart:763` | **必須加 try/catch** | `localLoginPassword` | 目前對串流 401 **無 handler** → 拋出會變 unhandled async error，卡在等待畫面（比現況更糟）。落點沿用它自己 L744 / L787 既有的 login 慣例。 |
+| 3 | **pnp_admin_view** `pnp_admin_view.dart:556` | **零改動** | `localLoginPassword` | 三個 caller 皆已有 `.catchError(test: ExceptionAutoMasterUnauthorized) → goNamed(localLoginPassword)`（L115 / L366 / L638），拋出自然被接住。 |
+
+**落點原則（回應決策）**：使用者選定「維持 `goNamed(pnp)` 讓 router 決定」——
+此決策對應的正是 **#449 的 ISP-save 路徑**，該路徑透過 mixin 的 `completed` 結果**本來就**是
+`goNamed(pnp)`。故落點無需改，只讓它「更早在第一個 401 觸發」。
+setup / admin 兩條路徑維持既有的 `localLoginPassword`（**不**改成 pnp），以免對無關流程引入未審查的行為變動。
+
+#### 2.2.1 落點不一致——**已知、刻意保留（選項 1）**
+
+同一個「make-Master 401」事件，會依踩到哪條路徑落在**不同地方**，且**去向由不同機制決定**：
+
+| 路徑 | `goNamed(...)` | router redirect 分支 | 實際決定去向者 | 結果 |
+|------|---------------|---------------------|--------------|------|
+| ISP-save（mixin，#449 主場景） | `pnp` | L129 `startsWith('/pnp')` → `_goPnpPath` | **router 判斷**（`_autoConfigurationLogic` 的 `userAcknowledgedAutoConfiguration`） | pnp-vs-login 由 router 決定 |
+| setup / admin（正常 PnP） | `localLoginPassword` | L126 分支：`_autoConfigurationLogic(state)` 被呼叫但**未 `return`**（fire-and-forget，只有副作用），真正 `return` 的是 `_redirectLogic` | **強制停在 local login 密碼頁** | 直接到 login 頁 |
+
+- 此不一致**非本次引入**：mixin 路徑（#1180）刻意「不硬編 redirect、交給 router」；setup/admin（#980）早已硬編去 login。本修法只讓兩條路徑**更早在第一個 401 觸發**。
+- **factory-reset 場景殊途同歸**：`userAcknowledgedAutoConfiguration == false` 時，`goNamed(pnp)` 過 router 亦判定「留在 PnP」，而 PnP 首頁（admin view）若 session 已死會被既有防線再導向 login。**最終使用者都到 login 頁重輸新密碼**，差別僅「ISP 路徑多繞一跳 pnp」。
+- **決策：維持選項 1**（ISP→pnp/router 判斷；setup/admin→login/強制）。理由：各自沿用該路徑既有且經測試的慣例，回歸面最小；factory-reset 下 UX 等價。未採「強制三者一致都走 pnp」（選項 2），因其會動到 setup/admin 既有硬編行為，超出死結修復範圍。
+
+### 2.3 mixin try/catch 具體形狀
+
+```dart
+Future<AutoMasterFlowResult?> _waitForRunning(int threshold) async {
+  int consecutiveNulls = 0;
+  try {
+    await for (final status in ref.read(pnpProvider.notifier).pollAutoMasterUntilRunning()) {
+      // ...既有分支不變...
+    }
+  } on ExceptionAutoMasterUnauthorized {
+    // 串流層偵測到 make-Master 輪替密碼 → 視為 Auto Master 已完成 → recover
+    logger.i('[PnP]: wait-for-running unauthorized → completed (recover)');
+    return AutoMasterFlowResult.completed;
+  }
+  // ...既有 timeout 收尾不變...
+}
+```
+
+`_waitForCompletion` 同理包一層 `try / on ExceptionAutoMasterUnauthorized → return completed`。
+
+### 2.4 「零程式改動」≠「零行為改動」——共用改法的真實副作用（重要）
+
+`pnp_setup_view` 與 `pnp_admin_view` 雖為**加法/零程式改動**，但因採「共用改法」，其 poll 路徑在
+**「遇到真 401」時的 runtime 行為確實改變**（此前只有 #449 的 PPPoE ISP 路徑會踩到 make-Master 401，
+但正常 PnP 也可能在 config 期間遇 Auto Master 完成而 401）：
+
+| | 改動前 | 改動後 |
+|---|--------|--------|
+| poll 遇真 401 | 壓平成 `null` → 累積 3 次 → **顯示「連線錯誤」畫面**（誤導：401 非連線問題） | 第一個 401 → throw → 被既有 catch 接住 → **導向 login** |
+
+- 這是**嚴格改善**（401 本該去 login，不該顯示連線錯誤，也不該再燒額度）。
+- 但它是**超出 #449 ISP 路徑的行為變動**——共用改法讓 setup / admin 的正常 PnP poll 路徑一併受惠。
+- **此新 runtime 路徑目前無測試覆蓋** → §6 需為 setup / admin 各補一個「stream 拋 401 → login」回歸測試（非可選）。
+
+> 傳播已驗證：admin_view 的 `await for`（L556）在 `async` 方法內、**無內層 try**，throw 沿
+> `.then(...).catchError(test: ExceptionAutoMasterUnauthorized → login)` 傳到三個 caller
+> （L115 / L366 / L638）**全部接得住**，故程式零改動成立；setup_view 的 `await for`（L763）
+> **不在** L738 的 try 範圍內（該 try 於 L747 已閉合），故**必須**新增 try/catch（E7）。
+
+---
+
+## 3. 再次死結的安全性驗證（`goNamed(pnp)` 不會 re-burn）
+
+追過 `_autoConfigurationLogic`（`router_provider.dart:158`）+ PnP 進入路徑，確認 make-Master 後
+`goNamed(pnp)` **不會**再燒 CGI 額度：
+
+| 步驟 | 呼叫 | auth? | 額度 |
+|------|------|-------|------|
+| 路由決策 | `fetchDeviceInfo` / `autoConfigurationCheck` | **unauthed** | 0 |
+| 路由決策 | factory-reset 時 `userAcknowledgedAutoConfiguration == false` 在 L190 **短路** | — | 0（不呼叫 authed 的 `isRouterPasswordSet`） |
+| 登出 | `logout()`（L214）**清掉** stale `pLocalPassword` | — | 0 |
+| PnP entry | `checkRouterConfigured` → `getDeviceMode` | **unauthed** | 0 |
+| PnP entry | 無密碼時 `checkAdminPassword(null)` **本地拋錯不打網路**（L294） | — | 0 |
+| 使用者輸入 | 正確新密碼 → 額度第 **2** 次 → 成功 → HDK 自動清零 | auth | 1 |
+
+**總計最多 2 次 < 5**，死結解除。
+> 此安全性**完全依賴**「第一個 401 就終止」——正是 §2.1 的修法核心。若仍沿用舊的 4–5 次 poll，
+> 光 poll 就逼近上限，`goNamed(pnp)` 落點無論如何都救不了。
+
+---
+
+## 4. Edge Cases 盤點
+
+| # | 情境 | 修法後行為 | 判斷 |
+|---|------|-----------|------|
+| E1 | **真連線中斷**（非 401） | 仍走 `null` 路徑 → null-threshold → `_probeUnauthorized` → probe 也失敗 → `connectionError` | ✅ 不受影響，與 401 訊號完全分離 |
+| E2 | **make-Master 極快，錯過 running 邊緣** | `condition` 仍認 `complete/failed` → 提早停 | ✅ 既有行為保留 |
+| E3 | **401 發生在 `_waitForRunning`（Phase A）** | 串流 throw → try/catch → `completed`（QA 的 11:20–11:21 情境） | ✅ 正是主修復場景 |
+| E4 | **401 發生在 `_waitForCompletion`（Phase B）** | 同 E3 | ✅ |
+| E5 | **ISP-save 的 pre-save 檢查（`_checkAndWaitForAutoMaster` L65）** | 該處呼叫 `checkAutoMasterStatus()`（Future 版，**本來就** throw 401）→ L69 `goNamed(pnp)` | ✅ 已一致，無需改 |
+| E6 | **admin_view 拋出後 `_isWaitingForAutoMaster` 未 reset** | view 隨即被導航替換，spinner state moot | ✅ 可接受（無殘留 spinner） |
+| E7 | **setup_view 拋出但未加 try/catch** | unhandled async error → 卡等待畫面 | ⚠️ **必須修**（§2.2 #2），否則比現況更糟 |
+| E8 | **401 以外的 auth 問題（罕見 glitch）** | PnP 期間 session 剛被 internet check 證明有效，唯一會中途輪替 admin 憑證的就是 make-Master → 歸類 recover 合理 | ✅ 與既有註解一致 |
+| E9 | **`_probeUnauthorized` 的 unauthorized 分支是否變 dead code？** | 主 401 偵測移到串流層後，此分支僅在「session 死但 poll 回 null 非 401」的極罕見 timing 才觸發 | ⚠️ 見 §5.2 |
+| E10 | **老韌體不支援 GetAutoMasterStatus** | 回 `null`（非 401）→ 走既有 null/timeout 收尾 | ✅ 不受影響 |
+| E11 | **`condition` 回 true 造成 `exceedMaxRetry=false → onCompleted(false)`** | onCompleted 僅 log，無行為影響 | ✅（且見 §5.1，建議**不**改 condition） |
+
+---
+
+## 5. Over-Design 檢視（回應「是否過度設計」）
+
+### 5.1 **建議：只改 `.map` throw，不改 `condition`** ← 避免 over-design
+
+一個直覺是「同時在 `condition` 回 `true`（讓 `scheduledCommand` break）+ 在 `.map` throw」雙保險。
+**但經 Dart async* 取消語意分析，`condition` 改動是多餘的**：
+
+`scheduledCommand` 是 `async*`，在 `yield result` 處**因背壓而暫停**。當：
+1. `.map` 回呼 throw → mapped stream 發出 error event；
+2. 消費端 `await for` 收到 error → 迴圈體 rethrow → 退出迴圈 → **cancel subscription**；
+3. cancel 往上游傳遞 → async* 在 `yield` 暫停點被終止（**不會**執行 yield 之後的 `if(condition) / await Future.delayed`）。
+
+因此 generator 不會進入下一輪 delay+poll，**單靠 `.map` throw 就達成「1 次額度」**。
+`condition` 回 true 只有在「消費端吞掉 error 又繼續 listen」時才有意義——現有 3 個消費端**皆無**此行為。
+
+> **結論**：改 `condition` 屬 YAGNI 防禦，hotfix 上**不採用**。修法收斂為單一機制（`.map` throw），
+> 語意清晰、blast radius 最小。（若未來有以 `.listen` 手動消費且不 cancel-on-error 的新消費端，再議。）
+
+### 5.2 **既有 null-threshold + probe 機制：保留，不拆**
+
+#1180 引入的「3 連 null → probe」機制，當初正是為了繞過「401 被壓平成 null」。
+本修法讓 401 直接 throw 後，該機制的**角色縮小**為：僅處理**真正的連線失敗**（transient timeout / 老韌體 / 網路斷）
+以決定 `connectionError` vs 繼續等待。`_probeUnauthorized` 的 `ExceptionAutoMasterUnauthorized`
+分支（L189）雖大幅冷卻（E9），但仍是「session 由非 poll 路徑死亡」的 defense-in-depth，成本極低。
+
+> **結論**：**保留**。在 hotfix 分支上拆除運作中的防禦機制風險 > 收益。標記為未來可簡化項，但不在本次範圍。
+
+### 5.3 未採用的替代方案（記錄理由）
+
+| 方案 | 為何不採用 |
+|------|-----------|
+| mixin 層把 null-threshold 降為 1、首個 null 就 probe | probe 本身是 authed call（再燒 1 次）；且對 transient null 過度反應；且**不涵蓋** setup/admin（未用 mixin）。串流層修法一次覆蓋 3 個消費端，且只花 1 次額度。 |
+| 新增 `AutoMasterStatus.unauthorized` enum 值用 yield sentinel 取代 throw | 比 throw 更侵入（改 enum + 全 switch）；且無法自然被 admin_view 既有的 `.catchError` 接住。throw 復用既有 exception，friction 最低。 |
+| poll 方法加 `terminateOnUnauthorized` 參數（限縮只 ISP 路徑） | 使用者已選「共用改法」；且 setup_view 現況對串流 401 無防護，本就是隱性 bug，一併修較一致。 |
+
+---
+
+## 6. 測試影響
+
+**回歸基準（已對照全部現存測試確認）**：現存測試**無任何一個**注入「會 throw 的 stream」——
+全部是 `Stream.value(status)` / `Stream.fromIterable([null,...])` / `Stream.empty()`。
+本修法只在「stream **真的** throw 401」時改變行為，而該事件過去被壓平成 null，
+**現存測試與現存正常流程皆不依賴它**（它產生的正是死結本身）。故現存測試**全數維持綠燈**。
+
+| 測試檔 | 動作 | 結果 |
+|--------|------|--------|
+| `pnp_auto_master_flow_test.dart` | 現存 13 案例全綠（尤其 L177 的 `[null,null,null]+probe→completed`：stream 不 throw，新 catch 不觸發，結果不變）。**新增** Phase A / Phase B / Phase A-Running-then-B「stream throw 401 → `completed`」共 3 案例 | ✅ **+16 全綠**（純 logic，無 loc flag） |
+| `pnp_setup_view_test.dart` | 現存 running / null×3 案例不變。**新增**「stream throw 401 → 導向 `localLoginPassword`」（§2.2 #2 try/catch 的唯一覆蓋，此前無測試） | ✅ **+36 全綠**（`--tags=loc`） |
+| `pnp_admin_view_test.dart` | 現存 L297 的 `checkAutoMasterStatus` throw（Future 版）案例仍綠。**新增**「**stream**（`pollAutoMasterStatus`）throw 401 → 導向 login」（§2.4 的零程式改動、真行為改動路徑，此前無測試） | ✅ **+20 全綠**（`--tags=loc`） |
+| `test/common/testable_router.dart` | **新增** `extraRoutes`（預設 `const []` → 對全部現存呼叫零影響）。見下方「測試 harness」 | ✅ 附加式，無回歸 |
+| `test/mocks/pnp_notifier_mocks.dart` / spec mocks | 簽名不變，**無需重生** | — |
+
+> 補測試手法：`when(mock.pollAutoMasterStatus()).thenAnswer((_) => Stream.error(ExceptionAutoMasterUnauthorized()))`。
+>
+> **測試 harness（實作時發現的必要調整）**：這批是 `--tags=loc` 的 **localization / screenshot** 測試（用 `--update-goldens` 跑；**非** golden 斷言測試），非純 golden。`testableSingleRoute` 原本只註冊 `/` 這一條 route，因此新測試觸發的 `context.goNamed(RouteNamed.localLoginPassword)` 會拋 `unknown route name`——
+> - `setup_view`：直接把 exception 冒出來 → 測試紅燈；
+> - `admin_view`：exception 被 `initState` 鏈末端的 `.onError` 吞掉，但 `_isWaitingForAutoMaster` 停在 `true`，spinner 永遠轉 → `pumpAndSettle` timeout。
+>
+> 兩者都**只是 harness 缺目的地 route**（正式環境兩條 route 都在，log 也證實 redirect 有觸發），非 production 邏輯 bug。修法：`testableSingleRoute` 加一個附加式 `extraRoutes` 參數（預設空 → 全部現存測試零影響），新測試各塞一個 `localLoginPassword` stub route（`Key('loginStub')`），再 `expect(find.byKey('loginStub'), findsOneWidget)` 斷言 401 確實落到 login。
+
+---
+
+## 7. 變更檔案清單
+
+| 檔案 | 改動 |
+|------|------|
+| `lib/page/instant_setup/data/pnp_provider.dart` | 兩個 poll 方法 `.map` 段：401 → throw `ExceptionAutoMasterUnauthorized`（§2.1） |
+| `lib/page/instant_setup/widgets/pnp_auto_master_flow.dart` | `_waitForRunning` / `_waitForCompletion` 各包一層 `try / on ExceptionAutoMasterUnauthorized → return completed`（§2.3） |
+| `lib/page/instant_setup/pnp_setup_view.dart` | L763 `await for` 外層加 try/catch → `goNamed(localLoginPassword)`（§2.2 #2） |
+| `lib/page/instant_setup/pnp_admin_view.dart` | **零程式改動**（既有 catchError 接住；行為改動見 §2.4） |
+| `test/common/testable_router.dart` | 新增附加式 `extraRoutes` 參數（預設 `const []`），供測試註冊 redirect 目的地 route（見 §6） |
+| 測試 3 檔 | 見 §6 |
+
+> firmware 側維持不變（Jianrong / Vinh 已確認兩項皆 GUI-side）。
+> 目標分支：`fix/pnp-pppoe-auto-master-wan-up-1180`（尚未合入 release 1.3.0.700533）。

--- a/docs/pnp-auto-master-cgi-lockout-fix.md
+++ b/docs/pnp-auto-master-cgi-lockout-fix.md
@@ -4,7 +4,7 @@
 > [LinksysWRT#449](https://github.com/linksys/LinksysWRT/issues/449)
 > 目標分支：`fix/pnp-pppoe-auto-master-wan-up-1180`（base `dev-1.3.1`）· PR [#1181](https://github.com/linksys/PrivacyGUI/pull/1181)
 
-> **本文件已改寫四次,描述的都是現行設計。**
+> **本文件已改寫五次,描述的都是現行設計。**
 > ① 初版修法為「poll 收到第一個 401 就終止串流」（commit `371dbbf8`）,在 `05d2529a` 被
 > **移除並取代**為「Auto Master 狀態讀取一律不送憑證（`auth: false`）」;被取代的設計
 > 及其理由記錄在 §8,以免未來維護者從 git log 讀到 `371dbbf8` 時誤以為它還在。
@@ -18,6 +18,11 @@
 > gate 讀到 `complete` 卻直接放過（§2.7 寫的「`case completed` 也會接到它」是**錯的前提**）,
 > 舊憑證因此被帶進 internet check,其 401 又被讀成「沒網路」而跳 troubleshooter。
 > 見 **§2.8**。
+> ⑤ 第三份 QA log 片段證實 ④ 生效,同時暴露 ④ 的前提錯了:`complete` 是 **latch**
+> （韌體跑過 make-Master 之後餘生一直回它),所以「讀到 `complete` 就等於密碼被輪替」
+> 在**每一次**進 PnP 都成立 —— 使用者輸入正確新密碼後又被立刻登出。改為
+> 「`complete` **且**本 session 觀察到過 `running`」,見 **§2.9**
+> （§2.8 ① 修法表那格的無條件 throw 已作廢)。
 
 ---
 
@@ -371,7 +376,7 @@ if (status != AutoMasterStatus.running) return;   // complete 從這裡直接 re
 
 | # | 位置 | 修法 |
 |---|------|------|
-| ① | `pnp_admin_view.dart` `_checkAutoMasterStatus` | 在 `!= running` 早退**之前**加 `if (status == complete) throw ExceptionAutoMasterRotatedPassword();`。既有的 4 條 `.catchError` 鏈已能接住 |
+| ① | `pnp_admin_view.dart` `_checkAutoMasterStatus` | 在 `!= running` 早退**之前**加 `if (status == complete) throw ExceptionAutoMasterRotatedPassword();`。既有的 4 條 `.catchError` 鏈已能接住。**條件已由 §2.9 修正** —— 單看 `complete` 會在每次進 PnP 都成立 |
 | ② | `pnp_provider.dart` `checkInternetConnection` | 改用 `try/catch`:401 → `ExceptionInvalidAdminPassword` 並**立即中止**（不重試,見下）;其餘錯誤照舊進重試迴圈 |
 | ② | `pnp_admin_view.dart` `_checkInternetConnection` | 新增一條 `ExceptionInvalidAdminPassword` 分支:清 spinner 後 rethrow,交給呼叫端的密碼提示,**不去 troubleshooter** |
 | ② | `pnp_isp_save_settings_view.dart` / `pnp_waiting_modem_view.dart` | 同一個例外會逃出這兩處（原本只 catch `ExceptionNoInternetConnection`）。兩處都改為 `goNamed(pnp)` —— 這兩個呼叫是 `checkInternetConnection(30)`(≈90s 視窗),Auto Master 從 WAN-up 起算約 115s,輪替落在視窗內是**成功**而非設定失敗 |
@@ -397,6 +402,101 @@ if (status != AutoMasterStatus.running) return;   // complete 從這裡直接 re
 `defaultAdminPassword` = `'admin'`,恰好就是 log 中那個失效憑證。所以 ③ 的價值不是
 「停止送舊 header」,而是讓 `isLoggedIn()` 回 false,使下一輪 precheck **真的會驗密碼**。
 真正的安全網是 ②:任何路徑帶著死憑證走到 authed 呼叫,401 都會被正確歸類。
+
+---
+
+### 2.9 `complete` 是 latched 狀態:輪替必須由 `running` 定年（第三份 QA log 實測後新增）
+
+#### 症狀
+
+`5e7f5fe8` 之後同日 13:40 的重測片段先證實 §2.8 ① 生效了 —— 進來就是 `complete`
+確實會導到密碼提示,不再帶著死憑證去打 internet check。但使用者輸入**正確的新密碼**之後:
+
+```
+13:40:35.169  [PnP]: Auto Master status check result: AutoMasterStatus.complete
+13:40:35.169  [PnP]: Auto Master rotated the password, prompt for the new one
+13:40:35.170  [Prepare]: Logout                      ← §2.8 ③ 的 logout,正確
+...使用者輸入新密碼...
+13:41:21.481  REQUEST  CheckAdminPassword2 ... X-JNAP-Authorization: Basic ************
+13:41:22.164  RESPONSE 200, {"result": "OK"}         ← 密碼是對的
+13:41:22.167  [Auth]: Local login done: ... LoginType.local
+13:41:22.723  RESPONSE 200, {"output": {"autoMasterStatus": "Complete"}}
+13:41:22.725  [PnP]: Auto Master status check result: AutoMasterStatus.complete
+```
+
+最後這一行之後就是同一條路徑:gate 再次 throw → `_promptForRotatedPassword()` → `logout()`
+—— 把**剛剛才建立的 session 清掉**,再要一次密碼。使用者回報的
+「checkAdminPassword 過了 但還是會被登出」就是這個迴圈,而且**無法脫離**:
+密碼再正確也一樣。
+
+#### 根因:`complete` 是 latch,它不會回到 `idle`
+
+韌體跑完 make-Master 之後,`GetAutoMasterStatus` 會**餘生一直回 `Complete`**。
+所以單看這個狀態,它說的只是「這台路由器曾經被 auto-master 過」——
+這句話在該路由器上**永遠為真**,對「我手上的密碼還有效嗎」一個字都沒回答。
+
+§2.8 ① 因此不只在這個 QA 情境出錯:**任何曾經跑過 make-Master 的路由器,
+在後續每一次進 PnP 都會被那個 gate 攔下來**,即使密碼完全正確。
+使用者回報的登出迴圈只是這個缺陷最顯眼的一種表現。
+
+`running` 是唯一能**定年**的讀值:韌體只在 make-Master 真的在工作時回它。
+「有沒有走過 `running`」正是使用者提出的機制。
+
+#### 修法:記錄 + 清除兩個端點,gate 改看「輪替是否晚於我的憑證」
+
+| # | 位置 | 修法 |
+|---|------|------|
+| 記錄欄位 | `pnp_state.dart` | 新增 `autoMasterRotatedSinceLogin`(預設 `false`),加入 `props` |
+| **設** | `pnp_provider.dart` `_observeAutoMasterStatus()` | 新增私有 helper:讀到 `running` 就設旗標。`checkAutoMasterStatus` 與兩個 poll 的 `.map` **三處讀取全部匯流到它** |
+| **清** | `pnp_provider.dart` `checkAdminPassword` 成功分支 | `CheckAdminPassword` 回 200 就是路由器親口保證「這個憑證有效」,旗標歸零 |
+| gate | `pnp_admin_view.dart` `_checkAutoMasterStatus` | `status == complete` → `status == complete && autoMasterRotatedSinceLogin` |
+| gate | `pnp_isp_save_settings_view.dart` `_checkAndWaitForAutoMaster` | 同上（該處的 latch bug 是既有的,見下） |
+
+**為何記錄點放在 provider 而不是各 view。** 狀態有三個讀取入口(單次 `checkAutoMasterStatus`
+＋ 兩個 poll)、五個呼叫點(admin gate、ISP-save pre-check、setup-view pre-save、
+mixin Phase A、mixin Phase B)。把記錄放在 provider 的單一 choke point,
+記錄結果就**不取決於是哪一次讀取剛好撞進 `running` 的時間窗**,呼叫點也不必記得要記。
+這個 helper 刻意**不**加進 `BasePnpNotifier` 的抽象介面 —— 它是實作細節,
+加了還得重新產生 mockito mock。
+
+**`runAutoMasterFlow` 的 `case completed:` 刻意維持無條件 throw。** 那條路徑只有在
+已經觀察到 `running` 之後才會進入,輪替**由結構本身證明**,再檢查旗標是多餘的。
+
+#### 順帶修掉兩個既有缺陷（非本次要求,查證時發現)
+
+**① ISP-save 的 `complete → goNamed(pnp)` 有同一個 latch bug,而且後果更糟。**
+該分支自 `61bef92f Release 1.3.0` 就存在。在任何曾被 auto-master 過的路由器上:
+進 ISP-save view → 還沒存檔就跳回 PnP → PnP 查無網路 → 又回 troubleshooter → 再進 ISP-save,
+**PPPoE 設定永遠存不進去**。加上旗標之後才收斂到真正需要 redirect 的情況。
+
+**② `PnpState.copyWith` 讓 `setAttachedPassword(null)` 變成 no-op。**
+`attachedPassword` 原本是 `String?`,`copyWith` 用 `x ?? this.x`,所以傳 `null`
+被讀成「不要動它」而不是「清掉」。兩處 `setAttachedPassword` 實作因此**什麼都沒做**:
+§2.7 的「丟棄被輪替的憑證」與 `checkAdminPassword` 成功後的「清掉密碼」都沒有發生。
+這不只是無害的殘留 —— `pnp_no_internet_connection_view.dart:145-157` 會**不經詢問**
+把 `attachedPassword` 再送一次 `checkAdminPassword`,等於拿一個必定失敗的密碼
+去燒掉路由器 5 次 CGI 額度中的一次。
+改法沿用同檔 `autoMasterStatusOnEntry` 既有的 `ValueGetter<String?>?` 慣例,
+讓 `null` 可以被**指派**而不是被讀成「保持原值」。
+
+#### 降級行為:沒觀察到 `running` 的情況
+
+旗標活在 `pnpProvider` 上,而它**不是 autoDispose**,所以同一個 app process 內
+跨路由來回都留著（QA log 的 `[RouteChanged]:<pnp>` 重進 PnP 期間沒有重啟,
+旗標存活）。真正看不到 `running` 的是**輪替之後才冷啟動 app**:此時旗標為 `false`,
+gate 放行,舊憑證的 401 由 §2.8 ② 的 `checkInternetConnection` 接成
+`ExceptionInvalidAdminPassword`,**落在同一個密碼提示畫面**。
+代價是花掉 5 次 CGI 額度中的 1 次,且不重試（§2.8「為何 401 不重試」)。
+換句話說:gate 是**省下那一次額度的最佳化**,不是唯一防線;誤放行會退回安全網,
+而誤攔下來會做出一個進不去的 app —— 兩種錯誤的代價不對稱,這也是旗標該怎麼預設的理由。
+
+#### 為何 `pnp_setup_view` 的 `idle → complete` 分支不加旗標
+
+該分支的條件是 `statusOnEntry == idle && currentStatus == complete`。
+`idle`-on-entry 這一半**本身就在定年**:它證明 latch 是在**這一段 session 內**發生的。
+而早就被 auto-master 過的路由器一進來就讀到 `complete`,永遠滿足不了這個條件 ——
+它對 latch **由結構免疫**。兩者是互補的判別式(它還能抓到「沒有人 poll 的時間窗內
+發生的輪替」,那是旗標看不到的),所以刻意保留,只補上註解說明,不做統一。
 
 ---
 
@@ -513,7 +613,7 @@ E2 / E3 下,Auto Master 偵測**靜默失效**,PnP 退回它原本的**兩趟流
 
 ## 5. 測試
 
-### 5.1 `test/page/instant_setup/data/pnp_provider_auto_master_test.dart`（28 案例,全綠）
+### 5.1 `test/page/instant_setup/data/pnp_provider_auto_master_test.dart`（36 案例,全綠）
 
 以 `ProviderContainer` + `MockRouterRepository` 驅動**真的** `PnpNotifier`,
 是唯一直接驗證「JNAP result → status」映射的地方。
@@ -534,6 +634,22 @@ E2 / E3 下,Auto Master 偵測**靜默失效**,PnP 退回它原本的**兩趟流
 | `checkInternetConnection unauthorized does not retry` | 401 是終局。斷言只送了 **1** 次(`retries` 傳 30) —— 每輪重試都燒一次 CGI 額度,正是 §2.3 修掉的鎖定 |
 | `checkInternetConnection a transient failure still retries` | 只有 401 終局:timeout 照舊重試（第 3 次成功) |
 | `checkInternetConnection InternetConnected -> completes` / `a non-connected status -> ExceptionNoInternetConnection` | 原有語意未被新分支破壞 |
+
+§2.9 新增 `group('autoMasterRotatedSinceLogin')`,8 個案例把旗標的**每一條進出路徑**釘住:
+
+| 案例 | 鎖住什麼 |
+|------|---------|
+| `a running status records the rotation` | 設的唯一條件 |
+| `a latched complete on its own records nothing` | **§2.9 的核心**:latch 不算證據。這個案例失敗就等於登出迴圈回來了 |
+| `an idle status records nothing` / `a failed status records nothing` | 另兩個非 `running` 讀值同樣不算 |
+| `the completion poll records a running` / `the wait-for-running poll records a running` | 記錄點在 provider 的 choke point,**三處讀取都算**,不只單次讀取 |
+| `a poll that only sees complete records nothing` | poll 路徑上的 latch 一樣不算證據 |
+| `an accepted password clears the record` | 清的唯一條件:`CheckAdminPassword` 回 200 |
+| `a rejected password leaves the record standing` | 401 **不**清 —— 路由器沒有為這個憑證背書 |
+
+> 這一組要能跑,得先給 `flutter_secure_storage` 掛一個 `MethodChannel` mock handler:
+> `checkAdminPassword` 會經 `authProvider.localLogin` 把密碼寫進 secure storage,
+> 那是個平台通道,在 test binding 下沒有實作,不掛就 `MissingPluginException`。
 
 > 這三個參數斷言改用**讀取 mock 收到的 `Invocation` 具名引數**（`lastScheduled` / `lastSend`
 > 搭配 `sendArg` / `scheduledArg`),而非 `captureAnyNamed`。原因:`captured` 的順序跟著
@@ -615,22 +731,35 @@ admin view 那個案例特意保留 `expect(find.byKey(Key('pnpConfigStub')), fi
 | `Auto Master already complete on entry asks for the new password` | **§2.8 ① 的回歸鎖**。與既有的 `Tap Login with Auto Master complete ...` 是**不同分支**:那個先看到 `running` 再輪到 `complete`,這個進來就是 `complete` —— 故 `verifyNever(pollAutoMasterStatus())`,並且 `verifyNever(checkInternetConnection())` 釘住「不再帶著死憑證去打 internet check」 |
 | `Unauthorized internet check does not go to the troubleshooter` | **§2.8 ② 的 view 層安全網**。`checkInternetConnection` 拋 `ExceptionInvalidAdminPassword` 時停在 PnP;此案例**刻意不註冊** troubleshooter 路由,導過去就會拋 "unknown route name" |
 
+§2.9 之後 admin view 改 1 個、新增 1 個:
+
+| 案例 | 鎖住什麼 |
+|------|---------|
+| `Auto Master already complete on entry asks for the new password`（§2.8 新增,現改) | 前提補上 `autoMasterRotatedSinceLogin: true`,斷言不變 |
+| `latched Auto Master complete does not block a fresh login`（新增) | **§2.9 的回歸鎖**:旗標為 `false` + 狀態 `complete` → 直接進 config(`pnpConfigStub`),且 `verifyNever(setAttachedPassword(null))`。這個案例失敗就代表「進不去的 app」回來了 |
+
+> 這兩個案例都用 `when(mock.build()).thenReturn(PnpState(...))` 餵前提,而不是呼叫 setter:
+> `MockPnpNotifier` 的每個方法都是 `noSuchMethod` no-op,狀態寫入不會生效。
+> 這是 `pnp_setup_view_test.dart` 餵 `autoMasterStatusOnEntry` 時就已經在用的同一個手法。
+
 ### 5.4 測試結果
 
 | 範圍 | 結果 |
 |------|------|
-| `pnp_provider_auto_master_test.dart` | **28/28**（原 23 + §2.8 新增 5) |
+| `pnp_provider_auto_master_test.dart` | **36/36**（原 23 → §2.8 +5 → §2.9 +8) |
 | `pnp_auto_master_flow_test.dart` | **14/14** |
-| `test/page/instant_setup/ --exclude-tags loc` | **52/52**（原 50 + §2.8 新增 2) |
-| 全專案 `--exclude-tags loc` | **570 passed / 0 failed**（baseline 557;以 `--reporter json` 逐案清點:635 個 testDone、0 失敗) |
-| `flutter analyze lib/ test/` | **564**,對 §2.7 的 563 淨增 **1**:`pnp_waiting_modem_view.dart:132` 新增的 `goNamed` 帶一個 `use_build_context_synchronously` info。已加 `if (mounted)` 保護,但 `context` 是跨 `Future.delayed().then()` 從外層 closure 捕獲,分析器追不到（同檔既有的 119 / 123 兩行是同一情形)|
+| `test/page/instant_setup/ --exclude-tags loc` | **66/66**（36 + 14 + admin view 7 + setup view 9 —— 後兩檔的 `loc` tag 是**逐案**掛的,非 golden 的案例照跑) |
+| `test/page/instant_setup/`（**含** loc,即產生截圖) | **6188 testDone / 3 failed** —— 3 個失敗全是既有的 `Wifi ready (split SSID)` 版面 overflow（de / es / es_AR 的 480w:`A RenderFlex overflowed by 16 / 2.4 pixels`),見下方判讀準則 |
+| 全專案 `--exclude-tags loc` | **579 passed / 0 failed**（§2.8 時 570;+9 = provider 8 + admin view 1。以 `--reporter json` 逐案清點:644 個 testDone 含 hidden 的 loading,0 失敗) |
+| `flutter analyze lib/ test/` | **564**,與 §2.8 相同(§2.9 淨增 0),對 §2.7 的 563 淨增 **1**:`pnp_waiting_modem_view.dart:132` 新增的 `goNamed` 帶一個 `use_build_context_synchronously` info。已加 `if (mounted)` 保護,但 `context` 是跨 `Future.delayed().then()` 從外層 closure 捕獲,分析器追不到（同檔既有的 119 / 123 兩行是同一情形)|
 | loc 兩檔 `--tags loc --update-goldens` | **3247 passed / 3 failed（既有,已查清 — 見下）** |
 
 > **前一版記錄的「3 個失敗未查清」已查清,與本修法無關。**
 > 用 `--reporter json` 取代 compact reporter（後者以 `\r` 覆蓋同一行,失敗案例名會遺失)
-> 後可定位到:`Instant Setup - PnP: Wifi ready (split SSID)` 在 da / de 三個 variant 失敗,
-> 原因是 `pnp_setup_view.dart:538` 的 `Row`(Print / Download QR 兩顆按鈕)
-> `RenderFlex overflowed by 16 pixels` —— 長字語系在窄版面下擠不下。
+> 後可定位到:`Instant Setup - PnP: Wifi ready (split SSID)` 在三個 480w variant 失敗
+> （§2.8 當時是 da / de,§2.9 重跑是 de / es / es_AR —— 差多少 pixel 隨語系字串長度浮動,
+> 從 2.4px 到 16px),原因是 `pnp_setup_view.dart:538` 的 `Row`(Print / Download QR 兩顆按鈕)
+> `RenderFlex overflowed` —— 長字語系在窄版面下擠不下。
 > 該 `Row` 不在本分支的 diff 內（本分支只動 27 / 67 / 730+ 行),屬既有版面問題,**未處理**。
 >
 > 另外釘住一項判讀準則:此 loc suite **沒有 baseline** ——
@@ -645,12 +774,13 @@ admin view 那個案例特意保留 `expect(find.byKey(Key('pnpConfigStub')), fi
 
 | 檔案 | 改動 |
 |------|------|
-| `lib/page/instant_setup/data/pnp_provider.dart` | 三處 `auth: true` → `false`;兩處 `.map` 的 401→throw 刪除;`checkAutoMasterStatus` 的 401 分支併入通用 catch;4 處解析改用 `fromValue`（§2.1 / §2.3 / §2.6）;兩個 poll 加上有界預算參數、`testConnectionReconnected` 改 `retries: 2, timeoutMs: 5000`（§2.4）;`checkInternetConnection` 改 `try/catch`,401 → `ExceptionInvalidAdminPassword` 且不重試（§2.8 ②) |
+| `lib/page/instant_setup/data/pnp_state.dart` | 新增 `autoMasterRotatedSinceLogin`;`copyWith` 的 `attachedPassword` 改 `ValueGetter<String?>?`,讓清除真的生效（§2.9） |
+| `lib/page/instant_setup/data/pnp_provider.dart` | 三處 `auth: true` → `false`;兩處 `.map` 的 401→throw 刪除;`checkAutoMasterStatus` 的 401 分支併入通用 catch;4 處解析改用 `fromValue`（§2.1 / §2.3 / §2.6）;兩個 poll 加上有界預算參數、`testConnectionReconnected` 改 `retries: 2, timeoutMs: 5000`（§2.4）;`checkInternetConnection` 改 `try/catch`,401 → `ExceptionInvalidAdminPassword` 且不重試（§2.8 ②) ;新增 `_observeAutoMasterStatus()`(三處讀取匯流,`running` → 設旗標),`checkAdminPassword` 成功時清旗標,兩處 `setAttachedPassword` 改傳 `() => password`（§2.9) |
 | `lib/core/jnap/models/auto_master_status.dart` | `fromValue` 參數 `String?` → `Object?`（§2.6） |
 | `lib/page/instant_setup/widgets/pnp_auto_master_flow.dart` | 移除兩處 `on ExceptionAutoMasterUnauthorized`;**刪除 `consecutiveNullThreshold` 與 `_probe()`**;新增 `AutoMasterFlowResult.budgetExhausted`（§2.4) |
-| `lib/page/instant_setup/pnp_admin_view.dart` | 移除 4 處 `.catchError(test: e is ExceptionAutoMasterUnauthorized)`（§2.3);**改用 mixin**,~85 行 bespoke poll loop 刪除（§2.4);`case completed` 改拋 `ExceptionAutoMasterRotatedPassword`,新增 `_promptForRotatedPassword()`,4 條 `.catchError` 鏈各加一個分支（§2.7);gate 加 `complete` 分支、`_promptForRotatedPassword` 加 `logout()`、`_checkInternetConnection` 加 `ExceptionInvalidAdminPassword` 分支（§2.8) |
-| `lib/page/instant_setup/pnp_setup_view.dart` | 移除 pre-check 與 `await for` 外層的 `on ExceptionAutoMasterUnauthorized`（§2.3);**改用 mixin**,~75 行 bespoke poll loop 刪除;計數器改為 `_maxAutoMasterWaits`(先加再比)（§2.4);兩處 `localLoginPassword` → `RouteNamed.pnp`（§2.7) |
-| `lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart` | `_checkAndWaitForAutoMaster` 增加 `status == null` 顯式早退（§2.5);兩處呼叫點處理 `budgetExhausted`（§2.4);接住 `ExceptionInvalidAdminPassword` → `goNamed(pnp)`（§2.8 ②) |
+| `lib/page/instant_setup/pnp_admin_view.dart` | 移除 4 處 `.catchError(test: e is ExceptionAutoMasterUnauthorized)`（§2.3);**改用 mixin**,~85 行 bespoke poll loop 刪除（§2.4);`case completed` 改拋 `ExceptionAutoMasterRotatedPassword`,新增 `_promptForRotatedPassword()`,4 條 `.catchError` 鏈各加一個分支（§2.7);gate 加 `complete` 分支、`_promptForRotatedPassword` 加 `logout()`、`_checkInternetConnection` 加 `ExceptionInvalidAdminPassword` 分支（§2.8) ;gate 條件改為 `complete && autoMasterRotatedSinceLogin`（§2.9) |
+| `lib/page/instant_setup/pnp_setup_view.dart` | 移除 pre-check 與 `await for` 外層的 `on ExceptionAutoMasterUnauthorized`（§2.3);**改用 mixin**,~75 行 bespoke poll loop 刪除;計數器改為 `_maxAutoMasterWaits`(先加再比)（§2.4);兩處 `localLoginPassword` → `RouteNamed.pnp`（§2.7) ;`idle → complete` 分支加註解說明為何**不需要**旗標（§2.9) |
+| `lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart` | `_checkAndWaitForAutoMaster` 增加 `status == null` 顯式早退（§2.5);兩處呼叫點處理 `budgetExhausted`（§2.4);接住 `ExceptionInvalidAdminPassword` → `goNamed(pnp)`（§2.8 ②);`complete → goNamed(pnp)` 加上 `autoMasterRotatedSinceLogin` 條件（§2.9,修既有 bug) |
 | `lib/page/instant_setup/troubleshooter/views/pnp_waiting_modem_view.dart` | 接住 `ExceptionInvalidAdminPassword` → `goNamed(pnp)`（§2.8 ②) |
 | `lib/page/instant_setup/data/pnp_exception.dart` | 刪除 `ExceptionAutoMasterUnauthorized`（§2.3);新增 `ExceptionAutoMasterRotatedPassword`（§2.7） |
 | 測試 4 檔 | 見 §5 |
@@ -676,6 +806,7 @@ admin view 那個案例特意保留 `expect(find.byKey(Key('pnpConfigStub')), fi
 | `_isAuthFailure` / `_isRouterTemporarilyUnreachable` 缺單元測試 | 純 predicate,可加 `@visibleForTesting` 直接測。另開 issue |
 | `behind` / `others` 分支不尊重 `needAuth` | 見 §2.2:共用路徑,blast radius 遠大於 #1180 |
 | `docs/` 與 `doc/` 兩個目錄並存 | 與本議題無關 |
+| 輪替之後才**冷啟動** app → 旗標為 `false`,gate 放行 | **刻意接受**。落點相同(密碼提示),代價是 5 次 CGI 額度中的 1 次且不重試。要跨 process 記住輪替就得把它持久化,而持久化一個「我的密碼可能過期了」的推測,在使用者換過密碼、或換了另一台路由器之後會變成錯的前提 —— 誤攔的代價遠大於誤放（見 §2.9 降級一節） |
 | **PnP 之外**的 authed 呼叫在 make-Master 視窗內帶著 stale 憑證 | §2.8 只處理了 PnP 流程內的 `checkInternetConnection`(②)與 session 殘留(③)。核心 polling 已由 `polling_provider.dart` 的「只有憑證被拒才登出」擋住最糟的後果,但**其他** authed 呼叫仍可能在該視窗吃到 401。要普遍解決需在 `router_repository` 層區辨,blast radius 遠大於 #1180 |
 
 ---

--- a/docs/pnp-auto-master-cgi-lockout-fix.md
+++ b/docs/pnp-auto-master-cgi-lockout-fix.md
@@ -2,20 +2,31 @@
 
 > 追蹤：[PrivacyGUI#1180](https://github.com/linksys/PrivacyGUI/issues/1180) ·
 > [LinksysWRT#449](https://github.com/linksys/LinksysWRT/issues/449)
-> 前置修復：#980 / #1006 / #1180（`85f39a74` — WAN-up 早期偵測）
+> 目標分支：`fix/pnp-pppoe-auto-master-wan-up-1180`（base `dev-1.3.1`）· PR [#1181](https://github.com/linksys/PrivacyGUI/pull/1181)
+
+> **本文件已於 review 後改寫。** 初版的修法是「poll 收到第一個 401 就終止串流」
+> （commit `371dbbf8`）。該機制在 `05d2529a` 被**移除並取代**為「Auto Master 狀態讀取一律
+> 不送憑證（`auth: false`）」。本文件描述的是**現行**設計；被取代的設計及其理由記錄在 §8,
+> 以免未來維護者從 git log 讀到 `371dbbf8` 時誤以為它還在。
 
 ---
 
 ## 1. 背景與問題
 
-#1180 的「WAN-up 早期偵測」在真機（FW `v1.2.3.26072823_CF`）驗證**運作正確**：
+### 1.1 原始症狀（#1180 / #449）
 
-- `pollAutoMasterUntilRunning` 正確接手（log：`Auto Master wait-for-running status: running`）
-- `_probeUnauthorized` 的 `unauthorized → completed (recover)` 分類正確觸發
+Factory-reset 裝置走 ISP-settings troubleshooter（PPPoE / Static / DHCP）完成首次設定時,
+WAN 是在使用者送出 ISP 帳密**之後**才起來。WAN-up 觸發韌體 Auto Master（"make Master"）,
+約 1 分鐘後它會**更換 admin 密碼**並重啟服務,使 GUI 的已登入 session 失效,把使用者踢回 PnP。
+由於此時使用者已經前進到 WiFi 設定頁,他必須**把 WiFi 填第二次**。
 
-但驗證中浮現一層**更底層的死結**，位於 JNAP CGI 的 5 次認證失敗鎖定計數器（`jnap_auth_failed_attempts`）。
+`85f39a74` 把 Auto Master 偵測**提前到 WAN-up 這一點**,讓使用者在既有的等待畫面上等一次,
+而不是填一份會被丟掉的 WiFi 表單。
 
-### 1.1 失敗時序（QA log 摘錄）
+### 1.2 真機驗證中浮現的第二層問題：CGI 認證鎖定
+
+`85f39a74` 在真機（FW `v1.2.3.26072823_CF`）驗證運作正確,但驗證中浮現一層**更底層的死結**,
+位於 JNAP CGI 的 5 次認證失敗鎖定計數器（`jnap_auth_failed_attempts`）。
 
 ```
 11:21:01  console  Auto Master「makes Master」→ 輪替 admin 密碼
@@ -26,139 +37,224 @@
 11:21:18  GUI      poll → 401（attempt 4）
 11:21:20  GUI      poll → 401（attempt 5 — 額度用盡）
 11:21:21  GUI      redirect to login
-11:22:07  user     輸入「正確的新密碼」→ CheckAdminPassword2 回 invalid ×5（LED 恆亮白，無法登入）
+11:22:07  user     輸入「正確的新密碼」→ CheckAdminPassword2 回 invalid ×5（LED 恆亮白,無法登入）
 ```
 
-### 1.2 根因
-
-`pollAutoMasterStatus` / `pollAutoMasterUntilRunning` 走
+**根因**：`pollAutoMasterStatus` / `pollAutoMasterUntilRunning` 當時走
 `scheduledCommand(auth: true, retryDelayInMilliSec: 5000, ...)`。
 
-1. 在 `router_repository.dart:259` 401（`JNAPError`）被吞進 yielded result。
-2. `condition` 只認 `running/complete/idle/failed`，401 → 回 `false`
+1. 在 `router_repository.dart` 的 `scheduledCommand` 內,401（`JNAPError`）被 catch 起來
+   當成 yielded result（不是 exception）。
+2. `condition` 只認 `running/complete/idle/failed`,401 → 回 `false`
    → 每 5 秒**繼續用失效的 `admin:admin` 重打**。
-3. `.map()` 又把 401 壓平成 `null`；消費端要**累積 3 個 null** 才會 `_probeUnauthorized`。
+3. `.map()` 又把 401 壓平成 `null`;消費端要**累積 3 個 null** 才會 probe。
 
-結果：**還沒等使用者輸入任何東西，poll 就燒光 5 次額度**。計數器只在「登入成功」時由 HDK
-`AuthFn_Default` 自動清零（Vinh 確認），但鎖定後正確密碼也回 401 →「成功登入」永遠無法發生 →
-**死結**。（Auto Master 走 `platform.setAdminPassword` 繞過 JNAP，亦不觸碰計數器。）
+結果:**還沒等使用者輸入任何東西,poll 就燒光 5 次額度**。計數器只在「登入成功」時由 HDK
+`AuthFn_Default` 自動清零（Vinh 確認),但鎖定後正確密碼也回 401 →「成功登入」永遠無法發生 →
+**死結**。（Auto Master 走 `platform.setAdminPassword` 繞過 JNAP,亦不觸碰計數器。）
 
 ### 1.3 修復目標
 
-在 poll 串流收到**第一個 401** 時就終止，而不是壓平成 null 繼續重打。
-淨效果：make-Master 後 poll **最多只花 1 次 CGI 額度**（原本 4–5 次），把使用者的重登額度完整留住。
+**讓 Auto Master 狀態查詢完全不參與認證。** 它是一個純狀態讀取,不需要憑證;
+一旦不送憑證,它就**不可能**產生認證失敗,也就**不可能**燒 CGI 額度 —— 無論重打幾次。
+
+這比「第一個 401 就終止」更強:後者是把傷害限制在 1 次,前者是把傷害降到 0 次。
 
 ---
 
 ## 2. 修法
 
-訊號分離其實**早已存在**：`checkAutoMasterStatus`（`pnp_provider.dart:751`）對 401 已丟
-`ExceptionAutoMasterUnauthorized`，對不支援/逾時才 `return null`。只是兩個**串流**方法沒這麼做。
-本修法讓串流也採用同一套語意。
+### 2.1 核心改動 — 三處 Auto Master 讀取改為 `auth: false`
 
-### 2.1 核心改動 — `pnp_provider.dart`（兩個 poll 方法）
+`pnp_provider.dart` 的三個方法:
 
-`pollAutoMasterStatus`（L765）與 `pollAutoMasterUntilRunning`（L809）的 `.map` 段：
+| 方法 | 送法 |
+|------|------|
+| `checkAutoMasterStatus()` | `send(getAutoMasterStatus, auth: false, ...)` |
+| `pollAutoMasterStatus()` | `scheduledCommand(auth: false, maxRetry: 60, ...)` |
+| `pollAutoMasterUntilRunning()` | `scheduledCommand(auth: false, maxRetry: 18, ...)` |
 
-```dart
-.map((result) {
-  // NEW: 把 401 當串流錯誤丟出，消費端 await-for 立即中斷（1 次額度）
-  if (result is JNAPError && result.result == errorJNAPUnauthorized) {
-    throw ExceptionAutoMasterUnauthorized();
-  }
-  if (result is JNAPSuccess) { /* 既有：running/complete/idle/failed → 回 status */ }
-  return null; // 真正的連線失敗/不支援 仍走 null（不受影響）
-});
-```
+前置條件：韌體必須把 `GetAutoMasterStatus` 開放為 no-auth（dennisnltran 的韌體側改動）。
+**這是本修法的硬依賴** —— 見 §4 對「韌體尚未包含該改動」的降級行為分析。
 
-> `errorJNAPUnauthorized` 與 `ExceptionAutoMasterUnauthorized` 在此檔已 import（L305 / L752），無需新增依賴。
+### 2.2 `auth: false` 真的會拿掉 header 嗎？—— 只在 local 模式成立（重要）
 
-**為什麼「throw」足以停止重打（不需改 `condition`）— 見 §5.1。** 這是本設計刻意避免 over-design 的關鍵決定。
+`_buildCommandHeader`（`router_repository.dart:325`）三個分支中,**只有一個**尊重 `needAuth`：
 
-### 2.2 消費端影響（共用改法 → 3 個消費端全數盤點）
+| `newRouterType` | header 建法 | 尊重 `needAuth`? |
+|---|---|---|
+| `behindManaged`（L380-395） | `authKey: (needAuth \| isCloudLogin()) ? authValue : ''`（L393),之後 `removeWhere(value.isEmpty)`（L397） | ✅ **會**拿掉 |
+| `behind`（L359-379） | `authKey: authValue`（L375）—— 無條件 | ❌ 不看 `needAuth` |
+| `others`（L347-358） | cloud token（L352-357）—— 無條件 | ❌ 不看 `needAuth` |
 
-| # | 消費端 | 是否需改 | 401 落點 | 說明 |
-|---|--------|---------|---------|------|
-| 1 | **ISP-save**（mixin，#449 主路徑）<br>`pnp_auto_master_flow.dart` + `pnp_isp_save_settings_view.dart` | **需改**（mixin 加 try/catch） | **`goNamed(pnp)`** | `_waitForRunning` / `_waitForCompletion` 的 `await for` 包 try/catch → 回 `AutoMasterFlowResult.completed`；view 端 `completed → goNamed(pnp)` **已存在**（L99）。符合「router 決定 pnp-vs-login」的既定原則。 |
-| 2 | **pnp_setup_view** `pnp_setup_view.dart:763` | **必須加 try/catch** | `localLoginPassword` | 目前對串流 401 **無 handler** → 拋出會變 unhandled async error，卡在等待畫面（比現況更糟）。落點沿用它自己 L744 / L787 既有的 login 慣例。 |
-| 3 | **pnp_admin_view** `pnp_admin_view.dart:556` | **零改動** | `localLoginPassword` | 三個 caller 皆已有 `.catchError(test: ExceptionAutoMasterUnauthorized) → goNamed(localLoginPassword)`（L115 / L366 / L638），拋出自然被接住。 |
+而 `newRouterType` 的決定（L337-345）在 `kIsWeb` 時先過 `checkForce()`。GUI 出貨build
+以 `--dart-define=force=local`（`build_web.sh:7` / `.vscode/launch.json:20`）建置,
+`checkForce()` → `CommandType.local` → `newRouterType = behindManaged`
+→ **落在唯一尊重 `needAuth` 的那個分支**。
 
-**落點原則（回應決策）**：使用者選定「維持 `goNamed(pnp)` 讓 router 決定」——
-此決策對應的正是 **#449 的 ISP-save 路徑**，該路徑透過 mixin 的 `completed` 結果**本來就**是
-`goNamed(pnp)`。故落點無需改，只讓它「更早在第一個 401 觸發」。
-setup / admin 兩條路徑維持既有的 `localLoginPassword`（**不**改成 pnp），以免對無關流程引入未審查的行為變動。
+> **結論**：在 GUI 實際出貨的 local 模式下,`auth: false` 確實不送
+> `X-JNAP-Authorization`,§1.3 的推論成立。
+>
+> **但這個保證僅限 local 模式。** 若未來有非 local（`behind` / `others`）路徑要重用這三個方法,
+> `auth: false` 會被靜默忽略、憑證照送,§1.3 的「不可能燒額度」即不再成立。
+> 要讓保證與模式無關,得讓 `behind` / `others` 兩個分支也尊重 `needAuth` —— 那是所有 JNAP
+> 命令的共用路徑,blast radius 遠大於 #1180,**刻意不在此 hotfix 分支做**。
 
-#### 2.2.1 落點不一致——**已知、刻意保留（選項 1）**
+### 2.3 401 的語意隨之改變：不再是「密碼被輪替」的訊號
 
-同一個「make-Master 401」事件，會依踩到哪條路徑落在**不同地方**，且**去向由不同機制決定**：
+既然請求**不帶憑證**,一個 unauthorized 回應就**不可能**表示「make-Master 輪替了 admin 密碼」。
+它只表示一件事:**這台韌體還沒把 `GetAutoMasterStatus` 開放為 no-auth**。
 
-| 路徑 | `goNamed(...)` | router redirect 分支 | 實際決定去向者 | 結果 |
-|------|---------------|---------------------|--------------|------|
-| ISP-save（mixin，#449 主場景） | `pnp` | L129 `startsWith('/pnp')` → `_goPnpPath` | **router 判斷**（`_autoConfigurationLogic` 的 `userAcknowledgedAutoConfiguration`） | pnp-vs-login 由 router 決定 |
-| setup / admin（正常 PnP） | `localLoginPassword` | L126 分支：`_autoConfigurationLogic(state)` 被呼叫但**未 `return`**（fire-and-forget，只有副作用），真正 `return` 的是 `_redirectLogic` | **強制停在 local login 密碼頁** | 直接到 login 頁 |
-
-- 此不一致**非本次引入**：mixin 路徑（#1180）刻意「不硬編 redirect、交給 router」；setup/admin（#980）早已硬編去 login。本修法只讓兩條路徑**更早在第一個 401 觸發**。
-- **factory-reset 場景殊途同歸**：`userAcknowledgedAutoConfiguration == false` 時，`goNamed(pnp)` 過 router 亦判定「留在 PnP」，而 PnP 首頁（admin view）若 session 已死會被既有防線再導向 login。**最終使用者都到 login 頁重輸新密碼**，差別僅「ISP 路徑多繞一跳 pnp」。
-- **決策：維持選項 1**（ISP→pnp/router 判斷；setup/admin→login/強制）。理由：各自沿用該路徑既有且經測試的慣例，回歸面最小；factory-reset 下 UX 等價。未採「強制三者一致都走 pnp」（選項 2），因其會動到 setup/admin 既有硬編行為，超出死結修復範圍。
-
-### 2.3 mixin try/catch 具體形狀
+而「韌體要求認證」與「韌體不支援這個 action」對 GUI 而言**無法區分,且降級方式相同**
+（都是拿不到狀態）。因此 401 被歸類到與其他失敗相同的處理:
 
 ```dart
-Future<AutoMasterFlowResult?> _waitForRunning(int threshold) async {
-  int consecutiveNulls = 0;
-  try {
-    await for (final status in ref.read(pnpProvider.notifier).pollAutoMasterUntilRunning()) {
-      // ...既有分支不變...
-    }
-  } on ExceptionAutoMasterUnauthorized {
-    // 串流層偵測到 make-Master 輪替密碼 → 視為 Auto Master 已完成 → recover
-    logger.i('[PnP]: wait-for-running unauthorized → completed (recover)');
-    return AutoMasterFlowResult.completed;
-  }
-  // ...既有 timeout 收尾不變...
+// checkAutoMasterStatus
+} catch (e) {
+  // 401 is deliberately in here with the rest. The request carries no
+  // credential (auth: false), so an unauthorized result cannot mean
+  // make-Master rotated the admin password — it means this firmware still
+  // serves GetAutoMasterStatus as auth-required. ...
+  return null;
 }
 ```
 
-`_waitForCompletion` 同理包一層 `try / on ExceptionAutoMasterUnauthorized → return completed`。
+兩個串流方法的 `.map` 同理:非 `JNAPSuccess`（含 401）→ `null`,串流繼續。
+**不需要早期終止器**,因為沒有憑證可燒。
 
-### 2.4 「零程式改動」≠「零行為改動」——共用改法的真實副作用（重要）
+隨之刪除：`ExceptionAutoMasterUnauthorized`（`pnp_exception.dart`)、mixin 兩處
+`on ExceptionAutoMasterUnauthorized` 包裝、`pnp_setup_view` 一處 try/catch、
+`pnp_admin_view` 四處 `.catchError(test: e is ExceptionAutoMasterUnauthorized)`。
 
-`pnp_setup_view` 與 `pnp_admin_view` 雖為**加法/零程式改動**，但因採「共用改法」，其 poll 路徑在
-**「遇到真 401」時的 runtime 行為確實改變**（此前只有 #449 的 PPPoE ISP 路徑會踩到 make-Master 401，
-但正常 PnP 也可能在 config 期間遇 Auto Master 完成而 401）：
+### 2.4 Phase A 的 null probe 改判 `proceed`（review F1）
 
-| | 改動前 | 改動後 |
-|---|--------|--------|
-| poll 遇真 401 | 壓平成 `null` → 累積 3 次 → **顯示「連線錯誤」畫面**（誤導：401 非連線問題） | 第一個 401 → throw → 被既有 catch 接住 → **導向 login** |
+mixin 的 `_waitForRunning`（Phase A）累積 3 個 null 後會 `_probe()` 一次。
+probe 回 `null`（狀態無法判定）時,舊碼一律映射成 `connectionError`。
 
-- 這是**嚴格改善**（401 本該去 login，不該顯示連線錯誤，也不該再燒額度）。
-- 但它是**超出 #449 ISP 路徑的行為變動**——共用改法讓 setup / admin 的正常 PnP poll 路徑一併受惠。
-- **此新 runtime 路徑目前無測試覆蓋** → §6 需為 setup / admin 各補一個「stream 拋 401 → login」回歸測試（非可選）。
+在**不支援 no-auth 的韌體**上,每一次 poll 與 probe 都會落在 null,
+於是 Phase A 必然回 `connectionError` → 使用者在「ISP 設定剛存成功、internet check 剛通過」
+之後,看到「找不到路由器」。
 
-> 傳播已驗證：admin_view 的 `await for`（L556）在 `async` 方法內、**無內層 try**，throw 沿
-> `.then(...).catchError(test: ExceptionAutoMasterUnauthorized → login)` 傳到三個 caller
-> （L115 / L366 / L638）**全部接得住**，故程式零改動成立；setup_view 的 `await for`（L763）
-> **不在** L738 的 try 範圍內（該 try 於 L747 已閉合），故**必須**新增 try/catch（E7）。
+Phase A 的前提是**session 剛被 internet check 證明活著**,所以「狀態讀不到」不該解讀為連線問題:
+
+```dart
+if (probe == AutoMasterFlowResult.connectionError) {
+  logger.w('[PnP]: Auto Master wait-for-running undetermined, proceed');
+  return AutoMasterFlowResult.proceed;
+}
+```
+
+Phase B（`_waitForCompletion`）**維持** `connectionError`：它的前提不同 —— 已經觀察到
+`running`,狀態突然讀不到確實可能是路由器不見了,且該路徑末端還有
+`testConnectionReconnected()` 收尾。因此 `_probe()` 自身回傳「未判定」,由各 phase 決定意義。
+
+### 2.5 ISP-save pre-save 檢查的 null 早退
+
+`_checkAndWaitForAutoMaster`（`pnp_isp_save_settings_view.dart:65`）原本只判斷
+`running` / `complete`。狀態為 `null` 時會落到函式尾端的 `return true`,行為正確但**理由不明**。
+補上顯式早退,讓「讀不到狀態 → 沒有東西可等 → 繼續存檔」寫在程式裡而非靠 fall-through:
+
+```dart
+if (status == null) {
+  logger.d('[PnP]: Troubleshooter - Auto Master status unavailable, continue save');
+  return true;
+}
+```
+
+### 2.6 `autoMasterStatus` 解析不再用 unchecked cast（review W2 / F3）
+
+`AutoMasterStatus.fromValue` 的參數由 `String?` 放寬為 `Object?`：
+
+```dart
+static AutoMasterStatus? fromValue(Object? value) {
+  return switch (value) {
+    'Idle' => AutoMasterStatus.idle,
+    'Running' => AutoMasterStatus.running,
+    'Complete' => AutoMasterStatus.complete,
+    'Failed' => AutoMasterStatus.failed,
+    _ => null,
+  };
+}
+```
+
+原本共 5 個呼叫點做 unchecked cast:`pnp_provider.dart` 的 4 處
+（2 個 `condition` lambda + 2 個 `.map` body）寫 `result.output['autoMasterStatus'] as String?`,
+以及 `GetAutoMasterStatusResponse.fromMap` 的 `map['autoMasterStatus'] as String?`。
+兩者的 map 都是解碼後的 JSON,若韌體回了非字串,該 cast 會拋 `TypeError`。
+
+**關鍵在於它會落在哪裡**：`scheduledCommand` 的 try/catch 只接 `JNAPError` 與
+`TimeoutException`,而這個 cast 位於**它下游的 `.map` 回呼**內 —— `TypeError` 因此會
+**逸出 mapped stream**,消費端 `await for` 未接住 → 等待畫面的 spinner 永遠轉。
+
+放寬型別而非在 5 個點各加一道 guard：一次改動消除全部呼叫點的風險,且非字串值自然
+miss 掉所有 case、回 `null` —— 正是呼叫端已經在處理的「狀態無法取得」。
 
 ---
 
-## 3. 再次死結的安全性驗證（`goNamed(pnp)` 不會 re-burn）
+## 3. 死結解除的驗證（額度收支）
 
-追過 `_autoConfigurationLogic`（`router_provider.dart:158`）+ PnP 進入路徑，確認 make-Master 後
-`goNamed(pnp)` **不會**再燒 CGI 額度：
+修法後 Auto Master 相關請求**完全不參與認證**,因此:
 
 | 步驟 | 呼叫 | auth? | 額度 |
 |------|------|-------|------|
-| 路由決策 | `fetchDeviceInfo` / `autoConfigurationCheck` | **unauthed** | 0 |
-| 路由決策 | factory-reset 時 `userAcknowledgedAutoConfiguration == false` 在 L190 **短路** | — | 0（不呼叫 authed 的 `isRouterPasswordSet`） |
-| 登出 | `logout()`（L214）**清掉** stale `pLocalPassword` | — | 0 |
-| PnP entry | `checkRouterConfigured` → `getDeviceMode` | **unauthed** | 0 |
-| PnP entry | 無密碼時 `checkAdminPassword(null)` **本地拋錯不打網路**（L294） | — | 0 |
-| 使用者輸入 | 正確新密碼 → 額度第 **2** 次 → 成功 → HDK 自動清零 | auth | 1 |
+| Auto Master 偵測（全程,任意次數） | `getAutoMasterStatus` | **unauthed** | **0** |
+| 路由決策 | `fetchDeviceInfo` / `autoConfigurationCheck` | unauthed | 0 |
+| PnP entry | `checkRouterConfigured` → `getDeviceMode` | unauthed | 0 |
+| PnP entry | `PnpAdminView._examineAdminPassword` 用 stale `pLocalPassword` 重試一次 | auth | **1**（見下） |
+| 使用者輸入 | 正確新密碼 → 成功 → HDK 自動清零 | auth | 1 |
 
-**總計最多 2 次 < 5**，死結解除。
-> 此安全性**完全依賴**「第一個 401 就終止」——正是 §2.1 的修法核心。若仍沿用舊的 4–5 次 poll，
-> 光 poll 就逼近上限，`goNamed(pnp)` 落點無論如何都救不了。
+**總計最多 2 次 < 5**,死結解除。
+
+### 3.1 `logout()` 不會執行,stale 密碼不會被清（review F2 修正）
+
+初版文件在此處寫了一條**錯誤的因果鏈**:聲稱 ISP-save 完成後 `goNamed(pnp)` 會經
+`_autoConfigurationLogic`,並在其中 `logout()` 清掉 stale `pLocalPassword`。**該路徑不會執行。**
+
+`router_provider.dart:124-143` 的 redirect 分派是（行號為 L125 / L127 / L139）:
+
+```dart
+if (state.matchedLocation == '/') {
+  return router._autoConfigurationLogic(state);
+} else if (state.matchedLocation == RoutePath.localLoginPassword) {
+  return router._redirectLogic(state);
+} else if (state.matchedLocation.startsWith('/pnp')) {
+  return router._goPnpPath(state);      // ← ISP-save 的 goNamed(pnp) 走這裡
+}
+```
+
+`_goPnpPath`（L330-337）在 `pnpProvider.deviceInfo != null` 時**直接** `return state.uri.toString()`,
+完全繞過 `_autoConfigurationLogic`。而 `pnpProvider` 是非 autoDispose 的 `NotifierProvider`,
+ISP-save 導航時 `deviceInfo` 早已填好 —— **被走的就是這個繞過分支**。
+
+兩個後果:
+
+- §3 表中 `fetchDeviceInfo` / `autoConfigurationCheck` 那兩列**根本不會跑**。
+  額度上這比初版文件寫的**更好**（是 0 次呼叫,不是「呼叫但 unauthed 所以 0」）。
+- 但 `logout()` **也不會跑** → stale `pLocalPassword` **不會被清除**
+  → `PnpAdminView._examineAdminPassword` 會用它試一次,燒掉 1 次額度。
+  這就是 §3 表中那一列的來源。實際總計約 **2**,仍 < 5,死結結論不變,只是餘裕比初版所述少一格。
+
+### 3.2 落點不一致 —— 已知、刻意保留
+
+Auto Master 完成後三條路徑落在不同地方,且**去向由不同機制決定**:
+
+| 路徑 | `goNamed(...)` | redirect 分支 | 實際決定去向者 |
+|------|---------------|--------------|--------------|
+| ISP-save（mixin,#449 主場景） | `pnp` | L139 `startsWith('/pnp')` → `_goPnpPath` | **`_goPnpPath` 自己**:`deviceInfo != null` → 原路放行,直接落在 `PnpAdminView`,由該 view 自己的 precheck 鏈決定後續 |
+| setup view | `localLoginPassword` | L127 → `_redirectLogic`（L138） | 停在 local login 密碼頁 |
+| admin view | `localLoginPassword` | 同上 | 停在 local login 密碼頁 |
+
+- 初版文件在此處寫 ISP-save 的 pnp-vs-login「由 router 依
+  `userAcknowledgedAutoConfiguration` 判斷」—— **對這條路徑不成立**（同 §3.1,
+  `_autoConfigurationLogic` 不會被呼叫)。實際是落進 `PnpAdminView`,由 view 自己判斷。
+- 此不一致**非本次引入**：mixin 路徑（#1180）刻意不硬編 redirect;setup/admin（#980）
+  早已硬編去 login。
+- **維持現狀**。理由:各自沿用該路徑既有且經測試的慣例,回歸面最小;
+  三條路徑最終都讓使用者回到「用新密碼登入」,差別僅中間多繞一跳。
+
+> 註:`10b7881e` 已修掉 `localLoginPassword` 分支原本 fire-and-forget 呼叫
+> `_autoConfigurationLogic` 造成的 pnp ↔ login 迴圈。該分支現在只走 `_redirectLogic`,
+> 原因見 `router_provider.dart:128-137` 的註解。
 
 ---
 
@@ -166,92 +262,185 @@ Future<AutoMasterFlowResult?> _waitForRunning(int threshold) async {
 
 | # | 情境 | 修法後行為 | 判斷 |
 |---|------|-----------|------|
-| E1 | **真連線中斷**（非 401） | 仍走 `null` 路徑 → null-threshold → `_probeUnauthorized` → probe 也失敗 → `connectionError` | ✅ 不受影響，與 401 訊號完全分離 |
-| E2 | **make-Master 極快，錯過 running 邊緣** | `condition` 仍認 `complete/failed` → 提早停 | ✅ 既有行為保留 |
-| E3 | **401 發生在 `_waitForRunning`（Phase A）** | 串流 throw → try/catch → `completed`（QA 的 11:20–11:21 情境） | ✅ 正是主修復場景 |
-| E4 | **401 發生在 `_waitForCompletion`（Phase B）** | 同 E3 | ✅ |
-| E5 | **ISP-save 的 pre-save 檢查（`_checkAndWaitForAutoMaster` L65）** | 該處呼叫 `checkAutoMasterStatus()`（Future 版，**本來就** throw 401）→ L69 `goNamed(pnp)` | ✅ 已一致，無需改 |
-| E6 | **admin_view 拋出後 `_isWaitingForAutoMaster` 未 reset** | view 隨即被導航替換，spinner state moot | ✅ 可接受（無殘留 spinner） |
-| E7 | **setup_view 拋出但未加 try/catch** | unhandled async error → 卡等待畫面 | ⚠️ **必須修**（§2.2 #2），否則比現況更糟 |
-| E8 | **401 以外的 auth 問題（罕見 glitch）** | PnP 期間 session 剛被 internet check 證明有效，唯一會中途輪替 admin 憑證的就是 make-Master → 歸類 recover 合理 | ✅ 與既有註解一致 |
-| E9 | **`_probeUnauthorized` 的 unauthorized 分支是否變 dead code？** | 主 401 偵測移到串流層後，此分支僅在「session 死但 poll 回 null 非 401」的極罕見 timing 才觸發 | ⚠️ 見 §5.2 |
-| E10 | **老韌體不支援 GetAutoMasterStatus** | 回 `null`（非 401）→ 走既有 null/timeout 收尾 | ✅ 不受影響 |
-| E11 | **`condition` 回 true 造成 `exceedMaxRetry=false → onCompleted(false)`** | onCompleted 僅 log，無行為影響 | ✅（且見 §5.1，建議**不**改 condition） |
+| E1 | **韌體已開放 no-auth**（目標狀態) | 全程 unauthed 讀到真實狀態;`running` → 等待畫面 → `complete` → 依路徑導向 | ✅ 主要場景 |
+| E2 | **韌體尚未開放 no-auth** | 每次 poll 與 probe 都回 401 → 全部壓平成 `null` → Auto Master 偵測**完全失效** | ⚠️ **見 §4.1** |
+| E3 | **老韌體不支援 GetAutoMasterStatus** | 同 E2（`_ErrorUnknownAction` → `null`) | ⚠️ 同 §4.1 |
+| E4 | **真連線中斷** | poll 回 `null` → null-threshold → probe 也 `null` → Phase A `proceed`、Phase B `connectionError` | ✅ Phase B 末端另有 `testConnectionReconnected()` 把關 |
+| E5 | **make-Master 極快,錯過 running 邊緣** | `condition` 仍認 `complete/failed` → 提早停;Phase A 直接看到 `complete` → `completed` | ✅ 既有行為保留 |
+| E6 | **make-Master 在等待期間輪替密碼** | poll 不帶憑證,**不受影響**;狀態照常走到 `Complete` | ✅ 這正是本修法要達成的 |
+| E7 | **非字串 `autoMasterStatus` payload** | `fromValue(Object?)` → `null`,串流存活 | ✅ §2.6 |
+| E8 | **view 在 make-Master 期間被 dispose** | mixin 每個 `await` 後都檢查 `mounted`;`_checkAutoMasterStatus` 每個 `setState` 都有 guard（`c4b7acc4`) | ✅ |
+| E9 | **非 local 模式重用這三個方法** | `auth: false` 被靜默忽略,憑證照送,§1.3 的保證失效 | ⚠️ **見 §2.2**;目前無此呼叫端 |
+
+### 4.1 韌體未開放 no-auth 時的降級行為（必須與 FW/QA 對齊）
+
+E2 / E3 下,Auto Master 偵測**靜默失效**,PnP 退回它原本的**兩趟流程**:
+使用者填 WiFi → 被 make-Master 踢出 → 重新進 PnP → 再填一次。
+
+這一點必須事先講清楚,否則 QA 會把它讀成「偵測壞了」:
+
+- 這是**已知且可接受**的降級（Jamie 已認可兩趟流程作為 fallback),不是回歸。
+- 但**它與修法前的症狀長得一樣** —— 差別在於現在**不會**再燒 CGI 額度、不會鎖死登入。
+  也就是說:**#1180 的死結解除了,#449 的「填兩次」在這種韌體上仍會出現。**
+- 因此 §2.4 的 Phase A `proceed` 是必要的:沒有它,這種韌體上使用者會在 ISP 設定成功後
+  看到「找不到路由器」,比兩趟流程更糟。
+
+> **待確認項**：測試韌體 `FW_Pinnacle2.0_v1.2.4.26080716_PW` 是否包含 dennisnltran 的
+> `GetAutoMasterStatus` no-auth 改動。若否,這一輪 QA 會落在 E2,量測到的行為即為上述降級。
 
 ---
 
-## 5. Over-Design 檢視（回應「是否過度設計」）
+## 5. 測試
 
-### 5.1 **建議：只改 `.map` throw，不改 `condition`** ← 避免 over-design
+### 5.1 `test/page/instant_setup/data/pnp_provider_auto_master_test.dart`（20 案例,全綠）
 
-一個直覺是「同時在 `condition` 回 `true`（讓 `scheduledCommand` break）+ 在 `.map` throw」雙保險。
-**但經 Dart async* 取消語意分析，`condition` 改動是多餘的**：
+以 `ProviderContainer` + `MockRouterRepository` 驅動**真的** `PnpNotifier`,
+是唯一直接驗證「JNAP result → status」映射的地方。
 
-`scheduledCommand` 是 `async*`，在 `yield result` 處**因背壓而暫停**。當：
-1. `.map` 回呼 throw → mapped stream 發出 error event；
-2. 消費端 `await for` 收到 error → 迴圈體 rethrow → 退出迴圈 → **cancel subscription**；
-3. cancel 往上游傳遞 → async* 在 `yield` 暫停點被終止（**不會**執行 yield 之後的 `if(condition) / await Future.delayed`）。
+新增/改動的關鍵案例:
 
-因此 generator 不會進入下一輪 delay+poll，**單靠 `.map` throw 就達成「1 次額度」**。
-`condition` 回 true 只有在「消費端吞掉 error 又繼續 listen」時才有意義——現有 3 個消費端**皆無**此行為。
+| 案例 | 鎖住什麼 |
+|------|---------|
+| `sends the request unauthed` / `polls unauthed` ×2 | 用 `captureAnyNamed('auth')` 斷言**實際送出**的值是 `false` —— 這是 §1.3 全部推論的基礎 |
+| `401 maps to null` / `401 flattens to null and the stream keeps going` | 401 不再是特例;串流不終止 |
+| `a Running before a 401 keeps both in the stream` | 401 不會吃掉先前已 yield 的狀態 |
+| `non-String status payload maps to null instead of throwing` | §2.6,payload 餵 `42` |
+| `non-String status payload flattens to null, stream survives` | §2.6 的**真正後果**:`[42, 'Complete']` → `[null, complete]`,串流沒有被 TypeError 打斷 |
 
-> **結論**：改 `condition` 屬 YAGNI 防禦，hotfix 上**不採用**。修法收斂為單一機制（`.map` throw），
-> 語意清晰、blast radius 最小。（若未來有以 `.listen` 手動消費且不 cancel-on-error 的新消費端，再議。）
+### 5.2 `test/page/instant_setup/widgets/pnp_auto_master_flow_test.dart`（14 案例,全綠）
 
-### 5.2 **既有 null-threshold + probe 機制：保留，不拆**
+以最小 `_FlowHost` 混入 mixin 直接驅動狀態機,不啟動任何 view。
 
-#1180 引入的「3 連 null → probe」機制，當初正是為了繞過「401 被壓平成 null」。
-本修法讓 401 直接 throw 後，該機制的**角色縮小**為：僅處理**真正的連線失敗**（transient timeout / 老韌體 / 網路斷）
-以決定 `connectionError` vs 繼續等待。`_probeUnauthorized` 的 `ExceptionAutoMasterUnauthorized`
-分支（L189）雖大幅冷卻（E9），但仍是「session 由非 poll 路徑死亡」的 defense-in-depth，成本極低。
+| 案例 | 鎖住什麼 |
+|------|---------|
+| `Phase A: 3 nulls then probe null (undetermined) -> proceed` | **§2.4 的 F1 修正**;同時 `verifyNever(pollAutoMasterStatus())` 確認 Phase A 就地解決 |
+| `Phase B: 3 nulls then probe null (undetermined) -> connectionError` | Phase B **不**跟著改,兩者前提不同 |
+| `Phase A Running, then rotation mid-completion -> completed` | 取代舊的 3 個「stream 拋 401」案例:輪替現在是**普通路徑**（狀態走到 `Complete`),不再是 exception |
 
-> **結論**：**保留**。在 hotfix 分支上拆除運作中的防禦機制風險 > 收益。標記為未來可簡化項，但不在本次範圍。
+**刪除**的案例及理由:舊有 3 個 `Stream.error(ExceptionAutoMasterUnauthorized())` 案例
+與 1 個 `probe unauthorized -> completed` 案例,其前提（poll 會因輪替而 error）
+在 `auth: false` 之後**不可能發生**,該 exception 型別亦已刪除。
 
-### 5.3 未採用的替代方案（記錄理由）
+### 5.3 View 層 loc 測試
 
-| 方案 | 為何不採用 |
-|------|-----------|
-| mixin 層把 null-threshold 降為 1、首個 null 就 probe | probe 本身是 authed call（再燒 1 次）；且對 transient null 過度反應；且**不涵蓋** setup/admin（未用 mixin）。串流層修法一次覆蓋 3 個消費端，且只花 1 次額度。 |
-| 新增 `AutoMasterStatus.unauthorized` enum 值用 yield sentinel 取代 throw | 比 throw 更侵入（改 enum + 全 switch）；且無法自然被 admin_view 既有的 `.catchError` 接住。throw 復用既有 exception，friction 最低。 |
-| poll 方法加 `terminateOnUnauthorized` 參數（限縮只 ISP 路徑） | 使用者已選「共用改法」；且 setup_view 現況對串流 401 無防護，本就是隱性 bug，一併修較一致。 |
+`pnp_admin_view_test.dart` / `pnp_setup_view_test.dart` 中的兩個「狀態 `null`」案例
+從「阻擋」反轉為「不阻擋」,並各加 `verifyNever(pollAutoMasterStatus())`
+釘住「`null` 不等於 `running`」:
 
----
+- admin view：`Tap Login with Auto Master status unavailable enters config` —— 進入 config,不卡住。
+- setup view：`Auto Master status unavailable before save continues to save` —— 繼續存檔,不去 login。
 
-## 6. 測試影響
+同樣刪除 3 個 `unauthorized → login` 的 golden 案例（前提已不存在）。
+`test/**/goldens/*` 在 `.gitignore:89`,無 orphan golden 需清理。
 
-**回歸基準（已對照全部現存測試確認）**：現存測試**無任何一個**注入「會 throw 的 stream」——
-全部是 `Stream.value(status)` / `Stream.fromIterable([null,...])` / `Stream.empty()`。
-本修法只在「stream **真的** throw 401」時改變行為，而該事件過去被壓平成 null，
-**現存測試與現存正常流程皆不依賴它**（它產生的正是死結本身）。故現存測試**全數維持綠燈**。
+### 5.4 測試結果
 
-| 測試檔 | 動作 | 結果 |
-|--------|------|--------|
-| `pnp_auto_master_flow_test.dart` | 現存 13 案例全綠（尤其 L177 的 `[null,null,null]+probe→completed`：stream 不 throw，新 catch 不觸發，結果不變）。**新增** Phase A / Phase B / Phase A-Running-then-B「stream throw 401 → `completed`」共 3 案例 | ✅ **+16 全綠**（純 logic，無 loc flag） |
-| `pnp_setup_view_test.dart` | 現存 running / null×3 案例不變。**新增**「stream throw 401 → 導向 `localLoginPassword`」（§2.2 #2 try/catch 的唯一覆蓋，此前無測試） | ✅ **+36 全綠**（`--tags=loc`） |
-| `pnp_admin_view_test.dart` | 現存 L297 的 `checkAutoMasterStatus` throw（Future 版）案例仍綠。**新增**「**stream**（`pollAutoMasterStatus`）throw 401 → 導向 login」（§2.4 的零程式改動、真行為改動路徑，此前無測試） | ✅ **+20 全綠**（`--tags=loc`） |
-| `test/common/testable_router.dart` | **新增** `extraRoutes`（預設 `const []` → 對全部現存呼叫零影響）。見下方「測試 harness」 | ✅ 附加式，無回歸 |
-| `test/mocks/pnp_notifier_mocks.dart` / spec mocks | 簽名不變，**無需重生** | — |
+| 範圍 | 結果 |
+|------|------|
+| `pnp_provider_auto_master_test.dart` | **20/20** |
+| `pnp_auto_master_flow_test.dart` | **14/14** |
+| `test/page/instant_setup/ --exclude-tags loc` | **47/47** |
+| 全專案 `--exclude-tags loc` | **560 passed**（baseline 557,新增 3) |
+| `fvm flutter analyze` | 淨新增 **0** 個 issue（stash 前後對照皆 60） |
+| `test/page/instant_setup/ --tags loc --update-goldens` | **6107 passed / 3 failed — 未查清** |
 
-> 補測試手法：`when(mock.pollAutoMasterStatus()).thenAnswer((_) => Stream.error(ExceptionAutoMasterUnauthorized()))`。
+> **`--tags loc` 的 3 個失敗未查清。** compact reporter 以 `\r` 覆蓋同一行,輸出檔僅存
+> 1153 bytes,失敗案例名與斷言訊息均已遺失。已排除 `pnp_waiting_modem_view_test.dart`
+> （單獨跑全綠）。尚未逐檔確認的候選為本分支動過的 3 個 loc 檔:
+> `pnp_admin_view_test.dart`、`pnp_setup_view_test.dart`、
+> `troubleshooter/localizations/pnp_auto_master_waiting_view_test.dart`。
 >
-> **測試 harness（實作時發現的必要調整）**：這批是 `--tags=loc` 的 **localization / screenshot** 測試（用 `--update-goldens` 跑；**非** golden 斷言測試），非純 golden。`testableSingleRoute` 原本只註冊 `/` 這一條 route，因此新測試觸發的 `context.goNamed(RouteNamed.localLoginPassword)` 會拋 `unknown route name`——
-> - `setup_view`：直接把 exception 冒出來 → 測試紅燈；
-> - `admin_view`：exception 被 `initState` 鏈末端的 `.onError` 吞掉，但 `_isWaitingForAutoMaster` 停在 `true`，spinner 永遠轉 → `pumpAndSettle` timeout。
->
-> 兩者都**只是 harness 缺目的地 route**（正式環境兩條 route 都在，log 也證實 redirect 有觸發），非 production 邏輯 bug。修法：`testableSingleRoute` 加一個附加式 `extraRoutes` 參數（預設空 → 全部現存測試零影響），新測試各塞一個 `localLoginPassword` stub route（`Key('loginStub')`），再 `expect(find.byKey('loginStub'), findsOneWidget)` 斷言 401 確實落到 login。
+> 判讀準則（供後續查證）：`testLocalizations` 每案例跑遍 device × locale 矩陣,
+> 因此**邏輯壞掉會讓同一案例的整組 variant（20+）一起失敗**。只有 3 個更像是少數 variant
+> 的 timing 抖動 —— 這類測試同時存在兩個時鐘（mock future 走 `runAsync` 的真 microtask、
+> 內部 1 秒動畫走 fake timer),特定尺寸/語系下容易差一個 pump。此推論**尚未驗證**。
 
 ---
 
-## 7. 變更檔案清單
+## 6. 變更檔案清單
 
 | 檔案 | 改動 |
 |------|------|
-| `lib/page/instant_setup/data/pnp_provider.dart` | 兩個 poll 方法 `.map` 段：401 → throw `ExceptionAutoMasterUnauthorized`（§2.1） |
-| `lib/page/instant_setup/widgets/pnp_auto_master_flow.dart` | `_waitForRunning` / `_waitForCompletion` 各包一層 `try / on ExceptionAutoMasterUnauthorized → return completed`（§2.3） |
-| `lib/page/instant_setup/pnp_setup_view.dart` | L763 `await for` 外層加 try/catch → `goNamed(localLoginPassword)`（§2.2 #2） |
-| `lib/page/instant_setup/pnp_admin_view.dart` | **零程式改動**（既有 catchError 接住；行為改動見 §2.4） |
-| `test/common/testable_router.dart` | 新增附加式 `extraRoutes` 參數（預設 `const []`），供測試註冊 redirect 目的地 route（見 §6） |
-| 測試 3 檔 | 見 §6 |
+| `lib/page/instant_setup/data/pnp_provider.dart` | 三處 `auth: true` → `false`;兩處 `.map` 的 401→throw 刪除;`checkAutoMasterStatus` 的 401 分支併入通用 catch;4 處解析改用 `fromValue`（§2.1 / §2.3 / §2.6） |
+| `lib/core/jnap/models/auto_master_status.dart` | `fromValue` 參數 `String?` → `Object?`（§2.6） |
+| `lib/page/instant_setup/widgets/pnp_auto_master_flow.dart` | 移除兩處 `on ExceptionAutoMasterUnauthorized`;`_probeUnauthorized` → `_probe`（去掉 unauthorized 分支);Phase A 的 undetermined → `proceed`（§2.4） |
+| `lib/page/instant_setup/pnp_admin_view.dart` | 移除 4 處 `.catchError(test: e is ExceptionAutoMasterUnauthorized)`（§2.3） |
+| `lib/page/instant_setup/pnp_setup_view.dart` | 移除 pre-check 與 `await for` 外層的 `on ExceptionAutoMasterUnauthorized`（§2.3） |
+| `lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart` | `_checkAndWaitForAutoMaster` 增加 `status == null` 顯式早退（§2.5） |
+| `lib/page/instant_setup/data/pnp_exception.dart` | 刪除 `ExceptionAutoMasterUnauthorized`（§2.3） |
+| 測試 4 檔 | 見 §5 |
 
-> firmware 側維持不變（Jianrong / Vinh 已確認兩項皆 GUI-side）。
-> 目標分支：`fix/pnp-pppoe-auto-master-wan-up-1180`（尚未合入 release 1.3.0.700533）。
+> 韌體側:`GetAutoMasterStatus` 需開放 no-auth（dennisnltran)。**這是本修法的前置依賴**,
+> 未包含時的降級行為見 §4.1。
+
+---
+
+## 7. 尚未處理（刻意延後）
+
+以下為 review 中提出、經確認**不在本次範圍**的項目:
+
+| 項目 | 為何延後 |
+|------|---------|
+| `pollAutoMasterStatus` / `pollAutoMasterUntilRunning` 高度重複 | 兩者僅 `condition` 與 `maxRetry` 不同,可合併。屬重構,不在 hotfix 範圍 |
+| `fromValue(result.output['autoMasterStatus'])` 在 4 處重複 | 同上 |
+| mixin 放在 `widgets/` 目錄 | 它不是 widget。搬移會動到 import 面,延後 |
+| `_autoMasterPostWanUp` 這個暫態欄位 | 可用參數傳遞取代。延後 |
+| `PnpIspSaveSettingsView` 無測試覆蓋 | 該 view 的 Auto Master 分支目前只靠 mixin 的單元測試間接覆蓋 |
+| `_isAuthFailure` / `_isRouterTemporarilyUnreachable` 缺單元測試 | 純 predicate,可加 `@visibleForTesting` 直接測。另開 issue |
+| `behind` / `others` 分支不尊重 `needAuth` | 見 §2.2:共用路徑,blast radius 遠大於 #1180 |
+| `docs/` 與 `doc/` 兩個目錄並存 | 與本議題無關 |
+
+---
+
+## 8. 被取代的設計：「第一個 401 就終止」（commit `371dbbf8`）
+
+保留此節,是因為 `371dbbf8` 仍在 git 歷史中,且它的分析（尤其 §8.2）曾被獨立驗證為正確 ——
+未來若 `auth: false` 這條路走不通（例如韌體無法開放 no-auth),它是現成的 fallback。
+
+### 8.1 原設計
+
+poll 的 `.map` 在遇到 401 時 throw `ExceptionAutoMasterUnauthorized`,
+消費端 `await for` 立即中斷,把 make-Master 後的額度消耗從 4–5 次壓到 **1 次**。
+三個消費端各自把該 exception 對應到「Auto Master 已完成 → 導向重登」。
+
+### 8.2 為何單靠 `.map` throw 就足以停止重打（不需改 `condition`）
+
+`scheduledCommand` 是 `async*`,在 `yield result` 處因背壓而暫停。當:
+
+1. `.map` 回呼 throw → mapped stream 發出 error event;
+2. 消費端 `await for` 收到 error → 迴圈體 rethrow → 退出迴圈 → **cancel subscription**;
+3. cancel 往上游傳遞 → async\* 在 `yield` 暫停點被終止（**不會**執行 yield 之後的
+   `if(condition)` 與 `await Future.delayed`)。
+
+因此 generator 不會進入下一輪 delay+poll。此分析在 review 中被以獨立的最小重現程式驗證:
+
+```
+.map throws on 401       → 2 polls total  (stops at the first 401)
+.map flattens to null    → 5 polls total  (old behaviour, budget exhausted)
+```
+
+當時的決定是**不加** `condition` 的「雙保險」（YAGNI),該決定在 review 中被確認正確。
+
+### 8.3 為何被取代
+
+`c4b7acc4` 的 QA 再驗證（FW `v1.2.3.26080322_CF`）顯示:make-Master 輪替憑證的時間點
+比 Auto Master 回報 `complete` **早約 75 秒**。於是「第一個 401 就終止」會在這 75 秒的空窗中
+把使用者丟進 `pnpConfig` —— 他填完 WiFi,pre-save 檢查才輪到 `complete`,再把他踢第二次。
+**原始的「填兩次」症狀在死結修好之後依然存在。**
+
+根本原因是:401 被當成「Auto Master 完成」的**代理訊號**,而它其實只代表「憑證變了」,
+兩者相差 75 秒。`auth: false` 的做法從源頭移除這個代理:不送憑證 → 沒有 401 →
+只讀真正的狀態,等到它真的變成 `Complete` 才動作。
+
+副帶好處:額度消耗由 1 次進一步降到 0 次;`ExceptionAutoMasterUnauthorized` 這個
+穿過三個消費端的例外路徑整條消失。
+
+### 8.4 當時記錄、現已不適用的替代方案
+
+| 方案 | 當時不採用的理由 |
+|------|-----------|
+| null-threshold 降為 1,首個 null 就 probe | probe 當時是 authed call（再燒 1 次);且對 transient null 過度反應 |
+| 新增 `AutoMasterStatus.unauthorized` enum 值,用 yield sentinel 取代 throw | 比 throw 更侵入（改 enum + 全 switch);且無法被 admin_view 既有的 `.catchError` 接住 |
+| poll 加 `terminateOnUnauthorized` 參數（只限 ISP 路徑) | 已選共用改法;setup_view 當時對串流 401 無防護,本就是隱性 bug |
+
+> 三者在現行設計下均已無意義:probe 現在是 unauthed;已無 unauthorized 訊號需要表達。

--- a/lib/core/jnap/models/auto_master_status.dart
+++ b/lib/core/jnap/models/auto_master_status.dart
@@ -21,7 +21,17 @@ enum AutoMasterStatus {
     };
   }
 
-  static AutoMasterStatus? fromValue(String? value) {
+  /// Maps a raw JNAP `autoMasterStatus` payload to a status, or `null` for
+  /// anything unrecognized.
+  ///
+  /// Takes [Object?] rather than [String?] on purpose: callers pass
+  /// `result.output['autoMasterStatus']` straight from a decoded JSON map, and
+  /// an `as String?` cast there would throw a `TypeError` on an unexpected
+  /// payload type. `scheduledCommand` does not catch `TypeError`, so that would
+  /// escape the polling stream and strand the waiting spinner. A non-String
+  /// value simply misses every case below and yields `null`, which the callers
+  /// already handle as "status unavailable".
+  static AutoMasterStatus? fromValue(Object? value) {
     return switch (value) {
       'Idle' => AutoMasterStatus.idle,
       'Running' => AutoMasterStatus.running,
@@ -41,8 +51,7 @@ class GetAutoMasterStatusResponse extends Equatable {
 
   factory GetAutoMasterStatusResponse.fromMap(Map<String, dynamic> map) {
     return GetAutoMasterStatusResponse(
-      autoMasterStatus:
-          AutoMasterStatus.fromValue(map['autoMasterStatus'] as String?),
+      autoMasterStatus: AutoMasterStatus.fromValue(map['autoMasterStatus']),
     );
   }
 

--- a/lib/core/jnap/providers/polling_provider.dart
+++ b/lib/core/jnap/providers/polling_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/constants/build_config.dart';
+import 'package:privacy_gui/constants/error_code.dart';
 import 'package:privacy_gui/core/cache/linksys_cache_manager.dart';
 import 'package:privacy_gui/core/jnap/actions/better_action.dart';
 import 'package:privacy_gui/core/jnap/actions/jnap_service_supported.dart';
@@ -132,8 +133,16 @@ class PollingNotifier extends AsyncNotifier<CoreTransactionData> {
             ))
         .onError((error, stackTrace) {
       logger.e('Polling error: $error, $stackTrace');
-      logger.f('[Auth]: Force to log out because of failed polling');
-      ref.read(authProvider.notifier).logout();
+      // Only a rejected credential justifies logging the user out. A single
+      // failed poll used to do it, so anything that briefly took the router's
+      // HTTP service away - a service restart, the make-Master credential
+      // rotation - kicked the user back to the login page even though their
+      // password was still good. Leave the state in error and let the next
+      // poll tick recover.
+      if (_isAuthFailure(error)) {
+        logger.f('[Auth]: Force to log out because polling was unauthorized');
+        ref.read(authProvider.notifier).logout();
+      }
 
       throw error ?? '';
     });
@@ -169,6 +178,15 @@ class PollingNotifier extends AsyncNotifier<CoreTransactionData> {
 
     benchMark.end();
   }
+
+  /// Whether the router rejected our credential, as opposed to never having
+  /// answered. Only the former means the session is really gone.
+  ///
+  /// Cloud-side session invalidation is not checked here on purpose:
+  /// [LinksysHttpClient.onError] already routes `INVALID_SESSION_TOKEN` through
+  /// [AuthNotifier], which re-checks the session token before logging out.
+  bool _isAuthFailure(Object? error) =>
+      error is JNAPError && error.result == errorJNAPUnauthorized;
 
   Future _additionalPolling() async {
     if (serviceHelper.isSupportLedMode()) {

--- a/lib/page/instant_setup/data/pnp_exception.dart
+++ b/lib/page/instant_setup/data/pnp_exception.dart
@@ -40,11 +40,6 @@ class ExceptionInterruptAndExit extends PnpException {
       : super(message: 'Interrupted and exit to $route');
 }
 
-class ExceptionAutoMasterUnauthorized extends PnpException {
-  ExceptionAutoMasterUnauthorized()
-      : super(message: 'Auto Master check unauthorized');
-}
-
 class ExceptionAutoMasterPollingFailed extends PnpException {
   ExceptionAutoMasterPollingFailed()
       : super(message: 'Auto Master polling failed');

--- a/lib/page/instant_setup/data/pnp_exception.dart
+++ b/lib/page/instant_setup/data/pnp_exception.dart
@@ -44,3 +44,16 @@ class ExceptionAutoMasterPollingFailed extends PnpException {
   ExceptionAutoMasterPollingFailed()
       : super(message: 'Auto Master polling failed');
 }
+
+/// Auto Master ("make Master") completed, so the admin password has been
+/// rotated and no credential this session holds is usable any more.
+///
+/// Deliberately not an [ExceptionInterruptAndExit] carrying
+/// `localLoginPassword`: that page is where a *finished* setup lands
+/// (`userAcknowledgedAutoConfiguration == true`), and PnP has not finished. The
+/// user has to re-enter the password through PnP's own prompt, and where to go
+/// afterwards stays the router's decision.
+class ExceptionAutoMasterRotatedPassword extends PnpException {
+  ExceptionAutoMasterRotatedPassword()
+      : super(message: 'Auto Master rotated the admin password');
+}

--- a/lib/page/instant_setup/data/pnp_provider.dart
+++ b/lib/page/instant_setup/data/pnp_provider.dart
@@ -306,6 +306,13 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
   }
 
   /// check internet connection within 30 seconds
+  ///
+  /// Throws [ExceptionInvalidAdminPassword] if the router rejects the
+  /// credential, and [ExceptionNoInternetConnection] if it answers but the WAN
+  /// is down. Conflating the two is what sent #1180 to the troubleshooter: after
+  /// Auto Master rotated the admin password, this call went out with the stale
+  /// credential, got a 401, and reported "no internet" — so the user was told
+  /// their brand-new ISP settings had failed.
   @override
   Future checkInternetConnection([int retries = 1]) async {
     Future<bool> isInternetConnected() async {
@@ -313,20 +320,32 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
       for (int i = 0; i < retries; i++) {
         logger.i(
             '[PnP]: Check internet connections MAX retries <$retries>, i=$i');
-        isConnected = await ref
-            .read(routerRepositoryProvider)
-            .send(
-              JNAPAction.getInternetConnectionStatus,
-              fetchRemote: true,
-              auth: true,
-              retries: 0,
-              cacheLevel: CacheLevel.noCache,
-            )
-            .then((result) {
-          return result.output['connectionStatus'] == 'InternetConnected';
-        }).onError((error, stackTrece) {
-          return false;
-        });
+        try {
+          final result = await ref.read(routerRepositoryProvider).send(
+                JNAPAction.getInternetConnectionStatus,
+                fetchRemote: true,
+                auth: true,
+                retries: 0,
+                cacheLevel: CacheLevel.noCache,
+              );
+          isConnected =
+              result.output['connectionStatus'] == 'InternetConnected';
+        } on JNAPError catch (error) {
+          // A rejected credential says nothing about the WAN. Retrying cannot
+          // help either — the password will not become correct — and each round
+          // spends one of the router's 5 CGI auth attempts before it locks the
+          // account, so bail out immediately instead of looping.
+          if (error.result == errorJNAPUnauthorized) {
+            logger.e(
+                '[PnP]: Internet check was unauthorized - the credential is stale, not the WAN');
+            throw ExceptionInvalidAdminPassword();
+          }
+          isConnected = false;
+        } catch (_) {
+          // Anything else (timeout, unreachable, unparseable) is genuinely
+          // inconclusive about the WAN, so let the retry loop have another go.
+          isConnected = false;
+        }
         if (isConnected) {
           break;
         }

--- a/lib/page/instant_setup/data/pnp_provider.dart
+++ b/lib/page/instant_setup/data/pnp_provider.dart
@@ -787,6 +787,14 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
           },
         )
         .map((result) {
+      // A 401 here means make-Master rotated the admin password mid-poll. Surface
+      // it as an error so the consumer's await-for terminates on the FIRST 401
+      // instead of flattening it to null and re-polling with the now-stale
+      // credential (which burns the CGI auth-attempt budget → login lockout).
+      if (result is JNAPError && result.result == errorJNAPUnauthorized) {
+        logger.w('[PnP]: Auto Master polling unauthorized → terminate stream');
+        throw ExceptionAutoMasterUnauthorized();
+      }
       if (result is JNAPSuccess) {
         final status = AutoMasterStatus.fromValue(
             result.output['autoMasterStatus'] as String?);
@@ -831,6 +839,13 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
           },
         )
         .map((result) {
+      // See pollAutoMasterStatus: terminate on the first 401 (make-Master
+      // rotated the credential) rather than re-polling with stale credentials.
+      if (result is JNAPError && result.result == errorJNAPUnauthorized) {
+        logger.w(
+            '[PnP]: Auto Master wait-for-running unauthorized → terminate stream');
+        throw ExceptionAutoMasterUnauthorized();
+      }
       if (result is JNAPSuccess) {
         final status = AutoMasterStatus.fromValue(
             result.output['autoMasterStatus'] as String?);

--- a/lib/page/instant_setup/data/pnp_provider.dart
+++ b/lib/page/instant_setup/data/pnp_provider.dart
@@ -669,13 +669,18 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
   @override
   Future testConnectionReconnected() async {
     // Test connect to the propor router
+    //
+    // This is the sole arbiter of "router not found" once the Auto Master poll
+    // exhausts its budget, so it must not hinge on a single packet: retry a
+    // couple of times before condemning the connection. A router that is still
+    // finishing its restart answers on the second or third try.
     final result = await ref
         .read(routerRepositoryProvider)
         .send(JNAPAction.getDeviceInfo,
             fetchRemote: true,
             cacheLevel: CacheLevel.noCache,
-            retries: 0,
-            timeoutMs: 3000)
+            retries: 2,
+            timeoutMs: 5000)
         .onError((error, stackTrace) {
       // Can't get device info
       throw ExceptionNeedToReconnect();
@@ -769,7 +774,15 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
         .scheduledCommand(
           action: JNAPAction.getAutoMasterStatus,
           auth: false,
-          maxRetry: 60,
+          // The stream's own length IS the give-up rule, so its duration has to
+          // be predictable: make-Master takes the router's HTTP service away for
+          // the better part of a minute, and while it is gone the router may
+          // answer anything or nothing at all. Counting failures would be
+          // reading noise; instead every attempt is capped so the total is
+          // bounded — 24 x (3s request + 5s delay) = 192s, against ~65s of
+          // observed downtime and ~115s for Auto Master end to end.
+          maxRetry: 24,
+          requestTimeoutOverride: 3000,
           retryDelayInMilliSec: 5000,
           firstDelayInMilliSec: 1000,
           condition: (result) {
@@ -821,6 +834,10 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
           action: JNAPAction.getAutoMasterStatus,
           auth: false,
           maxRetry: 18,
+          // Same reasoning as pollAutoMasterStatus: cap each attempt so the
+          // stream's duration is bounded and a slow answer costs one 8s round
+          // rather than stalling the wait.
+          requestTimeoutOverride: 3000,
           retryDelayInMilliSec: 5000,
           firstDelayInMilliSec: 1000,
           condition: (result) {

--- a/lib/page/instant_setup/data/pnp_provider.dart
+++ b/lib/page/instant_setup/data/pnp_provider.dart
@@ -107,6 +107,7 @@ abstract class BasePnpNotifier extends Notifier<PnpState> {
   // Auto Master
   Future<AutoMasterStatus?> checkAutoMasterStatus();
   Stream<AutoMasterStatus?> pollAutoMasterStatus();
+  Stream<AutoMasterStatus?> pollAutoMasterUntilRunning();
   void setAutoMasterStatusOnEntry(AutoMasterStatus? status);
 }
 
@@ -242,6 +243,11 @@ class MockPnpNotifier extends BasePnpNotifier {
 
   @override
   Stream<AutoMasterStatus?> pollAutoMasterStatus() async* {
+    yield AutoMasterStatus.idle;
+  }
+
+  @override
+  Stream<AutoMasterStatus?> pollAutoMasterUntilRunning() async* {
     yield AutoMasterStatus.idle;
   }
 
@@ -785,6 +791,50 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
         final status = AutoMasterStatus.fromValue(
             result.output['autoMasterStatus'] as String?);
         logger.d('[PnP]: Auto Master polling status: $status');
+        return status;
+      }
+      return null;
+    });
+  }
+
+  /// Poll Auto Master status waiting for it to *start* (Idle -> Running).
+  ///
+  /// Unlike [pollAutoMasterStatus] (which waits for Auto Master to *finish*),
+  /// this is used right after WAN comes up (the ISP-save WAN-up point) where
+  /// the status is very likely still `Idle` during the make-Master delay
+  /// window. It stops as soon as the status becomes `running` (the case we
+  /// want to catch), or `complete`/`failed` (in case make-Master finished so
+  /// fast we miss the running edge). It keeps polling on `idle`/error/`null`.
+  @override
+  Stream<AutoMasterStatus?> pollAutoMasterUntilRunning() {
+    return ref
+        .read(routerRepositoryProvider)
+        .scheduledCommand(
+          action: JNAPAction.getAutoMasterStatus,
+          auth: true,
+          maxRetry: 18,
+          retryDelayInMilliSec: 5000,
+          firstDelayInMilliSec: 1000,
+          condition: (result) {
+            if (result is JNAPSuccess) {
+              final status = AutoMasterStatus.fromValue(
+                  result.output['autoMasterStatus'] as String?);
+              return status == AutoMasterStatus.running ||
+                  status == AutoMasterStatus.complete ||
+                  status == AutoMasterStatus.failed;
+            }
+            return false;
+          },
+          onCompleted: (exceedMaxRetry) {
+            logger.d(
+                '[PnP]: Auto Master wait-for-running done, exceeded max: $exceedMaxRetry');
+          },
+        )
+        .map((result) {
+      if (result is JNAPSuccess) {
+        final status = AutoMasterStatus.fromValue(
+            result.output['autoMasterStatus'] as String?);
+        logger.d('[PnP]: Auto Master wait-for-running status: $status');
         return status;
       }
       return null;

--- a/lib/page/instant_setup/data/pnp_provider.dart
+++ b/lib/page/instant_setup/data/pnp_provider.dart
@@ -739,7 +739,7 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
     try {
       final result = await ref.read(routerRepositoryProvider).send(
             JNAPAction.getAutoMasterStatus,
-            auth: true,
+            auth: false,
             fetchRemote: true,
             cacheLevel: CacheLevel.noCache,
             retries: 0,
@@ -748,14 +748,15 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
       final response = GetAutoMasterStatusResponse.fromMap(result.output);
       logger.d('[PnP]: Auto Master status: ${response.autoMasterStatus}');
       return response.autoMasterStatus;
-    } on JNAPError catch (e) {
-      if (e.result == errorJNAPUnauthorized) {
-        logger.w('[PnP]: Auto Master status check unauthorized');
-        throw ExceptionAutoMasterUnauthorized();
-      }
-      logger.d('[PnP]: GetAutoMasterStatus not supported or failed: $e');
-      return null;
     } catch (e) {
+      // 401 is deliberately in here with the rest. The request carries no
+      // credential (auth: false), so an unauthorized result cannot mean
+      // make-Master rotated the admin password — it means this firmware still
+      // serves GetAutoMasterStatus as auth-required. That is indistinguishable
+      // from the action being unsupported, and both degrade the same way: no
+      // Auto Master detection, PnP runs twice. Returning null keeps that
+      // degradation; throwing would send the user to login on the very first
+      // check.
       logger.d('[PnP]: GetAutoMasterStatus not supported or failed: $e');
       return null;
     }
@@ -767,7 +768,7 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
         .read(routerRepositoryProvider)
         .scheduledCommand(
           action: JNAPAction.getAutoMasterStatus,
-          auth: true,
+          auth: false,
           maxRetry: 60,
           retryDelayInMilliSec: 5000,
           firstDelayInMilliSec: 1000,
@@ -787,14 +788,13 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
           },
         )
         .map((result) {
-      // A 401 here means make-Master rotated the admin password mid-poll. Surface
-      // it as an error so the consumer's await-for terminates on the FIRST 401
-      // instead of flattening it to null and re-polling with the now-stale
-      // credential (which burns the CGI auth-attempt budget → login lockout).
-      if (result is JNAPError && result.result == errorJNAPUnauthorized) {
-        logger.w('[PnP]: Auto Master polling unauthorized → terminate stream');
-        throw ExceptionAutoMasterUnauthorized();
-      }
+      // Unauthorized is not special-cased here. The poll sends no credential
+      // (auth: false), so a 401 means the firmware still requires auth for this
+      // action rather than that make-Master rotated the password. It falls
+      // through to null below, same as an unsupported action: no detection, and
+      // PnP runs its second pass. Since no credential is sent, re-polling
+      // cannot burn the CGI auth-attempt budget, so no early terminator is
+      // needed to protect it.
       if (result is JNAPSuccess) {
         final status = AutoMasterStatus.fromValue(
             result.output['autoMasterStatus'] as String?);
@@ -819,7 +819,7 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
         .read(routerRepositoryProvider)
         .scheduledCommand(
           action: JNAPAction.getAutoMasterStatus,
-          auth: true,
+          auth: false,
           maxRetry: 18,
           retryDelayInMilliSec: 5000,
           firstDelayInMilliSec: 1000,
@@ -839,13 +839,8 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
           },
         )
         .map((result) {
-      // See pollAutoMasterStatus: terminate on the first 401 (make-Master
-      // rotated the credential) rather than re-polling with stale credentials.
-      if (result is JNAPError && result.result == errorJNAPUnauthorized) {
-        logger.w(
-            '[PnP]: Auto Master wait-for-running unauthorized → terminate stream');
-        throw ExceptionAutoMasterUnauthorized();
-      }
+      // See pollAutoMasterStatus: unauthorized falls through to null because
+      // this poll sends no credential.
       if (result is JNAPSuccess) {
         final status = AutoMasterStatus.fromValue(
             result.output['autoMasterStatus'] as String?);

--- a/lib/page/instant_setup/data/pnp_provider.dart
+++ b/lib/page/instant_setup/data/pnp_provider.dart
@@ -774,8 +774,8 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
           firstDelayInMilliSec: 1000,
           condition: (result) {
             if (result is JNAPSuccess) {
-              final status = AutoMasterStatus.fromValue(
-                  result.output['autoMasterStatus'] as String?);
+              final status =
+                  AutoMasterStatus.fromValue(result.output['autoMasterStatus']);
               return status == AutoMasterStatus.complete ||
                   status == AutoMasterStatus.idle ||
                   status == AutoMasterStatus.failed;
@@ -796,8 +796,8 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
       // cannot burn the CGI auth-attempt budget, so no early terminator is
       // needed to protect it.
       if (result is JNAPSuccess) {
-        final status = AutoMasterStatus.fromValue(
-            result.output['autoMasterStatus'] as String?);
+        final status =
+            AutoMasterStatus.fromValue(result.output['autoMasterStatus']);
         logger.d('[PnP]: Auto Master polling status: $status');
         return status;
       }
@@ -825,8 +825,8 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
           firstDelayInMilliSec: 1000,
           condition: (result) {
             if (result is JNAPSuccess) {
-              final status = AutoMasterStatus.fromValue(
-                  result.output['autoMasterStatus'] as String?);
+              final status =
+                  AutoMasterStatus.fromValue(result.output['autoMasterStatus']);
               return status == AutoMasterStatus.running ||
                   status == AutoMasterStatus.complete ||
                   status == AutoMasterStatus.failed;
@@ -842,8 +842,8 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
       // See pollAutoMasterStatus: unauthorized falls through to null because
       // this poll sends no credential.
       if (result is JNAPSuccess) {
-        final status = AutoMasterStatus.fromValue(
-            result.output['autoMasterStatus'] as String?);
+        final status =
+            AutoMasterStatus.fromValue(result.output['autoMasterStatus']);
         logger.d('[PnP]: Auto Master wait-for-running status: $status');
         return status;
       }

--- a/lib/page/instant_setup/data/pnp_provider.dart
+++ b/lib/page/instant_setup/data/pnp_provider.dart
@@ -228,7 +228,7 @@ class MockPnpNotifier extends BasePnpNotifier {
 
   @override
   void setAttachedPassword(String? password) {
-    state = state.copyWith(attachedPassword: password);
+    state = state.copyWith(attachedPassword: () => password);
   }
 
   @override
@@ -300,6 +300,14 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
         .then((value) {
       // Clear the password in pnp state once logging in successfully
       setAttachedPassword(null);
+      // The router has just vouched for this credential, so whatever rotation
+      // we had recorded is now behind us. Without this clear, the sticky
+      // `complete` status keeps reading as "your password is stale" for ever:
+      // the gate would throw again on the very next check, drop the session
+      // this login just created, and ask for the password again — the #1180
+      // login loop, where CheckAdminPassword returns 200 and the user is
+      // logged out anyway.
+      state = state.copyWith(autoMasterRotatedSinceLogin: false);
     }).catchError((error) => throw ExceptionInvalidAdminPassword(),
             test: (error) =>
                 error is JNAPError && error.result == errorJNAPUnauthorized);
@@ -750,12 +758,28 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
 
   @override
   void setAttachedPassword(String? password) {
-    state = state.copyWith(attachedPassword: password);
+    state = state.copyWith(attachedPassword: () => password);
   }
 
   @override
   void setForceLogin(bool force) {
     state = state.copyWith(forceLogin: force);
+  }
+
+  /// Notes a freshly-read status and returns it unchanged.
+  ///
+  /// `running` is the only reading that *dates* the rotation — firmware reports
+  /// it just while make-Master is working, whereas `complete` latches on for
+  /// good. Every status read in this class funnels through here so no call site
+  /// has to remember to record it, and so the record cannot depend on which of
+  /// the three reads (single-shot or either poll) happened to catch the window.
+  AutoMasterStatus? _observeAutoMasterStatus(AutoMasterStatus? status) {
+    if (status == AutoMasterStatus.running &&
+        !state.autoMasterRotatedSinceLogin) {
+      logger.i('[PnP]: Auto Master is running - our credential is now stale');
+      state = state.copyWith(autoMasterRotatedSinceLogin: true);
+    }
+    return status;
   }
 
   @override
@@ -771,7 +795,7 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
           );
       final response = GetAutoMasterStatusResponse.fromMap(result.output);
       logger.d('[PnP]: Auto Master status: ${response.autoMasterStatus}');
-      return response.autoMasterStatus;
+      return _observeAutoMasterStatus(response.autoMasterStatus);
     } catch (e) {
       // 401 is deliberately in here with the rest. The request carries no
       // credential (auth: false), so an unauthorized result cannot mean
@@ -831,7 +855,7 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
         final status =
             AutoMasterStatus.fromValue(result.output['autoMasterStatus']);
         logger.d('[PnP]: Auto Master polling status: $status');
-        return status;
+        return _observeAutoMasterStatus(status);
       }
       return null;
     });
@@ -881,7 +905,7 @@ class PnpNotifier extends BasePnpNotifier with AvailabilityChecker {
         final status =
             AutoMasterStatus.fromValue(result.output['autoMasterStatus']);
         logger.d('[PnP]: Auto Master wait-for-running status: $status');
-        return status;
+        return _observeAutoMasterStatus(status);
       }
       return null;
     });

--- a/lib/page/instant_setup/data/pnp_state.dart
+++ b/lib/page/instant_setup/data/pnp_state.dart
@@ -20,6 +20,22 @@ class PnpState extends Equatable {
   final bool isPrePaired;
   final AutoMasterStatus? autoMasterStatusOnEntry;
 
+  /// Whether Auto Master has been seen rotating the admin password since the
+  /// last time the router accepted a credential from us.
+  ///
+  /// Set when a status read returns `running` — the one reading that *dates* the
+  /// rotation, because firmware reports it only while make-Master is actually
+  /// working. Cleared when `CheckAdminPassword` succeeds, since the router has
+  /// then just vouched for the credential we hold.
+  ///
+  /// This exists because `complete` is sticky: firmware leaves the status at
+  /// `complete` for good once make-Master has run, so "the status is complete"
+  /// says nothing about *when* it happened. Read on its own it means "this
+  /// router was auto-mastered at some point", which is true forever and of no
+  /// use to anyone. Paired with this flag it becomes the question that matters:
+  /// is the credential we are about to send older than the rotation?
+  final bool autoMasterRotatedSinceLogin;
+
   const PnpState({
     required this.deviceInfo,
     this.attachedPassword,
@@ -30,11 +46,18 @@ class PnpState extends Equatable {
     this.forceLogin = false,
     this.isPrePaired = false,
     this.autoMasterStatusOnEntry,
+    this.autoMasterRotatedSinceLogin = false,
   });
 
   PnpState copyWith({
     NodeDeviceInfo? deviceInfo,
-    String? attachedPassword,
+    // A ValueGetter, not a plain String?, so `null` can be *assigned* rather
+    // than read as "leave it alone". Clearing this is load-bearing: it holds the
+    // credential PnP arrived with, and the no-internet troubleshooter re-sends
+    // it unprompted — so a credential Auto Master has invalidated has to be
+    // droppable, or that resend spends one of the router's 5 CGI auth attempts
+    // on a password that cannot work.
+    ValueGetter<String?>? attachedPassword,
     Map<int, PnpStepState>? stepStateList,
     bool? isUnconfigured,
     Map<JNAPAction, JNAPResult>? data,
@@ -42,10 +65,12 @@ class PnpState extends Equatable {
     bool? forceLogin,
     bool? isPrePaired,
     ValueGetter<AutoMasterStatus?>? autoMasterStatusOnEntry,
+    bool? autoMasterRotatedSinceLogin,
   }) {
     return PnpState(
       deviceInfo: deviceInfo ?? this.deviceInfo,
-      attachedPassword: attachedPassword ?? this.attachedPassword,
+      attachedPassword:
+          attachedPassword != null ? attachedPassword() : this.attachedPassword,
       stepStateList: stepStateList ?? this.stepStateList,
       isUnconfigured: isUnconfigured ?? this.isUnconfigured,
       data: data ?? this.data,
@@ -55,6 +80,8 @@ class PnpState extends Equatable {
       autoMasterStatusOnEntry: autoMasterStatusOnEntry != null
           ? autoMasterStatusOnEntry()
           : this.autoMasterStatusOnEntry,
+      autoMasterRotatedSinceLogin:
+          autoMasterRotatedSinceLogin ?? this.autoMasterRotatedSinceLogin,
     );
   }
 
@@ -69,6 +96,7 @@ class PnpState extends Equatable {
         forceLogin,
         isPrePaired,
         autoMasterStatusOnEntry,
+        autoMasterRotatedSinceLogin,
       ];
 
   bool get isRouterUnConfigured => isUnconfigured ?? false;

--- a/lib/page/instant_setup/pnp_admin_view.dart
+++ b/lib/page/instant_setup/pnp_admin_view.dart
@@ -12,6 +12,7 @@ import 'package:privacy_gui/page/components/views/arguments_view.dart';
 import 'package:privacy_gui/core/jnap/models/auto_master_status.dart';
 import 'package:privacy_gui/page/instant_setup/data/pnp_exception.dart';
 import 'package:privacy_gui/page/instant_setup/data/pnp_provider.dart';
+import 'package:privacy_gui/page/instant_setup/widgets/pnp_auto_master_flow.dart';
 import 'package:privacy_gui/page/instant_setup/widgets/pnp_auto_master_waiting_view.dart';
 import 'package:privacy_gui/page/instant_setup/troubleshooter/providers/pnp_troubleshooter_provider.dart';
 import 'package:privacy_gui/providers/auth/auth_provider.dart';
@@ -33,7 +34,8 @@ class PnpAdminView extends ArgumentsBaseConsumerStatefulView {
   ConsumerState<PnpAdminView> createState() => _PnpAdminViewState();
 }
 
-class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
+class _PnpAdminViewState extends ConsumerState<PnpAdminView>
+    with PnpAutoMasterFlowMixin<PnpAdminView> {
   late final TextEditingController _textEditController;
   late final BasePnpNotifier pnp;
   final InputValidator _validator = InputValidator([
@@ -111,6 +113,9 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
           logger.e('[PnP]: Auto Master polling failed, stay on error view');
           // Do nothing - UI already showing error view with retry button
         }, test: (error) => error is ExceptionAutoMasterPollingFailed)
+        .catchError((error, stackTrace) {
+          _promptForRotatedPassword();
+        }, test: (error) => error is ExceptionAutoMasterRotatedPassword)
         // .catchError((error, stackTrace) {
         //   logger.e(
         //       '[PnP Troubleshooter]: Internet connection failed - initiate the troubleshooter');
@@ -354,7 +359,12 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
               // Do nothing - UI already showing error view with retry button
             },
                     test: (error) =>
-                        error is ExceptionAutoMasterPollingFailed).onError(
+                        error is ExceptionAutoMasterPollingFailed).catchError(
+                    (error, stackTrace) {
+              _promptForRotatedPassword();
+            },
+                    test: (error) =>
+                        error is ExceptionAutoMasterRotatedPassword).onError(
                     (error, stackTrace) {
               logger.e(
                 '[PnP]: ${_password == null ? 'There is no admin password, bring up the input view' : 'The given password is invalid'}',
@@ -446,11 +456,6 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
         context.goNamed(RouteNamed.pnpConfig);
       }
     }).catchError((error, stackTrace) {
-      // Auto Master finished (make-Master rotated the credential) — send the
-      // user back to re-login with the new password instead of into the WiFi
-      // form. Consistent with the auto-login and default-password paths; this
-      // is the primary running→complete outcome and without it the flow would
-      // fall through to the catch-all below and surface a bogus error.
       final route = (error as ExceptionInterruptAndExit).route;
       logger.e('[PnP]: Interrupted, go to: $route');
       if (mounted) {
@@ -460,7 +465,15 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
         (error, stackTrace) {
       // PnpAutoMasterWaitingView already shows the error + retry button.
       logger.e('[PnP]: Auto Master polling failed, stay on error view');
-    }, test: (error) => error is ExceptionAutoMasterPollingFailed).onError(
+    }, test: (error) => error is ExceptionAutoMasterPollingFailed).catchError(
+        (error, stackTrace) {
+      // Auto Master finished while the user was logging in, so the password they
+      // just typed is already obsolete. Ask again rather than dropping them into
+      // the WiFi form — this is the primary running→complete outcome here, and
+      // without an explicit branch it would fall through to the catch-all below
+      // and surface a bogus "invalid password" error.
+      _promptForRotatedPassword();
+    }, test: (error) => error is ExceptionAutoMasterRotatedPassword).onError(
         (error, stackTrace) {
       logger.e('[PnP]: The input admin password is invalid');
       setState(() {
@@ -557,88 +570,72 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
     final status = await pnp.checkAutoMasterStatus();
     logger.i('[PnP]: Auto Master status check result: $status');
 
-    if (status == AutoMasterStatus.running) {
-      // Every setState below follows an await, and the make-Master window is
+    if (status != AutoMasterStatus.running) return;
+    if (!mounted) return;
+
+    final result = await runAutoMasterFlow(
+      // Every setState here follows an await, and the make-Master window is
       // exactly when the router bounces us between routes — so this view can be
-      // disposed mid-flow. Guard each one instead of crashing on a defunct State.
-      if (!mounted) return;
-      setState(() {
+      // disposed mid-flow. The mixin only fires these while mounted.
+      onEnterWaiting: () => setState(() {
         _isWaitingForAutoMaster = true;
         _showAutoMasterConnectionError = false;
-      });
+      }),
+      onShowConnectionError: () =>
+          setState(() => _showAutoMasterConnectionError = true),
+      onExitWaiting: () => setState(() => _isWaitingForAutoMaster = false),
+    );
 
-      int consecutiveFailures = 0;
-      const maxConsecutiveFailures = 3;
-
-      await for (final pollStatus in pnp.pollAutoMasterStatus()) {
-        logger.d('[PnP]: Auto Master polling status: $pollStatus');
-
-        if (pollStatus == null) {
-          consecutiveFailures++;
-          logger.w(
-              '[PnP]: Auto Master polling failed, consecutive failures: $consecutiveFailures');
-
-          if (consecutiveFailures >= maxConsecutiveFailures) {
-            logger.e(
-                '[PnP]: Auto Master polling failed $maxConsecutiveFailures times, showing connection error');
-            if (mounted) {
-              setState(() {
-                _showAutoMasterConnectionError = true;
-              });
-            }
-            throw ExceptionAutoMasterPollingFailed();
-          }
-        } else {
-          consecutiveFailures = 0;
-
-          if (pollStatus == AutoMasterStatus.complete ||
-              pollStatus == AutoMasterStatus.idle) {
-            // Auto Master completed successfully, password may have changed
-            if (mounted) {
-              setState(() {
-                _isWaitingForAutoMaster = false;
-              });
-            }
-            throw ExceptionInterruptAndExit(
-                route: RouteNamed.localLoginPassword);
-          }
-
-          if (pollStatus == AutoMasterStatus.failed) {
-            // Auto Master failed (e.g., found another Master), password is still admin
-            // Continue normal PnP flow
-            logger.i('[PnP]: Auto Master failed, continuing PnP flow');
-            if (mounted) {
-              setState(() {
-                _isWaitingForAutoMaster = false;
-              });
-            }
-            return;
-          }
-        }
-      }
-
-      // Polling exceeded max retry (timeout)
-      logger
-          .w('[PnP]: Auto Master polling timeout, checking router connection');
-      try {
-        await pnp.testConnectionReconnected();
-        logger.i('[PnP]: Router connected after timeout, proceed to next step');
-        if (mounted) {
-          setState(() {
-            _isWaitingForAutoMaster = false;
-          });
-        }
-        // Continue normal flow
-      } catch (e) {
-        logger.e('[PnP]: Router not connected after timeout');
-        if (mounted) {
-          setState(() {
-            _showAutoMasterConnectionError = true;
-          });
-        }
+    switch (result) {
+      case AutoMasterFlowResult.completed:
+        // make-Master rotated the admin password, so whatever credential got us
+        // here is dead and the user has to supply the new one.
+        //
+        // That means PnP's own password prompt, not `localLoginPassword`: the
+        // local login page is where a *finished* setup lands
+        // (userAcknowledgedAutoConfiguration == true). Reaching it from inside
+        // PnP strands the user on a page for a flow they have not completed —
+        // which is exactly the reported symptom, a reconnect landing on login
+        // instead of back in PnP.
+        //
+        // Note this branch is also hit by a freshly-entered view that merely
+        // *finds* Auto Master already `complete` (the post-reconnect case): it
+        // never had a session to lose, but it equally cannot know the current
+        // password, so the same prompt is the right destination.
+        throw ExceptionAutoMasterRotatedPassword();
+      case AutoMasterFlowResult.proceed:
+      case AutoMasterFlowResult.budgetExhausted:
+        // Nothing is pending here — the next steps (internet check, then
+        // pnpConfig) re-read live router state, so an unknown Auto Master
+        // outcome needs no extra handling: if the credential did rotate, the
+        // next authed call fails and the existing error paths take over.
+        logger.i('[PnP]: Auto Master not blocking, continuing PnP flow');
+        return;
+      case AutoMasterFlowResult.connectionError:
+        // The waiting view is showing the error + retry button.
         throw ExceptionAutoMasterPollingFailed();
-      }
     }
+  }
+
+  /// Auto Master rotated the admin password — put this view back on its own
+  /// password prompt so the user can enter the new one.
+  ///
+  /// No navigation: this *is* the PnP entry view, so the prompt is one setState
+  /// away. Clearing [_password] is the load-bearing part — it holds the
+  /// credential we arrived with (the `p` route arg, or the factory default),
+  /// which the rotation has just invalidated. Leaving it set would let the next
+  /// precheck retry it and spend another CGI auth attempt on a password that
+  /// cannot work.
+  void _promptForRotatedPassword() {
+    logger.i('[PnP]: Auto Master rotated the password, prompt for the new one');
+    if (!mounted) return;
+    setState(() {
+      _isWaitingForAutoMaster = false;
+      _password = null;
+      _inputError = '';
+      _processing = false;
+    });
+    pnp.setAttachedPassword(null);
   }
 
   void _retryAutoMasterCheck() {
@@ -660,7 +657,10 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
         (error, stackTrace) {
       logger.e('[PnP]: Auto Master polling failed, stay on error view');
       // Do nothing - UI already showing error view with retry button
-    }, test: (error) => error is ExceptionAutoMasterPollingFailed);
+    }, test: (error) => error is ExceptionAutoMasterPollingFailed).catchError(
+        (error, stackTrace) {
+      _promptForRotatedPassword();
+    }, test: (error) => error is ExceptionAutoMasterRotatedPassword);
   }
 
   _showRouterPasswordModal() {

--- a/lib/page/instant_setup/pnp_admin_view.dart
+++ b/lib/page/instant_setup/pnp_admin_view.dart
@@ -108,12 +108,6 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
           });
         }, test: (error) => error is ExceptionInvalidAdminPassword)
         .catchError((error, stackTrace) {
-          logger.e('[PnP]: Auto Master check unauthorized, redirect to login');
-          if (mounted) {
-            context.goNamed(RouteNamed.localLoginPassword);
-          }
-        }, test: (error) => error is ExceptionAutoMasterUnauthorized)
-        .catchError((error, stackTrace) {
           logger.e('[PnP]: Auto Master polling failed, stay on error view');
           // Do nothing - UI already showing error view with retry button
         }, test: (error) => error is ExceptionAutoMasterPollingFailed)
@@ -356,15 +350,6 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
               }
             }, test: (error) => error is ExceptionInterruptAndExit).catchError(
                     (error, stackTrace) {
-              logger.e(
-                  '[PnP]: Auto Master check unauthorized, redirect to login');
-              if (mounted) {
-                context.goNamed(RouteNamed.localLoginPassword);
-              }
-            },
-                    test: (error) =>
-                        error is ExceptionAutoMasterUnauthorized).catchError(
-                    (error, stackTrace) {
               logger.e('[PnP]: Auto Master polling failed, stay on error view');
               // Do nothing - UI already showing error view with retry button
             },
@@ -472,13 +457,6 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
         context.goNamed(route);
       }
     }, test: (error) => error is ExceptionInterruptAndExit).catchError(
-        (error, stackTrace) {
-      // Auto Master rotated the credential again mid-check → back to login.
-      logger.e('[PnP]: Auto Master check unauthorized, redirect to login');
-      if (mounted) {
-        context.goNamed(RouteNamed.localLoginPassword);
-      }
-    }, test: (error) => error is ExceptionAutoMasterUnauthorized).catchError(
         (error, stackTrace) {
       // PnpAutoMasterWaitingView already shows the error + retry button.
       logger.e('[PnP]: Auto Master polling failed, stay on error view');
@@ -679,12 +657,6 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
         context.goNamed(route);
       }
     }, test: (error) => error is ExceptionInterruptAndExit).catchError(
-        (error, stackTrace) {
-      logger.e('[PnP]: Auto Master check unauthorized, redirect to login');
-      if (mounted) {
-        context.goNamed(RouteNamed.localLoginPassword);
-      }
-    }, test: (error) => error is ExceptionAutoMasterUnauthorized).catchError(
         (error, stackTrace) {
       logger.e('[PnP]: Auto Master polling failed, stay on error view');
       // Do nothing - UI already showing error view with retry button

--- a/lib/page/instant_setup/pnp_admin_view.dart
+++ b/lib/page/instant_setup/pnp_admin_view.dart
@@ -447,20 +447,55 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
       _processing = true;
     });
     _examineAdminPassword(_textEditController.text)
+        // Gate on Auto Master before entering config, consistent with the
+        // auto-login and default-password paths. Without this, a user manually
+        // re-logging in after make-Master rotated the credential is dropped
+        // straight into the WiFi form while Auto Master is still `running`, then
+        // bounced again by the pre-save check — filling the form twice.
+        .then((_) => _checkAutoMasterStatus())
         .then((_) => _checkInternetConnection())
         .then((_) {
       logger.i(
           '[PnP]: Logged in successfully by tapping Login, go to Setup page');
-      context.goNamed(RouteNamed.pnpConfig);
-    }).onError((error, stackTrace) {
+      if (mounted) {
+        context.goNamed(RouteNamed.pnpConfig);
+      }
+    }).catchError((error, stackTrace) {
+      // Auto Master finished (make-Master rotated the credential) — send the
+      // user back to re-login with the new password instead of into the WiFi
+      // form. Consistent with the auto-login and default-password paths; this
+      // is the primary running→complete outcome and without it the flow would
+      // fall through to the catch-all below and surface a bogus error.
+      final route = (error as ExceptionInterruptAndExit).route;
+      logger.e('[PnP]: Interrupted, go to: $route');
+      if (mounted) {
+        context.goNamed(route);
+      }
+    }, test: (error) => error is ExceptionInterruptAndExit).catchError(
+        (error, stackTrace) {
+      // Auto Master rotated the credential again mid-check → back to login.
+      logger.e('[PnP]: Auto Master check unauthorized, redirect to login');
+      if (mounted) {
+        context.goNamed(RouteNamed.localLoginPassword);
+      }
+    }, test: (error) => error is ExceptionAutoMasterUnauthorized).catchError(
+        (error, stackTrace) {
+      // PnpAutoMasterWaitingView already shows the error + retry button.
+      logger.e('[PnP]: Auto Master polling failed, stay on error view');
+    }, test: (error) => error is ExceptionAutoMasterPollingFailed).onError(
+        (error, stackTrace) {
       logger.e('[PnP]: The input admin password is invalid');
       setState(() {
         _error = error;
       });
     }).whenComplete(() {
-      setState(() {
-        _processing = false;
-      });
+      // A redirect above may have already disposed this view; guard the
+      // setState so it doesn't fire after dispose.
+      if (mounted) {
+        setState(() {
+          _processing = false;
+        });
+      }
     });
   }
 
@@ -545,6 +580,10 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
     logger.i('[PnP]: Auto Master status check result: $status');
 
     if (status == AutoMasterStatus.running) {
+      // Every setState below follows an await, and the make-Master window is
+      // exactly when the router bounces us between routes — so this view can be
+      // disposed mid-flow. Guard each one instead of crashing on a defunct State.
+      if (!mounted) return;
       setState(() {
         _isWaitingForAutoMaster = true;
         _showAutoMasterConnectionError = false;
@@ -564,9 +603,11 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
           if (consecutiveFailures >= maxConsecutiveFailures) {
             logger.e(
                 '[PnP]: Auto Master polling failed $maxConsecutiveFailures times, showing connection error');
-            setState(() {
-              _showAutoMasterConnectionError = true;
-            });
+            if (mounted) {
+              setState(() {
+                _showAutoMasterConnectionError = true;
+              });
+            }
             throw ExceptionAutoMasterPollingFailed();
           }
         } else {
@@ -575,9 +616,11 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
           if (pollStatus == AutoMasterStatus.complete ||
               pollStatus == AutoMasterStatus.idle) {
             // Auto Master completed successfully, password may have changed
-            setState(() {
-              _isWaitingForAutoMaster = false;
-            });
+            if (mounted) {
+              setState(() {
+                _isWaitingForAutoMaster = false;
+              });
+            }
             throw ExceptionInterruptAndExit(
                 route: RouteNamed.localLoginPassword);
           }
@@ -586,9 +629,11 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
             // Auto Master failed (e.g., found another Master), password is still admin
             // Continue normal PnP flow
             logger.i('[PnP]: Auto Master failed, continuing PnP flow');
-            setState(() {
-              _isWaitingForAutoMaster = false;
-            });
+            if (mounted) {
+              setState(() {
+                _isWaitingForAutoMaster = false;
+              });
+            }
             return;
           }
         }
@@ -600,15 +645,19 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView> {
       try {
         await pnp.testConnectionReconnected();
         logger.i('[PnP]: Router connected after timeout, proceed to next step');
-        setState(() {
-          _isWaitingForAutoMaster = false;
-        });
+        if (mounted) {
+          setState(() {
+            _isWaitingForAutoMaster = false;
+          });
+        }
         // Continue normal flow
       } catch (e) {
         logger.e('[PnP]: Router not connected after timeout');
-        setState(() {
-          _showAutoMasterConnectionError = true;
-        });
+        if (mounted) {
+          setState(() {
+            _showAutoMasterConnectionError = true;
+          });
+        }
         throw ExceptionAutoMasterPollingFailed();
       }
     }

--- a/lib/page/instant_setup/pnp_admin_view.dart
+++ b/lib/page/instant_setup/pnp_admin_view.dart
@@ -590,6 +590,17 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView>
     // `completed` branch: that flow only runs when the status is `running`, so a
     // status that is *already* `complete` never reaches it.
     //
+    // `complete` alone is NOT enough to conclude that, though: firmware latches
+    // the status there for the rest of the router's life, so on its own it only
+    // says "this router was auto-mastered at some point" — true for ever after,
+    // including on every later visit with a perfectly good password. Pairing it
+    // with `autoMasterRotatedSinceLogin` asks the question that actually
+    // matters: is the credential we hold older than the rotation? The flag is
+    // set when a status read sees `running` and cleared when the router accepts
+    // a password. Without it the user could never get in: they typed the correct
+    // new password, CheckAdminPassword returned 200, and this gate threw anyway
+    // and logged the fresh session straight back out.
+    //
     // The other statuses deliberately fall through to the early return below:
     // - `failed` — Auto Master gave up (it found another Master), and firmware
     //   leaves the admin password untouched. The credential still works.
@@ -598,7 +609,8 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView>
     //   reset"; that reading is only valid once `running` has been observed.
     // - `null` — status unavailable (unreachable, or firmware that will not
     //   serve it unauthed). Nothing is known, so nothing is assumed.
-    if (status == AutoMasterStatus.complete) {
+    if (status == AutoMasterStatus.complete &&
+        ref.read(pnpProvider).autoMasterRotatedSinceLogin) {
       throw ExceptionAutoMasterRotatedPassword();
     }
     if (status != AutoMasterStatus.running) return;

--- a/lib/page/instant_setup/pnp_admin_view.dart
+++ b/lib/page/instant_setup/pnp_admin_view.dart
@@ -543,7 +543,17 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView>
         extra: ssid.isEmpty ? null : {'ssid': ssid},
       );
       throw error;
-    }, test: (error) => error is ExceptionNoInternetConnection);
+    }, test: (error) => error is ExceptionNoInternetConnection).catchError(
+        (error, stackTrace) {
+      // A stale credential, not a WAN fault — the internet check now tells the
+      // two apart. Leave the spinner behind and rethrow so the caller's own
+      // handler asks for the password; going to the troubleshooter here is
+      // exactly the wrong answer (#1180: the ISP settings were fine).
+      setState(() {
+        _isCheckingInternet = false;
+      });
+      throw error;
+    }, test: (error) => error is ExceptionInvalidAdminPassword);
   }
 
   List<Widget> _checkError(BuildContext context, Object? error) {
@@ -570,6 +580,27 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView>
     final status = await pnp.checkAutoMasterStatus();
     logger.i('[PnP]: Auto Master status check result: $status');
 
+    // make-Master already finished before this view even loaded — the
+    // post-reconnect case: the router bounced us back to PnP and by the time we
+    // got here the status was already `complete`. There is nothing to wait for,
+    // but the admin password has been rotated all the same, so whatever
+    // credential we hold is dead and the next authed call would 401.
+    //
+    // This has to be caught here rather than by `runAutoMasterFlow`'s
+    // `completed` branch: that flow only runs when the status is `running`, so a
+    // status that is *already* `complete` never reaches it.
+    //
+    // The other statuses deliberately fall through to the early return below:
+    // - `failed` — Auto Master gave up (it found another Master), and firmware
+    //   leaves the admin password untouched. The credential still works.
+    // - `idle` — it has not started. Note this is the opposite of `idle` inside
+    //   `_waitForCompletion`, where it means "was running, now finished and
+    //   reset"; that reading is only valid once `running` has been observed.
+    // - `null` — status unavailable (unreachable, or firmware that will not
+    //   serve it unauthed). Nothing is known, so nothing is assumed.
+    if (status == AutoMasterStatus.complete) {
+      throw ExceptionAutoMasterRotatedPassword();
+    }
     if (status != AutoMasterStatus.running) return;
     if (!mounted) return;
 
@@ -598,10 +629,10 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView>
         // which is exactly the reported symptom, a reconnect landing on login
         // instead of back in PnP.
         //
-        // Note this branch is also hit by a freshly-entered view that merely
-        // *finds* Auto Master already `complete` (the post-reconnect case): it
-        // never had a session to lose, but it equally cannot know the current
-        // password, so the same prompt is the right destination.
+        // This is the running -> complete transition only: the flow above is
+        // entered exclusively from a `running` status. A view that finds Auto
+        // Master already `complete` on entry is caught by the gate before this
+        // point, and lands on the same prompt from there.
         throw ExceptionAutoMasterRotatedPassword();
       case AutoMasterFlowResult.proceed:
       case AutoMasterFlowResult.budgetExhausted:
@@ -636,6 +667,18 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView>
       _processing = false;
     });
     pnp.setAttachedPassword(null);
+    // Drop the stale local session too. `_password` and the pnp state are not
+    // where the JNAP auth header comes from: it is built from the auth session's
+    // stored local password, so a session left behind by a login that happened
+    // *before* the rotation keeps `isLoggedIn()` true. The entry precheck then
+    // skips `_examineAdminPassword` entirely — observed in #1180's QA log, where
+    // no CheckAdminPassword went out at all after the reconnect — and the very
+    // next authed call goes out with the dead credential.
+    //
+    // Logging out is safe from here: the `/pnp*` redirect branch does not watch
+    // authProvider, and it leaves pnpProvider (hence `deviceInfo`) intact, so
+    // this view stays put instead of being re-elected elsewhere.
+    ref.read(authProvider.notifier).logout();
   }
 
   void _retryAutoMasterCheck() {
@@ -660,7 +703,15 @@ class _PnpAdminViewState extends ConsumerState<PnpAdminView>
     }, test: (error) => error is ExceptionAutoMasterPollingFailed).catchError(
         (error, stackTrace) {
       _promptForRotatedPassword();
-    }, test: (error) => error is ExceptionAutoMasterRotatedPassword);
+    },
+        test: (error) =>
+            // Both land on the password prompt. The second arrives from the
+            // internet check rather than the Auto Master gate — the status read
+            // came back inconclusive, so the check ran and its 401 revealed the
+            // rotation the status could not. Without this branch it would escape
+            // this chain entirely as an unhandled error.
+            error is ExceptionAutoMasterRotatedPassword ||
+            error is ExceptionInvalidAdminPassword);
   }
 
   _showRouterPasswordModal() {

--- a/lib/page/instant_setup/pnp_setup_view.dart
+++ b/lib/page/instant_setup/pnp_setup_view.dart
@@ -760,43 +760,55 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
       const maxConsecutiveFailures = 3;
       bool autoMasterFailed = false;
 
-      await for (final pollStatus
-          in ref.read(pnpProvider.notifier).pollAutoMasterStatus()) {
-        logger.d('[PnP]: Auto Master polling status: $pollStatus');
+      try {
+        await for (final pollStatus
+            in ref.read(pnpProvider.notifier).pollAutoMasterStatus()) {
+          logger.d('[PnP]: Auto Master polling status: $pollStatus');
 
-        if (pollStatus == null) {
-          consecutiveFailures++;
-          logger.w(
-              '[PnP]: Auto Master polling failed, consecutive failures: $consecutiveFailures');
+          if (pollStatus == null) {
+            consecutiveFailures++;
+            logger.w(
+                '[PnP]: Auto Master polling failed, consecutive failures: $consecutiveFailures');
 
-          if (consecutiveFailures >= maxConsecutiveFailures) {
-            logger.e(
-                '[PnP]: Auto Master polling failed $maxConsecutiveFailures times, showing connection error');
-            setState(() {
-              _showAutoMasterConnectionError = true;
-            });
-            return;
-          }
-        } else {
-          consecutiveFailures = 0;
-
-          if (pollStatus == AutoMasterStatus.complete ||
-              pollStatus == AutoMasterStatus.idle) {
-            // Redirect to login page - password changed
-            if (mounted) {
-              context.goNamed(RouteNamed.localLoginPassword);
+            if (consecutiveFailures >= maxConsecutiveFailures) {
+              logger.e(
+                  '[PnP]: Auto Master polling failed $maxConsecutiveFailures times, showing connection error');
+              setState(() {
+                _showAutoMasterConnectionError = true;
+              });
+              return;
             }
-            return;
-          }
+          } else {
+            consecutiveFailures = 0;
 
-          if (pollStatus == AutoMasterStatus.failed) {
-            // Auto Master failed (e.g., found another Master), password is still admin
-            // Continue normal save flow
-            logger.i('[PnP]: Auto Master failed, continuing save flow');
-            autoMasterFailed = true;
-            break;
+            if (pollStatus == AutoMasterStatus.complete ||
+                pollStatus == AutoMasterStatus.idle) {
+              // Redirect to login page - password changed
+              if (mounted) {
+                context.goNamed(RouteNamed.localLoginPassword);
+              }
+              return;
+            }
+
+            if (pollStatus == AutoMasterStatus.failed) {
+              // Auto Master failed (e.g., found another Master), password is still admin
+              // Continue normal save flow
+              logger.i('[PnP]: Auto Master failed, continuing save flow');
+              autoMasterFailed = true;
+              break;
+            }
           }
         }
+      } on ExceptionAutoMasterUnauthorized {
+        // Stream terminated on the first 401: make-Master rotated the admin
+        // password mid-poll. Go to login instead of re-polling with the stale
+        // credential (which would burn the CGI auth-attempt budget).
+        logger.w(
+            '[PnP]: Auto Master polling unauthorized → redirect to login');
+        if (mounted) {
+          context.goNamed(RouteNamed.localLoginPassword);
+        }
+        return;
       }
 
       // Skip timeout handling if Auto Master failed - continue to save logic

--- a/lib/page/instant_setup/pnp_setup_view.dart
+++ b/lib/page/instant_setup/pnp_setup_view.dart
@@ -734,17 +734,10 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
 
     // Check Auto Master status before save (Second Defense)
     final statusOnEntry = ref.read(pnpProvider).autoMasterStatusOnEntry;
-    final AutoMasterStatus? currentStatus;
-    try {
-      currentStatus =
-          await ref.read(pnpProvider.notifier).checkAutoMasterStatus();
-    } on ExceptionAutoMasterUnauthorized {
-      logger.e('[PnP]: Auto Master check unauthorized, redirect to login');
-      if (mounted) {
-        context.goNamed(RouteNamed.localLoginPassword);
-      }
-      return;
-    }
+    // null when the status is unavailable (unreachable, or firmware that does
+    // not serve GetAutoMasterStatus unauthed) → fall through to the save.
+    final AutoMasterStatus? currentStatus =
+        await ref.read(pnpProvider.notifier).checkAutoMasterStatus();
 
     logger.d('[PnP]: Auto Master check before save - '
         'entry status: $statusOnEntry, current: $currentStatus');
@@ -760,55 +753,43 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
       const maxConsecutiveFailures = 3;
       bool autoMasterFailed = false;
 
-      try {
-        await for (final pollStatus
-            in ref.read(pnpProvider.notifier).pollAutoMasterStatus()) {
-          logger.d('[PnP]: Auto Master polling status: $pollStatus');
+      await for (final pollStatus
+          in ref.read(pnpProvider.notifier).pollAutoMasterStatus()) {
+        logger.d('[PnP]: Auto Master polling status: $pollStatus');
 
-          if (pollStatus == null) {
-            consecutiveFailures++;
-            logger.w(
-                '[PnP]: Auto Master polling failed, consecutive failures: $consecutiveFailures');
+        if (pollStatus == null) {
+          consecutiveFailures++;
+          logger.w(
+              '[PnP]: Auto Master polling failed, consecutive failures: $consecutiveFailures');
 
-            if (consecutiveFailures >= maxConsecutiveFailures) {
-              logger.e(
-                  '[PnP]: Auto Master polling failed $maxConsecutiveFailures times, showing connection error');
-              setState(() {
-                _showAutoMasterConnectionError = true;
-              });
-              return;
+          if (consecutiveFailures >= maxConsecutiveFailures) {
+            logger.e(
+                '[PnP]: Auto Master polling failed $maxConsecutiveFailures times, showing connection error');
+            setState(() {
+              _showAutoMasterConnectionError = true;
+            });
+            return;
+          }
+        } else {
+          consecutiveFailures = 0;
+
+          if (pollStatus == AutoMasterStatus.complete ||
+              pollStatus == AutoMasterStatus.idle) {
+            // Redirect to login page - password changed
+            if (mounted) {
+              context.goNamed(RouteNamed.localLoginPassword);
             }
-          } else {
-            consecutiveFailures = 0;
+            return;
+          }
 
-            if (pollStatus == AutoMasterStatus.complete ||
-                pollStatus == AutoMasterStatus.idle) {
-              // Redirect to login page - password changed
-              if (mounted) {
-                context.goNamed(RouteNamed.localLoginPassword);
-              }
-              return;
-            }
-
-            if (pollStatus == AutoMasterStatus.failed) {
-              // Auto Master failed (e.g., found another Master), password is still admin
-              // Continue normal save flow
-              logger.i('[PnP]: Auto Master failed, continuing save flow');
-              autoMasterFailed = true;
-              break;
-            }
+          if (pollStatus == AutoMasterStatus.failed) {
+            // Auto Master failed (e.g., found another Master), password is still admin
+            // Continue normal save flow
+            logger.i('[PnP]: Auto Master failed, continuing save flow');
+            autoMasterFailed = true;
+            break;
           }
         }
-      } on ExceptionAutoMasterUnauthorized {
-        // Stream terminated on the first 401: make-Master rotated the admin
-        // password mid-poll. Go to login instead of re-polling with the stale
-        // credential (which would burn the CGI auth-attempt budget).
-        logger.w(
-            '[PnP]: Auto Master polling unauthorized → redirect to login');
-        if (mounted) {
-          context.goNamed(RouteNamed.localLoginPassword);
-        }
-        return;
       }
 
       // Skip timeout handling if Auto Master failed - continue to save logic

--- a/lib/page/instant_setup/pnp_setup_view.dart
+++ b/lib/page/instant_setup/pnp_setup_view.dart
@@ -24,6 +24,7 @@ import 'package:privacy_gui/page/instant_setup/model/impl/night_mode_step.dart';
 import 'package:privacy_gui/page/instant_setup/model/impl/personal_wifi_step.dart';
 import 'package:privacy_gui/page/instant_setup/model/impl/your_network_step.dart';
 import 'package:privacy_gui/page/instant_setup/model/pnp_step.dart';
+import 'package:privacy_gui/page/instant_setup/widgets/pnp_auto_master_flow.dart';
 import 'package:privacy_gui/page/instant_setup/widgets/pnp_auto_master_waiting_view.dart';
 import 'package:privacy_gui/page/instant_setup/widgets/pnp_stepper.dart';
 import 'package:privacy_gui/route/constants.dart';
@@ -63,7 +64,7 @@ class PnpSetupView extends ConsumerStatefulWidget {
 }
 
 class _PnpSetupViewState extends ConsumerState<PnpSetupView>
-    with PageSnackbarMixin {
+    with PageSnackbarMixin, PnpAutoMasterFlowMixin<PnpSetupView> {
   late final List<PnpStep> steps;
   _PnpSetupStep _setupStep = _PnpSetupStep.init;
   String _loadingMessage = '';
@@ -727,9 +728,14 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
     );
   }
 
-  static const int _maxAutoMasterSaveAttempts = 2;
+  /// How many Auto Master waits one save may spend before giving up.
+  ///
+  /// Counted in waits, not retries, because each wait now costs a full poll
+  /// budget (~3 minutes) — the recursion below has to be read as wall-clock, not
+  /// as a cheap re-check.
+  static const int _maxAutoMasterWaits = 2;
 
-  Future _saveChanges({int autoMasterSaveAttempt = 0}) async {
+  Future _saveChanges({int autoMasterWaitsSpent = 0}) async {
     final isUnconfigured = ref.read(pnpProvider).isRouterUnConfigured;
 
     // Check Auto Master status before save (Second Defense)
@@ -743,87 +749,57 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
         'entry status: $statusOnEntry, current: $currentStatus');
 
     if (currentStatus == AutoMasterStatus.running) {
-      // Show waiting view and poll
-      setState(() {
-        _setupStep = _PnpSetupStep.waitingAutoMaster;
-        _showAutoMasterConnectionError = false;
-      });
+      // No onExitWaiting: each outcome below moves the step itself, and the
+      // error outcomes have to stay on the waiting view to show the error.
+      final result = await runAutoMasterFlow(
+        onEnterWaiting: () => setState(() {
+          _setupStep = _PnpSetupStep.waitingAutoMaster;
+          _showAutoMasterConnectionError = false;
+        }),
+        onShowConnectionError: () =>
+            setState(() => _showAutoMasterConnectionError = true),
+      );
+      if (!mounted) return;
 
-      int consecutiveFailures = 0;
-      const maxConsecutiveFailures = 3;
-      bool autoMasterFailed = false;
-
-      await for (final pollStatus
-          in ref.read(pnpProvider.notifier).pollAutoMasterStatus()) {
-        logger.d('[PnP]: Auto Master polling status: $pollStatus');
-
-        if (pollStatus == null) {
-          consecutiveFailures++;
-          logger.w(
-              '[PnP]: Auto Master polling failed, consecutive failures: $consecutiveFailures');
-
-          if (consecutiveFailures >= maxConsecutiveFailures) {
+      switch (result) {
+        case AutoMasterFlowResult.completed:
+          // make-Master rotated the admin password, so the pending save would
+          // come back 401. Re-enter PnP so its precheck can ask for the new
+          // password — the same destination the unauthorized-during-save branch
+          // below already uses. Not `localLoginPassword`: that page belongs to a
+          // finished setup (userAcknowledgedAutoConfiguration == true), and this
+          // one never got saved.
+          logger.w('[PnP]: Auto Master completed before save - password changed');
+          context.goNamed(RouteNamed.pnp);
+          return;
+        case AutoMasterFlowResult.proceed:
+          // Auto Master left the credential alone — the save can go ahead.
+          logger.i('[PnP]: Auto Master not blocking, continuing save flow');
+          break;
+        case AutoMasterFlowResult.budgetExhausted:
+          // Out of time, but the router answers — so Auto Master may still be
+          // mid-flight. Unlike the other callers, this one has a save pending
+          // that a rotation would break, so re-check from the top instead of
+          // committing. Bounded, or a router stuck on `running` would loop for
+          // ever.
+          final waitsSpent = autoMasterWaitsSpent + 1;
+          if (waitsSpent >= _maxAutoMasterWaits) {
             logger.e(
-                '[PnP]: Auto Master polling failed $maxConsecutiveFailures times, showing connection error');
+                '[PnP]: Auto Master still unresolved after $waitsSpent waits, giving up');
             setState(() {
               _showAutoMasterConnectionError = true;
             });
             return;
           }
-        } else {
-          consecutiveFailures = 0;
-
-          if (pollStatus == AutoMasterStatus.complete ||
-              pollStatus == AutoMasterStatus.idle) {
-            // Redirect to login page - password changed
-            if (mounted) {
-              context.goNamed(RouteNamed.localLoginPassword);
-            }
-            return;
-          }
-
-          if (pollStatus == AutoMasterStatus.failed) {
-            // Auto Master failed (e.g., found another Master), password is still admin
-            // Continue normal save flow
-            logger.i('[PnP]: Auto Master failed, continuing save flow');
-            autoMasterFailed = true;
-            break;
-          }
-        }
-      }
-
-      // Skip timeout handling if Auto Master failed - continue to save logic
-      if (autoMasterFailed) {
-        logger.d('[PnP]: Auto Master failed, skipping timeout handling');
-      } else {
-        // Polling exceeded max retry (timeout)
-        logger.w(
-            '[PnP]: Auto Master polling timeout, checking router connection');
-
-        if (autoMasterSaveAttempt >= _maxAutoMasterSaveAttempts) {
-          logger.e(
-              '[PnP]: Auto Master retry limit reached after $autoMasterSaveAttempt attempts');
-          setState(() {
-            _showAutoMasterConnectionError = true;
-          });
-          return;
-        }
-
-        try {
-          await ref.read(pnpProvider.notifier).testConnectionReconnected();
-          logger.i(
-              '[PnP]: Router connected after timeout, attempt ${autoMasterSaveAttempt + 1}/$_maxAutoMasterSaveAttempts');
+          logger.w(
+              '[PnP]: Auto Master outcome unknown, re-checking (wait $waitsSpent/$_maxAutoMasterWaits spent)');
           setState(() {
             _setupStep = _PnpSetupStep.config;
           });
-          return _saveChanges(autoMasterSaveAttempt: autoMasterSaveAttempt + 1);
-        } catch (e) {
-          logger.e('[PnP]: Router not connected after timeout');
-          setState(() {
-            _showAutoMasterConnectionError = true;
-          });
+          return _saveChanges(autoMasterWaitsSpent: waitsSpent);
+        case AutoMasterFlowResult.connectionError:
+          // The waiting view is showing the error + retry button.
           return;
-        }
       }
     }
 
@@ -833,7 +809,9 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
       logger.w(
           '[PnP]: Auto Master completed during PnP config - password changed');
       if (mounted) {
-        context.goNamed(RouteNamed.localLoginPassword);
+        // Same destination as the branch above and as the
+        // unauthorized-during-save handler: back into PnP for the new password.
+        context.goNamed(RouteNamed.pnp);
       }
       return;
     }

--- a/lib/page/instant_setup/pnp_setup_view.dart
+++ b/lib/page/instant_setup/pnp_setup_view.dart
@@ -803,7 +803,14 @@ class _PnpSetupViewState extends ConsumerState<PnpSetupView>
       }
     }
 
-    // Edge case: Was Idle on entry but now Complete
+    // Edge case: Was Idle on entry but now Complete.
+    //
+    // The `statusOnEntry == idle` half is what dates the transition, and is why
+    // this branch does not need the `autoMasterRotatedSinceLogin` guard the two
+    // gates outside this view carry: `complete` latches for ever, but `idle` on
+    // entry proves it latched *during* this session rather than on some earlier
+    // day. A router that was auto-mastered long ago reads `complete` on entry
+    // too, so it never satisfies this condition.
     if (statusOnEntry == AutoMasterStatus.idle &&
         currentStatus == AutoMasterStatus.complete) {
       logger.w(

--- a/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
+++ b/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
@@ -110,7 +110,17 @@ class _PnpIspSaveSettingsViewState extends ConsumerState<PnpIspSaveSettingsView>
       }
     }
 
-    if (status == AutoMasterStatus.complete) {
+    // Only when the rotation happened *since* our last accepted password. The
+    // firmware latches this status at `complete` permanently, so read on its own
+    // it says "this router was auto-mastered at some point" — which, on any
+    // router that has ever been auto-mastered, is true on every subsequent
+    // visit. That made this branch a trap: entering the ISP-save view would
+    // bounce to PnP before saving anything, PnP would find no internet and route
+    // back into the troubleshooter, and the user could never get their PPPoE
+    // settings saved at all. The flag narrows it to the case that needs the
+    // redirect: a credential older than the rotation.
+    if (status == AutoMasterStatus.complete &&
+        ref.read(pnpProvider).autoMasterRotatedSinceLogin) {
       logger.i(
           '[PnP]: Troubleshooter - Auto Master already completed, redirect to PnP');
       if (mounted) context.goNamed(RouteNamed.pnp);

--- a/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
+++ b/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
@@ -13,6 +13,7 @@ import 'package:privacy_gui/page/components/views/arguments_view.dart';
 import 'package:privacy_gui/page/instant_setup/data/pnp_exception.dart';
 import 'package:privacy_gui/page/instant_setup/data/pnp_provider.dart';
 import 'package:privacy_gui/page/instant_setup/troubleshooter/providers/pnp_troubleshooter_provider.dart';
+import 'package:privacy_gui/page/instant_setup/widgets/pnp_auto_master_flow.dart';
 import 'package:privacy_gui/page/instant_setup/widgets/pnp_auto_master_waiting_view.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/util/error_code_helper.dart';
@@ -29,8 +30,8 @@ class PnpIspSaveSettingsView extends ArgumentsConsumerStatefulView {
       _PnpIspSaveSettingsViewState();
 }
 
-class _PnpIspSaveSettingsViewState
-    extends ConsumerState<PnpIspSaveSettingsView> {
+class _PnpIspSaveSettingsViewState extends ConsumerState<PnpIspSaveSettingsView>
+    with PnpAutoMasterFlowMixin<PnpIspSaveSettingsView> {
   final _passwordController = TextEditingController();
   late final InternetSettingsState newSettings;
   String? _spinnerText; //TODO: all spinner text is not confirmed
@@ -39,6 +40,11 @@ class _PnpIspSaveSettingsViewState
   // Auto Master state
   bool _waitingForAutoMaster = false;
   bool _showAutoMasterConnectionError = false;
+
+  // Whether the current Auto Master wait was triggered after WAN came up
+  // (post internet-check), as opposed to the pre-save check. Governs the retry
+  // path in [build].
+  bool _autoMasterPostWanUp = false;
 
   @override
   void initState() {
@@ -75,54 +81,29 @@ class _PnpIspSaveSettingsViewState
     }
 
     if (status == AutoMasterStatus.running) {
+      _autoMasterPostWanUp = false;
+      final result = await runAutoMasterFlow(
+        onEnterWaiting: () => setState(() {
+          _waitingForAutoMaster = true;
+          _showAutoMasterConnectionError = false;
+        }),
+        onShowConnectionError: () =>
+            setState(() => _showAutoMasterConnectionError = true),
+        onExitWaiting: () => setState(() => _waitingForAutoMaster = false),
+      );
       if (!mounted) return false;
-      setState(() {
-        _waitingForAutoMaster = true;
-        _showAutoMasterConnectionError = false;
-      });
-
-      int consecutiveFailures = 0;
-      const maxConsecutiveFailures = 3;
-
-      await for (final pollStatus
-          in ref.read(pnpProvider.notifier).pollAutoMasterStatus()) {
-        if (!mounted) return false;
-
-        if (pollStatus == null) {
-          consecutiveFailures++;
-          logger.w(
-              '[PnP]: Troubleshooter - Auto Master polling failed, consecutive: $consecutiveFailures');
-          if (consecutiveFailures >= maxConsecutiveFailures) {
-            setState(() => _showAutoMasterConnectionError = true);
-            return false;
-          }
-        } else {
-          consecutiveFailures = 0;
-          if (pollStatus == AutoMasterStatus.complete ||
-              pollStatus == AutoMasterStatus.idle) {
-            logger.i(
-                '[PnP]: Troubleshooter - Auto Master completed, redirect to PnP');
-            if (mounted) context.goNamed(RouteNamed.pnp);
-            return false;
-          }
-          if (pollStatus == AutoMasterStatus.failed) {
-            logger
-                .i('[PnP]: Troubleshooter - Auto Master failed, continue save');
-            if (mounted) setState(() => _waitingForAutoMaster = false);
-            return true;
-          }
-        }
-      }
-
-      // Polling timeout
-      logger.w('[PnP]: Troubleshooter - Auto Master polling timeout');
-      try {
-        await ref.read(pnpProvider.notifier).testConnectionReconnected();
-        if (mounted) setState(() => _waitingForAutoMaster = false);
-        return true;
-      } catch (e) {
-        if (mounted) setState(() => _showAutoMasterConnectionError = true);
-        return false;
+      switch (result) {
+        case AutoMasterFlowResult.completed:
+          logger.i(
+              '[PnP]: Troubleshooter - Auto Master completed, redirect to PnP');
+          context.goNamed(RouteNamed.pnp);
+          return false;
+        case AutoMasterFlowResult.proceed:
+          logger.i('[PnP]: Troubleshooter - Auto Master done, continue save');
+          return true;
+        case AutoMasterFlowResult.connectionError:
+          // Waiting view already shows the error + retry.
+          return false;
       }
     }
 
@@ -175,11 +156,31 @@ class _PnpIspSaveSettingsViewState
                 ref
                     .read(pnpProvider.notifier)
                     .checkInternetConnection(30)
-                    .then((value) {
+                    .then((value) async {
                   logger.i(
                       '[PnP]: Troubleshooter - Check internet connection with new settings - OK');
-                  // Internet connection is OK
-                  context.goNamed(RouteNamed.pnp);
+                  // Internet connection is OK. WAN is now up, so firmware may
+                  // start Auto Master ("make Master") shortly. Detect it here
+                  // (★) so the user waits once instead of filling WiFi twice.
+                  _autoMasterPostWanUp = true;
+                  final result = await runAutoMasterFlow(
+                    waitForRunningFirst: true,
+                    onEnterWaiting: () => setState(() {
+                      _waitingForAutoMaster = true;
+                      _showAutoMasterConnectionError = false;
+                    }),
+                    onShowConnectionError: () =>
+                        setState(() => _showAutoMasterConnectionError = true),
+                    onExitWaiting: () =>
+                        setState(() => _waitingForAutoMaster = false),
+                  );
+                  if (!mounted) return;
+                  if (result != AutoMasterFlowResult.connectionError) {
+                    // proceed / completed → let the router decide pnp-vs-login
+                    // via userAcknowledgedAutoConfiguration.
+                    context.goNamed(RouteNamed.pnp);
+                  }
+                  // connectionError → waiting view shows error + retry.
                 }).catchError((error) {
                   logger.e(
                       '[PnP]: Troubleshooter - Check internet connection with new settings - Failed');
@@ -248,7 +249,15 @@ class _PnpIspSaveSettingsViewState
             _showAutoMasterConnectionError = false;
             _waitingForAutoMaster = false;
           });
-          _saveNewSettings();
+          if (_autoMasterPostWanUp) {
+            // The error happened after WAN was already up (settings saved).
+            // Re-saving would be wrong; restart the flow via PnP (re-entry is
+            // itself the recovery path).
+            context.goNamed(RouteNamed.pnp);
+          } else {
+            // Pre-save error → re-run the save from the top.
+            _saveNewSettings();
+          }
         },
       );
     }

--- a/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
+++ b/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
@@ -95,6 +95,15 @@ class _PnpIspSaveSettingsViewState extends ConsumerState<PnpIspSaveSettingsView>
         case AutoMasterFlowResult.proceed:
           logger.i('[PnP]: Troubleshooter - Auto Master done, continue save');
           return true;
+        case AutoMasterFlowResult.budgetExhausted:
+          // Out of time but the router answers, so Auto Master may still be
+          // mid-flight. Save anyway: we have already waited out the full
+          // budget, and if the credential does get rotated under us the save
+          // fails as a JNAPError, which _saveNewSettings' error path already
+          // turns into a message the user can act on.
+          logger.w(
+              '[PnP]: Troubleshooter - Auto Master outcome unknown, continue save');
+          return true;
         case AutoMasterFlowResult.connectionError:
           // Waiting view already shows the error + retry.
           return false;
@@ -170,8 +179,11 @@ class _PnpIspSaveSettingsViewState extends ConsumerState<PnpIspSaveSettingsView>
                   );
                   if (!mounted) return;
                   if (result != AutoMasterFlowResult.connectionError) {
-                    // proceed / completed → let the router decide pnp-vs-login
-                    // via userAcknowledgedAutoConfiguration.
+                    // completed / proceed / budgetExhausted → go to PnP and let
+                    // its entry precheck decide. Nothing is pending here (the
+                    // settings are already saved), so an unknown Auto Master
+                    // outcome needs no special handling: PnP re-reads whatever
+                    // state the router is actually in.
                     context.goNamed(RouteNamed.pnp);
                   }
                   // connectionError → waiting view shows error + retry.

--- a/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
+++ b/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
@@ -192,7 +192,17 @@ class _PnpIspSaveSettingsViewState extends ConsumerState<PnpIspSaveSettingsView>
                       '[PnP]: Troubleshooter - Check internet connection with new settings - Failed');
                   // Internet connection is Not OK
                   context.pop(_getErrorMessage(wanType));
-                }, test: (error) => error is ExceptionNoInternetConnection);
+                }, test: (error) => error is ExceptionNoInternetConnection).catchError(
+                    (error) {
+                  // The credential was rotated while we were checking. This
+                  // window is 30 retries wide (~90s) and Auto Master runs for
+                  // ~115s from WAN-up, so a rotation can land inside it — and
+                  // that is *success*, not a settings failure. Popping an ISP
+                  // error here would blame the settings the user just got right.
+                  logger.i(
+                      '[PnP]: Troubleshooter - Auto Master rotated the password mid-check, back to PnP');
+                  if (mounted) context.goNamed(RouteNamed.pnp);
+                }, test: (error) => error is ExceptionInvalidAdminPassword);
               }
               subscription?.cancel();
             },

--- a/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
+++ b/lib/page/instant_setup/troubleshooter/views/isp_settings/pnp_isp_save_settings_view.dart
@@ -63,20 +63,14 @@ class _PnpIspSaveSettingsViewState extends ConsumerState<PnpIspSaveSettingsView>
   /// Check Auto Master status before saving ISP settings.
   /// Returns true if save should continue, false if redirected or waiting.
   Future<bool> _checkAndWaitForAutoMaster() async {
-    AutoMasterStatus? status;
-    try {
-      status = await ref.read(pnpProvider.notifier).checkAutoMasterStatus();
-    } on ExceptionAutoMasterUnauthorized {
-      // Session expired, redirect to PnP entry
-      logger.w('[PnP]: Troubleshooter - Auto Master check unauthorized');
-      if (mounted) context.goNamed(RouteNamed.pnp);
-      return false;
-    }
+    final status = await ref.read(pnpProvider.notifier).checkAutoMasterStatus();
 
-    // null means Auto Master not supported, continue save
+    // null means the status is unavailable — unreachable router, or firmware
+    // that does not serve GetAutoMasterStatus unauthed. Either way there is
+    // nothing to wait for, so continue the save.
     if (status == null) {
       logger.d(
-          '[PnP]: Troubleshooter - Auto Master not supported, continue save');
+          '[PnP]: Troubleshooter - Auto Master status unavailable, continue save');
       return true;
     }
 

--- a/lib/page/instant_setup/troubleshooter/views/pnp_waiting_modem_view.dart
+++ b/lib/page/instant_setup/troubleshooter/views/pnp_waiting_modem_view.dart
@@ -123,7 +123,14 @@ class _PnpWaitingModemViewState extends ConsumerState<PnpWaitingModemView> {
                     context.goNamed(RouteNamed.pnpNoInternetConnection);
                   }, test: (error) {
                     return error is ExceptionNoInternetConnection;
-                  });
+                  }).catchError((error, stackTrace) {
+                    // Auto Master rotated the admin password during the check.
+                    // Nothing is wrong with the modem — go back to PnP, whose
+                    // entry precheck asks for the new password.
+                    logger.i(
+                        '[PnP Troubleshooter]: Password was rotated during the modem check, back to PnP');
+                    if (mounted) context.goNamed(RouteNamed.pnp);
+                  }, test: (error) => error is ExceptionInvalidAdminPassword);
                 });
               },
             ),

--- a/lib/page/instant_setup/widgets/pnp_auto_master_flow.dart
+++ b/lib/page/instant_setup/widgets/pnp_auto_master_flow.dart
@@ -16,14 +16,20 @@ enum AutoMasterFlowResult {
   /// route onward to recover.
   completed,
 
-  /// Auto Master did not change anything: it `failed`, or it timed out with the
-  /// session still alive, or it never engaged. The session is valid and the
-  /// caller may proceed with whatever it was doing (e.g. resume a pending save,
-  /// or continue to the next step).
+  /// Auto Master did not change anything: it `failed`, or it never engaged. The
+  /// session is valid and the caller may proceed with whatever it was doing
+  /// (e.g. resume a pending save, or continue to the next step).
   proceed,
 
-  /// A genuine connection error was detected (repeated polling failures that a
-  /// probe could not attribute to a completed / dead-session state). The caller
+  /// The wait ran out of time, but the router is still reachable — so Auto
+  /// Master's outcome is simply unknown. Distinct from [proceed], where Auto
+  /// Master is known to have left the credential alone: here it may still be
+  /// mid-flight, and a caller about to do something the rotation would break
+  /// (saving settings) may want another look before committing. Callers with
+  /// nothing at stake can treat it as [proceed].
+  budgetExhausted,
+
+  /// The router could not be reached after the wait ran out of time. The caller
   /// should surface the error and offer a retry.
   connectionError,
 }
@@ -55,7 +61,6 @@ mixin PnpAutoMasterFlowMixin<T extends ConsumerStatefulWidget>
   /// All callbacks are only invoked while `mounted`.
   Future<AutoMasterFlowResult> runAutoMasterFlow({
     bool waitForRunningFirst = false,
-    int consecutiveNullThreshold = 3,
     required VoidCallback onEnterWaiting,
     required VoidCallback onShowConnectionError,
     VoidCallback? onExitWaiting,
@@ -64,11 +69,11 @@ mixin PnpAutoMasterFlowMixin<T extends ConsumerStatefulWidget>
 
     AutoMasterFlowResult result;
     if (waitForRunningFirst) {
-      final phaseA = await _waitForRunning(consecutiveNullThreshold);
+      final phaseA = await _waitForRunning();
       // null => observed Running, fall through to waiting for completion.
-      result = phaseA ?? await _waitForCompletion(consecutiveNullThreshold);
+      result = phaseA ?? await _waitForCompletion();
     } else {
-      result = await _waitForCompletion(consecutiveNullThreshold);
+      result = await _waitForCompletion();
     }
 
     if (!mounted) return result;
@@ -84,8 +89,7 @@ mixin PnpAutoMasterFlowMixin<T extends ConsumerStatefulWidget>
   ///
   /// Returns a terminal [AutoMasterFlowResult], or `null` to signal "Running
   /// observed, proceed to wait for completion".
-  Future<AutoMasterFlowResult?> _waitForRunning(int threshold) async {
-    int consecutiveNulls = 0;
+  Future<AutoMasterFlowResult?> _waitForRunning() async {
     await for (final status
         in ref.read(pnpProvider.notifier).pollAutoMasterUntilRunning()) {
       if (!mounted) return AutoMasterFlowResult.proceed;
@@ -99,42 +103,28 @@ mixin PnpAutoMasterFlowMixin<T extends ConsumerStatefulWidget>
       if (status == AutoMasterStatus.failed) {
         return AutoMasterFlowResult.proceed;
       }
-      if (status == null) {
-        consecutiveNulls++;
-        logger.w(
-            '[PnP]: Auto Master wait-for-running null, consecutive: $consecutiveNulls');
-        if (consecutiveNulls >= threshold) {
-          final probe = await _probe();
-          if (!mounted) return AutoMasterFlowResult.proceed;
-          // An undetermined probe means Auto Master status is unavailable — on
-          // firmware that does not serve it unauthed, every poll lands here.
-          // Phase A runs after ISP settings saved and WAN came up, so the
-          // session was just proven alive; treating that as a connection error
-          // would show "router not found" right after a successful setup.
-          // Proceed instead and let PnP's own second pass handle recovery.
-          if (probe == AutoMasterFlowResult.connectionError) {
-            logger.w(
-                '[PnP]: Auto Master wait-for-running undetermined, proceed');
-            return AutoMasterFlowResult.proceed;
-          }
-          if (probe != null) return probe;
-          consecutiveNulls = 0; // probe saw Running → keep waiting
-        }
-      } else {
-        // idle → not started yet, keep waiting
-        consecutiveNulls = 0;
-      }
+      // null (unreachable, unsupported, or a firmware that will not serve the
+      // status) and idle both mean "not started yet" — keep waiting until the
+      // stream's own budget runs out.
     }
 
-    // Stream ended without Running (timeout). The session was just proven alive
-    // by the upstream internet check, so we do NOT re-test the connection here.
-    logger.w('[PnP]: Auto Master wait-for-running timeout, proceed');
+    // Stream ended without Running (budget spent). The session was just proven
+    // alive by the upstream internet check, so we do NOT re-test the connection
+    // here: Auto Master simply never announced itself.
+    logger.w('[PnP]: Auto Master wait-for-running budget spent, proceed');
     return AutoMasterFlowResult.proceed;
   }
 
   /// Phase B — wait for Auto Master to *finish*.
-  Future<AutoMasterFlowResult> _waitForCompletion(int threshold) async {
-    int consecutiveNulls = 0;
+  ///
+  /// A `null` status is not evidence of anything here. make-Master takes the
+  /// router's HTTP service down for the better part of a minute, and during that
+  /// window the router may time out, refuse, or answer something unrecognised —
+  /// so counting nulls to decide the router is gone reads noise as signal, and
+  /// gives up (~50s) before the service is even back (~65s). The poll's own
+  /// bounded length is the give-up rule instead, and only then does an actual
+  /// reachability test decide.
+  Future<AutoMasterFlowResult> _waitForCompletion() async {
     await for (final status
         in ref.read(pnpProvider.notifier).pollAutoMasterStatus()) {
       if (!mounted) return AutoMasterFlowResult.proceed;
@@ -146,56 +136,19 @@ mixin PnpAutoMasterFlowMixin<T extends ConsumerStatefulWidget>
       if (status == AutoMasterStatus.failed) {
         return AutoMasterFlowResult.proceed;
       }
-      if (status == null) {
-        consecutiveNulls++;
-        logger.w(
-            '[PnP]: Auto Master polling null, consecutive: $consecutiveNulls');
-        if (consecutiveNulls >= threshold) {
-          final probe = await _probe();
-          if (!mounted) return AutoMasterFlowResult.proceed;
-          if (probe != null) return probe;
-          consecutiveNulls = 0; // probe saw Running → keep waiting
-        }
-      } else {
-        // running → keep waiting for completion
-        consecutiveNulls = 0;
-      }
+      // running / null → keep waiting.
     }
 
-    // Stream ended (timeout). Verify the session survived make-Master.
-    logger.w('[PnP]: Auto Master polling timeout, verifying connection');
+    // Budget spent without a terminal status. Ask the one question that can be
+    // answered reliably: is the router there?
+    logger.w('[PnP]: Auto Master polling budget spent, verifying connection');
     try {
       await ref.read(pnpProvider.notifier).testConnectionReconnected();
-      return AutoMasterFlowResult.proceed;
+      // Reachable, but Auto Master's outcome is unknown — it may still be
+      // running. Report that honestly and let the caller decide.
+      return AutoMasterFlowResult.budgetExhausted;
     } catch (_) {
       return AutoMasterFlowResult.connectionError;
-    }
-  }
-
-  /// Disambiguate a run of null poll results with one direct status read.
-  ///
-  /// The polls flatten every non-success result to `null`, so a router that is
-  /// genuinely unreachable looks the same as firmware that will not serve the
-  /// status. This probe re-reads the status once to see which it is.
-  ///
-  /// Returns a terminal [AutoMasterFlowResult], or `null` to signal "keep
-  /// polling" (Auto Master is still Running). Callers decide what an
-  /// undetermined status ([AutoMasterFlowResult.connectionError]) means for
-  /// their phase — Phase A downgrades it to `proceed`.
-  Future<AutoMasterFlowResult?> _probe() async {
-    final status = await ref.read(pnpProvider.notifier).checkAutoMasterStatus();
-    switch (status) {
-      case AutoMasterStatus.complete:
-      case AutoMasterStatus.idle:
-        return AutoMasterFlowResult.completed;
-      case AutoMasterStatus.failed:
-        return AutoMasterFlowResult.proceed;
-      case AutoMasterStatus.running:
-        return null; // reset + keep polling
-      case null:
-        // Status unavailable: unreachable router, or firmware that does not
-        // serve GetAutoMasterStatus unauthed.
-        return AutoMasterFlowResult.connectionError;
     }
   }
 }

--- a/lib/page/instant_setup/widgets/pnp_auto_master_flow.dart
+++ b/lib/page/instant_setup/widgets/pnp_auto_master_flow.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/core/jnap/models/auto_master_status.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
-import 'package:privacy_gui/page/instant_setup/data/pnp_exception.dart';
 import 'package:privacy_gui/page/instant_setup/data/pnp_provider.dart';
 
 /// Outcome of [PnpAutoMasterFlowMixin.runAutoMasterFlow].
@@ -13,9 +12,8 @@ import 'package:privacy_gui/page/instant_setup/data/pnp_provider.dart';
 /// (`userAcknowledgedAutoConfiguration`) rather than hardcoding a redirect here.
 enum AutoMasterFlowResult {
   /// Auto Master finished making this router the Master (status reached
-  /// `complete`/`idle`), or the authenticated session died mid make-Master
-  /// (unauthorized) — which likewise means make-Master happened. The router's
-  /// admin state changed, so the caller should route onward to recover.
+  /// `complete`/`idle`). The router's admin state changed, so the caller should
+  /// route onward to recover.
   completed,
 
   /// Auto Master did not change anything: it `failed`, or it timed out with the
@@ -88,40 +86,44 @@ mixin PnpAutoMasterFlowMixin<T extends ConsumerStatefulWidget>
   /// observed, proceed to wait for completion".
   Future<AutoMasterFlowResult?> _waitForRunning(int threshold) async {
     int consecutiveNulls = 0;
-    try {
-      await for (final status
-          in ref.read(pnpProvider.notifier).pollAutoMasterUntilRunning()) {
-        if (!mounted) return AutoMasterFlowResult.proceed;
+    await for (final status
+        in ref.read(pnpProvider.notifier).pollAutoMasterUntilRunning()) {
+      if (!mounted) return AutoMasterFlowResult.proceed;
 
-        if (status == AutoMasterStatus.running) {
-          return null; // → wait for completion
-        }
-        if (status == AutoMasterStatus.complete) {
-          return AutoMasterFlowResult.completed;
-        }
-        if (status == AutoMasterStatus.failed) {
-          return AutoMasterFlowResult.proceed;
-        }
-        if (status == null) {
-          consecutiveNulls++;
-          logger.w(
-              '[PnP]: Auto Master wait-for-running null, consecutive: $consecutiveNulls');
-          if (consecutiveNulls >= threshold) {
-            final probe = await _probeUnauthorized();
-            if (!mounted) return AutoMasterFlowResult.proceed;
-            if (probe != null) return probe;
-            consecutiveNulls = 0; // probe saw Running → keep waiting
-          }
-        } else {
-          // idle → not started yet, keep waiting
-          consecutiveNulls = 0;
-        }
+      if (status == AutoMasterStatus.running) {
+        return null; // → wait for completion
       }
-    } on ExceptionAutoMasterUnauthorized {
-      // The stream terminated on the first 401: make-Master rotated the admin
-      // password mid-poll → Auto Master effectively completed → recover.
-      logger.i('[PnP]: Auto Master wait-for-running unauthorized → completed');
-      return AutoMasterFlowResult.completed;
+      if (status == AutoMasterStatus.complete) {
+        return AutoMasterFlowResult.completed;
+      }
+      if (status == AutoMasterStatus.failed) {
+        return AutoMasterFlowResult.proceed;
+      }
+      if (status == null) {
+        consecutiveNulls++;
+        logger.w(
+            '[PnP]: Auto Master wait-for-running null, consecutive: $consecutiveNulls');
+        if (consecutiveNulls >= threshold) {
+          final probe = await _probe();
+          if (!mounted) return AutoMasterFlowResult.proceed;
+          // An undetermined probe means Auto Master status is unavailable — on
+          // firmware that does not serve it unauthed, every poll lands here.
+          // Phase A runs after ISP settings saved and WAN came up, so the
+          // session was just proven alive; treating that as a connection error
+          // would show "router not found" right after a successful setup.
+          // Proceed instead and let PnP's own second pass handle recovery.
+          if (probe == AutoMasterFlowResult.connectionError) {
+            logger.w(
+                '[PnP]: Auto Master wait-for-running undetermined, proceed');
+            return AutoMasterFlowResult.proceed;
+          }
+          if (probe != null) return probe;
+          consecutiveNulls = 0; // probe saw Running → keep waiting
+        }
+      } else {
+        // idle → not started yet, keep waiting
+        consecutiveNulls = 0;
+      }
     }
 
     // Stream ended without Running (timeout). The session was just proven alive
@@ -133,38 +135,31 @@ mixin PnpAutoMasterFlowMixin<T extends ConsumerStatefulWidget>
   /// Phase B — wait for Auto Master to *finish*.
   Future<AutoMasterFlowResult> _waitForCompletion(int threshold) async {
     int consecutiveNulls = 0;
-    try {
-      await for (final status
-          in ref.read(pnpProvider.notifier).pollAutoMasterStatus()) {
-        if (!mounted) return AutoMasterFlowResult.proceed;
+    await for (final status
+        in ref.read(pnpProvider.notifier).pollAutoMasterStatus()) {
+      if (!mounted) return AutoMasterFlowResult.proceed;
 
-        if (status == AutoMasterStatus.complete ||
-            status == AutoMasterStatus.idle) {
-          return AutoMasterFlowResult.completed;
-        }
-        if (status == AutoMasterStatus.failed) {
-          return AutoMasterFlowResult.proceed;
-        }
-        if (status == null) {
-          consecutiveNulls++;
-          logger.w(
-              '[PnP]: Auto Master polling null, consecutive: $consecutiveNulls');
-          if (consecutiveNulls >= threshold) {
-            final probe = await _probeUnauthorized();
-            if (!mounted) return AutoMasterFlowResult.proceed;
-            if (probe != null) return probe;
-            consecutiveNulls = 0; // probe saw Running → keep waiting
-          }
-        } else {
-          // running → keep waiting for completion
-          consecutiveNulls = 0;
-        }
+      if (status == AutoMasterStatus.complete ||
+          status == AutoMasterStatus.idle) {
+        return AutoMasterFlowResult.completed;
       }
-    } on ExceptionAutoMasterUnauthorized {
-      // The stream terminated on the first 401: make-Master rotated the admin
-      // password mid-poll → Auto Master effectively completed → recover.
-      logger.i('[PnP]: Auto Master polling unauthorized → completed');
-      return AutoMasterFlowResult.completed;
+      if (status == AutoMasterStatus.failed) {
+        return AutoMasterFlowResult.proceed;
+      }
+      if (status == null) {
+        consecutiveNulls++;
+        logger.w(
+            '[PnP]: Auto Master polling null, consecutive: $consecutiveNulls');
+        if (consecutiveNulls >= threshold) {
+          final probe = await _probe();
+          if (!mounted) return AutoMasterFlowResult.proceed;
+          if (probe != null) return probe;
+          consecutiveNulls = 0; // probe saw Running → keep waiting
+        }
+      } else {
+        // running → keep waiting for completion
+        consecutiveNulls = 0;
+      }
     }
 
     // Stream ended (timeout). Verify the session survived make-Master.
@@ -177,33 +172,30 @@ mixin PnpAutoMasterFlowMixin<T extends ConsumerStatefulWidget>
     }
   }
 
-  /// Disambiguate a run of null poll results. `pollAutoMasterStatus`/
-  /// `pollAutoMasterUntilRunning` flatten an unauthorized error to `null`, so a
-  /// dead session (caused by make-Master) looks identical to a connection loss.
-  /// This explicit probe tells them apart.
+  /// Disambiguate a run of null poll results with one direct status read.
+  ///
+  /// The polls flatten every non-success result to `null`, so a router that is
+  /// genuinely unreachable looks the same as firmware that will not serve the
+  /// status. This probe re-reads the status once to see which it is.
   ///
   /// Returns a terminal [AutoMasterFlowResult], or `null` to signal "keep
-  /// polling" (Auto Master is still Running).
-  Future<AutoMasterFlowResult?> _probeUnauthorized() async {
-    try {
-      final status =
-          await ref.read(pnpProvider.notifier).checkAutoMasterStatus();
-      switch (status) {
-        case AutoMasterStatus.complete:
-        case AutoMasterStatus.idle:
-          return AutoMasterFlowResult.completed;
-        case AutoMasterStatus.failed:
-          return AutoMasterFlowResult.proceed;
-        case AutoMasterStatus.running:
-          return null; // reset + keep polling
-        case null:
-          // Could not determine the status → treat as a real connection error.
-          return AutoMasterFlowResult.connectionError;
-      }
-    } on ExceptionAutoMasterUnauthorized {
-      // Session died mid make-Master → Auto Master effectively completed.
-      logger.i('[PnP]: Auto Master probe unauthorized → completed (recover)');
-      return AutoMasterFlowResult.completed;
+  /// polling" (Auto Master is still Running). Callers decide what an
+  /// undetermined status ([AutoMasterFlowResult.connectionError]) means for
+  /// their phase — Phase A downgrades it to `proceed`.
+  Future<AutoMasterFlowResult?> _probe() async {
+    final status = await ref.read(pnpProvider.notifier).checkAutoMasterStatus();
+    switch (status) {
+      case AutoMasterStatus.complete:
+      case AutoMasterStatus.idle:
+        return AutoMasterFlowResult.completed;
+      case AutoMasterStatus.failed:
+        return AutoMasterFlowResult.proceed;
+      case AutoMasterStatus.running:
+        return null; // reset + keep polling
+      case null:
+        // Status unavailable: unreachable router, or firmware that does not
+        // serve GetAutoMasterStatus unauthed.
+        return AutoMasterFlowResult.connectionError;
     }
   }
 }

--- a/lib/page/instant_setup/widgets/pnp_auto_master_flow.dart
+++ b/lib/page/instant_setup/widgets/pnp_auto_master_flow.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/jnap/models/auto_master_status.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/page/instant_setup/data/pnp_exception.dart';
+import 'package:privacy_gui/page/instant_setup/data/pnp_provider.dart';
+
+/// Outcome of [PnpAutoMasterFlowMixin.runAutoMasterFlow].
+///
+/// The mixin reports *what happened* to Auto Master and never navigates itself;
+/// each caller maps these to the appropriate action (navigate / continue / show
+/// error). This keeps the pnp-vs-login decision with the router
+/// (`userAcknowledgedAutoConfiguration`) rather than hardcoding a redirect here.
+enum AutoMasterFlowResult {
+  /// Auto Master finished making this router the Master (status reached
+  /// `complete`/`idle`), or the authenticated session died mid make-Master
+  /// (unauthorized) — which likewise means make-Master happened. The router's
+  /// admin state changed, so the caller should route onward to recover.
+  completed,
+
+  /// Auto Master did not change anything: it `failed`, or it timed out with the
+  /// session still alive, or it never engaged. The session is valid and the
+  /// caller may proceed with whatever it was doing (e.g. resume a pending save,
+  /// or continue to the next step).
+  proceed,
+
+  /// A genuine connection error was detected (repeated polling failures that a
+  /// probe could not attribute to a completed / dead-session state). The caller
+  /// should surface the error and offer a retry.
+  connectionError,
+}
+
+/// Shared Auto Master wait/poll state machine for PnP views.
+///
+/// Auto Master (firmware "make Master") is triggered when WAN comes up and,
+/// after ~1 minute, changes the admin password and restarts services — which
+/// invalidates the GUI's authenticated session. This mixin encapsulates the
+/// polling/waiting logic that used to be copy-pasted across PnP views.
+///
+/// It requires [ConsumerState] (for `ref`, `context`, `mounted`, `setState`)
+/// and drives the caller's own waiting UI through the supplied callbacks. It
+/// deliberately performs no navigation of its own.
+mixin PnpAutoMasterFlowMixin<T extends ConsumerStatefulWidget>
+    on ConsumerState<T> {
+  /// Runs the Auto Master wait flow.
+  ///
+  /// When [waitForRunningFirst] is true (the ISP-save WAN-up point), it first
+  /// polls until Auto Master *starts* (Idle -> Running) before waiting for it to
+  /// finish. When false (the pre-save check), it goes straight to waiting for
+  /// completion (the caller has already observed `running`).
+  ///
+  /// Callbacks:
+  /// - [onEnterWaiting] fired once at the start (show the waiting UI).
+  /// - [onShowConnectionError] fired on [AutoMasterFlowResult.connectionError].
+  /// - [onExitWaiting] fired on the non-error outcomes (hide the waiting UI).
+  ///
+  /// All callbacks are only invoked while `mounted`.
+  Future<AutoMasterFlowResult> runAutoMasterFlow({
+    bool waitForRunningFirst = false,
+    int consecutiveNullThreshold = 3,
+    required VoidCallback onEnterWaiting,
+    required VoidCallback onShowConnectionError,
+    VoidCallback? onExitWaiting,
+  }) async {
+    if (mounted) onEnterWaiting();
+
+    AutoMasterFlowResult result;
+    if (waitForRunningFirst) {
+      final phaseA = await _waitForRunning(consecutiveNullThreshold);
+      // null => observed Running, fall through to waiting for completion.
+      result = phaseA ?? await _waitForCompletion(consecutiveNullThreshold);
+    } else {
+      result = await _waitForCompletion(consecutiveNullThreshold);
+    }
+
+    if (!mounted) return result;
+    if (result == AutoMasterFlowResult.connectionError) {
+      onShowConnectionError();
+    } else {
+      onExitWaiting?.call();
+    }
+    return result;
+  }
+
+  /// Phase A — wait for Auto Master to *start*.
+  ///
+  /// Returns a terminal [AutoMasterFlowResult], or `null` to signal "Running
+  /// observed, proceed to wait for completion".
+  Future<AutoMasterFlowResult?> _waitForRunning(int threshold) async {
+    int consecutiveNulls = 0;
+    await for (final status
+        in ref.read(pnpProvider.notifier).pollAutoMasterUntilRunning()) {
+      if (!mounted) return AutoMasterFlowResult.proceed;
+
+      if (status == AutoMasterStatus.running) {
+        return null; // → wait for completion
+      }
+      if (status == AutoMasterStatus.complete) {
+        return AutoMasterFlowResult.completed;
+      }
+      if (status == AutoMasterStatus.failed) {
+        return AutoMasterFlowResult.proceed;
+      }
+      if (status == null) {
+        consecutiveNulls++;
+        logger.w(
+            '[PnP]: Auto Master wait-for-running null, consecutive: $consecutiveNulls');
+        if (consecutiveNulls >= threshold) {
+          final probe = await _probeUnauthorized();
+          if (!mounted) return AutoMasterFlowResult.proceed;
+          if (probe != null) return probe;
+          consecutiveNulls = 0; // probe saw Running → keep waiting
+        }
+      } else {
+        // idle → not started yet, keep waiting
+        consecutiveNulls = 0;
+      }
+    }
+
+    // Stream ended without Running (timeout). The session was just proven alive
+    // by the upstream internet check, so we do NOT re-test the connection here.
+    logger.w('[PnP]: Auto Master wait-for-running timeout, proceed');
+    return AutoMasterFlowResult.proceed;
+  }
+
+  /// Phase B — wait for Auto Master to *finish*.
+  Future<AutoMasterFlowResult> _waitForCompletion(int threshold) async {
+    int consecutiveNulls = 0;
+    await for (final status
+        in ref.read(pnpProvider.notifier).pollAutoMasterStatus()) {
+      if (!mounted) return AutoMasterFlowResult.proceed;
+
+      if (status == AutoMasterStatus.complete ||
+          status == AutoMasterStatus.idle) {
+        return AutoMasterFlowResult.completed;
+      }
+      if (status == AutoMasterStatus.failed) {
+        return AutoMasterFlowResult.proceed;
+      }
+      if (status == null) {
+        consecutiveNulls++;
+        logger.w(
+            '[PnP]: Auto Master polling null, consecutive: $consecutiveNulls');
+        if (consecutiveNulls >= threshold) {
+          final probe = await _probeUnauthorized();
+          if (!mounted) return AutoMasterFlowResult.proceed;
+          if (probe != null) return probe;
+          consecutiveNulls = 0; // probe saw Running → keep waiting
+        }
+      } else {
+        // running → keep waiting for completion
+        consecutiveNulls = 0;
+      }
+    }
+
+    // Stream ended (timeout). Verify the session survived make-Master.
+    logger.w('[PnP]: Auto Master polling timeout, verifying connection');
+    try {
+      await ref.read(pnpProvider.notifier).testConnectionReconnected();
+      return AutoMasterFlowResult.proceed;
+    } catch (_) {
+      return AutoMasterFlowResult.connectionError;
+    }
+  }
+
+  /// Disambiguate a run of null poll results. `pollAutoMasterStatus`/
+  /// `pollAutoMasterUntilRunning` flatten an unauthorized error to `null`, so a
+  /// dead session (caused by make-Master) looks identical to a connection loss.
+  /// This explicit probe tells them apart.
+  ///
+  /// Returns a terminal [AutoMasterFlowResult], or `null` to signal "keep
+  /// polling" (Auto Master is still Running).
+  Future<AutoMasterFlowResult?> _probeUnauthorized() async {
+    try {
+      final status =
+          await ref.read(pnpProvider.notifier).checkAutoMasterStatus();
+      switch (status) {
+        case AutoMasterStatus.complete:
+        case AutoMasterStatus.idle:
+          return AutoMasterFlowResult.completed;
+        case AutoMasterStatus.failed:
+          return AutoMasterFlowResult.proceed;
+        case AutoMasterStatus.running:
+          return null; // reset + keep polling
+        case null:
+          // Could not determine the status → treat as a real connection error.
+          return AutoMasterFlowResult.connectionError;
+      }
+    } on ExceptionAutoMasterUnauthorized {
+      // Session died mid make-Master → Auto Master effectively completed.
+      logger.i('[PnP]: Auto Master probe unauthorized → completed (recover)');
+      return AutoMasterFlowResult.completed;
+    }
+  }
+}

--- a/lib/page/instant_setup/widgets/pnp_auto_master_flow.dart
+++ b/lib/page/instant_setup/widgets/pnp_auto_master_flow.dart
@@ -88,33 +88,40 @@ mixin PnpAutoMasterFlowMixin<T extends ConsumerStatefulWidget>
   /// observed, proceed to wait for completion".
   Future<AutoMasterFlowResult?> _waitForRunning(int threshold) async {
     int consecutiveNulls = 0;
-    await for (final status
-        in ref.read(pnpProvider.notifier).pollAutoMasterUntilRunning()) {
-      if (!mounted) return AutoMasterFlowResult.proceed;
+    try {
+      await for (final status
+          in ref.read(pnpProvider.notifier).pollAutoMasterUntilRunning()) {
+        if (!mounted) return AutoMasterFlowResult.proceed;
 
-      if (status == AutoMasterStatus.running) {
-        return null; // → wait for completion
-      }
-      if (status == AutoMasterStatus.complete) {
-        return AutoMasterFlowResult.completed;
-      }
-      if (status == AutoMasterStatus.failed) {
-        return AutoMasterFlowResult.proceed;
-      }
-      if (status == null) {
-        consecutiveNulls++;
-        logger.w(
-            '[PnP]: Auto Master wait-for-running null, consecutive: $consecutiveNulls');
-        if (consecutiveNulls >= threshold) {
-          final probe = await _probeUnauthorized();
-          if (!mounted) return AutoMasterFlowResult.proceed;
-          if (probe != null) return probe;
-          consecutiveNulls = 0; // probe saw Running → keep waiting
+        if (status == AutoMasterStatus.running) {
+          return null; // → wait for completion
         }
-      } else {
-        // idle → not started yet, keep waiting
-        consecutiveNulls = 0;
+        if (status == AutoMasterStatus.complete) {
+          return AutoMasterFlowResult.completed;
+        }
+        if (status == AutoMasterStatus.failed) {
+          return AutoMasterFlowResult.proceed;
+        }
+        if (status == null) {
+          consecutiveNulls++;
+          logger.w(
+              '[PnP]: Auto Master wait-for-running null, consecutive: $consecutiveNulls');
+          if (consecutiveNulls >= threshold) {
+            final probe = await _probeUnauthorized();
+            if (!mounted) return AutoMasterFlowResult.proceed;
+            if (probe != null) return probe;
+            consecutiveNulls = 0; // probe saw Running → keep waiting
+          }
+        } else {
+          // idle → not started yet, keep waiting
+          consecutiveNulls = 0;
+        }
       }
+    } on ExceptionAutoMasterUnauthorized {
+      // The stream terminated on the first 401: make-Master rotated the admin
+      // password mid-poll → Auto Master effectively completed → recover.
+      logger.i('[PnP]: Auto Master wait-for-running unauthorized → completed');
+      return AutoMasterFlowResult.completed;
     }
 
     // Stream ended without Running (timeout). The session was just proven alive
@@ -126,31 +133,38 @@ mixin PnpAutoMasterFlowMixin<T extends ConsumerStatefulWidget>
   /// Phase B — wait for Auto Master to *finish*.
   Future<AutoMasterFlowResult> _waitForCompletion(int threshold) async {
     int consecutiveNulls = 0;
-    await for (final status
-        in ref.read(pnpProvider.notifier).pollAutoMasterStatus()) {
-      if (!mounted) return AutoMasterFlowResult.proceed;
+    try {
+      await for (final status
+          in ref.read(pnpProvider.notifier).pollAutoMasterStatus()) {
+        if (!mounted) return AutoMasterFlowResult.proceed;
 
-      if (status == AutoMasterStatus.complete ||
-          status == AutoMasterStatus.idle) {
-        return AutoMasterFlowResult.completed;
-      }
-      if (status == AutoMasterStatus.failed) {
-        return AutoMasterFlowResult.proceed;
-      }
-      if (status == null) {
-        consecutiveNulls++;
-        logger.w(
-            '[PnP]: Auto Master polling null, consecutive: $consecutiveNulls');
-        if (consecutiveNulls >= threshold) {
-          final probe = await _probeUnauthorized();
-          if (!mounted) return AutoMasterFlowResult.proceed;
-          if (probe != null) return probe;
-          consecutiveNulls = 0; // probe saw Running → keep waiting
+        if (status == AutoMasterStatus.complete ||
+            status == AutoMasterStatus.idle) {
+          return AutoMasterFlowResult.completed;
         }
-      } else {
-        // running → keep waiting for completion
-        consecutiveNulls = 0;
+        if (status == AutoMasterStatus.failed) {
+          return AutoMasterFlowResult.proceed;
+        }
+        if (status == null) {
+          consecutiveNulls++;
+          logger.w(
+              '[PnP]: Auto Master polling null, consecutive: $consecutiveNulls');
+          if (consecutiveNulls >= threshold) {
+            final probe = await _probeUnauthorized();
+            if (!mounted) return AutoMasterFlowResult.proceed;
+            if (probe != null) return probe;
+            consecutiveNulls = 0; // probe saw Running → keep waiting
+          }
+        } else {
+          // running → keep waiting for completion
+          consecutiveNulls = 0;
+        }
       }
+    } on ExceptionAutoMasterUnauthorized {
+      // The stream terminated on the first 401: make-Master rotated the admin
+      // password mid-poll → Auto Master effectively completed → recover.
+      logger.i('[PnP]: Auto Master polling unauthorized → completed');
+      return AutoMasterFlowResult.completed;
     }
 
     // Stream ended (timeout). Verify the session survived make-Master.

--- a/lib/page/instant_topology/views/widgets/node_action_menu.dart
+++ b/lib/page/instant_topology/views/widgets/node_action_menu.dart
@@ -30,7 +30,16 @@ class NodeActionMenu extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          AppText.labelLarge(loc(context).instantAction),
+          // The node card can be as narrow as 180px on mobile, and the label
+          // is a full sentence in several locales. Let it give way to the menu
+          // button rather than overflow the row.
+          Expanded(
+            child: AppText.labelLarge(
+              loc(context).instantAction,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
           PopupMenuButton<NodeInstantActions>(
             color: Theme.of(context).colorScheme.surface,
             iconSize: 20,

--- a/lib/page/instant_topology/views/widgets/tree_node_item.dart
+++ b/lib/page/instant_topology/views/widgets/tree_node_item.dart
@@ -344,10 +344,13 @@ class SimpleTreeNodeItem extends StatelessWidget {
           : Theme.of(context).colorScheme.surfaceVariant,
       onTap: onTap,
       child: Container(
+        // With an action menu the card is sized by its content: the menu is a
+        // fixed 72 and the info row's own height depends on the text theme, so
+        // a hard maxHeight here just clipped the row (10px on a 480w screen).
         constraints: BoxConstraints(
             minWidth: 180,
             maxWidth: 300,
-            maxHeight: actions.isEmpty ? 92 : 150),
+            maxHeight: actions.isEmpty ? 92 : double.infinity),
         padding: node.data.isOnline && actions.isNotEmpty
             ? EdgeInsets.only(
                 top: Spacing.medium,
@@ -358,51 +361,49 @@ class SimpleTreeNodeItem extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Expanded(
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Stack(
-                    alignment: Alignment.centerRight,
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Stack(
+                  alignment: Alignment.centerRight,
+                  children: [
+                    SharedWidgets.resolveRouterImage(context, node.data.icon,
+                        size: 64),
+                  ],
+                ),
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      SharedWidgets.resolveRouterImage(context, node.data.icon,
-                          size: 64),
-                    ],
-                  ),
-                  Expanded(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        AppText.titleMedium(
-                          node.data.location,
+                      AppText.titleMedium(
+                        node.data.location,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      AppText.bodySmall(node.data.isOnline
+                          ? loc(context)
+                              .nDevices(node.data.connectedDeviceCount)
+                          : loc(context).offline),
+                      if (extra != null)
+                        AppText.bodySmall(
+                          extra!,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
-                        AppText.bodySmall(node.data.isOnline
-                            ? loc(context)
-                                .nDevices(node.data.connectedDeviceCount)
-                            : loc(context).offline),
-                        if (extra != null)
-                          AppText.bodySmall(
-                            extra!,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                      ],
-                    ),
+                    ],
                   ),
-                  Padding(
-                    padding: const EdgeInsets.only(right: Spacing.small2),
-                    child: SharedWidgets.resolveSignalStrengthIcon(
-                      context,
-                      node.data.signalStrength,
-                      isOnline: node.data.isOnline,
-                      isWired: node.data.isWiredConnection,
-                    ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(right: Spacing.small2),
+                  child: SharedWidgets.resolveSignalStrengthIcon(
+                    context,
+                    node.data.signalStrength,
+                    isOnline: node.data.isOnline,
+                    isWired: node.data.isWiredConnection,
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
             if (node.data.isOnline && actions.isNotEmpty) ...[
               const AppGap.medium(),

--- a/lib/route/router_provider.dart
+++ b/lib/route/router_provider.dart
@@ -124,7 +124,16 @@ final routerProvider = Provider<GoRouter>((ref) {
       if (state.matchedLocation == '/') {
         return router._autoConfigurationLogic(state);
       } else if (state.matchedLocation == RoutePath.localLoginPassword) {
-        router._autoConfigurationLogic(state);
+        // Deliberately NOT re-running _autoConfigurationLogic here. It was
+        // fired without await and its result discarded, but the damage was the
+        // side effect, not the lost return value: when it elects PnP (which it
+        // does whenever userAcknowledgedAutoConfiguration is false, i.e. all of
+        // first-time setup) it calls authProvider.logout(), and _redirectLogic
+        // watches authProvider — so the redirect re-ran and elected PnP again,
+        // bouncing pnp -> localLoginPassword -> pnp in a self-driving loop.
+        // Awaiting it would only serialise that loop, not break it.
+        // The '/' branch above already owns the pnp-vs-login election; once we
+        // have matched localLoginPassword the destination is settled.
         return router._redirectLogic(state);
       } else if (state.matchedLocation.startsWith('/pnp')) {
         return router._goPnpPath(state);

--- a/lib/route/router_provider.dart
+++ b/lib/route/router_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' show ClientException;
 import 'package:privacy_gui/constants/build_config.dart';
 import 'package:privacy_gui/constants/pref_key.dart';
 import 'package:privacy_gui/core/cache/linksys_cache_manager.dart';
@@ -145,6 +146,12 @@ final routerProvider = Provider<GoRouter>((ref) {
 });
 
 class RouterNotifier extends ChangeNotifier {
+  /// Budget for riding out a router service restart while preparing the
+  /// dashboard. Deliberately short: a genuinely missing device must still fail
+  /// fast, and this runs inside a go_router redirect the user is waiting on.
+  static const int _deviceInfoMaxRetries = 2;
+  static const Duration _deviceInfoRetryDelay = Duration(seconds: 2);
+
   final Ref _ref;
   StreamSubscription? _errorSub;
   RouterNotifier(this._ref) {
@@ -355,18 +362,7 @@ class RouterNotifier extends ChangeNotifier {
         .read(linksysCacheManagerProvider)
         .loadCache(serialNumber: serialNumber ?? '');
     logger.d('[Prepare]: device info check - $serialNumber');
-    final nodeDeviceInfo = await _ref
-        .read(dashboardManagerProvider.notifier)
-        .checkDeviceInfo(serialNumber)
-        .then<NodeDeviceInfo?>((nodeDeviceInfo) {
-      // Build/Update better actions
-      logger.d('[Prepare]: build better actions');
-      buildBetterActions(nodeDeviceInfo.services);
-      // Update global model number
-      _ref.read(globalModelNumberProvider.notifier).state =
-          nodeDeviceInfo.modelNumber;
-      return nodeDeviceInfo;
-    }).onError((error, stackTrace) => null);
+    final nodeDeviceInfo = await _checkDeviceInfoWithRetry(serialNumber);
 
     if (nodeDeviceInfo != null) {
       logger.d('[Prepare]: SN changed: ${nodeDeviceInfo.serialNumber}');
@@ -391,6 +387,50 @@ class RouterNotifier extends ChangeNotifier {
       return _home('error=noDeviceInfo');
     }
   }
+
+  /// Fetches deviceInfo, retrying only while the failure looks like the router
+  /// being temporarily unreachable rather than genuinely absent.
+  ///
+  /// The router drops its HTTP service while it restarts services - the
+  /// make-Master credential rotation is one such window - and the local
+  /// deviceInfo call is issued with `retries: 0` / `timeoutMs: 3000`, so that
+  /// window is guaranteed to surface as a socket/timeout failure. Treating it
+  /// as "no device info" sends the user to the login page with an error they
+  /// can do nothing about, when waiting a couple of seconds would have worked.
+  ///
+  /// Any other failure (JNAP error, unparsable payload) is final: return null
+  /// and let the caller show the error, exactly as before.
+  Future<NodeDeviceInfo?> _checkDeviceInfoWithRetry(
+      String? serialNumber) async {
+    for (var attempt = 0;; attempt++) {
+      try {
+        final nodeDeviceInfo = await _ref
+            .read(dashboardManagerProvider.notifier)
+            .checkDeviceInfo(serialNumber);
+        // Build/Update better actions
+        logger.d('[Prepare]: build better actions');
+        buildBetterActions(nodeDeviceInfo.services);
+        // Update global model number
+        _ref.read(globalModelNumberProvider.notifier).state =
+            nodeDeviceInfo.modelNumber;
+        return nodeDeviceInfo;
+      } catch (error) {
+        if (!_isRouterTemporarilyUnreachable(error) ||
+            attempt >= _deviceInfoMaxRetries) {
+          logger.e('[Prepare]: device info check failed - $error');
+          return null;
+        }
+        logger.i(
+            '[Prepare]: router temporarily unreachable ($error), retry ${attempt + 1}/$_deviceInfoMaxRetries');
+        await Future.delayed(_deviceInfoRetryDelay);
+      }
+    }
+  }
+
+  /// Connection-class failures, i.e. the request never reached a router that
+  /// could answer it. Mirrors the transient-error test in [PnpNotifier].
+  bool _isRouterTemporarilyUnreachable(Object? error) =>
+      error is ClientException || error is TimeoutException;
 
   Future<String?> _prepareRemote(
       String? networkId, String? serialNumber, String? sessionId) async {

--- a/lib/validator_rules/rules.dart
+++ b/lib/validator_rules/rules.dart
@@ -182,6 +182,9 @@ class IPv6Rule extends RegExValidationRule {
 
   @override
   bool validate(String input) {
+    // The unspecified address is syntactically valid but never a usable target:
+    // this rule only guards the IPv6 port-forwarding rule's device address,
+    // where :: names no host. Rejected deliberately, not by oversight.
     if (input == '::') {
       return false;
     }

--- a/test/common/testable_router.dart
+++ b/test/common/testable_router.dart
@@ -52,6 +52,7 @@ Widget testableSingleRoute({
   Locale? locale,
   ProviderContainer? provider,
   GlobalKey<NavigatorState>? navigatorKey,
+  List<RouteBase> extraRoutes = const [],
 }) {
   final router = GoRouter(
     navigatorKey: navigatorKey ?? shellNavigatorKey,
@@ -62,6 +63,10 @@ Widget testableSingleRoute({
         config: config,
         builder: (context, state) => child,
       ),
+      // Destinations the view under test may navigate to (e.g. the login page
+      // after an Auto Master 401). Without them, `context.goNamed(...)` throws
+      // "unknown route name" in this single-route harness.
+      ...extraRoutes,
     ],
   );
 

--- a/test/mocks/pnp_notifier_mocks.dart
+++ b/test/mocks/pnp_notifier_mocks.dart
@@ -402,6 +402,14 @@ class MockPnpNotifier extends _i2.Notifier<_i3.PnpState>
       ) as _i9.Stream<_i15.AutoMasterStatus?>);
 
   @override
+  _i9.Stream<_i15.AutoMasterStatus?> pollAutoMasterUntilRunning() =>
+      (super.noSuchMethod(
+        Invocation.method(#pollAutoMasterUntilRunning, []),
+        returnValue: _i9.Stream<_i15.AutoMasterStatus?>.empty(),
+        returnValueForMissingStub: _i9.Stream<_i15.AutoMasterStatus?>.empty(),
+      ) as _i9.Stream<_i15.AutoMasterStatus?>);
+
+  @override
   void setAutoMasterStatusOnEntry(_i15.AutoMasterStatus? status) =>
       super.noSuchMethod(
         Invocation.method(#setAutoMasterStatusOnEntry, [status]),

--- a/test/page/instant_setup/data/pnp_provider_auto_master_test.dart
+++ b/test/page/instant_setup/data/pnp_provider_auto_master_test.dart
@@ -28,9 +28,12 @@ import 'package:privacy_gui/page/instant_setup/data/pnp_state.dart';
 
 import '../../../mocks/router_repository_mocks.dart';
 
-/// Builds a getAutoMasterStatus JNAPSuccess with the given raw status string
+/// Builds a getAutoMasterStatus JNAPSuccess with the given raw status payload
 /// (matching the firmware's `{ "autoMasterStatus": "Running" }` shape).
-JNAPSuccess _statusSuccess(String? raw) => JNAPSuccess(
+///
+/// [raw] is [Object?] so tests can feed a non-String payload and prove the
+/// parse degrades to null instead of throwing a TypeError.
+JNAPSuccess _statusSuccess(Object? raw) => JNAPSuccess(
       result: 'OK',
       output: {if (raw != null) 'autoMasterStatus': raw},
     );
@@ -142,6 +145,15 @@ void main() {
       expect(await notifier.checkAutoMasterStatus(), isNull);
     });
 
+    test('non-String status payload maps to null instead of throwing',
+        () async {
+      // The parse takes Object? rather than casting to String?. A cast would
+      // raise a TypeError, which scheduledCommand does not catch — it would
+      // escape the polling stream and strand the waiting spinner.
+      whenSend(() async => _statusSuccess(42));
+      expect(await notifier.checkAutoMasterStatus(), isNull);
+    });
+
     test('sends the request unauthed', () async {
       // Load-bearing: sending a credential here is what let a mid-flow
       // rotation burn the CGI auth-attempt budget and lock the user out.
@@ -206,6 +218,22 @@ void main() {
       whenScheduled(Stream.fromIterable([_statusSuccess('Complete')]));
       await notifier.pollAutoMasterStatus().toList();
       expect(_capturedScheduledAuth(mockRepo), isFalse);
+    });
+
+    test('non-String status payload flattens to null, stream survives',
+        () async {
+      // A TypeError from casting the payload would escape the stream (
+      // scheduledCommand catches JNAPError/TimeoutException, not TypeError) and
+      // leave the caller's waiting spinner up forever. It must degrade to null
+      // and keep delivering.
+      whenScheduled(Stream.fromIterable([
+        _statusSuccess(42),
+        _statusSuccess('Complete'),
+      ]));
+      expect(
+        await notifier.pollAutoMasterStatus().toList(),
+        [null, AutoMasterStatus.complete],
+      );
     });
   });
 

--- a/test/page/instant_setup/data/pnp_provider_auto_master_test.dart
+++ b/test/page/instant_setup/data/pnp_provider_auto_master_test.dart
@@ -1,0 +1,250 @@
+// Unit tests for the Auto Master methods on the real [PnpNotifier].
+//
+// These bypass the widget layer entirely: a ProviderContainer hosts the real
+// notifier with routerRepositoryProvider overridden by a MockRouterRepository,
+// so we can assert exactly how each JNAP result is translated:
+//   - checkAutoMasterStatus()      : Future<AutoMasterStatus?>, 401 -> throw
+//   - pollAutoMasterStatus()       : Stream, terminal statuses, 401 -> stream error
+//   - pollAutoMasterUntilRunning() : Stream, running/complete/failed, 401 -> error
+//   - testConnectionReconnected()  : SN match -> ok, mismatch/send-fail -> throw
+//
+// This is the layer the widget/flow tests mock out, so it is the only place the
+// JNAP-result-to-status mapping (including the first-401 terminator that the
+// #1180 fix hinges on) is exercised against the real code.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:privacy_gui/constants/error_code.dart';
+import 'package:privacy_gui/core/jnap/models/auto_master_status.dart';
+import 'package:privacy_gui/core/jnap/models/device_info.dart';
+import 'package:privacy_gui/core/jnap/result/jnap_result.dart';
+import 'package:privacy_gui/core/jnap/router_repository.dart';
+import 'package:privacy_gui/page/instant_setup/data/pnp_exception.dart';
+import 'package:privacy_gui/page/instant_setup/data/pnp_provider.dart';
+import 'package:privacy_gui/page/instant_setup/data/pnp_state.dart';
+
+import '../../../mocks/router_repository_mocks.dart';
+
+/// Builds a getAutoMasterStatus JNAPSuccess with the given raw status string
+/// (matching the firmware's `{ "autoMasterStatus": "Running" }` shape).
+JNAPSuccess _statusSuccess(String? raw) => JNAPSuccess(
+      result: 'OK',
+      output: {if (raw != null) 'autoMasterStatus': raw},
+    );
+
+JNAPError _unauthorized() => const JNAPError(result: errorJNAPUnauthorized);
+
+void main() {
+  late MockRouterRepository mockRepo;
+  late ProviderContainer container;
+  late PnpNotifier notifier;
+
+  setUp(() {
+    mockRepo = MockRouterRepository();
+    container = ProviderContainer(overrides: [
+      routerRepositoryProvider.overrideWithValue(mockRepo),
+    ]);
+    // pnpProvider default factory is PnpNotifier (the real one) — read it so we
+    // exercise real code, not the MockPnpNotifier used by the widget tests.
+    notifier = container.read(pnpProvider.notifier) as PnpNotifier;
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  // Stubs RouterRepository.send(...) (used by checkAutoMasterStatus and
+  // testConnectionReconnected). All named args are matchers so the stub is hit
+  // regardless of the exact auth/timeout/retries values the notifier passes.
+  void whenSend(Future<JNAPSuccess> Function() answer) {
+    when(mockRepo.send(
+      any,
+      data: anyNamed('data'),
+      extraHeaders: anyNamed('extraHeaders'),
+      auth: anyNamed('auth'),
+      type: anyNamed('type'),
+      fetchRemote: anyNamed('fetchRemote'),
+      cacheLevel: anyNamed('cacheLevel'),
+      timeoutMs: anyNamed('timeoutMs'),
+      retries: anyNamed('retries'),
+      sideEffectOverrides: anyNamed('sideEffectOverrides'),
+    )).thenAnswer((_) => answer());
+  }
+
+  // Stubs RouterRepository.scheduledCommand(...) (the polling streams).
+  void whenScheduled(Stream<JNAPResult> stream) {
+    when(mockRepo.scheduledCommand(
+      action: anyNamed('action'),
+      retryDelayInMilliSec: anyNamed('retryDelayInMilliSec'),
+      maxRetry: anyNamed('maxRetry'),
+      firstDelayInMilliSec: anyNamed('firstDelayInMilliSec'),
+      data: anyNamed('data'),
+      condition: anyNamed('condition'),
+      onCompleted: anyNamed('onCompleted'),
+      requestTimeoutOverride: anyNamed('requestTimeoutOverride'),
+      auth: anyNamed('auth'),
+    )).thenAnswer((_) => stream);
+  }
+
+  group('checkAutoMasterStatus', () {
+    test('maps each firmware status string to the enum', () async {
+      for (final entry in {
+        'Idle': AutoMasterStatus.idle,
+        'Running': AutoMasterStatus.running,
+        'Complete': AutoMasterStatus.complete,
+        'Failed': AutoMasterStatus.failed,
+      }.entries) {
+        whenSend(() async => _statusSuccess(entry.key));
+        expect(await notifier.checkAutoMasterStatus(), entry.value,
+            reason: 'status "${entry.key}" should map to ${entry.value}');
+      }
+    });
+
+    test('401 throws ExceptionAutoMasterUnauthorized', () async {
+      whenSend(() async => throw _unauthorized());
+      expect(
+        () => notifier.checkAutoMasterStatus(),
+        throwsA(isA<ExceptionAutoMasterUnauthorized>()),
+      );
+    });
+
+    test('non-401 JNAPError is swallowed to null (feature unsupported)',
+        () async {
+      whenSend(() async => throw const JNAPError(result: '_ErrorUnknownAction'));
+      expect(await notifier.checkAutoMasterStatus(), isNull);
+    });
+
+    test('generic (non-JNAP) error is swallowed to null', () async {
+      whenSend(() async => throw Exception('timeout'));
+      expect(await notifier.checkAutoMasterStatus(), isNull);
+    });
+
+    test('unrecognized status string maps to null', () async {
+      whenSend(() async => _statusSuccess('SomethingNew'));
+      expect(await notifier.checkAutoMasterStatus(), isNull);
+    });
+  });
+
+  group('pollAutoMasterStatus', () {
+    test('maps JNAPSuccess statuses through the stream', () async {
+      whenScheduled(Stream.fromIterable([
+        _statusSuccess('Running'),
+        _statusSuccess('Complete'),
+      ]));
+      expect(
+        await notifier.pollAutoMasterStatus().toList(),
+        [AutoMasterStatus.running, AutoMasterStatus.complete],
+      );
+    });
+
+    test('terminates on the FIRST 401 (make-Master rotated the credential)',
+        () async {
+      // The first-401 fix: a 401 in the stream must surface as an error the
+      // consumer's await-for catches, NOT be flattened to null and re-polled.
+      whenScheduled(Stream.fromIterable([_unauthorized()]));
+      expect(
+        notifier.pollAutoMasterStatus(),
+        emitsInOrder([emitsError(isA<ExceptionAutoMasterUnauthorized>())]),
+      );
+    });
+
+    test('a Running before a 401 is emitted, then the stream errors', () async {
+      whenScheduled(Stream.fromIterable([
+        _statusSuccess('Running'),
+        _unauthorized(),
+      ]));
+      expect(
+        notifier.pollAutoMasterStatus(),
+        emitsInOrder([
+          AutoMasterStatus.running,
+          emitsError(isA<ExceptionAutoMasterUnauthorized>()),
+        ]),
+      );
+    });
+
+    test('non-success / non-401 results flatten to null', () async {
+      whenScheduled(Stream.fromIterable([
+        const JNAPError(result: '_SomethingElse'),
+      ]));
+      expect(await notifier.pollAutoMasterStatus().toList(), [null]);
+    });
+  });
+
+  group('pollAutoMasterUntilRunning', () {
+    test('maps running/complete/failed through the stream', () async {
+      whenScheduled(Stream.fromIterable([_statusSuccess('Running')]));
+      expect(await notifier.pollAutoMasterUntilRunning().toList(),
+          [AutoMasterStatus.running]);
+    });
+
+    test('terminates on the first 401', () async {
+      whenScheduled(Stream.fromIterable([_unauthorized()]));
+      expect(
+        notifier.pollAutoMasterUntilRunning(),
+        emitsInOrder([emitsError(isA<ExceptionAutoMasterUnauthorized>())]),
+      );
+    });
+
+    test('non-success / non-401 results flatten to null', () async {
+      whenScheduled(Stream.fromIterable([
+        const JNAPError(result: '_SomethingElse'),
+      ]));
+      expect(await notifier.pollAutoMasterUntilRunning().toList(), [null]);
+    });
+  });
+
+  group('testConnectionReconnected', () {
+    // The notifier compares the freshly-fetched device SN against the SN it
+    // already holds in state. Seed state with a known SN via fetchDeviceInfo's
+    // sibling path: set it directly through a device-info success.
+    const knownSn = 'SN-ALIVE-001';
+
+    JNAPSuccess deviceInfoSuccess(String sn) => JNAPSuccess(
+          result: 'OK',
+          output: <String, dynamic>{
+            'manufacturer': 'Linksys',
+            'modelNumber': 'MBE70',
+            'hardwareVersion': '1',
+            'description': 'Linksys Velop',
+            'serialNumber': sn,
+            'firmwareVersion': '1.0.0',
+            'firmwareDate': '2024-01-01T00:00:00Z',
+            'services': const <String>[],
+          },
+        );
+
+    // Puts a device with [knownSn] into state so the SN comparison has a
+    // baseline. testConnectionReconnected re-sends getDeviceInfo and compares
+    // the returned SN against this one.
+    void seedStateSn() {
+      notifier.state = PnpState(
+        deviceInfo: NodeDeviceInfo.fromJson(deviceInfoSuccess(knownSn).output),
+      );
+    }
+
+    test('same SN returned -> completes without throwing', () async {
+      seedStateSn();
+      whenSend(() async => deviceInfoSuccess(knownSn));
+      await expectLater(notifier.testConnectionReconnected(), completes);
+    });
+
+    test('different SN returned -> ExceptionNeedToReconnect', () async {
+      seedStateSn();
+      whenSend(() async => deviceInfoSuccess('SN-DIFFERENT-999'));
+      expect(
+        () => notifier.testConnectionReconnected(),
+        throwsA(isA<ExceptionNeedToReconnect>()),
+      );
+    });
+
+    test('send failure -> ExceptionNeedToReconnect', () async {
+      seedStateSn();
+      whenSend(() async => throw Exception('unreachable'));
+      expect(
+        () => notifier.testConnectionReconnected(),
+        throwsA(isA<ExceptionNeedToReconnect>()),
+      );
+    });
+  });
+}

--- a/test/page/instant_setup/data/pnp_provider_auto_master_test.dart
+++ b/test/page/instant_setup/data/pnp_provider_auto_master_test.dart
@@ -352,4 +352,69 @@ void main() {
       expect(sendArg<int>('timeoutMs'), 5000);
     });
   });
+
+  // The third #1180 defect: a rotated credential's 401 was read as "the WAN is
+  // down". GetInternetConnectionStatus goes out authed, so once make-Master
+  // rotates the admin password this call 401s — and the old code flattened every
+  // error to `isConnected = false`, then threw ExceptionNoInternetConnection.
+  // The user was sent to the troubleshooter to fix an internet connection that
+  // was working, right after the ISP settings they had just entered succeeded.
+  group('checkInternetConnection', () {
+    JNAPSuccess connectionStatus(String status) => JNAPSuccess(
+          result: 'OK',
+          output: {'connectionStatus': status},
+        );
+
+    test('InternetConnected -> completes', () async {
+      whenSend(() async => connectionStatus('InternetConnected'));
+      await expectLater(notifier.checkInternetConnection(), completes);
+    });
+
+    test('a non-connected status -> ExceptionNoInternetConnection', () async {
+      whenSend(() async => connectionStatus('InternetDisconnected'));
+      await expectLater(
+        notifier.checkInternetConnection(),
+        throwsA(isA<ExceptionNoInternetConnection>()),
+      );
+    });
+
+    test('unauthorized -> ExceptionInvalidAdminPassword, not NoInternet',
+        () async {
+      whenSend(() async => throw _unauthorized());
+      await expectLater(
+        notifier.checkInternetConnection(),
+        throwsA(isA<ExceptionInvalidAdminPassword>()),
+      );
+    });
+
+    test('unauthorized does not retry', () async {
+      // Each retry spends one of the router's 5 CGI auth attempts before it
+      // locks the admin account — the very lockout §2.3 fixed elsewhere. A
+      // password does not become correct by being sent again, so the first 401
+      // has to be terminal.
+      var calls = 0;
+      whenSend(() async {
+        calls++;
+        throw _unauthorized();
+      });
+      await expectLater(
+        notifier.checkInternetConnection(30),
+        throwsA(isA<ExceptionInvalidAdminPassword>()),
+      );
+      expect(calls, 1);
+    });
+
+    test('a transient failure still retries', () async {
+      // Only 401 is terminal. A timeout says nothing about the WAN, so the loop
+      // must keep trying — the router may still be finishing its restart.
+      var calls = 0;
+      whenSend(() async {
+        calls++;
+        if (calls < 3) throw Exception('timeout');
+        return connectionStatus('InternetConnected');
+      });
+      await expectLater(notifier.checkInternetConnection(5), completes);
+      expect(calls, 3);
+    });
+  });
 }

--- a/test/page/instant_setup/data/pnp_provider_auto_master_test.dart
+++ b/test/page/instant_setup/data/pnp_provider_auto_master_test.dart
@@ -14,6 +14,7 @@
 // firmware still requires auth for GetAutoMasterStatus — indistinguishable from
 // the action being unsupported, and mapped to null like any other failure.
 
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -41,6 +42,17 @@ JNAPSuccess _statusSuccess(Object? raw) => JNAPSuccess(
 JNAPError _unauthorized() => const JNAPError(result: errorJNAPUnauthorized);
 
 void main() {
+  // checkAdminPassword goes through authProvider.localLogin, which persists the
+  // accepted password to flutter_secure_storage — a platform channel with no
+  // implementation under the test binding. Stub it so the login can complete and
+  // the post-success bookkeeping (which is what the rotation tests assert on) is
+  // actually reached.
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const secureStorageChannel =
+      MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(secureStorageChannel, (_) async => null);
+
   late MockRouterRepository mockRepo;
   late ProviderContainer container;
   late PnpNotifier notifier;
@@ -168,6 +180,99 @@ void main() {
       whenSend(() async => _statusSuccess('Idle'));
       await notifier.checkAutoMasterStatus();
       expect(sendArg<bool>('auth'), isFalse);
+    });
+  });
+
+  // The fourth #1180 defect: `Complete` is a LATCHED firmware state. Once
+  // make-Master has run, GetAutoMasterStatus answers `Complete` for the rest of
+  // the router's life — so "the status is complete" only means "this router was
+  // auto-mastered at some point", which is true for ever and cannot tell anyone
+  // whether the password they are holding still works. The gates that read it as
+  // "your credential is stale" therefore fired on every visit: the user typed the
+  // correct new password, CheckAdminPassword returned 200, and the gate threw
+  // anyway and logged the fresh session back out — an unescapable loop.
+  //
+  // `running` is the reading that dates the rotation (firmware reports it only
+  // while make-Master is actually working), so that is what gets recorded, and a
+  // password the router accepts is what clears it.
+  group('autoMasterRotatedSinceLogin', () {
+    test('a running status records the rotation', () async {
+      expect(notifier.state.autoMasterRotatedSinceLogin, isFalse);
+      whenSend(() async => _statusSuccess('Running'));
+      await notifier.checkAutoMasterStatus();
+      expect(notifier.state.autoMasterRotatedSinceLogin, isTrue);
+    });
+
+    test('a latched complete status on its own records nothing', () async {
+      // The heart of the defect. Reading `Complete` must NOT set the flag:
+      // every visit to an already-auto-mastered router reads it, and treating
+      // that as evidence is what created the login loop.
+      whenSend(() async => _statusSuccess('Complete'));
+      await notifier.checkAutoMasterStatus();
+      expect(notifier.state.autoMasterRotatedSinceLogin, isFalse);
+    });
+
+    test('idle and failed record nothing either', () async {
+      for (final raw in ['Idle', 'Failed']) {
+        whenSend(() async => _statusSuccess(raw));
+        await notifier.checkAutoMasterStatus();
+        expect(notifier.state.autoMasterRotatedSinceLogin, isFalse,
+            reason: '"$raw" is not evidence of a rotation');
+      }
+    });
+
+    test('the completion poll records a running it sees', () async {
+      // All three status reads funnel through the same observation point, so
+      // whichever one happens to catch the window records it. Which matters:
+      // the single-shot read is the only one the admin view's gate makes, but
+      // the polls are what run through the ~2 minutes make-Master takes.
+      whenScheduled(Stream.fromIterable([
+        _statusSuccess('Running'),
+        _statusSuccess('Complete'),
+      ]));
+      await notifier.pollAutoMasterStatus().toList();
+      expect(notifier.state.autoMasterRotatedSinceLogin, isTrue);
+    });
+
+    test('the wait-for-running poll records a running it sees', () async {
+      whenScheduled(Stream.fromIterable([_statusSuccess('Running')]));
+      await notifier.pollAutoMasterUntilRunning().toList();
+      expect(notifier.state.autoMasterRotatedSinceLogin, isTrue);
+    });
+
+    test('a poll that only ever sees complete records nothing', () async {
+      whenScheduled(Stream.fromIterable([_statusSuccess('Complete')]));
+      await notifier.pollAutoMasterStatus().toList();
+      expect(notifier.state.autoMasterRotatedSinceLogin, isFalse);
+    });
+
+    test('an accepted password clears the record', () async {
+      // The other endpoint, and the one the loop hinged on. The router accepting
+      // a password is proof that the credential we now hold post-dates the
+      // rotation, so the sticky `complete` must stop meaning "stale" from here.
+      notifier.state = const PnpState(
+        deviceInfo: null,
+        autoMasterRotatedSinceLogin: true,
+      );
+      whenSend(() async => JNAPSuccess(result: 'OK', output: const {}));
+      await notifier.checkAdminPassword('the-new-one');
+      expect(notifier.state.autoMasterRotatedSinceLogin, isFalse);
+    });
+
+    test('a rejected password leaves the record standing', () async {
+      // Only success is proof. A wrong guess says nothing about whether the
+      // rotation happened, so clearing here would let the next `complete` read
+      // pass the gate with a credential that is still stale.
+      notifier.state = const PnpState(
+        deviceInfo: null,
+        autoMasterRotatedSinceLogin: true,
+      );
+      whenSend(() async => throw _unauthorized());
+      await expectLater(
+        notifier.checkAdminPassword('a-wrong-guess'),
+        throwsA(isA<ExceptionInvalidAdminPassword>()),
+      );
+      expect(notifier.state.autoMasterRotatedSinceLogin, isTrue);
     });
   });
 

--- a/test/page/instant_setup/data/pnp_provider_auto_master_test.dart
+++ b/test/page/instant_setup/data/pnp_provider_auto_master_test.dart
@@ -3,14 +3,16 @@
 // These bypass the widget layer entirely: a ProviderContainer hosts the real
 // notifier with routerRepositoryProvider overridden by a MockRouterRepository,
 // so we can assert exactly how each JNAP result is translated:
-//   - checkAutoMasterStatus()      : Future<AutoMasterStatus?>, 401 -> throw
-//   - pollAutoMasterStatus()       : Stream, terminal statuses, 401 -> stream error
-//   - pollAutoMasterUntilRunning() : Stream, running/complete/failed, 401 -> error
+//   - checkAutoMasterStatus()      : Future<AutoMasterStatus?>, 401 -> null
+//   - pollAutoMasterStatus()       : Stream, terminal statuses, 401 -> null
+//   - pollAutoMasterUntilRunning() : Stream, running/complete/failed, 401 -> null
 //   - testConnectionReconnected()  : SN match -> ok, mismatch/send-fail -> throw
 //
 // This is the layer the widget/flow tests mock out, so it is the only place the
-// JNAP-result-to-status mapping (including the first-401 terminator that the
-// #1180 fix hinges on) is exercised against the real code.
+// JNAP-result-to-status mapping is exercised against the real code. All three
+// Auto Master calls send `auth: false`, so an unauthorized result means the
+// firmware still requires auth for GetAutoMasterStatus — indistinguishable from
+// the action being unsupported, and mapped to null like any other failure.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -34,6 +36,21 @@ JNAPSuccess _statusSuccess(String? raw) => JNAPSuccess(
     );
 
 JNAPError _unauthorized() => const JNAPError(result: errorJNAPUnauthorized);
+
+/// The `auth` value the notifier passed to the last `scheduledCommand` call.
+bool _capturedScheduledAuth(MockRouterRepository repo) => verify(
+      repo.scheduledCommand(
+        action: anyNamed('action'),
+        retryDelayInMilliSec: anyNamed('retryDelayInMilliSec'),
+        maxRetry: anyNamed('maxRetry'),
+        firstDelayInMilliSec: anyNamed('firstDelayInMilliSec'),
+        data: anyNamed('data'),
+        condition: anyNamed('condition'),
+        onCompleted: anyNamed('onCompleted'),
+        requestTimeoutOverride: anyNamed('requestTimeoutOverride'),
+        auth: captureAnyNamed('auth'),
+      ),
+    ).captured.single as bool;
 
 void main() {
   late MockRouterRepository mockRepo;
@@ -101,12 +118,12 @@ void main() {
       }
     });
 
-    test('401 throws ExceptionAutoMasterUnauthorized', () async {
+    test('401 maps to null (firmware still requires auth)', () async {
+      // The request is sent unauthed, so a 401 cannot mean make-Master rotated
+      // the password — it means this firmware has not moved
+      // GetAutoMasterStatus to no-auth yet. Same degradation as unsupported.
       whenSend(() async => throw _unauthorized());
-      expect(
-        () => notifier.checkAutoMasterStatus(),
-        throwsA(isA<ExceptionAutoMasterUnauthorized>()),
-      );
+      expect(await notifier.checkAutoMasterStatus(), isNull);
     });
 
     test('non-401 JNAPError is swallowed to null (feature unsupported)',
@@ -124,6 +141,28 @@ void main() {
       whenSend(() async => _statusSuccess('SomethingNew'));
       expect(await notifier.checkAutoMasterStatus(), isNull);
     });
+
+    test('sends the request unauthed', () async {
+      // Load-bearing: sending a credential here is what let a mid-flow
+      // rotation burn the CGI auth-attempt budget and lock the user out.
+      whenSend(() async => _statusSuccess('Idle'));
+      await notifier.checkAutoMasterStatus();
+      expect(
+        verify(mockRepo.send(
+          any,
+          data: anyNamed('data'),
+          extraHeaders: anyNamed('extraHeaders'),
+          auth: captureAnyNamed('auth'),
+          type: anyNamed('type'),
+          fetchRemote: anyNamed('fetchRemote'),
+          cacheLevel: anyNamed('cacheLevel'),
+          timeoutMs: anyNamed('timeoutMs'),
+          retries: anyNamed('retries'),
+          sideEffectOverrides: anyNamed('sideEffectOverrides'),
+        )).captured.single,
+        isFalse,
+      );
+    });
   });
 
   group('pollAutoMasterStatus', () {
@@ -138,28 +177,21 @@ void main() {
       );
     });
 
-    test('terminates on the FIRST 401 (make-Master rotated the credential)',
-        () async {
-      // The first-401 fix: a 401 in the stream must surface as an error the
-      // consumer's await-for catches, NOT be flattened to null and re-polled.
+    test('401 flattens to null and the stream keeps going', () async {
+      // No credential is sent, so a 401 is not a rotation signal and cannot
+      // burn the CGI auth-attempt budget — it needs no early terminator.
       whenScheduled(Stream.fromIterable([_unauthorized()]));
-      expect(
-        notifier.pollAutoMasterStatus(),
-        emitsInOrder([emitsError(isA<ExceptionAutoMasterUnauthorized>())]),
-      );
+      expect(await notifier.pollAutoMasterStatus().toList(), [null]);
     });
 
-    test('a Running before a 401 is emitted, then the stream errors', () async {
+    test('a Running before a 401 keeps both in the stream', () async {
       whenScheduled(Stream.fromIterable([
         _statusSuccess('Running'),
         _unauthorized(),
       ]));
       expect(
-        notifier.pollAutoMasterStatus(),
-        emitsInOrder([
-          AutoMasterStatus.running,
-          emitsError(isA<ExceptionAutoMasterUnauthorized>()),
-        ]),
+        await notifier.pollAutoMasterStatus().toList(),
+        [AutoMasterStatus.running, null],
       );
     });
 
@@ -168,6 +200,12 @@ void main() {
         const JNAPError(result: '_SomethingElse'),
       ]));
       expect(await notifier.pollAutoMasterStatus().toList(), [null]);
+    });
+
+    test('polls unauthed', () async {
+      whenScheduled(Stream.fromIterable([_statusSuccess('Complete')]));
+      await notifier.pollAutoMasterStatus().toList();
+      expect(_capturedScheduledAuth(mockRepo), isFalse);
     });
   });
 
@@ -178,12 +216,9 @@ void main() {
           [AutoMasterStatus.running]);
     });
 
-    test('terminates on the first 401', () async {
+    test('401 flattens to null', () async {
       whenScheduled(Stream.fromIterable([_unauthorized()]));
-      expect(
-        notifier.pollAutoMasterUntilRunning(),
-        emitsInOrder([emitsError(isA<ExceptionAutoMasterUnauthorized>())]),
-      );
+      expect(await notifier.pollAutoMasterUntilRunning().toList(), [null]);
     });
 
     test('non-success / non-401 results flatten to null', () async {
@@ -191,6 +226,12 @@ void main() {
         const JNAPError(result: '_SomethingElse'),
       ]));
       expect(await notifier.pollAutoMasterUntilRunning().toList(), [null]);
+    });
+
+    test('polls unauthed', () async {
+      whenScheduled(Stream.fromIterable([_statusSuccess('Running')]));
+      await notifier.pollAutoMasterUntilRunning().toList();
+      expect(_capturedScheduledAuth(mockRepo), isFalse);
     });
   });
 

--- a/test/page/instant_setup/data/pnp_provider_auto_master_test.dart
+++ b/test/page/instant_setup/data/pnp_provider_auto_master_test.dart
@@ -40,27 +40,21 @@ JNAPSuccess _statusSuccess(Object? raw) => JNAPSuccess(
 
 JNAPError _unauthorized() => const JNAPError(result: errorJNAPUnauthorized);
 
-/// The `auth` value the notifier passed to the last `scheduledCommand` call.
-bool _capturedScheduledAuth(MockRouterRepository repo) => verify(
-      repo.scheduledCommand(
-        action: anyNamed('action'),
-        retryDelayInMilliSec: anyNamed('retryDelayInMilliSec'),
-        maxRetry: anyNamed('maxRetry'),
-        firstDelayInMilliSec: anyNamed('firstDelayInMilliSec'),
-        data: anyNamed('data'),
-        condition: anyNamed('condition'),
-        onCompleted: anyNamed('onCompleted'),
-        requestTimeoutOverride: anyNamed('requestTimeoutOverride'),
-        auth: captureAnyNamed('auth'),
-      ),
-    ).captured.single as bool;
-
 void main() {
   late MockRouterRepository mockRepo;
   late ProviderContainer container;
   late PnpNotifier notifier;
 
+  // The last call the notifier made to each repository method. Read by name
+  // (see [scheduledArg] / [sendArg]) rather than through captureAnyNamed, whose
+  // `captured` ordering follows the invocation's own named-argument order — too
+  // implicit for assertions this design leans on.
+  Invocation? lastScheduled;
+  Invocation? lastSend;
+
   setUp(() {
+    lastScheduled = null;
+    lastSend = null;
     mockRepo = MockRouterRepository();
     container = ProviderContainer(overrides: [
       routerRepositoryProvider.overrideWithValue(mockRepo),
@@ -89,8 +83,19 @@ void main() {
       timeoutMs: anyNamed('timeoutMs'),
       retries: anyNamed('retries'),
       sideEffectOverrides: anyNamed('sideEffectOverrides'),
-    )).thenAnswer((_) => answer());
+    )).thenAnswer((invocation) {
+      lastSend = invocation;
+      return answer();
+    });
   }
+
+  /// A named argument of the notifier's last `send` call, by name.
+  T sendArg<T>(String name) =>
+      lastSend!.namedArguments[Symbol(name)] as T;
+
+  /// A named argument of the notifier's last `scheduledCommand` call, by name.
+  T scheduledArg<T>(String name) =>
+      lastScheduled!.namedArguments[Symbol(name)] as T;
 
   // Stubs RouterRepository.scheduledCommand(...) (the polling streams).
   void whenScheduled(Stream<JNAPResult> stream) {
@@ -104,7 +109,10 @@ void main() {
       onCompleted: anyNamed('onCompleted'),
       requestTimeoutOverride: anyNamed('requestTimeoutOverride'),
       auth: anyNamed('auth'),
-    )).thenAnswer((_) => stream);
+    )).thenAnswer((invocation) {
+      lastScheduled = invocation;
+      return stream;
+    });
   }
 
   group('checkAutoMasterStatus', () {
@@ -159,21 +167,7 @@ void main() {
       // rotation burn the CGI auth-attempt budget and lock the user out.
       whenSend(() async => _statusSuccess('Idle'));
       await notifier.checkAutoMasterStatus();
-      expect(
-        verify(mockRepo.send(
-          any,
-          data: anyNamed('data'),
-          extraHeaders: anyNamed('extraHeaders'),
-          auth: captureAnyNamed('auth'),
-          type: anyNamed('type'),
-          fetchRemote: anyNamed('fetchRemote'),
-          cacheLevel: anyNamed('cacheLevel'),
-          timeoutMs: anyNamed('timeoutMs'),
-          retries: anyNamed('retries'),
-          sideEffectOverrides: anyNamed('sideEffectOverrides'),
-        )).captured.single,
-        isFalse,
-      );
+      expect(sendArg<bool>('auth'), isFalse);
     });
   });
 
@@ -217,7 +211,23 @@ void main() {
     test('polls unauthed', () async {
       whenScheduled(Stream.fromIterable([_statusSuccess('Complete')]));
       await notifier.pollAutoMasterStatus().toList();
-      expect(_capturedScheduledAuth(mockRepo), isFalse);
+      expect(scheduledArg<bool>('auth'), isFalse);
+    });
+
+    test('bounds its own duration: 24 rounds of 3s request + 5s delay',
+        () async {
+      // These three numbers ARE the give-up rule. Since #1180 nothing counts
+      // failures any more: the flow waits until this stream ends, so how long
+      // it runs decides when the UI declares "router not found". 24 x (3s + 5s)
+      // = 192s, which has to stay comfortably clear of ~65s of make-Master
+      // downtime and ~115s for Auto Master end to end. Shrink any of them and
+      // the flow starts giving up before the router is back — exactly the
+      // regression #1180 reported.
+      whenScheduled(Stream.fromIterable([_statusSuccess('Complete')]));
+      await notifier.pollAutoMasterStatus().toList();
+      expect(scheduledArg<int>('maxRetry'), 24);
+      expect(scheduledArg<int?>('requestTimeoutOverride'), 3000);
+      expect(scheduledArg<int>('retryDelayInMilliSec'), 5000);
     });
 
     test('non-String status payload flattens to null, stream survives',
@@ -259,7 +269,20 @@ void main() {
     test('polls unauthed', () async {
       whenScheduled(Stream.fromIterable([_statusSuccess('Running')]));
       await notifier.pollAutoMasterUntilRunning().toList();
-      expect(_capturedScheduledAuth(mockRepo), isFalse);
+      expect(scheduledArg<bool>('auth'), isFalse);
+    });
+
+    test('bounds its own duration, shorter than the wait-for-completion poll',
+        () async {
+      // Same per-attempt caps as pollAutoMasterStatus, fewer rounds: this one
+      // only has to cover make-Master's delay before it *starts* (a Running
+      // edge), not the whole run, and giving up here merely proceeds with the
+      // flow. 18 x (3s + 5s) = 144s.
+      whenScheduled(Stream.fromIterable([_statusSuccess('Running')]));
+      await notifier.pollAutoMasterUntilRunning().toList();
+      expect(scheduledArg<int>('maxRetry'), 18);
+      expect(scheduledArg<int?>('requestTimeoutOverride'), 3000);
+      expect(scheduledArg<int>('retryDelayInMilliSec'), 5000);
     });
   });
 
@@ -314,6 +337,19 @@ void main() {
         () => notifier.testConnectionReconnected(),
         throwsA(isA<ExceptionNeedToReconnect>()),
       );
+    });
+
+    test('retries before condemning the connection', () async {
+      // This call is the sole arbiter of "router not found" once the poll's
+      // budget is spent, so it must not hinge on one packet: a router still
+      // finishing its restart answers on the second or third try. Deciding off
+      // a single attempt is what would put the user back on the login screen
+      // while the router was merely slow.
+      seedStateSn();
+      whenSend(() async => deviceInfoSuccess(knownSn));
+      await notifier.testConnectionReconnected();
+      expect(sendArg<int>('retries'), 2);
+      expect(sendArg<int>('timeoutMs'), 5000);
     });
   });
 }

--- a/test/page/instant_setup/localizations/pnp_admin_view_test.dart
+++ b/test/page/instant_setup/localizations/pnp_admin_view_test.dart
@@ -294,78 +294,6 @@ void main() async {
     await tester.pumpAndSettle();
   });
 
-  testLocalizations(
-      'Instant Setup - PnP: Auto Master check unauthorized redirects to login',
-      (tester, locale) async {
-    when(mockPnpNotifier.build()).thenReturn(
-      PnpState(
-        deviceInfo: NodeDeviceInfo.fromJson(
-          jsonDecode(testDeviceInfo)['output'],
-        ),
-      ),
-    );
-    when(mockPnpNotifier.fetchDeviceInfo()).thenAnswer((_) async {});
-    when(mockPnpNotifier.checkRouterConfigured()).thenAnswer((_) async {});
-    when(mockPnpNotifier.checkAdminPassword(any)).thenAnswer((_) async {});
-    when(mockPnpNotifier.checkAutoMasterStatus())
-        .thenThrow(ExceptionAutoMasterUnauthorized());
-
-    await tester.pumpWidget(
-      testableSingleRoute(
-        config: LinksysRouteConfig(
-          column: ColumnGrid(column: 6, centered: true),
-          noNaviRail: true,
-        ),
-        child: const PnpAdminView(),
-        locale: locale,
-        overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
-      ),
-    );
-    await tester.pump(const Duration(seconds: 2));
-    await tester.pumpAndSettle();
-  });
-
-  // Regression: the poll STREAM (not just the pre-check Future) now terminates
-  // on the first 401. make-Master rotates the admin password mid-poll; the
-  // stream throws ExceptionAutoMasterUnauthorized, which the caller chain routes
-  // to login instead of flattening to null and re-polling with stale creds.
-  testLocalizations(
-      'Instant Setup - PnP: Auto Master poll stream unauthorized redirects to login',
-      (tester, locale) async {
-    when(mockPnpNotifier.build()).thenReturn(
-      PnpState(
-        deviceInfo: NodeDeviceInfo.fromJson(
-          jsonDecode(testDeviceInfo)['output'],
-        ),
-      ),
-    );
-    when(mockPnpNotifier.fetchDeviceInfo()).thenAnswer((_) async {});
-    when(mockPnpNotifier.checkRouterConfigured()).thenAnswer((_) async {});
-    when(mockPnpNotifier.checkAdminPassword(any)).thenAnswer((_) async {});
-    when(mockPnpNotifier.checkAutoMasterStatus())
-        .thenAnswer((_) async => AutoMasterStatus.running);
-    when(mockPnpNotifier.pollAutoMasterStatus())
-        .thenAnswer((_) => Stream.error(ExceptionAutoMasterUnauthorized()));
-
-    await tester.pumpWidget(
-      testableSingleRoute(
-        config: LinksysRouteConfig(
-          column: ColumnGrid(column: 6, centered: true),
-          noNaviRail: true,
-        ),
-        child: const PnpAdminView(),
-        locale: locale,
-        overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
-        extraRoutes: [_loginStubRoute()],
-      ),
-    );
-    await tester.pump(const Duration(seconds: 2));
-    await tester.pumpAndSettle();
-    // The poll-stream 401 must land on the login page, not leave the waiting
-    // spinner up (which would hang pumpAndSettle) nor stay on the admin view.
-    expect(find.byKey(const Key('loginStub')), findsOneWidget);
-  });
-
   // ---------------------------------------------------------------------------
   // `_doLogin` (manual "tap Login") Auto Master gate — A/B/C.
   //
@@ -552,15 +480,18 @@ void main() async {
     expect(find.byKey(const Key('pnpConfigStub')), findsNothing);
   });
 
-  // C: the initial `checkAutoMasterStatus()` gate itself 401s (credential
-  // already rotated by the time the user tapped Login) → redirect to login.
+  // C: the `checkAutoMasterStatus()` gate cannot determine the status (null) —
+  // the router is unreachable, or its firmware still requires auth for
+  // GetAutoMasterStatus and answers 401 to the unauthed read. There is nothing
+  // to wait for, so the gate must not block: `_doLogin` proceeds into config.
+  // If Auto Master then does rotate the credential, PnP's own second pass (the
+  // pre-save check) is what recovers.
   testWidgets(
-      'Instant Setup - PnP: Tap Login with Auto Master check unauthorized redirects to login',
+      'Instant Setup - PnP: Tap Login with Auto Master status unavailable enters config',
       (tester) async {
     useLargeScreen(tester);
     stubConfiguredRouter();
-    when(mockPnpNotifier.checkAutoMasterStatus())
-        .thenThrow(ExceptionAutoMasterUnauthorized());
+    when(mockPnpNotifier.checkAutoMasterStatus()).thenAnswer((_) async => null);
 
     await tester.pumpWidget(
       testableSingleRoute(
@@ -575,9 +506,14 @@ void main() async {
     );
     await tester.pump(const Duration(seconds: 1));
     await tapLogin(tester);
+    // Same two-clock dance as B: mock futures resolve on real microtasks
+    // (runAsync), the 1s internet-connected view on the fake timer (pump).
+    await tester.runAsync(() => Future.delayed(const Duration(seconds: 1)));
+    await tester.pump(const Duration(seconds: 1));
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('loginStub')), findsOneWidget);
-    expect(find.byKey(const Key('pnpConfigStub')), findsNothing);
+    expect(find.byKey(const Key('pnpConfigStub')), findsOneWidget);
+    // Never polled: null is not `running`, so there was nothing to wait on.
+    verifyNever(mockPnpNotifier.pollAutoMasterStatus());
   });
 }

--- a/test/page/instant_setup/localizations/pnp_admin_view_test.dart
+++ b/test/page/instant_setup/localizations/pnp_admin_view_test.dart
@@ -526,7 +526,8 @@ void main() async {
     verifyNever(mockPnpNotifier.pollAutoMasterStatus());
   });
 
-  // D: Auto Master is ALREADY `complete` when the gate first reads it — the
+  // D: Auto Master is ALREADY `complete` when the gate first reads it AND a
+  // rotation has been recorded since our last accepted password — the
   // post-reconnect case from #1180's QA log. make-Master finished while the
   // router was rebooting, so by the time this view loaded there was nothing left
   // to wait for, but the admin password had been rotated regardless.
@@ -538,11 +539,24 @@ void main() async {
   // `return` on anything that was not `running`, so `complete` fell straight
   // through to the internet check, which 401'd on the dead credential and sent
   // the user to the troubleshooter with a working internet connection.
+  //
+  // `autoMasterRotatedSinceLogin` is seeded through `build()` because the mock's
+  // own state writers are no-ops — same reason pnp_setup_view_test.dart seeds
+  // `autoMasterStatusOnEntry` that way.
   testWidgets(
       'Instant Setup - PnP: Auto Master already complete on entry asks for the new password',
       (tester) async {
     useLargeScreen(tester);
     stubConfiguredRouter();
+    when(mockPnpNotifier.build()).thenReturn(
+      PnpState(
+        deviceInfo: NodeDeviceInfo.fromJson(
+          jsonDecode(testDeviceInfo)['output'],
+        ),
+        isUnconfigured: false,
+        autoMasterRotatedSinceLogin: true,
+      ),
+    );
     when(mockPnpNotifier.checkAutoMasterStatus())
         .thenAnswer((_) async => AutoMasterStatus.complete);
 
@@ -573,6 +587,50 @@ void main() async {
     // "no internet".
     verifyNever(mockPnpNotifier.pollAutoMasterStatus());
     verifyNever(mockPnpNotifier.checkInternetConnection());
+  });
+
+  // D': the same `complete` reading, but with NO rotation recorded since our
+  // last accepted password — so it is the *latched* status of a router that was
+  // auto-mastered at some earlier point, not news about our credential.
+  //
+  // The gate must let this through. `Complete` never reverts to `Idle`, so
+  // reading it alone as "your password is stale" fired on every single login:
+  // #1180's log has CheckAdminPassword2 returning 200 with the correct new
+  // password, immediately followed by the gate throwing and `[Prepare]: Logout`
+  // dropping the session that login had just created. The user could never get
+  // past this screen. This test is the regression lock for that loop — it is the
+  // exact counterpart of D, differing only in the flag.
+  testWidgets(
+      'Instant Setup - PnP: latched Auto Master complete does not block a fresh login',
+      (tester) async {
+    useLargeScreen(tester);
+    stubConfiguredRouter(); // build() leaves the flag at its false default
+    when(mockPnpNotifier.checkAutoMasterStatus())
+        .thenAnswer((_) async => AutoMasterStatus.complete);
+
+    await tester.pumpWidget(
+      testableSingleRoute(
+        config: LinksysRouteConfig(
+          column: ColumnGrid(column: 6, centered: true),
+          noNaviRail: true,
+        ),
+        child: const PnpAdminView(),
+        overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
+        extraRoutes: [pnpConfigStubRoute()],
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+    await tapLogin(tester);
+    // Two clocks, as in B/C: mock futures on real microtasks (runAsync), the 1s
+    // internet-connected view on the fake timer (pump).
+    await tester.runAsync(() => Future.delayed(const Duration(seconds: 1)));
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+
+    // Into config, and the credential the router just accepted is left alone.
+    expect(find.byKey(const Key('pnpConfigStub')), findsOneWidget);
+    verifyNever(mockPnpNotifier.setAttachedPassword(null));
+    verifyNever(mockPnpNotifier.pollAutoMasterStatus());
   });
 
   // E: the internet check itself reports a rejected credential rather than a

--- a/test/page/instant_setup/localizations/pnp_admin_view_test.dart
+++ b/test/page/instant_setup/localizations/pnp_admin_view_test.dart
@@ -8,6 +8,7 @@ import 'package:privacy_gui/core/jnap/models/device_info.dart';
 import 'package:privacy_gui/di.dart';
 import 'package:privacy_gui/page/instant_setup/data/pnp_exception.dart';
 import 'package:privacy_gui/page/instant_setup/data/pnp_provider.dart';
+import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/route/route_model.dart';
 import 'package:privacygui_widgets/theme/_theme.dart';
 import '../../../common/di.dart';
@@ -17,6 +18,16 @@ import 'package:privacy_gui/page/instant_setup/pnp_admin_view.dart';
 import '../../../common/test_responsive_widget.dart';
 import '../../../common/testable_router.dart';
 import '../../../test_data/device_info_test_data.dart';
+
+/// A stub destination for `RouteNamed.localLoginPassword` so redirect-to-login
+/// paths can navigate inside the single-route test harness (which otherwise
+/// only knows the '/' route and throws "unknown route name").
+LinksysRoute _loginStubRoute() => LinksysRoute(
+      name: RouteNamed.localLoginPassword,
+      path: RoutePath.localLoginPassword,
+      config: const LinksysRouteConfig(noNaviRail: true),
+      builder: (context, state) => const SizedBox.shrink(key: Key('loginStub')),
+    );
 
 void main() async {
   late Mock.MockPnpNotifier mockPnpNotifier;
@@ -309,5 +320,46 @@ void main() async {
     );
     await tester.pump(const Duration(seconds: 2));
     await tester.pumpAndSettle();
+  });
+
+  // Regression: the poll STREAM (not just the pre-check Future) now terminates
+  // on the first 401. make-Master rotates the admin password mid-poll; the
+  // stream throws ExceptionAutoMasterUnauthorized, which the caller chain routes
+  // to login instead of flattening to null and re-polling with stale creds.
+  testLocalizations(
+      'Instant Setup - PnP: Auto Master poll stream unauthorized redirects to login',
+      (tester, locale) async {
+    when(mockPnpNotifier.build()).thenReturn(
+      PnpState(
+        deviceInfo: NodeDeviceInfo.fromJson(
+          jsonDecode(testDeviceInfo)['output'],
+        ),
+      ),
+    );
+    when(mockPnpNotifier.fetchDeviceInfo()).thenAnswer((_) async {});
+    when(mockPnpNotifier.checkRouterConfigured()).thenAnswer((_) async {});
+    when(mockPnpNotifier.checkAdminPassword(any)).thenAnswer((_) async {});
+    when(mockPnpNotifier.checkAutoMasterStatus())
+        .thenAnswer((_) async => AutoMasterStatus.running);
+    when(mockPnpNotifier.pollAutoMasterStatus())
+        .thenAnswer((_) => Stream.error(ExceptionAutoMasterUnauthorized()));
+
+    await tester.pumpWidget(
+      testableSingleRoute(
+        config: LinksysRouteConfig(
+          column: ColumnGrid(column: 6, centered: true),
+          noNaviRail: true,
+        ),
+        child: const PnpAdminView(),
+        locale: locale,
+        overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
+        extraRoutes: [_loginStubRoute()],
+      ),
+    );
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
+    // The poll-stream 401 must land on the login page, not leave the waiting
+    // spinner up (which would hang pumpAndSettle) nor stay on the admin view.
+    expect(find.byKey(const Key('loginStub')), findsOneWidget);
   });
 }

--- a/test/page/instant_setup/localizations/pnp_admin_view_test.dart
+++ b/test/page/instant_setup/localizations/pnp_admin_view_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -11,10 +12,12 @@ import 'package:privacy_gui/page/instant_setup/data/pnp_provider.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/route/route_model.dart';
 import 'package:privacygui_widgets/theme/_theme.dart';
+import 'package:privacygui_widgets/widgets/_widgets.dart';
 import '../../../common/di.dart';
 import '../../../mocks/pnp_notifier_mocks.dart' as Mock;
 import 'package:privacy_gui/page/instant_setup/data/pnp_state.dart';
 import 'package:privacy_gui/page/instant_setup/pnp_admin_view.dart';
+import 'package:privacy_gui/page/instant_setup/widgets/pnp_auto_master_waiting_view.dart';
 import '../../../common/test_responsive_widget.dart';
 import '../../../common/testable_router.dart';
 import '../../../test_data/device_info_test_data.dart';
@@ -361,5 +364,220 @@ void main() async {
     // The poll-stream 401 must land on the login page, not leave the waiting
     // spinner up (which would hang pumpAndSettle) nor stay on the admin view.
     expect(find.byKey(const Key('loginStub')), findsOneWidget);
+  });
+
+  // ---------------------------------------------------------------------------
+  // `_doLogin` (manual "tap Login") Auto Master gate — A/B/C.
+  //
+  // Regression lock for the reported "WiFi form filled twice" symptom. After
+  // the first-401 fix bails out of the auto-login poll to avoid a lockout, the
+  // user re-logs in by tapping Login. Before the gate, `_doLogin` dropped them
+  // straight into the config/WiFi form even while Auto Master was still
+  // `running`, then the pre-save check bounced them back — filling the form
+  // twice. `_doLogin` now runs the same `_checkAutoMasterStatus()` gate as the
+  // auto-login and default-password paths.
+  //
+  // These tests mount a CONFIGURED router (isUnconfigured: false + a router-
+  // configured throw) so `_mainView` renders `_routerPasswordView` with the
+  // password field + Login button, and `isLoggedIn()` is false by default so
+  // the initState auto-login chain stops before navigating — leaving the manual
+  // login path as the thing under test.
+  // ---------------------------------------------------------------------------
+
+  // A `pnpConfig` destination so the "enter config once" path can navigate
+  // inside the single-route harness without throwing "unknown route name".
+  // Navigation is by NAME; the path just needs to be a valid absolute top-level
+  // route. RoutePath.pnpConfig itself is relative ('pnpConfig', a sub-route of
+  // pnp), which is illegal at the top level — so use an explicit '/' path here.
+  LinksysRoute pnpConfigStubRoute() => LinksysRoute(
+        name: RouteNamed.pnpConfig,
+        path: '/${RoutePath.pnpConfig}',
+        config: const LinksysRouteConfig(noNaviRail: true),
+        builder: (context, state) =>
+            const SizedBox.shrink(key: Key('pnpConfigStub')),
+      );
+
+  // Common notifier stubs to reach `_routerPasswordView` on a configured
+  // router; individual tests layer the Auto Master behavior on top.
+  void stubConfiguredRouter() {
+    when(mockPnpNotifier.build()).thenReturn(
+      PnpState(
+        deviceInfo: NodeDeviceInfo.fromJson(
+          jsonDecode(testDeviceInfo)['output'],
+        ),
+        isUnconfigured: false,
+      ),
+    );
+    when(mockPnpNotifier.fetchDeviceInfo()).thenAnswer((_) async {});
+    when(mockPnpNotifier.checkRouterConfigured()).thenAnswer((_) async {
+      throw ExceptionRouterUnconfigured();
+    });
+    when(mockPnpNotifier.checkAdminPassword(any)).thenAnswer((_) async {});
+    when(mockPnpNotifier.checkInternetConnection()).thenAnswer((_) async {});
+  }
+
+  // Gives the responsive layout room so `_mainView`'s card/image column doesn't
+  // overflow the default 800x600 test surface.
+  void useLargeScreen(WidgetTester tester) {
+    tester.view.physicalSize = const Size(1440, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+  }
+
+  // Types the password and taps the Login button to drive `_doLogin`.
+  // The router-password view has exactly one AppFilledButton (Login); the
+  // "Where is it" affordance is an AppTextButton. Matching by type keeps this
+  // locale-independent (the label is "Log in"/"Anmelden"/… per locale).
+  Future<void> tapLogin(WidgetTester tester) async {
+    await tester.enterText(find.byType(AppPasswordField), 'Password!!!');
+    await tester.pump();
+    await tester.tap(find.byType(AppFilledButton));
+  }
+
+  // These are pure flow/checkpoint regression tests (they assert on route stubs
+  // and the waiting view, not pixels), so they use plain `testWidgets` rather
+  // than `testLocalizations` — no golden image is meaningful here, matching the
+  // sibling pnp_auto_master_flow_test.dart.
+
+  // A: Auto Master still `running` when the user taps Login → the flow must
+  // STOP on the waiting view and NOT enter config. This is the direct
+  // regression lock for the "WiFi form filled twice" symptom. The poll stream
+  // stays open (never emits, never closes) so the flow parks on the waiting
+  // view without a pending timer.
+  testWidgets(
+      'Instant Setup - PnP: Tap Login while Auto Master running stays on waiting view',
+      (tester) async {
+    useLargeScreen(tester);
+    stubConfiguredRouter();
+    when(mockPnpNotifier.checkAutoMasterStatus())
+        .thenAnswer((_) async => AutoMasterStatus.running);
+    final pollController = StreamController<AutoMasterStatus?>();
+    addTearDown(pollController.close);
+    when(mockPnpNotifier.pollAutoMasterStatus())
+        .thenAnswer((_) => pollController.stream);
+
+    await tester.pumpWidget(
+      testableSingleRoute(
+        config: LinksysRouteConfig(
+          column: ColumnGrid(column: 6, centered: true),
+          noNaviRail: true,
+        ),
+        child: const PnpAdminView(),
+        overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
+        extraRoutes: [pnpConfigStubRoute()],
+      ),
+    );
+    // Let initState settle onto the password view, then drive `_doLogin`.
+    await tester.pump(const Duration(seconds: 1));
+    await tapLogin(tester);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byType(PnpAutoMasterWaitingView), findsOneWidget);
+    // Must NOT have entered config while Auto Master is still running.
+    expect(find.byKey(const Key('pnpConfigStub')), findsNothing);
+  });
+
+  // B: Auto Master `failed` (found another Master, credential NOT rotated) →
+  // `_checkAutoMasterStatus` returns normally, so `_doLogin` proceeds into
+  // config exactly once.
+  testWidgets(
+      'Instant Setup - PnP: Tap Login with Auto Master failed enters config',
+      (tester) async {
+    useLargeScreen(tester);
+    stubConfiguredRouter();
+    when(mockPnpNotifier.checkAutoMasterStatus())
+        .thenAnswer((_) async => AutoMasterStatus.running);
+    when(mockPnpNotifier.pollAutoMasterStatus())
+        .thenAnswer((_) => Stream.value(AutoMasterStatus.failed));
+
+    await tester.pumpWidget(
+      testableSingleRoute(
+        config: LinksysRouteConfig(
+          column: ColumnGrid(column: 6, centered: true),
+          noNaviRail: true,
+        ),
+        child: const PnpAdminView(),
+        overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
+        extraRoutes: [pnpConfigStubRoute()],
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+    await tapLogin(tester);
+    // The full `_doLogin` chain here spans BOTH clocks: mock futures / the poll
+    // stream resolve on real microtasks (advanced by `runAsync`), while the 1s
+    // internet-connected view uses a fake timer (advanced by `pump(Duration)`).
+    // Step both, then settle the route transition.
+    await tester.runAsync(() => Future.delayed(const Duration(seconds: 1)));
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('pnpConfigStub')), findsOneWidget);
+  });
+
+  // B': Auto Master resolves to `complete` (make-Master finished → credential
+  // rotated) → `_checkAutoMasterStatus` throws ExceptionInterruptAndExit and
+  // `_doLogin` must send the user to re-login, NOT into config with a stale
+  // session. Without the ExceptionInterruptAndExit handler this fell through to
+  // the catch-all and showed a bogus error on the password screen.
+  testWidgets(
+      'Instant Setup - PnP: Tap Login with Auto Master complete redirects to login',
+      (tester) async {
+    useLargeScreen(tester);
+    stubConfiguredRouter();
+    when(mockPnpNotifier.checkAutoMasterStatus())
+        .thenAnswer((_) async => AutoMasterStatus.running);
+    when(mockPnpNotifier.pollAutoMasterStatus())
+        .thenAnswer((_) => Stream.value(AutoMasterStatus.complete));
+
+    await tester.pumpWidget(
+      testableSingleRoute(
+        config: LinksysRouteConfig(
+          column: ColumnGrid(column: 6, centered: true),
+          noNaviRail: true,
+        ),
+        child: const PnpAdminView(),
+        overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
+        extraRoutes: [_loginStubRoute(), pnpConfigStubRoute()],
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+    await tapLogin(tester);
+    // Drive the real event loop so the poll `await for` runs to `complete`
+    // (throwing ExceptionInterruptAndExit) and the redirect resolves.
+    await tester.runAsync(() => Future.delayed(const Duration(seconds: 2)));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('loginStub')), findsOneWidget);
+    expect(find.byKey(const Key('pnpConfigStub')), findsNothing);
+  });
+
+  // C: the initial `checkAutoMasterStatus()` gate itself 401s (credential
+  // already rotated by the time the user tapped Login) → redirect to login.
+  testWidgets(
+      'Instant Setup - PnP: Tap Login with Auto Master check unauthorized redirects to login',
+      (tester) async {
+    useLargeScreen(tester);
+    stubConfiguredRouter();
+    when(mockPnpNotifier.checkAutoMasterStatus())
+        .thenThrow(ExceptionAutoMasterUnauthorized());
+
+    await tester.pumpWidget(
+      testableSingleRoute(
+        config: LinksysRouteConfig(
+          column: ColumnGrid(column: 6, centered: true),
+          noNaviRail: true,
+        ),
+        child: const PnpAdminView(),
+        overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
+        extraRoutes: [_loginStubRoute(), pnpConfigStubRoute()],
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+    await tapLogin(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('loginStub')), findsOneWidget);
+    expect(find.byKey(const Key('pnpConfigStub')), findsNothing);
   });
 }

--- a/test/page/instant_setup/localizations/pnp_admin_view_test.dart
+++ b/test/page/instant_setup/localizations/pnp_admin_view_test.dart
@@ -525,4 +525,93 @@ void main() async {
     // Never polled: null is not `running`, so there was nothing to wait on.
     verifyNever(mockPnpNotifier.pollAutoMasterStatus());
   });
+
+  // D: Auto Master is ALREADY `complete` when the gate first reads it — the
+  // post-reconnect case from #1180's QA log. make-Master finished while the
+  // router was rebooting, so by the time this view loaded there was nothing left
+  // to wait for, but the admin password had been rotated regardless.
+  //
+  // This is a distinct branch from B': there, `running` was observed and the
+  // poll ran to `complete`. Here the poll must never start (`verifyNever`) —
+  // which is exactly why `runAutoMasterFlow`'s `completed` case could not cover
+  // this: that flow is only entered on a `running` status. The gate used to
+  // `return` on anything that was not `running`, so `complete` fell straight
+  // through to the internet check, which 401'd on the dead credential and sent
+  // the user to the troubleshooter with a working internet connection.
+  testWidgets(
+      'Instant Setup - PnP: Auto Master already complete on entry asks for the new password',
+      (tester) async {
+    useLargeScreen(tester);
+    stubConfiguredRouter();
+    when(mockPnpNotifier.checkAutoMasterStatus())
+        .thenAnswer((_) async => AutoMasterStatus.complete);
+
+    await tester.pumpWidget(
+      testableSingleRoute(
+        config: LinksysRouteConfig(
+          column: ColumnGrid(column: 6, centered: true),
+          noNaviRail: true,
+        ),
+        child: const PnpAdminView(),
+        overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
+        extraRoutes: [pnpConfigStubRoute()],
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+    await tapLogin(tester);
+    await tester.runAsync(() => Future.delayed(const Duration(seconds: 2)));
+    await tester.pumpAndSettle();
+
+    // Back on PnP's own password prompt — not in config, not waiting.
+    expect(find.byType(PnpAdminView), findsOneWidget);
+    expect(find.byType(AppPasswordField), findsOneWidget);
+    expect(find.byType(PnpAutoMasterWaitingView), findsNothing);
+    expect(find.byKey(const Key('pnpConfigStub')), findsNothing);
+    verify(mockPnpNotifier.setAttachedPassword(null)).called(1);
+    // Nothing to poll, and — the actual #1180 defect — the internet check must
+    // not run: it would go out with the rotated credential and read its 401 as
+    // "no internet".
+    verifyNever(mockPnpNotifier.pollAutoMasterStatus());
+    verifyNever(mockPnpNotifier.checkInternetConnection());
+  });
+
+  // E: the internet check itself reports a rejected credential rather than a
+  // dead WAN (`ExceptionInvalidAdminPassword`, not
+  // `ExceptionNoInternetConnection`). The view must NOT go to the troubleshooter
+  // — the WAN is fine, only the password is stale. This is the safety net for
+  // every path that reaches an authed call with a credential Auto Master
+  // rotated, including the ones the gate cannot see.
+  testWidgets(
+      'Instant Setup - PnP: Unauthorized internet check does not go to the troubleshooter',
+      (tester) async {
+    useLargeScreen(tester);
+    stubConfiguredRouter();
+    when(mockPnpNotifier.checkAutoMasterStatus()).thenAnswer((_) async => null);
+    when(mockPnpNotifier.checkInternetConnection()).thenAnswer((_) async {
+      throw ExceptionInvalidAdminPassword();
+    });
+
+    await tester.pumpWidget(
+      testableSingleRoute(
+        config: LinksysRouteConfig(
+          column: ColumnGrid(column: 6, centered: true),
+          noNaviRail: true,
+        ),
+        child: const PnpAdminView(),
+        overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
+        extraRoutes: [pnpConfigStubRoute()],
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+    await tapLogin(tester);
+    await tester.runAsync(() => Future.delayed(const Duration(seconds: 2)));
+    await tester.pumpAndSettle();
+
+    // Still in PnP with a password field, and the spinner has been cleared.
+    expect(find.byType(PnpAdminView), findsOneWidget);
+    expect(find.byType(AppPasswordField), findsOneWidget);
+    expect(find.byKey(const Key('pnpConfigStub')), findsNothing);
+    // No troubleshooter route is registered here on purpose: navigating to it
+    // would throw "unknown route name" rather than pass quietly.
+  });
 }

--- a/test/page/instant_setup/localizations/pnp_admin_view_test.dart
+++ b/test/page/instant_setup/localizations/pnp_admin_view_test.dart
@@ -22,16 +22,6 @@ import '../../../common/test_responsive_widget.dart';
 import '../../../common/testable_router.dart';
 import '../../../test_data/device_info_test_data.dart';
 
-/// A stub destination for `RouteNamed.localLoginPassword` so redirect-to-login
-/// paths can navigate inside the single-route test harness (which otherwise
-/// only knows the '/' route and throws "unknown route name").
-LinksysRoute _loginStubRoute() => LinksysRoute(
-      name: RouteNamed.localLoginPassword,
-      path: RoutePath.localLoginPassword,
-      config: const LinksysRouteConfig(noNaviRail: true),
-      builder: (context, state) => const SizedBox.shrink(key: Key('loginStub')),
-    );
-
 void main() async {
   late Mock.MockPnpNotifier mockPnpNotifier;
 
@@ -274,10 +264,15 @@ void main() async {
     when(mockPnpNotifier.checkAutoMasterStatus()).thenAnswer((_) async {
       return AutoMasterStatus.running;
     });
-    // Return null 3 times to trigger connection error
+    // Nulls alone no longer condemn the connection — the poll runs its whole
+    // budget and only then does the reachability test decide. Spend the budget
+    // (stream ends with no terminal status) and fail that test, which is what
+    // actually renders this view.
     when(mockPnpNotifier.pollAutoMasterStatus()).thenAnswer((_) {
       return Stream.fromIterable([null, null, null]);
     });
+    when(mockPnpNotifier.testConnectionReconnected())
+        .thenAnswer((_) async => throw ExceptionNeedToReconnect());
 
     await tester.pumpWidget(
       testableSingleRoute(
@@ -444,12 +439,21 @@ void main() async {
   });
 
   // B': Auto Master resolves to `complete` (make-Master finished → credential
-  // rotated) → `_checkAutoMasterStatus` throws ExceptionInterruptAndExit and
-  // `_doLogin` must send the user to re-login, NOT into config with a stale
-  // session. Without the ExceptionInterruptAndExit handler this fell through to
-  // the catch-all and showed a bogus error on the password screen.
+  // rotated) → `_checkAutoMasterStatus` throws
+  // ExceptionAutoMasterRotatedPassword and `_doLogin` must ask for the new
+  // password, NOT enter config with a stale session.
+  //
+  // The prompt is this very view, so the correct outcome is *no navigation*:
+  // `_promptForRotatedPassword` leaves the waiting view and comes back to the
+  // password field. Asserting that here is what pins #1180's second defect —
+  // this branch used to redirect to `localLoginPassword`, which belongs to a
+  // setup that finished (`userAcknowledgedAutoConfiguration == true`) and
+  // stranded the user outside the flow they were still in. Hence
+  // `findsNothing` on a login stub that is no longer even registered: if some
+  // future change re-adds the redirect, the harness throws "unknown route
+  // name" rather than passing quietly.
   testWidgets(
-      'Instant Setup - PnP: Tap Login with Auto Master complete redirects to login',
+      'Instant Setup - PnP: Tap Login with Auto Master complete asks for the new password',
       (tester) async {
     useLargeScreen(tester);
     stubConfiguredRouter();
@@ -466,18 +470,23 @@ void main() async {
         ),
         child: const PnpAdminView(),
         overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
-        extraRoutes: [_loginStubRoute(), pnpConfigStubRoute()],
+        extraRoutes: [pnpConfigStubRoute()],
       ),
     );
     await tester.pump(const Duration(seconds: 1));
     await tapLogin(tester);
     // Drive the real event loop so the poll `await for` runs to `complete`
-    // (throwing ExceptionInterruptAndExit) and the redirect resolves.
+    // (throwing ExceptionAutoMasterRotatedPassword) and the handler runs.
     await tester.runAsync(() => Future.delayed(const Duration(seconds: 2)));
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('loginStub')), findsOneWidget);
+    // Back on PnP's own password prompt, off the waiting view, still inside PnP.
+    expect(find.byType(PnpAdminView), findsOneWidget);
+    expect(find.byType(AppPasswordField), findsOneWidget);
+    expect(find.byType(PnpAutoMasterWaitingView), findsNothing);
     expect(find.byKey(const Key('pnpConfigStub')), findsNothing);
+    // The rotated credential must be dropped, not retried on the next pass.
+    verify(mockPnpNotifier.setAttachedPassword(null)).called(1);
   });
 
   // C: the `checkAutoMasterStatus()` gate cannot determine the status (null) —
@@ -501,7 +510,7 @@ void main() async {
         ),
         child: const PnpAdminView(),
         overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
-        extraRoutes: [_loginStubRoute(), pnpConfigStubRoute()],
+        extraRoutes: [pnpConfigStubRoute()],
       ),
     );
     await tester.pump(const Duration(seconds: 1));

--- a/test/page/instant_setup/localizations/pnp_setup_view_test.dart
+++ b/test/page/instant_setup/localizations/pnp_setup_view_test.dart
@@ -16,6 +16,7 @@ import 'package:privacy_gui/page/instant_setup/data/pnp_step_state.dart';
 import 'package:privacy_gui/page/instant_setup/data/pnp_wifi_settings.dart';
 import 'package:privacy_gui/page/instant_setup/model/pnp_step.dart';
 import 'package:privacy_gui/page/instant_setup/pnp_setup_view.dart';
+import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/route/route_model.dart';
 import 'package:privacygui_widgets/icons/linksys_icons.dart';
 import 'package:privacygui_widgets/widgets/_widgets.dart';
@@ -27,6 +28,16 @@ import 'package:privacy_gui/page/instant_setup/data/pnp_state.dart';
 import '../../../common/test_responsive_widget.dart';
 import '../../../common/testable_router.dart';
 import '../../../test_data/device_info_test_data.dart';
+
+/// A stub destination for `RouteNamed.localLoginPassword` so redirect-to-login
+/// paths can navigate inside the single-route test harness (which otherwise
+/// only knows the '/' route and throws "unknown route name").
+LinksysRoute _loginStubRoute() => LinksysRoute(
+      name: RouteNamed.localLoginPassword,
+      path: RoutePath.localLoginPassword,
+      config: const LinksysRouteConfig(noNaviRail: true),
+      builder: (context, state) => const SizedBox.shrink(key: Key('loginStub')),
+    );
 
 void main() async {
   late Mock.MockPnpNotifier mockPnpNotifier;
@@ -734,5 +745,56 @@ void main() async {
     final btnFinder3 = find.byType(FilledButton);
     await tester.tap(btnFinder3.first);
     await tester.pump(const Duration(seconds: 2));
+  });
+
+  // Regression: the poll stream terminates on the first 401 (make-Master
+  // rotated the admin password mid-poll). Instead of flattening to null and
+  // re-polling with the stale credential, the save flow catches
+  // ExceptionAutoMasterUnauthorized and routes to login. This exercises the new
+  // try/catch around the await-for in _saveChanges.
+  testLocalizations('Instant Setup - PnP: Auto Master poll stream unauthorized',
+      (tester, locale) async {
+    var callCount = 0;
+    when(mockPnpNotifier.checkAutoMasterStatus()).thenAnswer((_) async {
+      callCount++;
+      return callCount == 1 ? AutoMasterStatus.idle : AutoMasterStatus.running;
+    });
+    when(mockPnpNotifier.pollAutoMasterStatus()).thenAnswer((_) {
+      return Stream<AutoMasterStatus?>.error(ExceptionAutoMasterUnauthorized());
+    });
+
+    await tester.pumpWidget(
+      testableSingleRoute(
+        child: const PnpSetupView(),
+        config: LinksysRouteConfig(
+            column: ColumnGrid(column: 6, centered: true), noNaviRail: true),
+        locale: locale,
+        overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
+        extraRoutes: [_loginStubRoute()],
+      ),
+    );
+    await tester.pump(const Duration(seconds: 6));
+    final state =
+        tester.state<ConsumerState<PnpSetupView>>(find.byType(PnpSetupView));
+    state.setState(() {});
+    await tester.pumpAndSettle();
+    final ssidEditFinder = find.byType(TextField).first;
+    final passwordEditFinder = find.byType(TextField).last;
+    await tester.enterText(ssidEditFinder, 'MyAwesomeWiFiName');
+    await tester.pumpAndSettle();
+    await tester.enterText(passwordEditFinder, 'MyAwesomeWiFiPassword!');
+    await tester.pumpAndSettle();
+    final btnFinder = find.byType(FilledButton);
+    await tester.tap(btnFinder.first);
+    await tester.pumpAndSettle();
+    final btnFinder2 = find.byType(FilledButton);
+    await tester.tap(btnFinder2.first);
+    await tester.pumpAndSettle();
+    final btnFinder3 = find.byType(FilledButton);
+    await tester.tap(btnFinder3.first);
+    await tester.pumpAndSettle();
+    // The poll-stream 401 during save must route to login instead of
+    // re-polling with the stale credential.
+    expect(find.byKey(const Key('loginStub')), findsOneWidget);
   });
 }

--- a/test/page/instant_setup/localizations/pnp_setup_view_test.dart
+++ b/test/page/instant_setup/localizations/pnp_setup_view_test.dart
@@ -34,14 +34,19 @@ import '../../../common/test_responsive_widget.dart';
 import '../../../common/testable_router.dart';
 import '../../../test_data/device_info_test_data.dart';
 
-/// A stub destination for `RouteNamed.localLoginPassword` so redirect-to-login
-/// paths can navigate inside the single-route test harness (which otherwise
-/// only knows the '/' route and throws "unknown route name").
-LinksysRoute _loginStubRoute() => LinksysRoute(
-      name: RouteNamed.localLoginPassword,
-      path: RoutePath.localLoginPassword,
+/// A stub destination for `RouteNamed.pnp` so the back-to-PnP paths can
+/// navigate inside the single-route test harness (which otherwise only knows
+/// the '/' route and throws "unknown route name").
+///
+/// Every abandoned-save path in this view lands here — a credential rotation
+/// mid-setup, and a 401 from the write itself. Not `localLoginPassword`: that
+/// page belongs to a setup that finished
+/// (`userAcknowledgedAutoConfiguration == true`), and none of these did.
+LinksysRoute _pnpStubRoute() => LinksysRoute(
+      name: RouteNamed.pnp,
+      path: RoutePath.pnp,
       config: const LinksysRouteConfig(noNaviRail: true),
-      builder: (context, state) => const SizedBox.shrink(key: Key('loginStub')),
+      builder: (context, state) => const SizedBox.shrink(key: Key('pnpStub')),
     );
 
 void main() async {
@@ -707,7 +712,13 @@ void main() async {
     await tester.pump(const Duration(seconds: 2));
   });
 
-  testLocalizations('Instant Setup - PnP: Auto Master connection error',
+  // Named "before save" like its sibling above, and not just "connection
+  // error": the golden filename is derived from this description alone, and
+  // pnp_admin_view_test.dart has its own connection-error screenshot in the
+  // same goldens/ directory. Two tests sharing a description quietly overwrite
+  // each other's screenshot, and whichever runs second fails the comparison.
+  testLocalizations(
+      'Instant Setup - PnP: Auto Master connection error before save',
       (tester, locale) async {
     // First call returns idle (for initState), subsequent calls return running (for save)
     var callCount = 0;
@@ -715,10 +726,15 @@ void main() async {
       callCount++;
       return callCount == 1 ? AutoMasterStatus.idle : AutoMasterStatus.running;
     });
-    // Return null to simulate connection failure during polling (3 consecutive failures)
+    // Nulls alone no longer condemn the connection — the poll runs its whole
+    // budget and only then does the reachability test decide. Spend the budget
+    // (stream ends with no terminal status) and fail that test, which is what
+    // actually renders this view.
     when(mockPnpNotifier.pollAutoMasterStatus()).thenAnswer((_) {
       return Stream<AutoMasterStatus?>.fromIterable([null, null, null]);
     });
+    when(mockPnpNotifier.testConnectionReconnected())
+        .thenAnswer((_) async => throw ExceptionNeedToReconnect());
 
     await tester.pumpWidget(
       testableSingleRoute(
@@ -859,9 +875,9 @@ void main() async {
 
   // running -> poll resolves complete: make-Master finished and rotated the
   // admin password. The GUI session is dead, so save must NOT be attempted;
-  // route to login instead.
+  // go back to PnP so its precheck can ask for the new password.
   testWidgets(
-      'Instant Setup - PnP: Auto Master poll complete before save redirects to login',
+      'Instant Setup - PnP: Auto Master poll complete before save redirects to pnp',
       (tester) async {
     useLargeScreen(tester);
     stubCheckAutoMaster(
@@ -869,11 +885,18 @@ void main() async {
     when(mockPnpNotifier.pollAutoMasterStatus())
         .thenAnswer((_) => Stream.value(AutoMasterStatus.complete));
 
-    await pumpSetup(tester, extraRoutes: [_loginStubRoute()]);
+    await pumpSetup(tester, extraRoutes: [_pnpStubRoute()]);
     await driveToSave(tester);
-    await tester.pumpAndSettle();
+    // Drain on the real event loop, as the sibling tests below do. The flow
+    // leaves the poll by returning out of its `await for`, which cancels the
+    // subscription — and the mock's Stream.value only settles that cancellation
+    // on real event-loop turns, so pumping fake time alone never gets past it.
+    await tester
+        .runAsync(() => Future.delayed(const Duration(milliseconds: 100)));
+    await tester.pump();
+    await tester.pump();
 
-    expect(find.byKey(const Key('loginStub')), findsOneWidget);
+    expect(find.byKey(const Key('pnpStub')), findsOneWidget);
     verifyNever(mockPnpNotifier.save());
   });
 
@@ -919,7 +942,7 @@ void main() async {
     final saveCompleter = Completer<void>();
     when(mockPnpNotifier.save()).thenAnswer((_) => saveCompleter.future);
 
-    await pumpSetup(tester, extraRoutes: [_loginStubRoute()]);
+    await pumpSetup(tester, extraRoutes: [_pnpStubRoute()]);
     await driveToSave(tester);
     // Not pumpAndSettle: setState(saving) starts an endless AppSpinner.
     await tester
@@ -929,16 +952,16 @@ void main() async {
     verify(mockPnpNotifier.save()).called(1);
     // null is not `running`, so there was nothing to poll or wait for.
     verifyNever(mockPnpNotifier.pollAutoMasterStatus());
-    expect(find.byKey(const Key('loginStub')), findsNothing);
+    expect(find.byKey(const Key('pnpStub')), findsNothing);
   });
 
   // Edge case (idle on entry, complete now): Auto Master was idle when PnP
   // started but completed during the WiFi-config step, so it never showed as
   // running at save time. The entry-vs-current comparison must still catch the
-  // credential rotation and route to login. The entry status lives in PnpState
+  // credential rotation and go back to PnP. The entry status lives in PnpState
   // (the mock's setAutoMasterStatusOnEntry is a no-op), so seed build() with it.
   testWidgets(
-      'Instant Setup - PnP: Auto Master idle on entry but complete during config redirects to login',
+      'Instant Setup - PnP: Auto Master idle on entry but complete during config redirects to pnp',
       (tester) async {
     useLargeScreen(tester);
     when(mockPnpNotifier.build()).thenReturn(PnpState(
@@ -955,11 +978,11 @@ void main() async {
     stubCheckAutoMaster(
         entry: AutoMasterStatus.idle, duringSave: AutoMasterStatus.complete);
 
-    await pumpSetup(tester, extraRoutes: [_loginStubRoute()]);
+    await pumpSetup(tester, extraRoutes: [_pnpStubRoute()]);
     await driveToSave(tester);
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('loginStub')), findsOneWidget);
+    expect(find.byKey(const Key('pnpStub')), findsOneWidget);
     verifyNever(mockPnpNotifier.save());
   });
 
@@ -989,13 +1012,7 @@ void main() async {
           const JNAPError(result: errorJNAPUnauthorized));
     });
 
-    final pnpStub = LinksysRoute(
-      name: RouteNamed.pnp,
-      path: RoutePath.pnp,
-      config: const LinksysRouteConfig(noNaviRail: true),
-      builder: (context, state) => const SizedBox.shrink(key: Key('pnpStub')),
-    );
-    await pumpSetup(tester, extraRoutes: [pnpStub]);
+    await pumpSetup(tester, extraRoutes: [_pnpStubRoute()]);
     await driveToSave(tester);
     await tester.pumpAndSettle();
 
@@ -1003,28 +1020,33 @@ void main() async {
   });
 
   // ---------------------------------------------------------------------------
-  // Timeout / reconnect-retry branch of `_saveChanges` (pnp_setup_view.dart
-  // L818-846). Reached when the poll stream ends WITHOUT a terminal status —
-  // make-Master neither finished (complete/idle), gave up (failed), nor tripped
-  // the 3-consecutive-failures guard within the poll window:
-  //   - timeout -> testConnectionReconnected() OK    -> retry _saveChanges once;
-  //       on the retry Auto Master has settled (idle), so the write proceeds
-  //   - timeout -> testConnectionReconnected() throws -> connection error view,
-  //       never save (router unreachable)
-  //   - timeout on every attempt until the retry limit
-  //       (_maxAutoMasterSaveAttempts == 2) -> connection error view, never save
-  // The connection-error sub-view is identified by its wifi-off icon, which only
-  // the error branch of PnpAutoMasterWaitingView renders.
+  // Budget-exhausted branch of `_saveChanges`. Reached when the poll stream ends
+  // WITHOUT a terminal status — Auto Master neither finished (complete/idle) nor
+  // gave up (failed) inside the poll's bounded budget. Nulls along the way are
+  // NOT a trigger: the poll's own length is the only give-up rule, and only then
+  // does testConnectionReconnected() decide.
+  //
+  //   - budget spent -> testConnectionReconnected() OK -> re-check from the top;
+  //       on the second pass Auto Master has settled (idle), so the write goes
+  //   - budget spent -> testConnectionReconnected() throws -> connection error
+  //       view, never save (router unreachable)
+  //   - still unresolved after _maxAutoMasterWaits (2) waits -> connection error
+  //       view, never save
+  //
+  // This caller is the only one that re-checks rather than proceeding on
+  // budgetExhausted: it has a save pending that a credential rotation would
+  // break. The connection-error sub-view is identified by its wifi-off icon,
+  // which only the error branch of PnpAutoMasterWaitingView renders.
   // ---------------------------------------------------------------------------
 
-  // poll ends on `running` (never a terminal status) -> timeout. Reconnect
-  // succeeds, so the flow retries _saveChanges; on the retry the status has
-  // settled to idle, so it falls through and actually writes settings.
+  // Poll ends on `running` (never a terminal status) -> budget spent. Reconnect
+  // succeeds, so the flow re-checks; the status has settled to idle by then, so
+  // it falls through and actually writes settings.
   testWidgets(
-      'Instant Setup - PnP: Auto Master poll timeout then reconnect retries and saves',
+      'Instant Setup - PnP: Auto Master budget spent then reconnect re-checks and saves',
       (tester) async {
     useLargeScreen(tester);
-    // initState -> idle; first save -> running (enters the poll); retry save ->
+    // initState -> idle; first save -> running (enters the poll); re-check ->
     // idle (Auto Master settled) so the write proceeds. stubCheckAutoMaster
     // can't express three distinct answers, so stub the call counter inline.
     var callCount = 0;
@@ -1032,22 +1054,22 @@ void main() async {
       callCount++;
       if (callCount == 1) return AutoMasterStatus.idle; // initState
       if (callCount == 2) return AutoMasterStatus.running; // first save
-      return AutoMasterStatus.idle; // retry save
+      return AutoMasterStatus.idle; // re-check
     });
     // Emits one running then completes -> the await-for ends without a terminal
-    // status -> timeout branch.
+    // status -> budget-spent branch.
     when(mockPnpNotifier.pollAutoMasterStatus())
         .thenAnswer((_) => Stream.value(AutoMasterStatus.running));
     // testConnectionReconnected returns Future.value() (success) by default.
     // Leave save() pending so the whenComplete tail (and its post-save 3s timer)
-    // never runs; we only assert save() was reached on the retry.
+    // never runs; we only assert save() was reached on the second pass.
     final saveCompleter = Completer<void>();
     when(mockPnpNotifier.save()).thenAnswer((_) => saveCompleter.future);
 
     await pumpSetup(tester);
     await driveToSave(tester);
-    // Drain poll-end -> timeout -> reconnect -> retry -> save on the real event
-    // loop. No pumpAndSettle: the retry ends in setState(saving), whose endless
+    // Drain poll-end -> reconnect -> re-check -> save on the real event loop. No
+    // pumpAndSettle: the second pass ends in setState(saving), whose endless
     // AppSpinner animation would time out pumpAndSettle.
     await tester
         .runAsync(() => Future.delayed(const Duration(milliseconds: 100)));
@@ -1057,11 +1079,11 @@ void main() async {
     verify(mockPnpNotifier.save()).called(1);
   });
 
-  // poll ends on `running` -> timeout, but the router is unreachable
+  // Poll ends on `running` -> budget spent, but the router is unreachable
   // (testConnectionReconnected throws). The flow must surface the connection
   // error view and never write settings.
   testWidgets(
-      'Instant Setup - PnP: Auto Master poll timeout then reconnect fails shows connection error',
+      'Instant Setup - PnP: Auto Master budget spent then reconnect fails shows connection error',
       (tester) async {
     useLargeScreen(tester);
     stubCheckAutoMaster(
@@ -1082,23 +1104,22 @@ void main() async {
     verifyNever(mockPnpNotifier.save());
   });
 
-  // Every attempt times out (status stays running and reconnect keeps
-  // succeeding), so _saveChanges recurses until autoMasterSaveAttempt reaches
-  // _maxAutoMasterSaveAttempts (2) and gives up with the connection error view.
-  // Exercises the retry-limit short-circuit (L822-828), distinct from the
-  // reconnect-failure branch (L839-844) above.
+  // Every wait ends with the status still `running` while reconnect keeps
+  // succeeding, so _saveChanges re-checks until autoMasterWaitsSpent reaches
+  // _maxAutoMasterWaits (2) and gives up with the connection error view. Each
+  // wait costs a full poll budget (~3 min), which is why the cap is this low.
   testWidgets(
-      'Instant Setup - PnP: Auto Master poll timeout exhausts retries shows connection error',
+      'Instant Setup - PnP: Auto Master unresolved after the wait limit shows connection error',
       (tester) async {
     useLargeScreen(tester);
-    // idle on entry, running on every save-time check so each retry re-enters
-    // the poll -> timeout loop.
+    // idle on entry, running on every save-time check so each pass re-enters the
+    // poll and spends another wait.
     stubCheckAutoMaster(
         entry: AutoMasterStatus.idle, duringSave: AutoMasterStatus.running);
     when(mockPnpNotifier.pollAutoMasterStatus())
         .thenAnswer((_) => Stream.value(AutoMasterStatus.running));
     // Reconnect succeeds each time, so the only thing that stops the recursion
-    // is the retry limit.
+    // is the wait limit.
     when(mockPnpNotifier.testConnectionReconnected()).thenAnswer((_) async {});
 
     await pumpSetup(tester);
@@ -1108,7 +1129,7 @@ void main() async {
     await tester.pump();
 
     expect(find.byIcon(LinksysIcons.signalWifiOff), findsOneWidget);
-    // Reconnected on attempts 0 and 1; attempt 2 short-circuits on the limit.
+    // One reconnect test per wait; the 2nd wait hits the limit and stops there.
     verify(mockPnpNotifier.testConnectionReconnected()).called(2);
     verifyNever(mockPnpNotifier.save());
   });

--- a/test/page/instant_setup/localizations/pnp_setup_view_test.dart
+++ b/test/page/instant_setup/localizations/pnp_setup_view_test.dart
@@ -1,14 +1,18 @@
 // ignore_for_file: invalid_use_of_protected_member
 
+import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mockito/mockito.dart';
+import 'package:privacy_gui/constants/error_code.dart';
 import 'package:privacy_gui/core/jnap/actions/jnap_service_supported.dart';
 import 'package:privacy_gui/core/jnap/models/auto_master_status.dart';
 import 'package:privacy_gui/core/jnap/models/device_info.dart';
 import 'package:privacy_gui/core/jnap/providers/firmware_update_provider.dart';
+import 'package:privacy_gui/core/jnap/result/jnap_result.dart';
 import 'package:privacy_gui/di.dart';
 import 'package:privacy_gui/page/instant_setup/data/pnp_exception.dart';
 import 'package:privacy_gui/page/instant_setup/data/pnp_provider.dart';
@@ -16,6 +20,7 @@ import 'package:privacy_gui/page/instant_setup/data/pnp_step_state.dart';
 import 'package:privacy_gui/page/instant_setup/data/pnp_wifi_settings.dart';
 import 'package:privacy_gui/page/instant_setup/model/pnp_step.dart';
 import 'package:privacy_gui/page/instant_setup/pnp_setup_view.dart';
+import 'package:privacy_gui/page/instant_setup/widgets/pnp_auto_master_waiting_view.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/route/route_model.dart';
 import 'package:privacygui_widgets/icons/linksys_icons.dart';
@@ -796,5 +801,361 @@ void main() async {
     // The poll-stream 401 during save must route to login instead of
     // re-polling with the stale credential.
     expect(find.byKey(const Key('loginStub')), findsOneWidget);
+  });
+
+  // ---------------------------------------------------------------------------
+  // `_saveChanges` Auto Master "second defense" — behavior/flow tests.
+  //
+  // The golden tests above capture pixels; these assert on the actual save-time
+  // decisions the #1180 fix hinges on. `_saveChanges` re-checks Auto Master
+  // right before writing settings, because make-Master can rotate the admin
+  // credential during the (potentially long) WiFi-config step:
+  //   - pre-check 401                     -> go to login (session already dead)
+  //   - status == running                 -> park on the waiting view and poll
+  //   - poll -> complete/idle             -> go to login (credential rotated)
+  //   - poll -> failed (found a Master)   -> credential intact, continue to save
+  //   - idle on entry but complete now    -> go to login (rotated during config)
+  //
+  // These are pure flow/checkpoint tests (route stubs + the waiting view, not
+  // pixels), so they use plain `testWidgets` — no golden image is meaningful,
+  // matching the sibling pnp_auto_master_flow_test.dart.
+  // ---------------------------------------------------------------------------
+
+  // Gives the stepper + WiFi form room so nothing overflows the default surface.
+  void useLargeScreen(WidgetTester tester) {
+    tester.view.physicalSize = const Size(1440, 1200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+  }
+
+  // checkAutoMasterStatus is called once in initState (record-on-entry) and
+  // again at the top of _saveChanges. Return [entry] on the first call and
+  // [duringSave] on every later call, so a test keeps initState benign while
+  // forcing the save-time branch under test.
+  void stubCheckAutoMaster({
+    required AutoMasterStatus? entry,
+    required AutoMasterStatus? duringSave,
+  }) {
+    var callCount = 0;
+    when(mockPnpNotifier.checkAutoMasterStatus()).thenAnswer((_) async {
+      callCount++;
+      return callCount == 1 ? entry : duringSave;
+    });
+  }
+
+  Future<void> pumpSetup(
+    WidgetTester tester, {
+    List<RouteBase> extraRoutes = const [],
+  }) =>
+      tester.pumpWidget(
+        testableSingleRoute(
+          config: LinksysRouteConfig(
+              column: ColumnGrid(column: 6, centered: true), noNaviRail: true),
+          child: const PnpSetupView(),
+          overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
+          extraRoutes: extraRoutes,
+        ),
+      );
+
+  // Drives the configured+prePaired stepper (Personal -> Guest -> NightMode) to
+  // its last step, whose "Next" fires onLastStep = _saveChanges. Mirrors the
+  // golden tests' tap sequence. The caller pumps the Auto Master flow that
+  // follows (which may park on the waiting spinner), so this deliberately does
+  // NOT settle after the final tap.
+  Future<void> driveToSave(WidgetTester tester) async {
+    await tester.pump(const Duration(seconds: 6));
+    // Trick - setState to trigger build (same as the golden tests).
+    final state =
+        tester.state<ConsumerState<PnpSetupView>>(find.byType(PnpSetupView));
+    state.setState(() {});
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).first, 'MyAwesomeWiFiName');
+    await tester.pumpAndSettle();
+    await tester.enterText(
+        find.byType(TextField).last, 'MyAwesomeWiFiPassword!');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(FilledButton).first); // Personal -> Guest
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(FilledButton).first); // Guest -> NightMode
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(FilledButton).first); // NightMode -> save
+  }
+
+  // running: make-Master is still electing when the user reaches save. The flow
+  // must park on the waiting view and NOT write settings (save) yet. The poll
+  // stream stays open (never emits) so it parks without a pending timer.
+  testWidgets(
+      'Instant Setup - PnP: Auto Master running before save stays on waiting view',
+      (tester) async {
+    useLargeScreen(tester);
+    stubCheckAutoMaster(
+        entry: AutoMasterStatus.idle, duringSave: AutoMasterStatus.running);
+    // Deliberately leave this controller open (no tearDown close): the flow is
+    // meant to park on the waiting view with the poll `await for` still pending.
+    // Closing it would end the loop and drive the (un-mounted-after-teardown)
+    // timeout branch, which setStates without a mounted guard -> crash. An open
+    // StreamController is fine in a widget test (unlike a dangling Timer).
+    final poll = StreamController<AutoMasterStatus?>();
+    when(mockPnpNotifier.pollAutoMasterStatus())
+        .thenAnswer((_) => poll.stream);
+
+    await pumpSetup(tester);
+    await driveToSave(tester);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.byType(PnpAutoMasterWaitingView), findsOneWidget);
+    verifyNever(mockPnpNotifier.save());
+  });
+
+  // running -> poll resolves complete: make-Master finished and rotated the
+  // admin password. The GUI session is dead, so save must NOT be attempted;
+  // route to login instead.
+  testWidgets(
+      'Instant Setup - PnP: Auto Master poll complete before save redirects to login',
+      (tester) async {
+    useLargeScreen(tester);
+    stubCheckAutoMaster(
+        entry: AutoMasterStatus.idle, duringSave: AutoMasterStatus.running);
+    when(mockPnpNotifier.pollAutoMasterStatus())
+        .thenAnswer((_) => Stream.value(AutoMasterStatus.complete));
+
+    await pumpSetup(tester, extraRoutes: [_loginStubRoute()]);
+    await driveToSave(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('loginStub')), findsOneWidget);
+    verifyNever(mockPnpNotifier.save());
+  });
+
+  // running -> poll resolves failed: make-Master found another Master, so the
+  // admin credential is intact. The flow must fall through and actually save.
+  // save() is left pending so the whenComplete tail (which would schedule a
+  // post-save timer) never runs; we only assert save was reached.
+  testWidgets(
+      'Instant Setup - PnP: Auto Master poll failed before save continues to save',
+      (tester) async {
+    useLargeScreen(tester);
+    stubCheckAutoMaster(
+        entry: AutoMasterStatus.idle, duringSave: AutoMasterStatus.running);
+    when(mockPnpNotifier.pollAutoMasterStatus())
+        .thenAnswer((_) => Stream.value(AutoMasterStatus.failed));
+    final saveCompleter = Completer<void>();
+    when(mockPnpNotifier.save()).thenAnswer((_) => saveCompleter.future);
+
+    await pumpSetup(tester);
+    await driveToSave(tester);
+    // Drain the poll stream on the real event loop so the `failed` event is
+    // delivered and the flow falls through to save(). We must NOT pumpAndSettle
+    // here: the failed path calls setState(saving), whose _loadingSpinner runs
+    // an endless AppSpinner animation that would time out pumpAndSettle.
+    await tester.runAsync(() => Future.delayed(const Duration(milliseconds: 50)));
+    await tester.pump();
+
+    verify(mockPnpNotifier.save()).called(1);
+  });
+
+  // Pre-save-check 401: the credential was already rotated by the time the user
+  // reached save, so the checkAutoMasterStatus() gate itself 401s. Route to
+  // login without polling or saving. (Distinct from the poll-stream 401 test
+  // above, which exercises the await-for terminator.)
+  testWidgets(
+      'Instant Setup - PnP: Auto Master pre-save check unauthorized redirects to login',
+      (tester) async {
+    useLargeScreen(tester);
+    var callCount = 0;
+    when(mockPnpNotifier.checkAutoMasterStatus()).thenAnswer((_) async {
+      callCount++;
+      if (callCount == 1) return AutoMasterStatus.idle; // keep initState benign
+      throw ExceptionAutoMasterUnauthorized();
+    });
+
+    await pumpSetup(tester, extraRoutes: [_loginStubRoute()]);
+    await driveToSave(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('loginStub')), findsOneWidget);
+    verifyNever(mockPnpNotifier.save());
+  });
+
+  // Edge case (idle on entry, complete now): Auto Master was idle when PnP
+  // started but completed during the WiFi-config step, so it never showed as
+  // running at save time. The entry-vs-current comparison must still catch the
+  // credential rotation and route to login. The entry status lives in PnpState
+  // (the mock's setAutoMasterStatusOnEntry is a no-op), so seed build() with it.
+  testWidgets(
+      'Instant Setup - PnP: Auto Master idle on entry but complete during config redirects to login',
+      (tester) async {
+    useLargeScreen(tester);
+    when(mockPnpNotifier.build()).thenReturn(PnpState(
+        deviceInfo:
+            NodeDeviceInfo.fromJson(jsonDecode(testDeviceInfo)['output']),
+        isUnconfigured: false,
+        isPrePaired: true,
+        autoMasterStatusOnEntry: AutoMasterStatus.idle,
+        stepStateList: const {
+          0: PnpStepState(status: StepViewStatus.data, data: {}),
+          1: PnpStepState(status: StepViewStatus.data, data: {}),
+          2: PnpStepState(status: StepViewStatus.data, data: {}),
+        }));
+    stubCheckAutoMaster(
+        entry: AutoMasterStatus.idle, duringSave: AutoMasterStatus.complete);
+
+    await pumpSetup(tester, extraRoutes: [_loginStubRoute()]);
+    await driveToSave(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('loginStub')), findsOneWidget);
+    verifyNever(mockPnpNotifier.save());
+  });
+
+  // save() itself 401s: Auto Master completed in the narrow window between the
+  // pre-check and the write. The JNAP unauthorized error is unwrapped and the
+  // user is routed to the pnp entry (re-login) rather than shown a raw error.
+  testWidgets(
+      'Instant Setup - PnP: Unauthorized during save redirects to pnp',
+      (tester) async {
+    useLargeScreen(tester);
+    // Unconfigured so the save whenComplete tail takes the stepContinue branch
+    // (no post-save 3s timer), keeping the test free of dangling timers.
+    when(mockPnpNotifier.build()).thenReturn(PnpState(
+        deviceInfo:
+            NodeDeviceInfo.fromJson(jsonDecode(testDeviceInfo)['output']),
+        isUnconfigured: true,
+        stepStateList: const {
+          0: PnpStepState(status: StepViewStatus.data, data: {}),
+          1: PnpStepState(status: StepViewStatus.data, data: {}),
+          2: PnpStepState(status: StepViewStatus.data, data: {}),
+          3: PnpStepState(status: StepViewStatus.data, data: {}),
+        }));
+    stubCheckAutoMaster(
+        entry: AutoMasterStatus.idle, duringSave: AutoMasterStatus.idle);
+    when(mockPnpNotifier.save()).thenAnswer((_) async {
+      throw ExceptionSavingChanges(
+          const JNAPError(result: errorJNAPUnauthorized));
+    });
+
+    final pnpStub = LinksysRoute(
+      name: RouteNamed.pnp,
+      path: RoutePath.pnp,
+      config: const LinksysRouteConfig(noNaviRail: true),
+      builder: (context, state) => const SizedBox.shrink(key: Key('pnpStub')),
+    );
+    await pumpSetup(tester, extraRoutes: [pnpStub]);
+    await driveToSave(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('pnpStub')), findsOneWidget);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Timeout / reconnect-retry branch of `_saveChanges` (pnp_setup_view.dart
+  // L818-846). Reached when the poll stream ends WITHOUT a terminal status —
+  // make-Master neither finished (complete/idle), gave up (failed), nor tripped
+  // the 3-consecutive-failures guard within the poll window:
+  //   - timeout -> testConnectionReconnected() OK    -> retry _saveChanges once;
+  //       on the retry Auto Master has settled (idle), so the write proceeds
+  //   - timeout -> testConnectionReconnected() throws -> connection error view,
+  //       never save (router unreachable)
+  //   - timeout on every attempt until the retry limit
+  //       (_maxAutoMasterSaveAttempts == 2) -> connection error view, never save
+  // The connection-error sub-view is identified by its wifi-off icon, which only
+  // the error branch of PnpAutoMasterWaitingView renders.
+  // ---------------------------------------------------------------------------
+
+  // poll ends on `running` (never a terminal status) -> timeout. Reconnect
+  // succeeds, so the flow retries _saveChanges; on the retry the status has
+  // settled to idle, so it falls through and actually writes settings.
+  testWidgets(
+      'Instant Setup - PnP: Auto Master poll timeout then reconnect retries and saves',
+      (tester) async {
+    useLargeScreen(tester);
+    // initState -> idle; first save -> running (enters the poll); retry save ->
+    // idle (Auto Master settled) so the write proceeds. stubCheckAutoMaster
+    // can't express three distinct answers, so stub the call counter inline.
+    var callCount = 0;
+    when(mockPnpNotifier.checkAutoMasterStatus()).thenAnswer((_) async {
+      callCount++;
+      if (callCount == 1) return AutoMasterStatus.idle; // initState
+      if (callCount == 2) return AutoMasterStatus.running; // first save
+      return AutoMasterStatus.idle; // retry save
+    });
+    // Emits one running then completes -> the await-for ends without a terminal
+    // status -> timeout branch.
+    when(mockPnpNotifier.pollAutoMasterStatus())
+        .thenAnswer((_) => Stream.value(AutoMasterStatus.running));
+    // testConnectionReconnected returns Future.value() (success) by default.
+    // Leave save() pending so the whenComplete tail (and its post-save 3s timer)
+    // never runs; we only assert save() was reached on the retry.
+    final saveCompleter = Completer<void>();
+    when(mockPnpNotifier.save()).thenAnswer((_) => saveCompleter.future);
+
+    await pumpSetup(tester);
+    await driveToSave(tester);
+    // Drain poll-end -> timeout -> reconnect -> retry -> save on the real event
+    // loop. No pumpAndSettle: the retry ends in setState(saving), whose endless
+    // AppSpinner animation would time out pumpAndSettle.
+    await tester
+        .runAsync(() => Future.delayed(const Duration(milliseconds: 100)));
+    await tester.pump();
+
+    verify(mockPnpNotifier.testConnectionReconnected()).called(1);
+    verify(mockPnpNotifier.save()).called(1);
+  });
+
+  // poll ends on `running` -> timeout, but the router is unreachable
+  // (testConnectionReconnected throws). The flow must surface the connection
+  // error view and never write settings.
+  testWidgets(
+      'Instant Setup - PnP: Auto Master poll timeout then reconnect fails shows connection error',
+      (tester) async {
+    useLargeScreen(tester);
+    stubCheckAutoMaster(
+        entry: AutoMasterStatus.idle, duringSave: AutoMasterStatus.running);
+    when(mockPnpNotifier.pollAutoMasterStatus())
+        .thenAnswer((_) => Stream.value(AutoMasterStatus.running));
+    when(mockPnpNotifier.testConnectionReconnected())
+        .thenAnswer((_) async => throw ExceptionNeedToReconnect());
+
+    await pumpSetup(tester);
+    await driveToSave(tester);
+    await tester
+        .runAsync(() => Future.delayed(const Duration(milliseconds: 100)));
+    await tester.pump();
+
+    // Connection-error sub-view (the wifi-off icon is unique to it).
+    expect(find.byIcon(LinksysIcons.signalWifiOff), findsOneWidget);
+    verifyNever(mockPnpNotifier.save());
+  });
+
+  // Every attempt times out (status stays running and reconnect keeps
+  // succeeding), so _saveChanges recurses until autoMasterSaveAttempt reaches
+  // _maxAutoMasterSaveAttempts (2) and gives up with the connection error view.
+  // Exercises the retry-limit short-circuit (L822-828), distinct from the
+  // reconnect-failure branch (L839-844) above.
+  testWidgets(
+      'Instant Setup - PnP: Auto Master poll timeout exhausts retries shows connection error',
+      (tester) async {
+    useLargeScreen(tester);
+    // idle on entry, running on every save-time check so each retry re-enters
+    // the poll -> timeout loop.
+    stubCheckAutoMaster(
+        entry: AutoMasterStatus.idle, duringSave: AutoMasterStatus.running);
+    when(mockPnpNotifier.pollAutoMasterStatus())
+        .thenAnswer((_) => Stream.value(AutoMasterStatus.running));
+    // Reconnect succeeds each time, so the only thing that stops the recursion
+    // is the retry limit.
+    when(mockPnpNotifier.testConnectionReconnected()).thenAnswer((_) async {});
+
+    await pumpSetup(tester);
+    await driveToSave(tester);
+    await tester
+        .runAsync(() => Future.delayed(const Duration(milliseconds: 150)));
+    await tester.pump();
+
+    expect(find.byIcon(LinksysIcons.signalWifiOff), findsOneWidget);
+    // Reconnected on attempts 0 and 1; attempt 2 short-circuits on the limit.
+    verify(mockPnpNotifier.testConnectionReconnected()).called(2);
+    verifyNever(mockPnpNotifier.save());
   });
 }

--- a/test/page/instant_setup/localizations/pnp_setup_view_test.dart
+++ b/test/page/instant_setup/localizations/pnp_setup_view_test.dart
@@ -752,57 +752,6 @@ void main() async {
     await tester.pump(const Duration(seconds: 2));
   });
 
-  // Regression: the poll stream terminates on the first 401 (make-Master
-  // rotated the admin password mid-poll). Instead of flattening to null and
-  // re-polling with the stale credential, the save flow catches
-  // ExceptionAutoMasterUnauthorized and routes to login. This exercises the new
-  // try/catch around the await-for in _saveChanges.
-  testLocalizations('Instant Setup - PnP: Auto Master poll stream unauthorized',
-      (tester, locale) async {
-    var callCount = 0;
-    when(mockPnpNotifier.checkAutoMasterStatus()).thenAnswer((_) async {
-      callCount++;
-      return callCount == 1 ? AutoMasterStatus.idle : AutoMasterStatus.running;
-    });
-    when(mockPnpNotifier.pollAutoMasterStatus()).thenAnswer((_) {
-      return Stream<AutoMasterStatus?>.error(ExceptionAutoMasterUnauthorized());
-    });
-
-    await tester.pumpWidget(
-      testableSingleRoute(
-        child: const PnpSetupView(),
-        config: LinksysRouteConfig(
-            column: ColumnGrid(column: 6, centered: true), noNaviRail: true),
-        locale: locale,
-        overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
-        extraRoutes: [_loginStubRoute()],
-      ),
-    );
-    await tester.pump(const Duration(seconds: 6));
-    final state =
-        tester.state<ConsumerState<PnpSetupView>>(find.byType(PnpSetupView));
-    state.setState(() {});
-    await tester.pumpAndSettle();
-    final ssidEditFinder = find.byType(TextField).first;
-    final passwordEditFinder = find.byType(TextField).last;
-    await tester.enterText(ssidEditFinder, 'MyAwesomeWiFiName');
-    await tester.pumpAndSettle();
-    await tester.enterText(passwordEditFinder, 'MyAwesomeWiFiPassword!');
-    await tester.pumpAndSettle();
-    final btnFinder = find.byType(FilledButton);
-    await tester.tap(btnFinder.first);
-    await tester.pumpAndSettle();
-    final btnFinder2 = find.byType(FilledButton);
-    await tester.tap(btnFinder2.first);
-    await tester.pumpAndSettle();
-    final btnFinder3 = find.byType(FilledButton);
-    await tester.tap(btnFinder3.first);
-    await tester.pumpAndSettle();
-    // The poll-stream 401 during save must route to login instead of
-    // re-polling with the stale credential.
-    expect(find.byKey(const Key('loginStub')), findsOneWidget);
-  });
-
   // ---------------------------------------------------------------------------
   // `_saveChanges` Auto Master "second defense" — behavior/flow tests.
   //
@@ -955,27 +904,32 @@ void main() async {
     verify(mockPnpNotifier.save()).called(1);
   });
 
-  // Pre-save-check 401: the credential was already rotated by the time the user
-  // reached save, so the checkAutoMasterStatus() gate itself 401s. Route to
-  // login without polling or saving. (Distinct from the poll-stream 401 test
-  // above, which exercises the await-for terminator.)
+  // Pre-save check undetermined (null): the router is unreachable, or its
+  // firmware still requires auth for GetAutoMasterStatus and answers 401 to the
+  // unauthed read. The gate cannot tell, so it must not block the user — the
+  // save proceeds. If the credential really was rotated, the save itself 401s
+  // and the ExceptionSavingChanges handler routes back to PnP.
   testWidgets(
-      'Instant Setup - PnP: Auto Master pre-save check unauthorized redirects to login',
+      'Instant Setup - PnP: Auto Master status unavailable before save continues to save',
       (tester) async {
     useLargeScreen(tester);
-    var callCount = 0;
-    when(mockPnpNotifier.checkAutoMasterStatus()).thenAnswer((_) async {
-      callCount++;
-      if (callCount == 1) return AutoMasterStatus.idle; // keep initState benign
-      throw ExceptionAutoMasterUnauthorized();
-    });
+    stubCheckAutoMaster(entry: AutoMasterStatus.idle, duringSave: null);
+    // Left pending so the whenComplete tail (which schedules a post-save timer)
+    // never runs; we only assert save was reached.
+    final saveCompleter = Completer<void>();
+    when(mockPnpNotifier.save()).thenAnswer((_) => saveCompleter.future);
 
     await pumpSetup(tester, extraRoutes: [_loginStubRoute()]);
     await driveToSave(tester);
-    await tester.pumpAndSettle();
+    // Not pumpAndSettle: setState(saving) starts an endless AppSpinner.
+    await tester
+        .runAsync(() => Future.delayed(const Duration(milliseconds: 50)));
+    await tester.pump();
 
-    expect(find.byKey(const Key('loginStub')), findsOneWidget);
-    verifyNever(mockPnpNotifier.save());
+    verify(mockPnpNotifier.save()).called(1);
+    // null is not `running`, so there was nothing to poll or wait for.
+    verifyNever(mockPnpNotifier.pollAutoMasterStatus());
+    expect(find.byKey(const Key('loginStub')), findsNothing);
   });
 
   // Edge case (idle on entry, complete now): Auto Master was idle when PnP

--- a/test/page/instant_setup/troubleshooter/localizations/pnp_auto_master_waiting_view_test.dart
+++ b/test/page/instant_setup/troubleshooter/localizations/pnp_auto_master_waiting_view_test.dart
@@ -1,0 +1,41 @@
+import 'package:privacy_gui/page/instant_setup/widgets/pnp_auto_master_waiting_view.dart';
+import 'package:privacy_gui/route/route_model.dart';
+
+import '../../../../common/test_responsive_widget.dart';
+import '../../../../common/testable_router.dart';
+
+// State -> screen goldens for the Auto Master waiting view. This is the only
+// user-visible surface the WAN-up Auto Master detection adds; the flow/branch
+// logic lives in PnpAutoMasterFlowMixin and is not exercised here.
+void main() async {
+  testLocalizations('Instant Setup - PnP Auto Master waiting: spinner',
+      (tester, locale) async {
+    await tester.pumpWidget(
+      testableSingleRoute(
+        child: const PnpAutoMasterWaitingView(showConnectionError: false),
+        config: LinksysRouteConfig(
+            column: ColumnGrid(column: 6, centered: true), noNaviRail: true),
+        locale: locale,
+      ),
+    );
+    // The spinner animates indefinitely, so a single settling pump (not
+    // pumpAndSettle) is enough to lay out the stable content.
+    await tester.pump();
+  });
+
+  testLocalizations('Instant Setup - PnP Auto Master waiting: connection error',
+      (tester, locale) async {
+    await tester.pumpWidget(
+      testableSingleRoute(
+        child: PnpAutoMasterWaitingView(
+          showConnectionError: true,
+          onRetry: () {},
+        ),
+        config: LinksysRouteConfig(
+            column: ColumnGrid(column: 6, centered: true), noNaviRail: true),
+        locale: locale,
+      ),
+    );
+    await tester.pumpAndSettle();
+  });
+}

--- a/test/page/instant_setup/widgets/pnp_auto_master_flow_test.dart
+++ b/test/page/instant_setup/widgets/pnp_auto_master_flow_test.dart
@@ -224,4 +224,49 @@ void main() {
       verify(mockPnpNotifier.checkAutoMasterStatus()).called(1);
     });
   });
+
+  group('PnpAutoMasterFlowMixin - stream terminates on first 401', () {
+    testWidgets(
+        'Phase A: wait-for-running stream throws 401 -> completed (recover)',
+        (tester) async {
+      // make-Master rotated the admin password mid-poll: the stream terminates
+      // on the FIRST 401 (no null-flatten, no probe round-trip).
+      when(mockPnpNotifier.pollAutoMasterUntilRunning())
+          .thenAnswer((_) => Stream.error(ExceptionAutoMasterUnauthorized()));
+
+      final r = await pumpFlow(tester, waitForRunningFirst: true);
+
+      expect(r.result, AutoMasterFlowResult.completed);
+      expect(r.state.events, ['enter', 'exit']);
+      // The 401 is handled by the stream terminator, not the null-threshold probe.
+      verifyNever(mockPnpNotifier.checkAutoMasterStatus());
+    });
+
+    testWidgets('Phase B: polling stream throws 401 -> completed (recover)',
+        (tester) async {
+      when(mockPnpNotifier.pollAutoMasterStatus())
+          .thenAnswer((_) => Stream.error(ExceptionAutoMasterUnauthorized()));
+
+      final r = await pumpFlow(tester, waitForRunningFirst: false);
+
+      expect(r.result, AutoMasterFlowResult.completed);
+      expect(r.state.events, ['enter', 'exit']);
+      verifyNever(mockPnpNotifier.checkAutoMasterStatus());
+    });
+
+    testWidgets(
+        'Phase A Running then Phase B stream throws 401 -> completed (recover)',
+        (tester) async {
+      // Running is observed in Phase A, then completion-poll dies on 401.
+      when(mockPnpNotifier.pollAutoMasterUntilRunning())
+          .thenAnswer((_) => Stream.value(AutoMasterStatus.running));
+      when(mockPnpNotifier.pollAutoMasterStatus())
+          .thenAnswer((_) => Stream.error(ExceptionAutoMasterUnauthorized()));
+
+      final r = await pumpFlow(tester, waitForRunningFirst: true);
+
+      expect(r.result, AutoMasterFlowResult.completed);
+      expect(r.state.events, ['enter', 'exit']);
+    });
+  });
 }

--- a/test/page/instant_setup/widgets/pnp_auto_master_flow_test.dart
+++ b/test/page/instant_setup/widgets/pnp_auto_master_flow_test.dart
@@ -102,7 +102,7 @@ void main() {
       expect(r.state.events, ['enter', 'exit']);
     });
 
-    testWidgets('Idle only then stream closes (timeout) -> proceed',
+    testWidgets('Idle only then stream closes (budget spent) -> proceed',
         (tester) async {
       // Never starts; session already proven alive upstream, so no reconnect
       // test is attempted.
@@ -113,6 +113,26 @@ void main() {
 
       expect(r.result, AutoMasterFlowResult.proceed);
       verifyNever(mockPnpNotifier.testConnectionReconnected());
+    });
+
+    testWidgets('nulls only then stream closes (budget spent) -> proceed',
+        (tester) async {
+      // Firmware that still requires auth for GetAutoMasterStatus answers 401
+      // to the unauthed poll, which the notifier flattens to null — so every
+      // poll comes back undetermined. Phase A runs right after the ISP save +
+      // internet check proved the session alive, so this must not surface
+      // "router not found"; it proceeds and lets PnP's second pass recover.
+      when(mockPnpNotifier.pollAutoMasterUntilRunning())
+          .thenAnswer((_) => Stream.fromIterable([null, null, null]));
+
+      final r = await pumpFlow(tester, waitForRunningFirst: true);
+
+      expect(r.result, AutoMasterFlowResult.proceed);
+      expect(r.state.events, ['enter', 'exit']);
+      // Phase A resolved it in place: no completion poll, and no extra probe
+      // round-trip — the stream's own budget is the only give-up rule.
+      verifyNever(mockPnpNotifier.pollAutoMasterStatus());
+      verifyNever(mockPnpNotifier.checkAutoMasterStatus());
     });
   });
 
@@ -144,8 +164,12 @@ void main() {
       expect(r.result, AutoMasterFlowResult.proceed);
     });
 
-    testWidgets('Timeout with session alive -> proceed', (tester) async {
-      // Stream closes with no terminal status; reconnect test succeeds.
+    testWidgets('Budget spent with router alive -> budgetExhausted',
+        (tester) async {
+      // Stream closes with no terminal status; reconnect test succeeds. The
+      // router is there but Auto Master's outcome was never observed, so the
+      // result is explicitly "unknown" rather than proceed — callers with a
+      // pending save need to tell the two apart.
       when(mockPnpNotifier.pollAutoMasterStatus())
           .thenAnswer((_) => const Stream.empty());
       when(mockPnpNotifier.testConnectionReconnected())
@@ -153,11 +177,12 @@ void main() {
 
       final r = await pumpFlow(tester, waitForRunningFirst: false);
 
-      expect(r.result, AutoMasterFlowResult.proceed);
+      expect(r.result, AutoMasterFlowResult.budgetExhausted);
+      expect(r.state.events, ['enter', 'exit']);
       verify(mockPnpNotifier.testConnectionReconnected()).called(1);
     });
 
-    testWidgets('Timeout with reconnect failure -> connectionError',
+    testWidgets('Budget spent with reconnect failure -> connectionError',
         (tester) async {
       when(mockPnpNotifier.pollAutoMasterStatus())
           .thenAnswer((_) => const Stream.empty());
@@ -171,65 +196,51 @@ void main() {
     });
   });
 
-  group('PnpAutoMasterFlowMixin - null-threshold probe', () {
-    testWidgets('3 nulls then probe Complete -> completed', (tester) async {
-      when(mockPnpNotifier.pollAutoMasterStatus())
-          .thenAnswer((_) => Stream.fromIterable([null, null, null]));
-      when(mockPnpNotifier.checkAutoMasterStatus())
-          .thenAnswer((_) async => AutoMasterStatus.complete);
+  group('PnpAutoMasterFlowMixin - nulls during the make-Master outage', () {
+    // make-Master takes the router's HTTP service down for the better part of a
+    // minute; while it is gone the router may time out, refuse, or answer
+    // something unrecognised — all of which flatten to null. These lock in that
+    // nulls are never treated as evidence: the poll runs its full budget, and
+    // only the reachability test at the end decides.
+    testWidgets('nulls then Complete -> completed, without probing',
+        (tester) async {
+      when(mockPnpNotifier.pollAutoMasterStatus()).thenAnswer((_) =>
+          Stream.fromIterable([null, null, null, AutoMasterStatus.complete]));
 
       final r = await pumpFlow(tester, waitForRunningFirst: false);
 
       expect(r.result, AutoMasterFlowResult.completed);
+      // No mid-poll probe: a run of nulls no longer triggers anything.
+      verifyNever(mockPnpNotifier.checkAutoMasterStatus());
+      verifyNever(mockPnpNotifier.testConnectionReconnected());
     });
 
-    testWidgets(
-        'Phase B: 3 nulls then probe null (undetermined) -> connectionError',
+    testWidgets('nulls to the end, router alive -> budgetExhausted',
+        (tester) async {
+      // The regression from #1180: three nulls used to be enough to declare
+      // "router not found" ~15s before the router's HTTP service came back.
+      when(mockPnpNotifier.pollAutoMasterStatus())
+          .thenAnswer((_) => Stream.fromIterable([null, null, null]));
+      when(mockPnpNotifier.testConnectionReconnected())
+          .thenAnswer((_) async {});
+
+      final r = await pumpFlow(tester, waitForRunningFirst: false);
+
+      expect(r.result, AutoMasterFlowResult.budgetExhausted);
+      expect(r.state.events, ['enter', 'exit']);
+    });
+
+    testWidgets('nulls to the end, router gone -> connectionError',
         (tester) async {
       when(mockPnpNotifier.pollAutoMasterStatus())
           .thenAnswer((_) => Stream.fromIterable([null, null, null]));
-      when(mockPnpNotifier.checkAutoMasterStatus())
-          .thenAnswer((_) async => null);
+      when(mockPnpNotifier.testConnectionReconnected())
+          .thenThrow(ExceptionNeedToReconnect());
 
       final r = await pumpFlow(tester, waitForRunningFirst: false);
 
       expect(r.result, AutoMasterFlowResult.connectionError);
       expect(r.state.events, ['enter', 'error']);
-    });
-
-    testWidgets('Phase A: 3 nulls then probe null (undetermined) -> proceed',
-        (tester) async {
-      // Firmware that still requires auth for GetAutoMasterStatus answers 401
-      // to the unauthed poll, which the notifier flattens to null — so every
-      // poll AND the probe come back undetermined. Phase A runs right after the
-      // ISP save + internet check proved the session alive, so this must not
-      // surface "router not found"; it proceeds and lets PnP's second pass
-      // recover.
-      when(mockPnpNotifier.pollAutoMasterUntilRunning())
-          .thenAnswer((_) => Stream.fromIterable([null, null, null]));
-      when(mockPnpNotifier.checkAutoMasterStatus())
-          .thenAnswer((_) async => null);
-
-      final r = await pumpFlow(tester, waitForRunningFirst: true);
-
-      expect(r.result, AutoMasterFlowResult.proceed);
-      expect(r.state.events, ['enter', 'exit']);
-      // Phase A resolved it; the completion poll is never reached.
-      verifyNever(mockPnpNotifier.pollAutoMasterStatus());
-    });
-
-    testWidgets('probe Running resets counter, then Complete -> completed',
-        (tester) async {
-      when(mockPnpNotifier.pollAutoMasterStatus()).thenAnswer((_) =>
-          Stream.fromIterable([null, null, null, AutoMasterStatus.complete]));
-      // Probe fires at the 3rd null: still Running -> reset and keep polling.
-      when(mockPnpNotifier.checkAutoMasterStatus())
-          .thenAnswer((_) async => AutoMasterStatus.running);
-
-      final r = await pumpFlow(tester, waitForRunningFirst: false);
-
-      expect(r.result, AutoMasterFlowResult.completed);
-      verify(mockPnpNotifier.checkAutoMasterStatus()).called(1);
     });
   });
 
@@ -248,7 +259,6 @@ void main() {
 
       expect(r.result, AutoMasterFlowResult.completed);
       expect(r.state.events, ['enter', 'exit']);
-      // Below the null threshold, so no probe round-trip was needed.
       verifyNever(mockPnpNotifier.checkAutoMasterStatus());
     });
   });

--- a/test/page/instant_setup/widgets/pnp_auto_master_flow_test.dart
+++ b/test/page/instant_setup/widgets/pnp_auto_master_flow_test.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:privacy_gui/core/jnap/models/auto_master_status.dart';
+import 'package:privacy_gui/page/instant_setup/data/pnp_exception.dart';
+import 'package:privacy_gui/page/instant_setup/data/pnp_provider.dart';
+import 'package:privacy_gui/page/instant_setup/data/pnp_state.dart';
+import 'package:privacy_gui/page/instant_setup/widgets/pnp_auto_master_flow.dart';
+
+import '../../../mocks/pnp_notifier_mocks.dart' as Mock;
+
+/// Minimal host that mixes in [PnpAutoMasterFlowMixin] so the flow state machine
+/// can be driven directly, without booting the ISP-save view or any animation.
+class _FlowHost extends ConsumerStatefulWidget {
+  const _FlowHost({super.key, required this.waitForRunningFirst});
+
+  final bool waitForRunningFirst;
+
+  @override
+  ConsumerState<_FlowHost> createState() => _FlowHostState();
+}
+
+class _FlowHostState extends ConsumerState<_FlowHost>
+    with PnpAutoMasterFlowMixin<_FlowHost> {
+  // Records the order of lifecycle callbacks for assertions.
+  final List<String> events = [];
+
+  Future<AutoMasterFlowResult> run() {
+    return runAutoMasterFlow(
+      waitForRunningFirst: widget.waitForRunningFirst,
+      onEnterWaiting: () => events.add('enter'),
+      onShowConnectionError: () => events.add('error'),
+      onExitWaiting: () => events.add('exit'),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+void main() {
+  late Mock.MockPnpNotifier mockPnpNotifier;
+
+  setUp(() {
+    mockPnpNotifier = Mock.MockPnpNotifier();
+    when(mockPnpNotifier.build()).thenReturn(const PnpState(deviceInfo: null));
+  });
+
+  // Mounts the host and drives the flow to completion on the real event loop
+  // (runAsync) so the stream/future chain fully drains. Returns the flow result
+  // together with the host state (for callback-order assertions).
+  Future<({AutoMasterFlowResult result, _FlowHostState state})> pumpFlow(
+    WidgetTester tester, {
+    required bool waitForRunningFirst,
+  }) async {
+    final key = GlobalKey<_FlowHostState>();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [pnpProvider.overrideWith(() => mockPnpNotifier)],
+        child: _FlowHost(key: key, waitForRunningFirst: waitForRunningFirst),
+      ),
+    );
+    final state = key.currentState!;
+    final result = await tester.runAsync(() => state.run());
+    await tester.pumpAndSettle();
+    return (result: result!, state: state);
+  }
+
+  group('PnpAutoMasterFlowMixin - waitForRunningFirst (WAN-up / Phase A)', () {
+    testWidgets('Running then Complete -> completed', (tester) async {
+      when(mockPnpNotifier.pollAutoMasterUntilRunning())
+          .thenAnswer((_) => Stream.value(AutoMasterStatus.running));
+      when(mockPnpNotifier.pollAutoMasterStatus())
+          .thenAnswer((_) => Stream.value(AutoMasterStatus.complete));
+
+      final r = await pumpFlow(tester, waitForRunningFirst: true);
+
+      expect(r.result, AutoMasterFlowResult.completed);
+      expect(r.state.events, ['enter', 'exit']);
+    });
+
+    testWidgets('Complete during Phase A (missed Running edge) -> completed',
+        (tester) async {
+      // make-Master finished so fast Phase A sees Complete directly.
+      when(mockPnpNotifier.pollAutoMasterUntilRunning())
+          .thenAnswer((_) => Stream.value(AutoMasterStatus.complete));
+
+      final r = await pumpFlow(tester, waitForRunningFirst: true);
+
+      expect(r.result, AutoMasterFlowResult.completed);
+      verifyNever(mockPnpNotifier.pollAutoMasterStatus());
+    });
+
+    testWidgets('Failed during Phase A -> proceed', (tester) async {
+      when(mockPnpNotifier.pollAutoMasterUntilRunning())
+          .thenAnswer((_) => Stream.value(AutoMasterStatus.failed));
+
+      final r = await pumpFlow(tester, waitForRunningFirst: true);
+
+      expect(r.result, AutoMasterFlowResult.proceed);
+      expect(r.state.events, ['enter', 'exit']);
+    });
+
+    testWidgets('Idle only then stream closes (timeout) -> proceed',
+        (tester) async {
+      // Never starts; session already proven alive upstream, so no reconnect
+      // test is attempted.
+      when(mockPnpNotifier.pollAutoMasterUntilRunning())
+          .thenAnswer((_) => Stream.value(AutoMasterStatus.idle));
+
+      final r = await pumpFlow(tester, waitForRunningFirst: true);
+
+      expect(r.result, AutoMasterFlowResult.proceed);
+      verifyNever(mockPnpNotifier.testConnectionReconnected());
+    });
+  });
+
+  group('PnpAutoMasterFlowMixin - Phase B (wait for completion)', () {
+    testWidgets('Complete -> completed', (tester) async {
+      when(mockPnpNotifier.pollAutoMasterStatus())
+          .thenAnswer((_) => Stream.value(AutoMasterStatus.complete));
+
+      final r = await pumpFlow(tester, waitForRunningFirst: false);
+
+      expect(r.result, AutoMasterFlowResult.completed);
+    });
+
+    testWidgets('Idle -> completed', (tester) async {
+      when(mockPnpNotifier.pollAutoMasterStatus())
+          .thenAnswer((_) => Stream.value(AutoMasterStatus.idle));
+
+      final r = await pumpFlow(tester, waitForRunningFirst: false);
+
+      expect(r.result, AutoMasterFlowResult.completed);
+    });
+
+    testWidgets('Failed -> proceed', (tester) async {
+      when(mockPnpNotifier.pollAutoMasterStatus())
+          .thenAnswer((_) => Stream.value(AutoMasterStatus.failed));
+
+      final r = await pumpFlow(tester, waitForRunningFirst: false);
+
+      expect(r.result, AutoMasterFlowResult.proceed);
+    });
+
+    testWidgets('Timeout with session alive -> proceed', (tester) async {
+      // Stream closes with no terminal status; reconnect test succeeds.
+      when(mockPnpNotifier.pollAutoMasterStatus())
+          .thenAnswer((_) => const Stream.empty());
+      when(mockPnpNotifier.testConnectionReconnected())
+          .thenAnswer((_) async {});
+
+      final r = await pumpFlow(tester, waitForRunningFirst: false);
+
+      expect(r.result, AutoMasterFlowResult.proceed);
+      verify(mockPnpNotifier.testConnectionReconnected()).called(1);
+    });
+
+    testWidgets('Timeout with reconnect failure -> connectionError',
+        (tester) async {
+      when(mockPnpNotifier.pollAutoMasterStatus())
+          .thenAnswer((_) => const Stream.empty());
+      when(mockPnpNotifier.testConnectionReconnected())
+          .thenThrow(ExceptionNeedToReconnect());
+
+      final r = await pumpFlow(tester, waitForRunningFirst: false);
+
+      expect(r.result, AutoMasterFlowResult.connectionError);
+      expect(r.state.events, ['enter', 'error']);
+    });
+  });
+
+  group('PnpAutoMasterFlowMixin - null-threshold unauthorized probe', () {
+    testWidgets('3 nulls then probe unauthorized -> completed (recover)',
+        (tester) async {
+      when(mockPnpNotifier.pollAutoMasterStatus())
+          .thenAnswer((_) => Stream.fromIterable([null, null, null]));
+      // Session died mid make-Master.
+      when(mockPnpNotifier.checkAutoMasterStatus())
+          .thenThrow(ExceptionAutoMasterUnauthorized());
+
+      final r = await pumpFlow(tester, waitForRunningFirst: false);
+
+      expect(r.result, AutoMasterFlowResult.completed);
+      verify(mockPnpNotifier.checkAutoMasterStatus()).called(1);
+    });
+
+    testWidgets('3 nulls then probe Complete -> completed', (tester) async {
+      when(mockPnpNotifier.pollAutoMasterStatus())
+          .thenAnswer((_) => Stream.fromIterable([null, null, null]));
+      when(mockPnpNotifier.checkAutoMasterStatus())
+          .thenAnswer((_) async => AutoMasterStatus.complete);
+
+      final r = await pumpFlow(tester, waitForRunningFirst: false);
+
+      expect(r.result, AutoMasterFlowResult.completed);
+    });
+
+    testWidgets('3 nulls then probe null (undetermined) -> connectionError',
+        (tester) async {
+      when(mockPnpNotifier.pollAutoMasterStatus())
+          .thenAnswer((_) => Stream.fromIterable([null, null, null]));
+      when(mockPnpNotifier.checkAutoMasterStatus())
+          .thenAnswer((_) async => null);
+
+      final r = await pumpFlow(tester, waitForRunningFirst: false);
+
+      expect(r.result, AutoMasterFlowResult.connectionError);
+      expect(r.state.events, ['enter', 'error']);
+    });
+
+    testWidgets('probe Running resets counter, then Complete -> completed',
+        (tester) async {
+      when(mockPnpNotifier.pollAutoMasterStatus()).thenAnswer((_) =>
+          Stream.fromIterable([null, null, null, AutoMasterStatus.complete]));
+      // Probe fires at the 3rd null: still Running -> reset and keep polling.
+      when(mockPnpNotifier.checkAutoMasterStatus())
+          .thenAnswer((_) async => AutoMasterStatus.running);
+
+      final r = await pumpFlow(tester, waitForRunningFirst: false);
+
+      expect(r.result, AutoMasterFlowResult.completed);
+      verify(mockPnpNotifier.checkAutoMasterStatus()).called(1);
+    });
+  });
+}

--- a/test/page/instant_setup/widgets/pnp_auto_master_flow_test.dart
+++ b/test/page/instant_setup/widgets/pnp_auto_master_flow_test.dart
@@ -171,21 +171,7 @@ void main() {
     });
   });
 
-  group('PnpAutoMasterFlowMixin - null-threshold unauthorized probe', () {
-    testWidgets('3 nulls then probe unauthorized -> completed (recover)',
-        (tester) async {
-      when(mockPnpNotifier.pollAutoMasterStatus())
-          .thenAnswer((_) => Stream.fromIterable([null, null, null]));
-      // Session died mid make-Master.
-      when(mockPnpNotifier.checkAutoMasterStatus())
-          .thenThrow(ExceptionAutoMasterUnauthorized());
-
-      final r = await pumpFlow(tester, waitForRunningFirst: false);
-
-      expect(r.result, AutoMasterFlowResult.completed);
-      verify(mockPnpNotifier.checkAutoMasterStatus()).called(1);
-    });
-
+  group('PnpAutoMasterFlowMixin - null-threshold probe', () {
     testWidgets('3 nulls then probe Complete -> completed', (tester) async {
       when(mockPnpNotifier.pollAutoMasterStatus())
           .thenAnswer((_) => Stream.fromIterable([null, null, null]));
@@ -197,7 +183,8 @@ void main() {
       expect(r.result, AutoMasterFlowResult.completed);
     });
 
-    testWidgets('3 nulls then probe null (undetermined) -> connectionError',
+    testWidgets(
+        'Phase B: 3 nulls then probe null (undetermined) -> connectionError',
         (tester) async {
       when(mockPnpNotifier.pollAutoMasterStatus())
           .thenAnswer((_) => Stream.fromIterable([null, null, null]));
@@ -208,6 +195,27 @@ void main() {
 
       expect(r.result, AutoMasterFlowResult.connectionError);
       expect(r.state.events, ['enter', 'error']);
+    });
+
+    testWidgets('Phase A: 3 nulls then probe null (undetermined) -> proceed',
+        (tester) async {
+      // Firmware that still requires auth for GetAutoMasterStatus answers 401
+      // to the unauthed poll, which the notifier flattens to null — so every
+      // poll AND the probe come back undetermined. Phase A runs right after the
+      // ISP save + internet check proved the session alive, so this must not
+      // surface "router not found"; it proceeds and lets PnP's second pass
+      // recover.
+      when(mockPnpNotifier.pollAutoMasterUntilRunning())
+          .thenAnswer((_) => Stream.fromIterable([null, null, null]));
+      when(mockPnpNotifier.checkAutoMasterStatus())
+          .thenAnswer((_) async => null);
+
+      final r = await pumpFlow(tester, waitForRunningFirst: true);
+
+      expect(r.result, AutoMasterFlowResult.proceed);
+      expect(r.state.events, ['enter', 'exit']);
+      // Phase A resolved it; the completion poll is never reached.
+      verifyNever(mockPnpNotifier.pollAutoMasterStatus());
     });
 
     testWidgets('probe Running resets counter, then Complete -> completed',
@@ -225,48 +233,23 @@ void main() {
     });
   });
 
-  group('PnpAutoMasterFlowMixin - stream terminates on first 401', () {
-    testWidgets(
-        'Phase A: wait-for-running stream throws 401 -> completed (recover)',
+  group('PnpAutoMasterFlowMixin - mid-flow password rotation', () {
+    testWidgets('Phase A Running, then rotation mid-completion -> completed',
         (tester) async {
-      // make-Master rotated the admin password mid-poll: the stream terminates
-      // on the FIRST 401 (no null-flatten, no probe round-trip).
-      when(mockPnpNotifier.pollAutoMasterUntilRunning())
-          .thenAnswer((_) => Stream.error(ExceptionAutoMasterUnauthorized()));
-
-      final r = await pumpFlow(tester, waitForRunningFirst: true);
-
-      expect(r.result, AutoMasterFlowResult.completed);
-      expect(r.state.events, ['enter', 'exit']);
-      // The 401 is handled by the stream terminator, not the null-threshold probe.
-      verifyNever(mockPnpNotifier.checkAutoMasterStatus());
-    });
-
-    testWidgets('Phase B: polling stream throws 401 -> completed (recover)',
-        (tester) async {
-      when(mockPnpNotifier.pollAutoMasterStatus())
-          .thenAnswer((_) => Stream.error(ExceptionAutoMasterUnauthorized()));
-
-      final r = await pumpFlow(tester, waitForRunningFirst: false);
-
-      expect(r.result, AutoMasterFlowResult.completed);
-      expect(r.state.events, ['enter', 'exit']);
-      verifyNever(mockPnpNotifier.checkAutoMasterStatus());
-    });
-
-    testWidgets(
-        'Phase A Running then Phase B stream throws 401 -> completed (recover)',
-        (tester) async {
-      // Running is observed in Phase A, then completion-poll dies on 401.
+      // The polls are unauthed, so make-Master rotating the admin password no
+      // longer breaks them — nothing throws. Rotation is observed the normal
+      // way: the status reaches Complete.
       when(mockPnpNotifier.pollAutoMasterUntilRunning())
           .thenAnswer((_) => Stream.value(AutoMasterStatus.running));
-      when(mockPnpNotifier.pollAutoMasterStatus())
-          .thenAnswer((_) => Stream.error(ExceptionAutoMasterUnauthorized()));
+      when(mockPnpNotifier.pollAutoMasterStatus()).thenAnswer(
+          (_) => Stream.fromIterable([null, AutoMasterStatus.complete]));
 
       final r = await pumpFlow(tester, waitForRunningFirst: true);
 
       expect(r.result, AutoMasterFlowResult.completed);
       expect(r.state.events, ['enter', 'exit']);
+      // Below the null threshold, so no probe round-trip was needed.
+      verifyNever(mockPnpNotifier.checkAutoMasterStatus());
     });
   });
 }

--- a/test/page/nodes/views/node_detail_view_test.dart
+++ b/test/page/nodes/views/node_detail_view_test.dart
@@ -1,46 +1,93 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:privacy_gui/core/jnap/actions/better_action.dart';
 import 'package:privacy_gui/core/jnap/actions/jnap_service_supported.dart';
+import 'package:privacy_gui/core/jnap/providers/device_manager_provider.dart';
+import 'package:privacy_gui/core/jnap/providers/device_manager_state.dart';
 import 'package:privacy_gui/core/jnap/providers/firmware_update_provider.dart';
 import 'package:privacy_gui/core/jnap/providers/firmware_update_state.dart';
 import 'package:privacy_gui/di.dart';
+import 'package:privacy_gui/page/instant_device/_instant_device.dart';
+import 'package:privacy_gui/page/instant_device/providers/device_filtered_list_state.dart';
 import 'package:privacy_gui/page/nodes/_nodes.dart';
+import 'package:privacy_gui/page/wifi_settings/providers/wifi_list_provider.dart';
+import 'package:privacy_gui/page/wifi_settings/providers/wifi_state.dart';
 import 'package:privacygui_widgets/theme/_theme.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../../common/_index.dart';
 import '../../../common/di.dart';
+import '../../../mocks/device_filter_config_notifier_mocks.dart';
+import '../../../mocks/device_manager_notifier_mocks.dart';
 import '../../../mocks/firmware_update_notifier_mocks.dart';
 import '../../../mocks/jnap_service_supported_mocks.dart';
+import '../../../mocks/wifi_list_notifier_mocks.dart';
+import '../../../test_data/device_filter_config_test_state.dart';
+import '../../../test_data/device_filtered_list_test_data.dart';
+import '../../../test_data/device_manager_test_state.dart';
 import '../../../test_data/node_details_data.dart';
+import '../../../test_data/wifi_list_test_state.dart';
 import '../../../mocks/node_detail_notifier_mocks.dart';
 
 void main() {
   late NodeDetailNotifier mockNodeDetailNotifier;
   late FirmwareUpdateNotifier mockFirmwareUpdateNotifier;
+  late DeviceFilterConfigNotifier mockDeviceFilterConfigNotifier;
+  late MockDeviceManagerNotifier mockDeviceManagerNotifier;
+  late WifiListNotifier mockWifiListNotifier;
   mockDependencyRegister();
   ServiceHelper mockServiceHelper = getIt.get<ServiceHelper>();
 
   setUp(() {
     mockNodeDetailNotifier = MockNodeDetailNotifier();
     mockFirmwareUpdateNotifier = MockFirmwareUpdateNotifier();
+    mockDeviceFilterConfigNotifier = MockDeviceFilterConfigNotifier();
+    mockDeviceManagerNotifier = MockDeviceManagerNotifier();
+    mockWifiListNotifier = MockWifiListNotifier();
     // when(mockNodeDetailNotifier.isSupportLedBlinking()).thenReturn(true);
     // when(mockNodeDetailNotifier.isSupportLedMode()).thenReturn(true);
     initBetterActions();
   });
-  testResponsiveWidgets('Test node details view with mobile layout',
-      (tester) async {
+
+  /// NodeDetailView.initState drives deviceFilterConfigProvider.initFilter,
+  /// which reads deviceManagerProvider and wifiListProvider. Without these the
+  /// real WifiListNotifier builds from an empty dashboardManagerProvider and
+  /// dies on `wifiItems.first`, taking the whole test down before any
+  /// assertion runs. Same override set as the localizations sibling test.
+  List<Override> nodeDetailOverrides() => [
+        nodeDetailProvider.overrideWith(() => mockNodeDetailNotifier),
+        firmwareUpdateProvider.overrideWith(() => mockFirmwareUpdateNotifier),
+        deviceManagerProvider.overrideWith(() => mockDeviceManagerNotifier),
+        deviceFilterConfigProvider
+            .overrideWith(() => mockDeviceFilterConfigNotifier),
+        wifiListProvider.overrideWith(() => mockWifiListNotifier),
+        filteredDeviceListProvider.overrideWith((ref) => deviceFilteredTestData
+            .map((e) => DeviceListItem.fromMap(e))
+            .toList()),
+      ];
+
+  void stubNodeDetailState() {
     when(mockNodeDetailNotifier.build())
         .thenReturn(NodeDetailState.fromMap(fakeNodeDetailsState1));
     when(mockFirmwareUpdateNotifier.build())
         .thenReturn(FirmwareUpdateState.empty());
+    when(mockDeviceFilterConfigNotifier.build()).thenReturn(
+        DeviceFilterConfigState.fromMap(deviceFilterConfigTestState));
+    when(mockDeviceManagerNotifier.build())
+        .thenReturn(DeviceManagerState.fromMap(deviceManagerCherry7TestState));
+    when(mockWifiListNotifier.build())
+        .thenReturn(WiFiState.fromMap(wifiListTestState));
+    when(mockDeviceManagerNotifier.getBandConnectedBy(any))
+        .thenReturn('2.4GHz');
+  }
+
+  testResponsiveWidgets('Test node details view with mobile layout',
+      (tester) async {
+    stubNodeDetailState();
     final widget = testableSingleRoute(
         themeMode: ThemeMode.dark,
-        overrides: [
-          nodeDetailProvider.overrideWith(() => mockNodeDetailNotifier),
-          firmwareUpdateProvider.overrideWith(() => mockFirmwareUpdateNotifier),
-        ],
+        overrides: nodeDetailOverrides(),
         child: const NodeDetailView());
     await tester.pumpWidget(widget);
 
@@ -49,16 +96,10 @@ void main() {
   }, variants: responsiveMobileVariants);
   testResponsiveWidgets('Test node details view with desktop layout',
       (tester) async {
-    when(mockNodeDetailNotifier.build())
-        .thenReturn(NodeDetailState.fromMap(fakeNodeDetailsState1));
-    when(mockFirmwareUpdateNotifier.build())
-        .thenReturn(FirmwareUpdateState.empty());
+    stubNodeDetailState();
     final widget = testableSingleRoute(
         themeMode: ThemeMode.dark,
-        overrides: [
-          nodeDetailProvider.overrideWith(() => mockNodeDetailNotifier),
-          firmwareUpdateProvider.overrideWith(() => mockFirmwareUpdateNotifier),
-        ],
+        overrides: nodeDetailOverrides(),
         child: const NodeDetailView());
     await tester.pumpWidget(widget);
 
@@ -66,8 +107,11 @@ void main() {
     final nameFinder = find.text('Router123');
     expect(nameFinder, findsNWidgets(2));
 
+    // fakeNodeDetailsState1 is an MBE70, whose icon class routerMbe7000 is
+    // folded into routerMx6200 by _iconMapping. getRouterImage defaults to
+    // xl = true, so the view resolves the devices_xl asset, not devices.
     final routerImageFinder =
-        find.image(CustomTheme.of(context).images.devices.routerMx6200);
+        find.image(CustomTheme.of(context).images.devices_xl.routerMx6200);
     expect(routerImageFinder, findsOneWidget);
   }, variants: responsiveDesktopVariants);
 }

--- a/test/validator_rules/input_validators_test.dart
+++ b/test/validator_rules/input_validators_test.dart
@@ -189,10 +189,6 @@ void main() {
         expect(rule.validate('2001:db8:a0b:12f0::'), isTrue);
       });
 
-      test('should return true for the unspecified address (::)', () {
-        expect(rule.validate('::'), isTrue);
-      });
-
       test('should return true for an address with leading zeros in a group',
           () {
         expect(
@@ -221,6 +217,13 @@ void main() {
     });
 
     group('Invalid IPv6 Addresses', () {
+      // The unspecified address is well-formed but rejected on purpose: the
+      // only caller is the IPv6 port-forwarding rule's target device address,
+      // where :: names no host. See IPv6Rule.validate.
+      test('should return false for the unspecified address (::)', () {
+        expect(rule.validate('::'), isFalse);
+      });
+
       test('should return false for an address with more than 8 groups', () {
         expect(rule.validate('2001:0db8:85a3:0000:0000:8a2e:0370:7334:1234'),
             isFalse);


### PR DESCRIPTION
## What & Why

Fixes #1180 (LinksysWRT#449) — PnP "fill WiFi twice" after PPPoE/ISP setup,
plus the CGI auth lockout and two premature give-up bugs found while QA'ing it.

Factory-reset devices that finish first-time setup via the ISP-settings
troubleshooter (PPPoE / Static / DHCP) bring WAN up only **after** the user
submits credentials. WAN-up triggers firmware Auto Master ("make Master"), which
~1 min later rotates the admin password and restarts services, invalidating the
GUI session and kicking the user back to PnP. Since they had already advanced to
WiFi setup, they had to fill it out **twice**.

The original fix moves Auto Master detection **earlier, to the WAN-up point**, so
the user waits once on the existing waiting screen instead of filling a form that
gets discarded: *"fill WiFi → kicked → fill WiFi again"* becomes *"waiting screen
→ fill WiFi once"*.

Real-device QA then surfaced three further defects, each fixed here:

1. **CGI auth lockout.** Auto Master polling sent credentials. During the
   rotation window every poll came back 401, and the router's CGI layer locks
   the account after 5 failed auth attempts — so the user could not log in with
   the *correct* new password either. Auto Master status is now read
   **unauthed**, spending 0 of the 5 attempts.
2. **"Router not found" during the normal outage.** The flow gave up after 3
   consecutive nulls (~50s), but make-Master legitimately takes the HTTP service
   away for ~65s. The user saw a false error right after a *successful* ISP
   setup. Null counting is gone; a bounded time budget plus one reachability
   test now decides.
3. **Landing on `localLoginPassword` after reconnect.** That page belongs to a
   setup that *finished* (`userAcknowledgedAutoConfiguration == true`). Sending an
   unfinished PnP there strands the user outside the flow they were still in. All
   paths now return to PnP and ask for the new password there.

Design doc (rationale, edge-case table, superseded designs):
[`docs/pnp-auto-master-cgi-lockout-fix.md`](docs/pnp-auto-master-cgi-lockout-fix.md).

## Changes

**Auto Master detection**
- **`pnp_auto_master_flow.dart`** (new) — navigation-free `PnpAutoMasterFlowMixin`
  holding the whole wait/poll state machine: Phase A start-detection, Phase B
  completion-wait. It reports *what happened* as an `AutoMasterFlowResult`
  (`completed` / `proceed` / `budgetExhausted` / `connectionError`); **callers own
  navigation and retry policy**. All four call sites now share it — ~160 lines of
  duplicated bespoke poll loops deleted from the admin and setup views.
- **`pnp_provider.dart`** — add `pollAutoMasterUntilRunning()` (Idle→Running; also
  stops on `complete`/`failed` in case the running edge is missed). All three
  Auto Master reads go out with `auth: false`. 401 is no longer a special case:
  it flattens to `null` like any other unavailable status.
- **Bounded budget replaces null counting** — `maxRetry: 24` ×
  (`requestTimeoutOverride: 3s` + `retryDelay: 5s`) = **192s**, comfortably clear
  of ~65s of downtime and ~115s for Auto Master end-to-end. The stream's own
  length is the only give-up rule; when it runs out,
  `testConnectionReconnected()` (`retries: 2`) is the single judge of
  router-not-found.
- **`auto_master_status.dart`** — `fromValue` takes `Object?` instead of
  `String?`. The old unchecked cast lived inside a `.map` callback downstream of
  `scheduledCommand`'s try/catch, so a non-String payload threw a `TypeError`
  that escaped the stream and left the spinner turning forever.

**Landing after completion**
- **`pnp_exception.dart`** — add `ExceptionAutoMasterRotatedPassword`.
  Deliberately *not* an `ExceptionInterruptAndExit` carrying a route: where to go
  is not the throw site's decision.
- **`pnp_admin_view.dart`** — the `completed` branch throws it, and
  `_promptForRotatedPassword()` handles it **without navigating** (this view *is*
  the prompt). The load-bearing part is clearing `_password`: it holds the
  credential we arrived with, which the rotation just invalidated, and retrying
  it would spend a CGI attempt on a password that cannot work.
- **`pnp_setup_view.dart`** — both `localLoginPassword` redirects → `goNamed(pnp)`,
  converging on the destination its own unauthorized-during-save handler already
  used. `grep localLoginPassword lib/page/instant_setup/` now finds only comments.

**Session robustness (the reason a transient blip logged people out)**
- **`polling_provider.dart`** — only a rejected credential forces logout. One
  failed poll used to do it, so anything that briefly took the HTTP service away
  — a service restart, the make-Master rotation — kicked the user to login even
  though their password was fine.
- **`router_provider.dart`** — retry `deviceInfo` while the failure looks like
  temporary unreachability rather than a missing device; stop the login redirect
  from re-electing PnP in a loop.

**Also in this branch, unrelated to #1180** (small, self-contained, happy to split
out if you'd rather):
- `tree_node_item.dart` / `node_action_menu.dart` — mobile topology node card was
  clipping its content.
- `rules.dart` — IPv6 `::` expectation aligned with the rule's deliberate
  rejection.
- `node_detail_view_test.dart` responsive test fixes.

## Testing

| Scope | Result |
|---|---|
| `pnp_provider_auto_master_test.dart` | **23/23** — the only place the JNAP-result→status mapping is verified directly, against a real `PnpNotifier` |
| `pnp_auto_master_flow_test.dart` | **14/14** — every mixin branch in isolation |
| `pnp_auto_master_waiting_view_test.dart` | **2/2** — state→screen |
| `test/page/instant_setup/ --exclude-tags loc` | **50/50** (14 new view-level flow/checkpoint cases) |
| Whole repo `--exclude-tags loc` | **563 passed** |
| loc suites (screenshot generation) | **3247 passed / 3 failed** — pre-existing `RenderFlex overflowed by 16px` at `pnp_setup_view.dart:538` (Print / Download-QR row) in de/es/es_AR at 480w; not on any line this branch touches |
| `flutter analyze lib/ test/` | **563 issues, identical before and after** — net new **0** |

Three assertions worth calling out, because nothing else pins them: the budget's
`maxRetry`/timeout/delay values **are** the give-up rule now, so a test asserts
all three; and the admin-view case asserts the rotated credential is dropped
(`verify(setAttachedPassword(null))`) and that **no** navigation happens.

**Not yet manually verified on a device.** Manual QA results will be added as a
comment once the run happens.

## Notes / risks

- Base branch is `dev-1.3.1` (cut from `main`, version bumped to 1.3.1).
- **Firmware dependency:** `GetAutoMasterStatus` must be readable without auth
  (dennisnltran's change). Without it, every poll 401s → flattens to `null` →
  detection **silently degrades to the old two-pass flow**. That is a known,
  accepted fallback — *not* a regression — but it looks identical to the original
  symptom, so QA needs to know: **#1180's lockout is fixed either way; #449's
  "fill twice" can still appear on firmware without the no-auth read.** Please
  confirm whether `FW_Pinnacle2.0_v1.2.4.26080716_PW` includes it.
- `371dbbf8` ("terminate poll on first 401") is **superseded** by `05d2529a` and
  no longer active. It stays in the history and is documented in §8 of the design
  doc as a ready fallback if the no-auth read cannot ship.
- Recommend running QA on a build containing `05d2529a` + `154983a1` + `7d1bd1e5`
  — the pasted QA log predates all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
