### PR TITLE
fix(usp): stop back-filling absent concrete GET paths in _rawGet (#1184)

### DIFF
--- a/lib/core/usp/services/usp_client.dart
+++ b/lib/core/usp/services/usp_client.dart
@@ -287,25 +287,12 @@ class UspClient {
         logger.w('$_tag$label GET response EMPTY for paths: $paths');
       }
 
-      final Map<String, dynamic> result = {};
-
-      for (final entry in rawMap.entries) {
-        result[entry.key] = _coerceValue(entry.key, entry.value);
-      }
-
-      // Ensure all requested non-wildcard paths exist in the result to prevent
-      // Null Cast errors in codegen. Wildcard search paths (containing '*') are
-      // expanded by the router into concrete instance paths, so the original
-      // wildcard path won't appear in the response — skip those.
-      for (final path in paths) {
-        if (path.contains('*')) continue;
-        if (!result.containsKey(path)) {
-          logger.w('$_tag$label GET missing path in response: "$path"');
-        }
-        result.putIfAbsent(path, () => null);
-      }
-
-      return result;
+      return normalizeGetResponse(
+        paths,
+        rawMap,
+        onMissingPath: (path) =>
+            logger.w('$_tag$label GET missing path in response: "$path"'),
+      );
     } catch (e) {
       sw.stop();
       final label = _idLabel(id);
@@ -314,13 +301,48 @@ class UspClient {
     }
   }
 
+  /// Normalizes a raw USP GET response into the map consumed by codegen models.
+  ///
+  /// Two responsibilities, kept as pure logic so it is unit-testable without a
+  /// live WASM client:
+  /// 1. Coerce every returned value via [_coerceValue].
+  /// 2. Warn (via [onMissingPath]) for each requested non-wildcard path absent
+  ///    from the response — but deliberately do NOT back-fill it. Back-filling
+  ///    absent paths with null used to silently suppress the codegen
+  ///    required-leaf check (code 9998 → ServiceErrorView), because it flipped
+  ///    `containsKey` to true without preventing any Null Cast (the real guard
+  ///    is the `?? ''` on each codegen assignment). Leaving the key absent lets
+  ///    the required-leaf contract fire as designed (#1184).
+  ///
+  /// Wildcard search paths (containing '*') are expanded by the router into
+  /// concrete instance paths, so the original wildcard path won't appear in the
+  /// response — those are skipped by the missing-path warning.
+  @visibleForTesting
+  static Map<String, dynamic> normalizeGetResponse(
+    List<String> paths,
+    Map<String, String?> rawMap, {
+    void Function(String path)? onMissingPath,
+  }) {
+    final Map<String, dynamic> result = {};
+    for (final entry in rawMap.entries) {
+      result[entry.key] = _coerceValue(entry.key, entry.value);
+    }
+    for (final path in paths) {
+      if (path.contains('*')) continue;
+      if (!result.containsKey(path)) {
+        onMissingPath?.call(path);
+      }
+    }
+    return result;
+  }
+
   /// Coerce a raw string value from USP into the appropriate Dart type.
   /// - "true" / "false" →bool (any path)
   /// - "1" / "0" →bool (for known boolean suffixes: Enable, Active)
   /// - null →null (key absent from response)
   /// - Empty string →'' (preserve String type for generated code)
   /// - Everything else stays as String (generated code handles int parsing)
-  dynamic _coerceValue(String path, String? raw) {
+  static dynamic _coerceValue(String path, String? raw) {
     if (raw == null) return null;
     if (raw.isEmpty) return '';
 

--- a/test/core/usp/services/usp_client_normalize_response_test.dart
+++ b/test/core/usp/services/usp_client_normalize_response_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/core/usp/services/usp_client.dart';
+
+/// Regression tests for issue #1184.
+///
+/// `UspClient._rawGet` used to back-fill every absent non-wildcard requested
+/// path with `null` before returning. That silently defeated the codegen
+/// required-leaf check (`code: 9998` → `ServiceErrorView`) for models that GET
+/// with concrete paths: a back-filled key made `response.containsKey(path)`
+/// return true, so the `missing` list stayed empty and 9998 never fired.
+///
+/// The fix removes the back-fill. These tests pin that behaviour on the pure,
+/// testable [UspClient.normalizeGetResponse] seam (the real `_rawGet` cannot be
+/// unit-tested directly — its constructor throws off-Web and the WASM client is
+/// not injectable, which is exactly why the back-fill was never covered).
+void main() {
+  group('UspClient.normalizeGetResponse — no back-fill (#1184)', () {
+    test('absent concrete path is NOT added to the result', () {
+      // The router omitted a requested concrete leaf entirely.
+      final result = UspClient.normalizeGetResponse(
+        ['Device.DHCPv4.Server.Pool.1.MinAddress'],
+        <String, String?>{},
+      );
+
+      // The load-bearing assertion: adding `putIfAbsent(path, () => null)` back
+      // makes containsKey true and fails this test.
+      expect(
+        result.containsKey('Device.DHCPv4.Server.Pool.1.MinAddress'),
+        isFalse,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('present paths are kept and value-coerced', () {
+      final result = UspClient.normalizeGetResponse(
+        [
+          'Device.DHCPv4.Server.Pool.1.Enable', // bool suffix
+          'Device.DHCPv4.Server.Pool.1.MinAddress', // plain string
+        ],
+        <String, String?>{
+          'Device.DHCPv4.Server.Pool.1.Enable': '1',
+          'Device.DHCPv4.Server.Pool.1.MinAddress': '192.168.1.100',
+        },
+      );
+
+      expect(result['Device.DHCPv4.Server.Pool.1.Enable'], isTrue);
+      expect(
+        result['Device.DHCPv4.Server.Pool.1.MinAddress'],
+        '192.168.1.100',
+      );
+    });
+
+    test(
+        'a path present with an empty string stays present (not treated as '
+        'missing)', () {
+      final result = UspClient.normalizeGetResponse(
+        ['Device.DHCPv4.Server.Pool.1.DNSServers'],
+        <String, String?>{'Device.DHCPv4.Server.Pool.1.DNSServers': ''},
+      );
+
+      // Empty string is a real value → key present, coerced to ''.
+      expect(
+          result.containsKey('Device.DHCPv4.Server.Pool.1.DNSServers'), isTrue);
+      expect(result['Device.DHCPv4.Server.Pool.1.DNSServers'], '');
+    });
+
+    test('wildcard request paths never trigger a missing-path warning', () {
+      final missing = <String>[];
+      // Router expands the wildcard into a concrete instance; the original
+      // wildcard path is absent from the response but must be ignored.
+      UspClient.normalizeGetResponse(
+        ['Device.DNS.Client.Server.*.DNSServer'],
+        <String, String?>{'Device.DNS.Client.Server.1.DNSServer': '8.8.8.8'},
+        onMissingPath: missing.add,
+      );
+
+      expect(missing, isEmpty);
+    });
+
+    test('absent concrete path invokes onMissingPath; present one does not',
+        () {
+      final missing = <String>[];
+      UspClient.normalizeGetResponse(
+        [
+          'Device.DHCPv4.Server.Pool.1.MinAddress', // absent
+          'Device.DHCPv4.Server.Pool.1.MaxAddress', // present
+        ],
+        <String, String?>{
+          'Device.DHCPv4.Server.Pool.1.MaxAddress': '192.168.1.200',
+        },
+        onMissingPath: missing.add,
+      );
+
+      expect(missing, ['Device.DHCPv4.Server.Pool.1.MinAddress']);
+    });
+  });
+
+  group('Codegen required-leaf contract is reachable again (#1184)', () {
+    // Ties the normalize seam to a real concrete-path model. When a required
+    // leaf is omitted, normalizeGetResponse leaves it absent, so the model's
+    // `containsKey` required-check adds it to `missing` and throws 9998.
+    // (Before the fix the back-fill made this branch unreachable.)
+    const instancePath = 'Device.IP.Interface.1.';
+
+    List<String> lanPaths() => [
+          '${instancePath}IPv4Address.1.IPAddress',
+          '${instancePath}IPv4Address.1.SubnetMask',
+          'Device.DHCPv4.Server.Pool.1.Enable',
+          'Device.DHCPv4.Server.Pool.1.MinAddress',
+          'Device.DHCPv4.Server.Pool.1.MaxAddress',
+          'Device.DHCPv4.Server.Pool.1.LeaseTime',
+          'Device.DHCPv4.Server.Pool.1.DNSServers',
+          'Device.DeviceInfo.HostName',
+          '${instancePath}IPv6Enable',
+        ];
+
+    Map<String, String?> fullLanResponse() => <String, String?>{
+          '${instancePath}IPv4Address.1.IPAddress': '192.168.1.1',
+          '${instancePath}IPv4Address.1.SubnetMask': '255.255.255.0',
+          'Device.DHCPv4.Server.Pool.1.Enable': '1',
+          'Device.DHCPv4.Server.Pool.1.MinAddress': '192.168.1.100',
+          'Device.DHCPv4.Server.Pool.1.MaxAddress': '192.168.1.200',
+          'Device.DHCPv4.Server.Pool.1.LeaseTime': '86400',
+          'Device.DHCPv4.Server.Pool.1.DNSServers': '8.8.8.8',
+          'Device.DeviceInfo.HostName': 'router',
+          '${instancePath}IPv6Enable': 'true',
+        };
+
+    test(
+        'normalized response omitting a required leaf makes the codegen check '
+        'see it as missing (→ 9998)', () {
+      final withMissing = fullLanResponse()
+        ..remove('Device.DHCPv4.Server.Pool.1.MinAddress');
+
+      final normalized =
+          UspClient.normalizeGetResponse(lanPaths(), withMissing);
+
+      // This is precisely the predicate the generated `_fromResponse` evaluates;
+      // false here means `missing.add(...)` runs and 9998 is thrown.
+      expect(
+        normalized.containsKey('Device.DHCPv4.Server.Pool.1.MinAddress'),
+        isFalse,
+      );
+    });
+
+    test(
+        'complete normalized response keeps every required leaf present '
+        '(no false 9998)', () {
+      final normalized =
+          UspClient.normalizeGetResponse(lanPaths(), fullLanResponse());
+
+      // Every required leaf the generated check inspects must be present, so
+      // `missing` stays empty and the model builds normally.
+      for (final path in lanPaths()) {
+        expect(normalized.containsKey(path), isTrue,
+            reason: 'required leaf $path must survive normalization');
+      }
+      // Spot-check coercion feeding the generated assignments.
+      expect(normalized['Device.DHCPv4.Server.Pool.1.Enable'], isTrue);
+      expect(normalized['Device.DHCPv4.Server.Pool.1.MinAddress'],
+          '192.168.1.100');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #1184.

`UspClient._rawGet` back-filled every absent non-wildcard requested path with `null` before returning. That flipped `response.containsKey(path)` to `true`, silently defeating the codegen required-leaf check (`code: 9998` → `ServiceErrorView`) for **every model that GETs with concrete paths** — 15 models, 67 required leaves, including the mixed concrete+wildcard `dns_client`.

This PR removes the back-fill and locks the behaviour with tests.

## Why the back-fill was the bug (not the protection)

The back-fill carried this comment:

```dart
// Ensure all requested non-wildcard paths exist in the result to prevent
// Null Cast errors in codegen.
result.putIfAbsent(path, () => null);
```

**The comment is inaccurate.** A Dart map already returns `null` for an absent key, so `response[path] as String` receives `null` *whether or not* the back-fill ran — `null as String` throws either way. The back-fill prevents no Null Cast; the real Null-Cast guard is the `?? ''` on each generated assignment, which runs *after* the 9998 check anyway. The back-fill's only observable effect was flipping `containsKey()` from `false` to `true`, which suppressed 9998.

**Framed as a contract:** the YAML/codegen `required: true` set *is* the contract between UI and firmware. The back-fill made the UI unilaterally absorb any contract violation as a silent empty value — a violation that no one could see or fix. Removing it restores contract fidelity: a genuinely missing required leaf now surfaces as `9998 → ServiceError` instead of being swallowed. Treating a missing `required` leaf as a real signal (to be resolved at the contract layer — firmware or YAML) is the correct default, not something the UI should paper over.

## The change

- **`lib/core/usp/services/usp_client.dart`**
  - Drop the `putIfAbsent(path, () => null)` back-fill from `_rawGet`.
  - Extract the pure coerce + missing-path-warning logic into a `@visibleForTesting static normalizeGetResponse(...)` seam. `_rawGet` now delegates to it, passing the logger as `onMissingPath`. Behaviour is otherwise unchanged.
  - Make `_coerceValue` `static` (it was already pure).

  The seam is necessary because `_rawGet` is private and `UspClient` can't be instantiated in the test VM (its constructor throws off-Web and the WASM client isn't injectable) — which is *exactly why the back-fill was never test-covered*. All existing tests mock the high-level `get()`, bypassing `_rawGet` entirely.

- **`test/core/usp/services/usp_client_normalize_response_test.dart`** (new, 7 tests)
  - No-back-fill group: absent concrete path is not added; present values coerced; empty string stays present; wildcard paths never warn; absent concrete path invokes `onMissingPath`.
  - Codegen-contract group: a normalized response omitting a required leaf leaves `containsKey(leaf) == false` — the exact predicate the generated `_fromResponse` evaluates to reach 9998; a complete response keeps every required leaf.

## Affected scope (per-leaf, for reviewers)

**14 fully-affected models:** `system_info` (11), `lan_network_info` (9), `wan_settings` (9), `ipv6settings` (6), `time_settings` (6), `wan_status` (6), `wan_static_ip` (5), `wan_traffic_stats` (4), `wan_pppoe` (3), `setup_state` (1), `wan_bridge` (1), `wan_dhcp` (1), `gre_tunnel` (1), `l2tp_tunnel` (1).

**1 mixed model:** `dns_client` — 3 concrete top-level required leaves silenced (`Device.DNS.Client.Enable`, `.Status`, `.ServerNumberOfEntries`); wildcard `Server.*.*` leaves were already protected.

**Total: 15 models, 67 silenced required leaves** now restored.

## Verification

| Check | Result |
|---|---|
| `flutter analyze` | clean |
| New tests | +7 pass |
| Regression-lock (temporarily re-add the back-fill) | the 2 load-bearing assertions fail as expected — the tests genuinely guard the fix |
| Full functional suite (`run_tests.sh`, golden/loc/ui excluded) | **3346 pass / 0 fail / 0 skip** |

Consumer behaviour is preserved: a revived 9998 surfaces as a `ServiceError` and is caught where it matters — e.g. `pnp_notifier.startPostLoginFlow` transitions to `AdminReadFailure` rather than crashing or showing a false "no internet".

## Behavioural change reviewers should be aware of

For the 15 models above, a missing required leaf changes from *"empty value, page still usable"* to *"full `ServiceErrorView`"*. This is intended: a missing `required` leaf is a contract violation and should be visible, not silently degraded. To keep that safe operationally, 9998 remains logged so a real firmware/YAML violation surfaces as a signal we can act on at the contract layer — the opposite of what the back-fill did.

**Blast radius is not uniformly page-scoped.** For most of the 15 models the effect is exactly "one settings page shows `ServiceErrorView`", but two paths are wider:

- **`system_info` is session-scoped, not page-scoped.** `session_service.dart:73` fetches `SystemInfo` during device-info bootstrap (at login, via `login_local_view.dart`) and wraps any failure as `ConnectivityError` (`session_service.dart:78`); the same model is also polled by `usp_system_monitor_service`, and `usp_system_monitor_notifier` counts `ConnectivityError` up to `_errorThreshold` before flipping app-wide connection state. So a single missing `system_info` leaf can take out bootstrap / connection state, not just a page.
- **Internet Settings is fail-fast.** `usp_internet_settings_service.fetchSettings()` (`usp_internet_settings_service.dart:52-60`) fetches WAN / IPv6 / PPP / VLAN / GRE / L2TP in one `Future.wait`, so any single missing required leaf turns the *entire* Internet Settings page into `ServiceErrorView` rather than blanking one field group.

**This does not add a new source of 9998 — it widens the reach of an existing one.** 9998-from-firmware-omission was already live on wildcard models (Port Forwarding is the issue's own example of a page that can reach the error view); the back-fill loop iterated the *requested* paths and `continue`d on `*`, while codegen checks the *expanded* `${p}` keys that were never in the back-fill's coverage. What this PR changes is that reach: from peripheral wildcard pages to core ones (WAN family, `system_info`, LAN), +15 models / 67 leaves. Note the user-facing message does not distinguish a transport failure from a genuine firmware omission — both map through `category=validation → InvalidInputError → errorInvalidInput`; only the engineer-facing 9998 message (which lists the missing paths) and the retained `onMissingPath` log tell them apart. Improving that user-facing message is tracked separately (`doc/error-handling/usp-error-handling-reference.md` §2.5) and is orthogonal to this fix.

**Watch-item (not a blocker) — a few `required` leaves sit on optional instances.** `Device.GRE.Tunnel.1.RemoteEndpoints`, `Device.L2TPv2.Tunnel.1.RemoteEndpoints`, and `Device.PPP.Interface.1.Username`/`.Password` live on instances that may legitimately not exist on a router never configured for GRE/L2TP/PPPoE. If this surfaces, it is most likely the YAML marking those leaves `required` when they should be optional (fix belongs in the contract, not the client), not firmware violating the contract. Because they share the fail-fast `fetchSettings()` above, any one of them missing fails the whole Internet Settings page — so this is the first place to look if 9998 appears there. This is the same "does firmware ever legitimately omit a `required` leaf?" question raised in #1184: the default remains "trust the YAML"; recalibrate the required set only if a concrete case appears.

---

> **Update (2026-08-07, post-review):** the "Behavioural change" section above was expanded after review to fold in @HankYuLinksys's three framing corrections — (1) `system_info` / Internet Settings blast radius is session-scoped / fail-fast rather than single-page; (2) this widens an existing 9998 source rather than adding a new one; (3) the GRE/L2TP/PPP optional-instance watch-item. The code and tests are unchanged from the reviewed commit `8c36d329`; this edit is documentation only.

