### PR TITLE
fix(ai): batch tool results into one message per assistant turn (#1191)

### DIFF
--- a/lib/ai/orchestrator/router_chat_controller.dart
+++ b/lib/ai/orchestrator/router_chat_controller.dart
@@ -1,3 +1,4 @@
+import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:generative_ui/generative_ui.dart';
 
@@ -5,23 +6,49 @@ import 'package:privacy_gui/ai/abstraction/_abstraction.dart';
 import 'package:privacy_gui/ai/prompts/router_system_prompt.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 
+/// Results accumulated for one assistant turn, owned by the exchange that
+/// opened it.
+///
+/// Pairing the results with the generation they belong to is what makes
+/// staleness safe to act on: work resuming after an `await` holds a reference
+/// to *its own* batch, so it can never read, clear, or append to results that
+/// belong to a later exchange.
+class ToolResultBatch {
+  ToolResultBatch(this.generation);
+
+  /// Conversation generation this batch was opened in.
+  final int generation;
+
+  /// Tool results collected so far, in execution order.
+  ///
+  /// Order does not have to match the assistant's `tool_use` order — a
+  /// confirmed write is appended after its siblings — because the API matches
+  /// results to requests by `tool_use_id`. What matters is that they all arrive
+  /// in the single user message following the assistant turn.
+  final List<ToolResultPart> results = [];
+}
+
 /// Pending confirmation state for write/admin operations.
-class PendingConfirmation {
+class PendingConfirmation extends Equatable {
   final RouterCommand command;
   final Map<String, dynamic> params;
   final ToolUseBlock toolUse;
 
-  /// Conversation generation the batch that produced this confirmation belongs
-  /// to. Validated before the result is emitted so a confirmation resolving
-  /// after the conversation moved on cannot inject an orphaned `tool_result`.
-  final int generation;
+  /// The batch this confirmation was raised from. Its result rejoins that
+  /// batch's siblings, and its generation decides whether the batch may still
+  /// be emitted — so a confirmation answered after the conversation moved on
+  /// cannot inject an orphaned `tool_result`.
+  final ToolResultBatch batch;
 
   const PendingConfirmation({
     required this.command,
     required this.params,
     required this.toolUse,
-    required this.generation,
+    required this.batch,
   });
+
+  @override
+  List<Object?> get props => [command, params, toolUse, batch];
 }
 
 /// Controller for managing Router AI Assistant conversations.
@@ -42,7 +69,7 @@ class PendingConfirmation {
 ///
 /// The Claude Messages API requires every `tool_use` block in an assistant
 /// message to be answered within the *single* user message that immediately
-/// follows it. Results are therefore accumulated in [_pendingResults] and
+/// follows it. Results are therefore accumulated in a [ToolResultBatch] and
 /// flushed as one [ChatMessage.toolResults] message once every tool in the
 /// batch has a result.
 ///
@@ -86,14 +113,13 @@ class RouterChatController extends ChangeNotifier {
   Map<String, RouterCommand>? _commandsByName;
   Future<Map<String, RouterCommand>>? _commandsLoad;
 
-  /// Tool results for the batch currently being processed. Flushed by
-  /// [_flushPendingResults].
+  /// The batch currently accumulating results, or null between exchanges.
   ///
-  /// Ordering follows execution, not the assistant's `tool_use` order — a
-  /// confirmed write is appended after its siblings. That is fine: the API
-  /// matches results to requests by `tool_use_id`, and only requires them all
-  /// to arrive in the single user message following the assistant turn.
-  final List<ToolResultPart> _pendingResults = [];
+  /// Owning the results together with the generation they belong to is what
+  /// makes staleness safe to act on: work returning from an `await` can only
+  /// ever touch *its own* batch, so it can never clear or append to results
+  /// belonging to a later exchange.
+  ToolResultBatch? _batch;
 
   /// Incremented whenever the conversation is reset, so work that was already
   /// in flight (e.g. a confirmation awaiting the device) can tell that its
@@ -157,7 +183,10 @@ class RouterChatController extends ChangeNotifier {
   /// drift apart. The future itself is cached so concurrent first calls share
   /// one query.
   Future<Map<String, RouterCommand>> _loadCommands() {
-    return _commandsLoad ??= _commandProvider.listCommands().then((commands) {
+    final cached = _commandsLoad;
+    if (cached != null) return cached;
+
+    final load = _commandProvider.listCommands().then((commands) {
       _routerTools = commands
           .map((cmd) => GenTool(
                 name: cmd.name,
@@ -167,12 +196,21 @@ class RouterChatController extends ChangeNotifier {
           .toList();
       return _commandsByName = {for (final c in commands) c.name: c};
     });
+
+    // Drop a rejected load so a transient provider failure does not stick for
+    // the rest of the conversation.
+    _commandsLoad = load.catchError((Object e) {
+      _commandsLoad = null;
+      throw e;
+    });
+    return _commandsLoad!;
   }
 
   /// Tool definitions for the model, loading the registry if needed.
   Future<List<GenTool>> _getRouterTools() async {
     await _loadCommands();
-    return _routerTools!;
+    // Set by the load above; the map and the list are always populated together.
+    return _routerTools ?? const [];
   }
 
   /// Send a user message and process response.
@@ -205,13 +243,24 @@ class RouterChatController extends ChangeNotifier {
   /// - Detecting confirmation requirements
   /// - Looping for multi-turn tool use
   Future<void> _processConversation() async {
-    // Snapshot the generation this exchange belongs to. Every await below is a
-    // point where the user can reset the conversation, and anything written
-    // afterwards would land in a conversation this work no longer belongs to.
-    final generation = _conversationGeneration;
+    // This exchange owns its own batch, stamped with the generation it belongs
+    // to. Every await below is a point where the user can reset the
+    // conversation; because results live on the batch rather than in shared
+    // state, work resuming afterwards can only ever discard its own.
+    final batch = ToolResultBatch(_conversationGeneration);
+    _batch = batch;
 
-    final tools = await _getRouterTools();
-    if (_isStale(generation)) return;
+    final List<GenTool> tools;
+    try {
+      tools = await _getRouterTools();
+    } catch (e) {
+      _log('_processConversation: loading commands failed: $e');
+      if (_isStale(batch)) return;
+      _state = _state.withError('An unexpected error occurred: $e');
+      notifyListeners();
+      return;
+    }
+    if (_isStale(batch)) return;
 
     var loopCount = 0;
     const maxLoops = 5;
@@ -234,7 +283,7 @@ class RouterChatController extends ChangeNotifier {
           tools: tools.isNotEmpty ? tools : null,
           systemPromptParts: _systemPromptParts,
         );
-        if (_isStale(generation)) return;
+        if (_isStale(batch)) return;
         _log(
             '_processConversation: LLM responded, stopReason=${response.stopReason}');
 
@@ -289,7 +338,7 @@ class RouterChatController extends ChangeNotifier {
 
         // Process each tool use. Results are accumulated rather than emitted
         // one by one, so the whole batch can be flushed as a single message.
-        _pendingResults.clear();
+        batch.results.clear();
 
         for (final toolUse in toolUseBlocks) {
           // Every tool is wrapped so that a failure anywhere — including a
@@ -301,12 +350,12 @@ class RouterChatController extends ChangeNotifier {
             // keeps the batch complete and tells the model to ask again.
             if (deferred != null) {
               final command = await _findCommand(toolUse.name);
-              if (_isStale(generation)) return;
+              if (_isStale(batch)) return;
               if (command?.requiresConfirmation ?? false) {
                 _log(
                     '_processConversation: deferring extra confirmation-required '
                     'tool "${toolUse.name}" to a later turn');
-                _pendingResults.add(ToolResultPart(
+                batch.results.add(ToolResultPart(
                   toolUseId: toolUse.id,
                   result: {
                     'status': _statusNotExecuted,
@@ -321,8 +370,8 @@ class RouterChatController extends ChangeNotifier {
             }
 
             _log('_processConversation: executing tool "${toolUse.name}"');
-            final result = await _executeToolUse(toolUse, generation);
-            if (_isStale(generation)) return;
+            final result = await _executeToolUse(toolUse, batch);
+            if (_isStale(batch)) return;
 
             if (result.requiresConfirmation) {
               _log('_processConversation: tool requires confirmation');
@@ -331,7 +380,7 @@ class RouterChatController extends ChangeNotifier {
             } else {
               _log(
                   '_processConversation: tool result: ${result.isError ? "ERROR" : "SUCCESS"}');
-              _pendingResults.add(ToolResultPart(
+              batch.results.add(ToolResultPart(
                 toolUseId: toolUse.id,
                 result: result.data,
                 isError: result.isError,
@@ -339,7 +388,7 @@ class RouterChatController extends ChangeNotifier {
             }
           } catch (e) {
             _log('_processConversation: tool "${toolUse.name}" threw: $e');
-            _pendingResults.add(ToolResultPart(
+            batch.results.add(ToolResultPart(
               toolUseId: toolUse.id,
               result: {'error': e.toString()},
               isError: true,
@@ -356,7 +405,7 @@ class RouterChatController extends ChangeNotifier {
           return;
         }
 
-        if (!_completeBatch(generation)) return;
+        if (!_completeBatch(batch)) return;
 
         // Restore loading state before continuing loop
         _log('_processConversation: continuing to next loop iteration');
@@ -364,13 +413,13 @@ class RouterChatController extends ChangeNotifier {
         notifyListeners();
       } on GenUiException catch (e) {
         _log('_processConversation: GenUiException: ${e.message}');
-        _abandonBatch(generation, deferred);
+        _abandonBatch(batch, deferred);
         _state = _state.withError(e.message, retryable: e.isRetryable);
         notifyListeners();
         return;
       } catch (e) {
         _log('_processConversation: unexpected error: $e');
-        _abandonBatch(generation, deferred);
+        _abandonBatch(batch, deferred);
         _state = _state.withError('An unexpected error occurred: $e');
         notifyListeners();
         return;
@@ -387,17 +436,17 @@ class RouterChatController extends ChangeNotifier {
   Future<RouterCommand?> _findCommand(String name) async =>
       (await _loadCommands())[name];
 
-  /// Whether [generation] belongs to a conversation that has since been reset.
+  /// Whether [batch] belongs to a conversation that has since been reset.
   ///
-  /// Work in flight across an `await` must check this before touching state:
-  /// writing into a conversation it no longer belongs to would leave a
-  /// `tool_result` with no matching `tool_use` and invalidate every later
-  /// request.
-  bool _isStale(int generation) {
-    if (generation == _conversationGeneration) return false;
-    _log('_isStale: conversation moved on (batch gen $generation, '
+  /// A pure predicate — it deliberately touches no state, so a losing exchange
+  /// cannot disturb the one that replaced it. Work resuming after an `await`
+  /// checks this before writing anything: a `tool_result` landing in a
+  /// conversation it does not belong to has no matching `tool_use` and
+  /// invalidates every later request.
+  bool _isStale(ToolResultBatch batch) {
+    if (batch.generation == _conversationGeneration) return false;
+    _log('_isStale: conversation moved on (batch gen ${batch.generation}, '
         'current $_conversationGeneration) — abandoning this exchange');
-    _pendingResults.clear();
     return true;
   }
 
@@ -406,29 +455,43 @@ class RouterChatController extends ChangeNotifier {
   /// Any tools that already ran are answered so the assistant turn is not left
   /// with unanswered `tool_use` blocks, and a confirmation discovered before
   /// the failure is still surfaced so the user's write request is not lost.
-  void _abandonBatch(int generation, PendingConfirmation? deferred) {
+  void _abandonBatch(ToolResultBatch batch, PendingConfirmation? deferred) {
     if (deferred != null) {
+      // Re-arming only makes sense while the batch still owns the conversation.
+      if (_isStale(batch)) return;
       _log(
           '_abandonBatch: keeping confirmation for "${deferred.command.name}"');
       _pendingConfirmation = deferred;
       return;
     }
-    _completeBatch(generation);
+    _completeBatch(batch);
   }
 
-  /// Emit [_pendingResults] as a single tool result message and clear the batch.
+  /// Emit [batch]'s results as a single tool result message.
   ///
-  /// Does nothing when the batch is empty, since a tool result message with no
-  /// content is not valid.
-  void _flushPendingResults() {
-    if (_pendingResults.isEmpty) return;
-    _log('_flushPendingResults: emitting ${_pendingResults.length} result(s) '
-        'in one message');
-    _state = _state.withMessage(
-      ChatMessage.toolResults(List.of(_pendingResults)),
-    );
-    _pendingResults.clear();
-    notifyListeners();
+  /// Returns false when the batch no longer owns the conversation, in which
+  /// case nothing is written. Does nothing for an empty batch either, since a
+  /// tool result message with no content is not valid.
+  bool _completeBatch(ToolResultBatch batch) {
+    if (_isStale(batch)) {
+      _log(
+          '_completeBatch: discarding ${batch.results.length} stale result(s)');
+      batch.results.clear();
+      return false;
+    }
+    if (batch.results.isNotEmpty) {
+      _log('_completeBatch: emitting ${batch.results.length} result(s) '
+          'in one message');
+      // Copy: the message must not alias a list this batch still owns.
+      _state = _state.withMessage(
+        ChatMessage.toolResults(List.of(batch.results)),
+      );
+      // Emptied so a later wind-down of the same batch cannot re-emit them.
+      batch.results.clear();
+      notifyListeners();
+    }
+    if (_batch == batch) _batch = null;
+    return true;
   }
 
   /// Execute a single tool use block.
@@ -438,7 +501,7 @@ class RouterChatController extends ChangeNotifier {
   /// the dialog cannot appear while sibling tools are still executing.
   Future<_ToolExecutionResult> _executeToolUse(
     ToolUseBlock toolUse,
-    int generation,
+    ToolResultBatch batch,
   ) async {
     final command = await _findCommand(toolUse.name);
 
@@ -456,7 +519,7 @@ class RouterChatController extends ChangeNotifier {
           command: command,
           params: toolUse.input,
           toolUse: toolUse,
-          generation: generation,
+          batch: batch,
         ),
       );
     }
@@ -487,9 +550,9 @@ class RouterChatController extends ChangeNotifier {
     final pending = _pendingConfirmation;
     if (pending == null) return;
 
-    // Validate against the generation the batch was opened in, not the current
-    // one — the conversation may have moved on while the dialog was showing.
-    final generation = pending.generation;
+    // The confirmation carries the batch it belongs to, so the result joins
+    // that batch's siblings — not whatever is open when the user answers.
+    final batch = pending.batch;
     _pendingConfirmation = null;
     _state = _state.loading();
     notifyListeners();
@@ -502,44 +565,30 @@ class RouterChatController extends ChangeNotifier {
 
       // Complete the batch this confirmation belongs to, then flush it as one
       // message so every tool_use in the assistant turn is answered together.
-      _pendingResults.add(ToolResultPart(
+      batch.results.add(ToolResultPart(
         toolUseId: pending.toolUse.id,
         result: result.success
-            ? {...result.data, 'status': _statusExecuted}
+            // Nested so a 'status' field the device itself returns is not
+            // silently overwritten by ours.
+            ? {'status': _statusExecuted, 'result': result.data}
             : {'error': result.error ?? 'Operation failed'},
         isError: !result.success,
       ));
-      if (!_completeBatch(generation)) return;
+      if (!_completeBatch(batch)) return;
 
       // Continue conversation to get LLM's follow-up response
       await _processConversation();
     } catch (e) {
-      _pendingResults.add(ToolResultPart(
+      batch.results.add(ToolResultPart(
         toolUseId: pending.toolUse.id,
         result: {'error': e.toString()},
         isError: true,
       ));
-      if (!_completeBatch(generation)) return;
+      if (!_completeBatch(batch)) return;
 
       // Still continue to get LLM response about the error
       await _processConversation();
     }
-  }
-
-  /// Flush the batch unless the conversation moved on while we were awaiting.
-  ///
-  /// Returns false when [generation] is stale — the results belong to a
-  /// conversation that has since been cleared, so emitting them would leave a
-  /// `tool_result` with no matching `tool_use` and break every later request.
-  bool _completeBatch(int generation) {
-    if (generation != _conversationGeneration) {
-      _log('_completeBatch: conversation was reset, discarding '
-          '${_pendingResults.length} stale result(s)');
-      _pendingResults.clear();
-      return false;
-    }
-    _flushPendingResults();
-    return true;
   }
 
   /// Cancel the pending action.
@@ -550,22 +599,21 @@ class RouterChatController extends ChangeNotifier {
     final pending = _pendingConfirmation;
     if (pending == null) return;
 
-    // Validate against the generation the batch was opened in, not the current
-    // one — the conversation may have moved on while the dialog was showing.
-    final generation = pending.generation;
+    // The cancellation joins the batch the confirmation came from.
+    final batch = pending.batch;
     _pendingConfirmation = null;
     _state = _state.loading();
     notifyListeners();
 
     // Complete the batch with the cancellation, then flush it as one message.
-    _pendingResults.add(ToolResultPart(
+    batch.results.add(ToolResultPart(
       toolUseId: pending.toolUse.id,
       result: {
         'status': _statusCancelled,
         'message': 'User declined to execute ${pending.command.name}',
       },
     ));
-    if (!_completeBatch(generation)) return;
+    if (!_completeBatch(batch)) return;
 
     // Continue conversation to get LLM's response to cancellation
     await _processConversation();
@@ -573,11 +621,11 @@ class RouterChatController extends ChangeNotifier {
 
   /// Handle tool action from A2UI component.
   Future<void> handleToolAction(ToolActionOutput action) async {
-    // A UI action answers a single rendered component, so it is its own batch.
     // Close out whatever the previous turn left open first — including a
     // confirmation the user never answered, whose tool_use would otherwise stay
-    // unanswered while this action's result is appended.
-    _closeOutOpenBatch();
+    // unanswered while this action's result is appended. The id this action
+    // answers is excluded so it is not answered twice.
+    _closeOutOpenBatch(except: {action.toolUseId});
 
     final toolResultMessage = action.toChatMessage();
     _state = _state.withMessage(toolResultMessage);
@@ -599,21 +647,29 @@ class RouterChatController extends ChangeNotifier {
   ///
   /// Results already computed for that turn are **preserved** — they hold real
   /// device data — and only the genuinely missing ids are synthesised. The
-  /// generation is bumped so a confirmation still awaiting the device cannot
-  /// come back and answer an id this method just answered.
-  void _closeOutOpenBatch() {
-    final hadOpenWork =
-        _pendingConfirmation != null || _pendingResults.isNotEmpty;
+  /// generation is always bumped, so anything still in flight for the closed
+  /// batch (a confirmation awaiting the device, or an LLM call mid-request)
+  /// cannot come back and answer an id this method just answered.
+  void _closeOutOpenBatch({Set<String> except = const {}}) {
+    final hadConfirmation = _pendingConfirmation != null;
     _pendingConfirmation = null;
-    if (hadOpenWork) {
-      // Invalidate in-flight work belonging to the batch being closed.
-      _conversationGeneration++;
-    }
 
     // Results computed for the turn being closed are real; keep them and only
     // fill the gaps below.
-    final carried = List<ToolResultPart>.of(_pendingResults);
-    _pendingResults.clear();
+    final closed = _batch;
+    _batch = null;
+
+    // Bump only when work for the closed batch may still be in flight — an
+    // unanswered confirmation awaiting the device, or a batch left open by an
+    // exchange that has not finished. A batch that already completed sets
+    // _batch to null, so a normal turn does not invalidate the next one.
+    if (hadConfirmation || closed != null) {
+      _conversationGeneration++;
+    }
+
+    final carried = closed == null
+        ? <ToolResultPart>[]
+        : List<ToolResultPart>.of(closed.results);
 
     if (_state.messages.isEmpty) return;
 
@@ -642,6 +698,8 @@ class RouterChatController extends ChangeNotifier {
 
     // Carried results answer their ids too — do not synthesise over them.
     answeredIds.addAll(carried.map((p) => p.toolUseId));
+    // Ids the caller is about to answer itself.
+    answeredIds.addAll(except);
 
     final synthesised = [
       for (final block in response.content.whereType<ToolUseBlock>())
@@ -734,7 +792,7 @@ class RouterChatController extends ChangeNotifier {
     // the new conversation once the device responds.
     _conversationGeneration++;
     _pendingConfirmation = null;
-    _pendingResults.clear();
+    _batch = null;
     _lastUserMessage = null;
     _routerTools = null;
     _commandsByName = null;

--- a/lib/ai/orchestrator/router_chat_controller.dart
+++ b/lib/ai/orchestrator/router_chat_controller.dart
@@ -31,6 +31,19 @@ class PendingConfirmation {
 /// 3. If command requires confirmation → set pendingConfirmation, notify UI
 /// 4. User confirms → execute command → add tool_result → get LLM response
 /// 5. User cancels → add cancellation tool_result → get LLM response
+///
+/// ## Batching tool results
+///
+/// The Claude Messages API requires every `tool_use` block in an assistant
+/// message to be answered within the *single* user message that immediately
+/// follows it. Results are therefore accumulated in [_pendingResults] and
+/// flushed as one [ChatMessage.toolResults] message once every tool in the
+/// batch has a result.
+///
+/// When a command requires confirmation the batch stays open across the
+/// confirmation dialog: results for the sibling tools are held back until the
+/// user confirms or cancels, then flushed together with the write result. This
+/// is invisible to the user because tool results are never rendered in the chat.
 class RouterChatController extends ChangeNotifier {
   RouterChatController({
     required IConversationGenerator generator,
@@ -57,6 +70,21 @@ class RouterChatController extends ChangeNotifier {
   String? _lastUserMessage;
   List<SystemPromptPart>? _systemPromptParts;
   List<GenTool>? _routerTools;
+  Map<String, RouterCommand>? _commandsByName;
+
+  /// Tool results for the batch currently being processed. Flushed by
+  /// [_flushPendingResults].
+  ///
+  /// Ordering follows execution, not the assistant's `tool_use` order — a
+  /// confirmed write is appended after its siblings. That is fine: the API
+  /// matches results to requests by `tool_use_id`, and only requires them all
+  /// to arrive in the single user message following the assistant turn.
+  final List<ToolResultPart> _pendingResults = [];
+
+  /// Incremented whenever the conversation is reset, so work that was already
+  /// in flight (e.g. a confirmation awaiting the device) can tell that its
+  /// conversation is gone and drop its result instead of injecting an orphan.
+  int _conversationGeneration = 0;
 
   // Token usage tracking
   int _totalInputTokens = 0;
@@ -164,6 +192,10 @@ class RouterChatController extends ChangeNotifier {
       loopCount++;
       _log('_processConversation: loop $loopCount/$maxLoops');
 
+      // Declared outside the try so the catch blocks can still surface a
+      // confirmation that was discovered before the failure.
+      PendingConfirmation? deferred;
+
       try {
         _log('_processConversation: calling LLM...');
         final response = await _generator.generateWithHistory(
@@ -223,35 +255,61 @@ class RouterChatController extends ChangeNotifier {
         _state = _state.loading();
         notifyListeners();
 
-        // Process each tool use
-        var requiresConfirmation = false;
+        // Process each tool use. Results are accumulated rather than emitted
+        // one by one, so the whole batch can be flushed as a single message.
+        _pendingResults.clear();
 
         for (final toolUse in toolUseBlocks) {
+          // Only the first confirmation-required command is executed in this
+          // batch. Answering the rest with an explicit "not executed" result
+          // keeps the batch complete and tells the model to ask again.
+          if (deferred != null) {
+            final command = await _findCommand(toolUse.name);
+            if (command?.requiresConfirmation ?? false) {
+              _log(
+                  '_processConversation: deferring extra confirmation-required '
+                  'tool "${toolUse.name}" to a later turn');
+              _pendingResults.add(ToolResultPart(
+                toolUseId: toolUse.id,
+                result: {
+                  'status': 'not_executed',
+                  'reason': 'Only one operation requiring confirmation can be '
+                      'handled at a time. Request this one again in a '
+                      'follow-up turn.',
+                },
+              ));
+              continue;
+            }
+          }
+
           _log('_processConversation: executing tool "${toolUse.name}"');
           final result = await _executeToolUse(toolUse);
 
           if (result.requiresConfirmation) {
             _log('_processConversation: tool requires confirmation');
-            requiresConfirmation = true;
-            // Don't add tool_result yet — wait for user confirmation
+            // Hold the batch open — the result is added once the user decides.
+            deferred = result.pendingConfirmation;
           } else {
             _log(
                 '_processConversation: tool result: ${result.isError ? "ERROR" : "SUCCESS"}');
-            // Add tool result immediately
-            _state = _state.withMessage(ChatMessage.toolResult(
+            _pendingResults.add(ToolResultPart(
               toolUseId: toolUse.id,
               result: result.data,
               isError: result.isError,
             ));
-            notifyListeners();
           }
         }
 
-        if (requiresConfirmation) {
-          // Stop loop, UI will handle confirmation
+        if (deferred != null) {
+          // Surface the dialog only now that every sibling tool has finished,
+          // so confirming cannot re-enter _processConversation mid-loop.
           _log('_processConversation: waiting for user confirmation');
+          _pendingConfirmation = deferred;
+          notifyListeners();
           return;
         }
+
+        _flushPendingResults();
 
         // Restore loading state before continuing loop
         _log('_processConversation: continuing to next loop iteration');
@@ -259,11 +317,13 @@ class RouterChatController extends ChangeNotifier {
         notifyListeners();
       } on GenUiException catch (e) {
         _log('_processConversation: GenUiException: ${e.message}');
+        _abandonBatch(deferred);
         _state = _state.withError(e.message, retryable: e.isRetryable);
         notifyListeners();
         return;
       } catch (e) {
         _log('_processConversation: unexpected error: $e');
+        _abandonBatch(deferred);
         _state = _state.withError('An unexpected error occurred: $e');
         notifyListeners();
         return;
@@ -276,14 +336,55 @@ class RouterChatController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Look up a command by name, or null when it is not registered.
+  ///
+  /// Cached alongside [_routerTools] so a batch does not re-query the provider
+  /// once per tool.
+  Future<RouterCommand?> _findCommand(String name) async {
+    if (_commandsByName == null) {
+      final commands = await _commandProvider.listCommands();
+      _commandsByName = {for (final c in commands) c.name: c};
+    }
+    return _commandsByName![name];
+  }
+
+  /// Wind down a batch that failed part-way through.
+  ///
+  /// Any tools that already ran are answered so the assistant turn is not left
+  /// with unanswered `tool_use` blocks, and a confirmation discovered before
+  /// the failure is still surfaced so the user's write request is not lost.
+  void _abandonBatch(PendingConfirmation? deferred) {
+    if (deferred != null) {
+      _log(
+          '_abandonBatch: keeping confirmation for "${deferred.command.name}"');
+      _pendingConfirmation = deferred;
+      return;
+    }
+    _flushPendingResults();
+  }
+
+  /// Emit [_pendingResults] as a single tool result message and clear the batch.
+  ///
+  /// Does nothing when the batch is empty, since a tool result message with no
+  /// content is not valid.
+  void _flushPendingResults() {
+    if (_pendingResults.isEmpty) return;
+    _log('_flushPendingResults: emitting ${_pendingResults.length} result(s) '
+        'in one message');
+    _state = _state.withMessage(
+      ChatMessage.toolResults(List.of(_pendingResults)),
+    );
+    _pendingResults.clear();
+    notifyListeners();
+  }
+
   /// Execute a single tool use block.
+  ///
+  /// When the command requires confirmation this only *reports* that fact — it
+  /// deliberately does not set [_pendingConfirmation] or notify listeners, so
+  /// the dialog cannot appear while sibling tools are still executing.
   Future<_ToolExecutionResult> _executeToolUse(ToolUseBlock toolUse) async {
-    // Find the command
-    final commands = await _commandProvider.listCommands();
-    final command = commands.cast<RouterCommand?>().firstWhere(
-          (c) => c?.name == toolUse.name,
-          orElse: () => null,
-        );
+    final command = await _findCommand(toolUse.name);
 
     if (command == null) {
       return _ToolExecutionResult(
@@ -294,13 +395,14 @@ class RouterChatController extends ChangeNotifier {
 
     // Check if confirmation required
     if (command.requiresConfirmation) {
-      _pendingConfirmation = PendingConfirmation(
-        command: command,
-        params: toolUse.input,
-        toolUse: toolUse,
+      return _ToolExecutionResult(
+        requiresConfirmation: true,
+        pendingConfirmation: PendingConfirmation(
+          command: command,
+          params: toolUse.input,
+          toolUse: toolUse,
+        ),
       );
-      notifyListeners();
-      return _ToolExecutionResult(requiresConfirmation: true);
     }
 
     // Execute immediately
@@ -329,6 +431,7 @@ class RouterChatController extends ChangeNotifier {
     final pending = _pendingConfirmation;
     if (pending == null) return;
 
+    final generation = _conversationGeneration;
     _pendingConfirmation = null;
     _state = _state.loading();
     notifyListeners();
@@ -339,29 +442,46 @@ class RouterChatController extends ChangeNotifier {
         pending.params,
       );
 
-      // Add tool result
-      _state = _state.withMessage(ChatMessage.toolResult(
+      // Complete the batch this confirmation belongs to, then flush it as one
+      // message so every tool_use in the assistant turn is answered together.
+      _pendingResults.add(ToolResultPart(
         toolUseId: pending.toolUse.id,
         result: result.success
             ? {...result.data, 'status': 'executed'}
             : {'error': result.error ?? 'Operation failed'},
         isError: !result.success,
       ));
-      notifyListeners();
+      if (!_completeBatch(generation)) return;
 
       // Continue conversation to get LLM's follow-up response
       await _processConversation();
     } catch (e) {
-      _state = _state.withMessage(ChatMessage.toolResult(
+      _pendingResults.add(ToolResultPart(
         toolUseId: pending.toolUse.id,
         result: {'error': e.toString()},
         isError: true,
       ));
-      notifyListeners();
+      if (!_completeBatch(generation)) return;
 
       // Still continue to get LLM response about the error
       await _processConversation();
     }
+  }
+
+  /// Flush the batch unless the conversation moved on while we were awaiting.
+  ///
+  /// Returns false when [generation] is stale — the results belong to a
+  /// conversation that has since been cleared, so emitting them would leave a
+  /// `tool_result` with no matching `tool_use` and break every later request.
+  bool _completeBatch(int generation) {
+    if (generation != _conversationGeneration) {
+      _log('_completeBatch: conversation was reset, discarding '
+          '${_pendingResults.length} stale result(s)');
+      _pendingResults.clear();
+      return false;
+    }
+    _flushPendingResults();
+    return true;
   }
 
   /// Cancel the pending action.
@@ -372,19 +492,20 @@ class RouterChatController extends ChangeNotifier {
     final pending = _pendingConfirmation;
     if (pending == null) return;
 
+    final generation = _conversationGeneration;
     _pendingConfirmation = null;
     _state = _state.loading();
     notifyListeners();
 
-    // Add cancellation result
-    _state = _state.withMessage(ChatMessage.toolResult(
+    // Complete the batch with the cancellation, then flush it as one message.
+    _pendingResults.add(ToolResultPart(
       toolUseId: pending.toolUse.id,
       result: {
         'status': 'cancelled',
         'message': 'User declined to execute ${pending.command.name}',
       },
     ));
-    notifyListeners();
+    if (!_completeBatch(generation)) return;
 
     // Continue conversation to get LLM's response to cancellation
     await _processConversation();
@@ -392,6 +513,12 @@ class RouterChatController extends ChangeNotifier {
 
   /// Handle tool action from A2UI component.
   Future<void> handleToolAction(ToolActionOutput action) async {
+    // A UI action answers a single rendered component, so it is its own batch.
+    // Close out whatever the previous turn left open first — including a
+    // confirmation the user never answered, whose tool_use would otherwise stay
+    // unanswered while this action's result is appended.
+    _insertPendingToolResults();
+
     final toolResultMessage = action.toChatMessage();
     _state = _state.withMessage(toolResultMessage);
     _state = _state.toolActionCompleted();
@@ -403,57 +530,109 @@ class RouterChatController extends ChangeNotifier {
     await _processConversation();
   }
 
-  /// Insert tool_result messages for any pending tool_use blocks.
+  /// Answer any `tool_use` blocks of the trailing assistant message that do not
+  /// have a result yet.
+  ///
+  /// This happens when the previous turn ended without completing its batch —
+  /// for example the user typed a new message instead of answering a pending
+  /// confirmation dialog. Leaving a `tool_use` unanswered makes the API reject
+  /// the next request, so the gaps are filled with an acknowledgment.
   void _insertPendingToolResults() {
+    // A confirmation is still open: drop it and abandon its batch, otherwise
+    // the stale results would be flushed alongside the next turn's.
+    _pendingConfirmation = null;
+    _pendingResults.clear();
+
     if (_state.messages.isEmpty) return;
 
-    // Find the last assistant message
+    // Walk back to the trailing assistant message, collecting the tool_use ids
+    // already answered along the way.
     ChatMessage? lastAssistantMessage;
+    final answeredIds = <String>{};
     for (var i = _state.messages.length - 1; i >= 0; i--) {
       final msg = _state.messages[i];
       if (msg.isAssistant) {
         lastAssistantMessage = msg;
         break;
       }
-      if (msg.isToolResult) return;
+      if (msg.isToolResult) {
+        final parts = msg.content;
+        if (parts is List<ContentPart>) {
+          answeredIds.addAll(
+            parts.whereType<ToolResultPart>().map((p) => p.toolUseId),
+          );
+        }
+      }
     }
 
-    if (lastAssistantMessage == null) return;
-
-    final response = lastAssistantMessage.response;
+    final response = lastAssistantMessage?.response;
     if (response == null) return;
 
-    final toolUseBlocks = response.content.whereType<ToolUseBlock>().toList();
-    if (toolUseBlocks.isEmpty) return;
+    final unanswered = response.content
+        .whereType<ToolUseBlock>()
+        .where((block) => !answeredIds.contains(block.id))
+        .toList();
+    if (unanswered.isEmpty) return;
 
-    // Insert tool_result for each tool_use block (UI rendered acknowledgment)
-    for (final toolUse in toolUseBlocks) {
-      _state = _state.withMessage(ChatMessage.toolResult(
-        toolUseId: toolUse.id,
-        result: {'status': 'rendered', 'component': toolUse.name},
-      ));
-    }
+    _log('_insertPendingToolResults: answering ${unanswered.length} '
+        'unanswered tool_use block(s)');
+    _state = _state.withMessage(ChatMessage.toolResults([
+      for (final toolUse in unanswered)
+        ToolResultPart(
+          toolUseId: toolUse.id,
+          result: _abandonedToolResult(toolUse.name),
+        ),
+    ]));
     notifyListeners();
+  }
+
+  /// Result body for a `tool_use` the user walked away from.
+  ///
+  /// Router commands must not be reported as done — they never ran. Anything
+  /// that is not a known command is an A2UI component, which really was
+  /// rendered, so the original acknowledgment still applies.
+  Map<String, dynamic> _abandonedToolResult(String toolName) {
+    if (_commandsByName?.containsKey(toolName) ?? false) {
+      return {
+        'status': 'not_executed',
+        'reason': 'The user moved on without responding to the confirmation.',
+      };
+    }
+    return {'status': 'rendered', 'component': toolName};
   }
 
   /// Retry the last failed operation.
   Future<void> retry() async {
     if (!_state.hasError || _lastUserMessage == null) return;
 
-    // Remove the failed user message
-    final messagesWithoutLast = [..._state.messages];
-    if (messagesWithoutLast.isNotEmpty &&
-        messagesWithoutLast.last.role == ChatRole.user) {
-      messagesWithoutLast.removeLast();
+    // Drop the trailing user message so [sendMessage] can re-add it. Tool
+    // result messages also carry the user role, but they answer a preceding
+    // assistant turn and hold real device data — removing one would both
+    // orphan that turn's tool_use and destroy the result.
+    final messages = [..._state.messages];
+    final trailing = messages.isEmpty ? null : messages.last;
+    final removedUserTurn = trailing != null &&
+        trailing.role == ChatRole.user &&
+        !trailing.isToolResult;
+    if (removedUserTurn) {
+      messages.removeLast();
     }
 
     _state = ConversationState(
       viewState: ChatViewState.content,
-      messages: messagesWithoutLast,
+      messages: messages,
     );
     notifyListeners();
 
-    await sendMessage(_lastUserMessage!);
+    if (removedUserTurn) {
+      await sendMessage(_lastUserMessage!);
+    } else {
+      // The user turn is still in history (the failure happened after tools
+      // ran), so resume the exchange instead of duplicating the question.
+      _state = _state.loading();
+      notifyListeners();
+      await _processConversation();
+    }
   }
 
   /// Clear conversation and reset state.
@@ -461,9 +640,14 @@ class RouterChatController extends ChangeNotifier {
     _log(
         'clearConversation: session summary - input: $_totalInputTokens, output: $_totalOutputTokens, cacheRead: $_totalCacheReadTokens, cacheWrite: $_totalCacheWriteTokens');
     _state = ConversationState.initial();
+    // Invalidate any in-flight confirmation so it cannot inject its result into
+    // the new conversation once the device responds.
+    _conversationGeneration++;
     _pendingConfirmation = null;
+    _pendingResults.clear();
     _lastUserMessage = null;
     _routerTools = null;
+    _commandsByName = null;
     _totalInputTokens = 0;
     _totalOutputTokens = 0;
     _totalCacheReadTokens = 0;
@@ -486,9 +670,14 @@ class _ToolExecutionResult {
   final bool isError;
   final bool requiresConfirmation;
 
+  /// Set when [requiresConfirmation] is true — the confirmation the caller
+  /// should surface once the rest of the batch has finished executing.
+  final PendingConfirmation? pendingConfirmation;
+
   const _ToolExecutionResult({
     this.data = const {},
     this.isError = false,
     this.requiresConfirmation = false,
+    this.pendingConfirmation,
   });
 }

--- a/lib/ai/orchestrator/router_chat_controller.dart
+++ b/lib/ai/orchestrator/router_chat_controller.dart
@@ -11,10 +11,16 @@ class PendingConfirmation {
   final Map<String, dynamic> params;
   final ToolUseBlock toolUse;
 
+  /// Conversation generation the batch that produced this confirmation belongs
+  /// to. Validated before the result is emitted so a confirmation resolving
+  /// after the conversation moved on cannot inject an orphaned `tool_result`.
+  final int generation;
+
   const PendingConfirmation({
     required this.command,
     required this.params,
     required this.toolUse,
+    required this.generation,
   });
 }
 
@@ -61,6 +67,13 @@ class RouterChatController extends ChangeNotifier {
     logger.d('[AI]: $message');
   }
 
+  // Tool result `status` values. These are part of the protocol the model
+  // reads, so they are defined once rather than spelled out at each site.
+  static const _statusExecuted = 'executed';
+  static const _statusCancelled = 'cancelled';
+  static const _statusNotExecuted = 'not_executed';
+  static const _statusRendered = 'rendered';
+
   final IConversationGenerator _generator;
   final IRouterCommandProvider _commandProvider;
   final String _routerContext;
@@ -71,6 +84,7 @@ class RouterChatController extends ChangeNotifier {
   List<SystemPromptPart>? _systemPromptParts;
   List<GenTool>? _routerTools;
   Map<String, RouterCommand>? _commandsByName;
+  Future<Map<String, RouterCommand>>? _commandsLoad;
 
   /// Tool results for the batch currently being processed. Flushed by
   /// [_flushPendingResults].
@@ -136,18 +150,28 @@ class RouterChatController extends ChangeNotifier {
         'System prompt initialized: ${_systemPromptParts!.length} parts, static cached: ${_systemPromptParts!.first.cache}');
   }
 
-  /// Build router tools from command provider.
-  Future<List<GenTool>> _getRouterTools() async {
-    if (_routerTools != null) return _routerTools!;
+  /// Load the command registry once per conversation.
+  ///
+  /// Both the tool definitions sent to the model and the per-name lookup are
+  /// derived here so the provider is queried once, and the two views cannot
+  /// drift apart. The future itself is cached so concurrent first calls share
+  /// one query.
+  Future<Map<String, RouterCommand>> _loadCommands() {
+    return _commandsLoad ??= _commandProvider.listCommands().then((commands) {
+      _routerTools = commands
+          .map((cmd) => GenTool(
+                name: cmd.name,
+                description: cmd.description,
+                inputSchema: cmd.inputSchema,
+              ))
+          .toList();
+      return _commandsByName = {for (final c in commands) c.name: c};
+    });
+  }
 
-    final commands = await _commandProvider.listCommands();
-    _routerTools = commands
-        .map((cmd) => GenTool(
-              name: cmd.name,
-              description: cmd.description,
-              inputSchema: cmd.inputSchema,
-            ))
-        .toList();
+  /// Tool definitions for the model, loading the registry if needed.
+  Future<List<GenTool>> _getRouterTools() async {
+    await _loadCommands();
     return _routerTools!;
   }
 
@@ -159,7 +183,7 @@ class RouterChatController extends ChangeNotifier {
     _lastUserMessage = message;
 
     // Insert pending tool results if needed
-    _insertPendingToolResults();
+    _closeOutOpenBatch();
 
     // Add user message
     final userMessage = ChatMessage.user(message);
@@ -181,7 +205,14 @@ class RouterChatController extends ChangeNotifier {
   /// - Detecting confirmation requirements
   /// - Looping for multi-turn tool use
   Future<void> _processConversation() async {
+    // Snapshot the generation this exchange belongs to. Every await below is a
+    // point where the user can reset the conversation, and anything written
+    // afterwards would land in a conversation this work no longer belongs to.
+    final generation = _conversationGeneration;
+
     final tools = await _getRouterTools();
+    if (_isStale(generation)) return;
+
     var loopCount = 0;
     const maxLoops = 5;
 
@@ -203,6 +234,7 @@ class RouterChatController extends ChangeNotifier {
           tools: tools.isNotEmpty ? tools : null,
           systemPromptParts: _systemPromptParts,
         );
+        if (_isStale(generation)) return;
         _log(
             '_processConversation: LLM responded, stopReason=${response.stopReason}');
 
@@ -260,42 +292,57 @@ class RouterChatController extends ChangeNotifier {
         _pendingResults.clear();
 
         for (final toolUse in toolUseBlocks) {
-          // Only the first confirmation-required command is executed in this
-          // batch. Answering the rest with an explicit "not executed" result
-          // keeps the batch complete and tells the model to ask again.
-          if (deferred != null) {
-            final command = await _findCommand(toolUse.name);
-            if (command?.requiresConfirmation ?? false) {
+          // Every tool is wrapped so that a failure anywhere — including a
+          // provider lookup — still yields a result. Leaving one unanswered
+          // would make the next request invalid.
+          try {
+            // Only the first confirmation-required command is executed in this
+            // batch. Answering the rest with an explicit "not executed" result
+            // keeps the batch complete and tells the model to ask again.
+            if (deferred != null) {
+              final command = await _findCommand(toolUse.name);
+              if (_isStale(generation)) return;
+              if (command?.requiresConfirmation ?? false) {
+                _log(
+                    '_processConversation: deferring extra confirmation-required '
+                    'tool "${toolUse.name}" to a later turn');
+                _pendingResults.add(ToolResultPart(
+                  toolUseId: toolUse.id,
+                  result: {
+                    'status': _statusNotExecuted,
+                    'reason':
+                        'Only one operation requiring confirmation can be '
+                            'handled at a time. Request this one again in a '
+                            'follow-up turn.',
+                  },
+                ));
+                continue;
+              }
+            }
+
+            _log('_processConversation: executing tool "${toolUse.name}"');
+            final result = await _executeToolUse(toolUse, generation);
+            if (_isStale(generation)) return;
+
+            if (result.requiresConfirmation) {
+              _log('_processConversation: tool requires confirmation');
+              // Hold the batch open — the result is added once the user decides.
+              deferred = result.pendingConfirmation;
+            } else {
               _log(
-                  '_processConversation: deferring extra confirmation-required '
-                  'tool "${toolUse.name}" to a later turn');
+                  '_processConversation: tool result: ${result.isError ? "ERROR" : "SUCCESS"}');
               _pendingResults.add(ToolResultPart(
                 toolUseId: toolUse.id,
-                result: {
-                  'status': 'not_executed',
-                  'reason': 'Only one operation requiring confirmation can be '
-                      'handled at a time. Request this one again in a '
-                      'follow-up turn.',
-                },
+                result: result.data,
+                isError: result.isError,
               ));
-              continue;
             }
-          }
-
-          _log('_processConversation: executing tool "${toolUse.name}"');
-          final result = await _executeToolUse(toolUse);
-
-          if (result.requiresConfirmation) {
-            _log('_processConversation: tool requires confirmation');
-            // Hold the batch open — the result is added once the user decides.
-            deferred = result.pendingConfirmation;
-          } else {
-            _log(
-                '_processConversation: tool result: ${result.isError ? "ERROR" : "SUCCESS"}');
+          } catch (e) {
+            _log('_processConversation: tool "${toolUse.name}" threw: $e');
             _pendingResults.add(ToolResultPart(
               toolUseId: toolUse.id,
-              result: result.data,
-              isError: result.isError,
+              result: {'error': e.toString()},
+              isError: true,
             ));
           }
         }
@@ -309,7 +356,7 @@ class RouterChatController extends ChangeNotifier {
           return;
         }
 
-        _flushPendingResults();
+        if (!_completeBatch(generation)) return;
 
         // Restore loading state before continuing loop
         _log('_processConversation: continuing to next loop iteration');
@@ -317,13 +364,13 @@ class RouterChatController extends ChangeNotifier {
         notifyListeners();
       } on GenUiException catch (e) {
         _log('_processConversation: GenUiException: ${e.message}');
-        _abandonBatch(deferred);
+        _abandonBatch(generation, deferred);
         _state = _state.withError(e.message, retryable: e.isRetryable);
         notifyListeners();
         return;
       } catch (e) {
         _log('_processConversation: unexpected error: $e');
-        _abandonBatch(deferred);
+        _abandonBatch(generation, deferred);
         _state = _state.withError('An unexpected error occurred: $e');
         notifyListeners();
         return;
@@ -337,15 +384,21 @@ class RouterChatController extends ChangeNotifier {
   }
 
   /// Look up a command by name, or null when it is not registered.
+  Future<RouterCommand?> _findCommand(String name) async =>
+      (await _loadCommands())[name];
+
+  /// Whether [generation] belongs to a conversation that has since been reset.
   ///
-  /// Cached alongside [_routerTools] so a batch does not re-query the provider
-  /// once per tool.
-  Future<RouterCommand?> _findCommand(String name) async {
-    if (_commandsByName == null) {
-      final commands = await _commandProvider.listCommands();
-      _commandsByName = {for (final c in commands) c.name: c};
-    }
-    return _commandsByName![name];
+  /// Work in flight across an `await` must check this before touching state:
+  /// writing into a conversation it no longer belongs to would leave a
+  /// `tool_result` with no matching `tool_use` and invalidate every later
+  /// request.
+  bool _isStale(int generation) {
+    if (generation == _conversationGeneration) return false;
+    _log('_isStale: conversation moved on (batch gen $generation, '
+        'current $_conversationGeneration) — abandoning this exchange');
+    _pendingResults.clear();
+    return true;
   }
 
   /// Wind down a batch that failed part-way through.
@@ -353,14 +406,14 @@ class RouterChatController extends ChangeNotifier {
   /// Any tools that already ran are answered so the assistant turn is not left
   /// with unanswered `tool_use` blocks, and a confirmation discovered before
   /// the failure is still surfaced so the user's write request is not lost.
-  void _abandonBatch(PendingConfirmation? deferred) {
+  void _abandonBatch(int generation, PendingConfirmation? deferred) {
     if (deferred != null) {
       _log(
           '_abandonBatch: keeping confirmation for "${deferred.command.name}"');
       _pendingConfirmation = deferred;
       return;
     }
-    _flushPendingResults();
+    _completeBatch(generation);
   }
 
   /// Emit [_pendingResults] as a single tool result message and clear the batch.
@@ -383,7 +436,10 @@ class RouterChatController extends ChangeNotifier {
   /// When the command requires confirmation this only *reports* that fact — it
   /// deliberately does not set [_pendingConfirmation] or notify listeners, so
   /// the dialog cannot appear while sibling tools are still executing.
-  Future<_ToolExecutionResult> _executeToolUse(ToolUseBlock toolUse) async {
+  Future<_ToolExecutionResult> _executeToolUse(
+    ToolUseBlock toolUse,
+    int generation,
+  ) async {
     final command = await _findCommand(toolUse.name);
 
     if (command == null) {
@@ -395,12 +451,12 @@ class RouterChatController extends ChangeNotifier {
 
     // Check if confirmation required
     if (command.requiresConfirmation) {
-      return _ToolExecutionResult(
-        requiresConfirmation: true,
-        pendingConfirmation: PendingConfirmation(
+      return _ToolExecutionResult.awaitingConfirmation(
+        PendingConfirmation(
           command: command,
           params: toolUse.input,
           toolUse: toolUse,
+          generation: generation,
         ),
       );
     }
@@ -431,7 +487,9 @@ class RouterChatController extends ChangeNotifier {
     final pending = _pendingConfirmation;
     if (pending == null) return;
 
-    final generation = _conversationGeneration;
+    // Validate against the generation the batch was opened in, not the current
+    // one — the conversation may have moved on while the dialog was showing.
+    final generation = pending.generation;
     _pendingConfirmation = null;
     _state = _state.loading();
     notifyListeners();
@@ -447,7 +505,7 @@ class RouterChatController extends ChangeNotifier {
       _pendingResults.add(ToolResultPart(
         toolUseId: pending.toolUse.id,
         result: result.success
-            ? {...result.data, 'status': 'executed'}
+            ? {...result.data, 'status': _statusExecuted}
             : {'error': result.error ?? 'Operation failed'},
         isError: !result.success,
       ));
@@ -492,7 +550,9 @@ class RouterChatController extends ChangeNotifier {
     final pending = _pendingConfirmation;
     if (pending == null) return;
 
-    final generation = _conversationGeneration;
+    // Validate against the generation the batch was opened in, not the current
+    // one — the conversation may have moved on while the dialog was showing.
+    final generation = pending.generation;
     _pendingConfirmation = null;
     _state = _state.loading();
     notifyListeners();
@@ -501,7 +561,7 @@ class RouterChatController extends ChangeNotifier {
     _pendingResults.add(ToolResultPart(
       toolUseId: pending.toolUse.id,
       result: {
-        'status': 'cancelled',
+        'status': _statusCancelled,
         'message': 'User declined to execute ${pending.command.name}',
       },
     ));
@@ -517,7 +577,7 @@ class RouterChatController extends ChangeNotifier {
     // Close out whatever the previous turn left open first — including a
     // confirmation the user never answered, whose tool_use would otherwise stay
     // unanswered while this action's result is appended.
-    _insertPendingToolResults();
+    _closeOutOpenBatch();
 
     final toolResultMessage = action.toChatMessage();
     _state = _state.withMessage(toolResultMessage);
@@ -530,17 +590,29 @@ class RouterChatController extends ChangeNotifier {
     await _processConversation();
   }
 
-  /// Answer any `tool_use` blocks of the trailing assistant message that do not
-  /// have a result yet.
+  /// Close out the previous turn before starting a new one.
   ///
-  /// This happens when the previous turn ended without completing its batch —
-  /// for example the user typed a new message instead of answering a pending
-  /// confirmation dialog. Leaving a `tool_use` unanswered makes the API reject
-  /// the next request, so the gaps are filled with an acknowledgment.
-  void _insertPendingToolResults() {
-    // A confirmation is still open: drop it and abandon its batch, otherwise
-    // the stale results would be flushed alongside the next turn's.
+  /// Called when the user moves on without completing a batch — typing a new
+  /// message instead of answering a confirmation dialog, or triggering a UI
+  /// action. Leaving a `tool_use` unanswered makes the API reject the next
+  /// request, so any gap in the trailing assistant turn is filled.
+  ///
+  /// Results already computed for that turn are **preserved** — they hold real
+  /// device data — and only the genuinely missing ids are synthesised. The
+  /// generation is bumped so a confirmation still awaiting the device cannot
+  /// come back and answer an id this method just answered.
+  void _closeOutOpenBatch() {
+    final hadOpenWork =
+        _pendingConfirmation != null || _pendingResults.isNotEmpty;
     _pendingConfirmation = null;
+    if (hadOpenWork) {
+      // Invalidate in-flight work belonging to the batch being closed.
+      _conversationGeneration++;
+    }
+
+    // Results computed for the turn being closed are real; keep them and only
+    // fill the gaps below.
+    final carried = List<ToolResultPart>.of(_pendingResults);
     _pendingResults.clear();
 
     if (_state.messages.isEmpty) return;
@@ -568,42 +640,60 @@ class RouterChatController extends ChangeNotifier {
     final response = lastAssistantMessage?.response;
     if (response == null) return;
 
-    final unanswered = response.content
-        .whereType<ToolUseBlock>()
-        .where((block) => !answeredIds.contains(block.id))
-        .toList();
-    if (unanswered.isEmpty) return;
+    // Carried results answer their ids too — do not synthesise over them.
+    answeredIds.addAll(carried.map((p) => p.toolUseId));
 
-    _log('_insertPendingToolResults: answering ${unanswered.length} '
-        'unanswered tool_use block(s)');
-    _state = _state.withMessage(ChatMessage.toolResults([
-      for (final toolUse in unanswered)
-        ToolResultPart(
-          toolUseId: toolUse.id,
-          result: _abandonedToolResult(toolUse.name),
-        ),
-    ]));
+    final synthesised = [
+      for (final block in response.content.whereType<ToolUseBlock>())
+        if (!answeredIds.contains(block.id))
+          ToolResultPart(
+            toolUseId: block.id,
+            result: _abandonedToolResult(block.name),
+          ),
+    ];
+
+    final parts = [...carried, ...synthesised];
+    if (parts.isEmpty) return;
+
+    _log('_closeOutOpenBatch: emitting ${carried.length} carried + '
+        '${synthesised.length} synthesised result(s)');
+    _state = _state.withMessage(ChatMessage.toolResults(parts));
     notifyListeners();
   }
 
   /// Result body for a `tool_use` the user walked away from.
   ///
-  /// Router commands must not be reported as done — they never ran. Anything
-  /// that is not a known command is an A2UI component, which really was
-  /// rendered, so the original acknowledgment still applies.
+  /// A router command must never be reported as done — it never ran. Only names
+  /// the registry positively confirms are *not* commands are treated as A2UI
+  /// components, which genuinely were rendered. When the registry is unavailable
+  /// the answer falls to `not_executed`: claiming an unexecuted write succeeded
+  /// is the harmful direction to be wrong in.
   Map<String, dynamic> _abandonedToolResult(String toolName) {
-    if (_commandsByName?.containsKey(toolName) ?? false) {
-      return {
-        'status': 'not_executed',
-        'reason': 'The user moved on without responding to the confirmation.',
-      };
+    final registry = _commandsByName;
+    final isKnownComponent =
+        registry != null && !registry.containsKey(toolName);
+    if (isKnownComponent) {
+      return {'status': _statusRendered, 'component': toolName};
     }
-    return {'status': 'rendered', 'component': toolName};
+    return {
+      'status': _statusNotExecuted,
+      'reason': 'The user moved on without responding to the confirmation.',
+    };
   }
 
   /// Retry the last failed operation.
   Future<void> retry() async {
     if (!_state.hasError || _lastUserMessage == null) return;
+
+    // A batch that failed while holding a confirmation still owns its results
+    // and the user's write request. Retrying would clear both and leave the
+    // assistant turn unanswered, so the confirmation takes precedence — the
+    // user must answer the dialog first.
+    if (_pendingConfirmation != null) {
+      _log('retry: ignored — a confirmation is still awaiting the user');
+      notifyListeners();
+      return;
+    }
 
     // Drop the trailing user message so [sendMessage] can re-add it. Tool
     // result messages also carry the user role, but they answer a preceding
@@ -648,6 +738,7 @@ class RouterChatController extends ChangeNotifier {
     _lastUserMessage = null;
     _routerTools = null;
     _commandsByName = null;
+    _commandsLoad = null;
     _totalInputTokens = 0;
     _totalOutputTokens = 0;
     _totalCacheReadTokens = 0;
@@ -662,22 +753,35 @@ class RouterChatController extends ChangeNotifier {
   void refreshContext() {
     _initializeSystemPrompt();
   }
+
+  /// Test seam for [_abandonedToolResult], which is otherwise only reachable
+  /// through a specific abandonment sequence.
+  @visibleForTesting
+  Map<String, dynamic> debugAbandonedToolResultFor(String toolName) =>
+      _abandonedToolResult(toolName);
 }
 
 /// Internal result type for tool execution.
 class _ToolExecutionResult {
   final Map<String, dynamic> data;
   final bool isError;
-  final bool requiresConfirmation;
 
-  /// Set when [requiresConfirmation] is true — the confirmation the caller
-  /// should surface once the rest of the batch has finished executing.
+  /// The confirmation the caller must surface once the rest of the batch has
+  /// finished, or null when the tool ran to completion.
   final PendingConfirmation? pendingConfirmation;
 
   const _ToolExecutionResult({
     this.data = const {},
     this.isError = false,
-    this.requiresConfirmation = false,
-    this.pendingConfirmation,
-  });
+  }) : pendingConfirmation = null;
+
+  /// The tool was not run because it needs the user to confirm first.
+  const _ToolExecutionResult.awaitingConfirmation(
+    PendingConfirmation this.pendingConfirmation,
+  )   : data = const {},
+        isError = false;
+
+  /// Whether the caller must surface [pendingConfirmation] instead of recording
+  /// a result. Cannot disagree with [pendingConfirmation] being set.
+  bool get requiresConfirmation => pendingConfirmation != null;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -110,6 +110,21 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   args: ^2.6.0
 
+# TEMPORARY — local development only. Do not merge.
+# Points the UI kit packages at the local checkout so the unreleased
+# ChatMessage.toolResults() API can be used while fixing #1191.
+# All three must be overridden together: generative_ui and ui_kit_library
+# share gen_ui_contracts, and pub rejects mixing path and git sources for it.
+# Remove once the UI kit cuts a tag containing that commit and the
+# generative_ui / ui_kit_library refs above are bumped to it.
+dependency_overrides:
+  generative_ui:
+    path: ../privacyGUI-UI-kit/generative_ui
+  ui_kit_library:
+    path: ../privacyGUI-UI-kit
+  gen_ui_contracts:
+    path: ../privacyGUI-UI-kit/gen_ui_contracts
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,11 +59,11 @@ dependencies:
   ui_kit_library:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.30.1
+      ref: v2.31.0
   generative_ui:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.30.1
+      ref: v2.31.0
       path: generative_ui
   flutter_blue_plus: ^1.4.0
   crypto: ^3.0.2
@@ -109,21 +109,6 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^2.0.1
   args: ^2.6.0
-
-# TEMPORARY — local development only. Do not merge.
-# Points the UI kit packages at the local checkout so the unreleased
-# ChatMessage.toolResults() API can be used while fixing #1191.
-# All three must be overridden together: generative_ui and ui_kit_library
-# share gen_ui_contracts, and pub rejects mixing path and git sources for it.
-# Remove once the UI kit cuts a tag containing that commit and the
-# generative_ui / ui_kit_library refs above are bumped to it.
-dependency_overrides:
-  generative_ui:
-    path: ../privacyGUI-UI-kit/generative_ui
-  ui_kit_library:
-    path: ../privacyGUI-UI-kit
-  gen_ui_contracts:
-    path: ../privacyGUI-UI-kit/gen_ui_contracts
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/ai/orchestrator/router_chat_controller_test.dart
+++ b/test/ai/orchestrator/router_chat_controller_test.dart
@@ -526,6 +526,145 @@ void main() {
             .called(1);
       });
 
+      test('discards read results when the conversation is cleared mid-tool',
+          () async {
+        // The read tool is still in flight when the user hits Clear.
+        final gate = Completer<RouterCommandResult>();
+        when(() => mockCommandProvider.execute('getSystemInfo', any()))
+            .thenAnswer((_) => gate.future);
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async => _multiToolUseResponse([
+              ('read-1', 'getSystemInfo', const <String, dynamic>{}),
+            ]));
+
+        final pending = controller.sendMessage('Check my router');
+        await Future<void>.delayed(Duration.zero);
+
+        controller.clearConversation();
+        gate.complete(RouterCommandResult.success(const {'ok': true}));
+        await pending;
+
+        expect(controller.messages, isEmpty,
+            reason: 'a tool_result must never be written into a conversation '
+                'that was reset while the tool was running');
+      });
+
+      test('keeps a confirmation from re-arming in a cleared conversation',
+          () async {
+        final gate = Completer<RouterCommandResult>();
+        when(() => mockCommandProvider.execute('getSystemInfo', any()))
+            .thenAnswer((_) => gate.future);
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async => _multiToolUseResponse([
+              ('write-1', 'setWifiPassword', const {'password': 'secret'}),
+              ('read-1', 'getSystemInfo', const <String, dynamic>{}),
+            ]));
+
+        final pending = controller.sendMessage('Change then check');
+        await Future<void>.delayed(Duration.zero);
+
+        controller.clearConversation();
+        gate.complete(RouterCommandResult.success(const {'ok': true}));
+        await pending;
+
+        expect(controller.hasPendingConfirmation, isFalse,
+            reason: 'a confirmation belonging to a discarded conversation must '
+                'not be presented against the fresh one');
+        expect(controller.messages, isEmpty);
+      });
+
+      test('preserves real read results when a confirmation is abandoned',
+          () async {
+        var call = 0;
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async {
+          call++;
+          return call == 1
+              ? _multiToolUseResponse([
+                  ('read-1', 'getSystemInfo', const <String, dynamic>{}),
+                  ('write-1', 'setWifiPassword', const {'password': 'secret'}),
+                ])
+              : _textResponse('done');
+        });
+        when(() => mockCommandProvider.execute('getSystemInfo', any()))
+            .thenAnswer((_) async =>
+                RouterCommandResult.success(const {'model': 'MR7500'}));
+
+        await controller.sendMessage('Check and change');
+        expect(controller.hasPendingConfirmation, isTrue);
+
+        // User types instead of answering the dialog.
+        await controller.sendMessage('Never mind');
+
+        final parts = _partsOf(_toolResultMessages(controller.messages).first);
+        final byId = {for (final p in parts) p.toolUseId: p.result};
+
+        expect(byId['read-1']?['model'], 'MR7500',
+            reason: 'the read genuinely ran — its device data must survive');
+        expect(byId['write-1']?['status'], 'not_executed',
+            reason: 'the write never ran');
+      });
+
+      test('does not report an unexecuted command as rendered without registry',
+          () async {
+        // No command has been looked up yet, so the registry cache is null.
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async => _textResponse('hi'));
+        await controller.sendMessage('hello');
+
+        expect(
+          controller.debugAbandonedToolResultFor('setWifiPassword')['status'],
+          'not_executed',
+          reason: 'when the registry is unknown the safe answer is '
+              'not_executed — claiming success is the harmful direction',
+        );
+      });
+
+      test('ignores retry while a confirmation is still pending', () async {
+        var call = 0;
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async {
+          call++;
+          if (call == 1) {
+            return _multiToolUseResponse([
+              ('write-1', 'setWifiPassword', const {'password': 'secret'}),
+              ('read-1', 'getSystemInfo', const <String, dynamic>{}),
+            ]);
+          }
+          throw NetworkException('flaky');
+        });
+        when(() => mockCommandProvider.execute('getSystemInfo', any()))
+            .thenThrow(StateError('boom'));
+
+        await controller.sendMessage('Change then check');
+        expect(controller.hasPendingConfirmation, isTrue);
+
+        await controller.retry();
+
+        expect(controller.hasPendingConfirmation, isTrue,
+            reason: 'retry must not discard the pending write request');
+      });
+
       test('discards a confirmation result when the conversation was cleared',
           () async {
         final gate = Completer<RouterCommandResult>();

--- a/test/ai/orchestrator/router_chat_controller_test.dart
+++ b/test/ai/orchestrator/router_chat_controller_test.dart
@@ -526,6 +526,61 @@ void main() {
             .called(1);
       });
 
+      test('a stale exchange cannot discard the results of a live one',
+          () async {
+        // Gen 0's read is parked; the user clears, sends again, and gen 1
+        // accumulates its own results. Gen 0 must not touch them when it
+        // resumes.
+        final firstRead = Completer<RouterCommandResult>();
+        var reads = 0;
+        when(() => mockCommandProvider.execute('getSystemInfo', any()))
+            .thenAnswer((_) {
+          reads++;
+          return reads == 1
+              ? firstRead.future
+              : Future.value(RouterCommandResult.success(const {'gen': 1}));
+        });
+
+        // Ask for a read whenever the turn has no results yet, otherwise wrap
+        // up — independent of how many times the registry is reloaded.
+        var toolId = 0;
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((invocation) async {
+          final history =
+              invocation.positionalArguments[0] as List<ChatMessage>;
+          if (history.any((m) => m.isToolResult)) return _textResponse('done');
+          toolId++;
+          return _multiToolUseResponse([
+            ('read-$toolId', 'getSystemInfo', const <String, dynamic>{}),
+          ]);
+        });
+
+        final genZero = controller.sendMessage('First question');
+        await Future<void>.delayed(Duration.zero);
+
+        controller.clearConversation();
+        await controller.sendMessage('Second question');
+
+        // Gen 1 finished and emitted its own result.
+        final afterGenOne = _toolResultMessages(controller.messages);
+        expect(afterGenOne, hasLength(1));
+        expect(_partsOf(afterGenOne.single).single.result['gen'], 1);
+
+        // Now let gen 0's device call return.
+        firstRead.complete(RouterCommandResult.success(const {'gen': 0}));
+        await genZero;
+
+        final afterGenZero = _toolResultMessages(controller.messages);
+        expect(afterGenZero, hasLength(1),
+            reason: 'the stale exchange must neither emit nor erase anything');
+        expect(_partsOf(afterGenZero.single).single.result['gen'], 1,
+            reason: "gen 1's real result must survive gen 0 resuming");
+      });
+
       test('discards read results when the conversation is cleared mid-tool',
           () async {
         // The read tool is still in flight when the user hits Clear.

--- a/test/ai/orchestrator/router_chat_controller_test.dart
+++ b/test/ai/orchestrator/router_chat_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:generative_ui/generative_ui.dart';
 import 'package:mocktail/mocktail.dart';
@@ -298,6 +300,366 @@ void main() {
             )).called(1);
       });
     });
+
+    // =========================================================================
+    // Batched tool results (#1191)
+    //
+    // The Claude Messages API requires every tool_use block in an assistant
+    // message to be answered within the single user message that immediately
+    // follows it.
+    // =========================================================================
+
+    group('tool result batching', () {
+      test('answers parallel read tools in one message', () async {
+        when(() => mockCommandProvider.execute(any(), any())).thenAnswer(
+            (_) async => RouterCommandResult.success(const {'ok': true}));
+
+        var call = 0;
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async {
+          call++;
+          return call == 1
+              ? _multiToolUseResponse([
+                  ('read-1', 'getSystemInfo', const <String, dynamic>{}),
+                  ('read-2', 'getSystemInfo', const <String, dynamic>{}),
+                ])
+              : _textResponse('done');
+        });
+
+        await controller.sendMessage('Check twice');
+
+        final results = _toolResultMessages(controller.messages);
+        expect(results, hasLength(1),
+            reason: 'both results must share a single message');
+        expect(_partsOf(results.single).map((p) => p.toolUseId),
+            ['read-1', 'read-2']);
+      });
+
+      test('holds sibling results back until a confirmation is answered',
+          () async {
+        when(() => mockCommandProvider.execute(any(), any())).thenAnswer(
+            (_) async => RouterCommandResult.success(const {'ok': true}));
+
+        var call = 0;
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async {
+          call++;
+          return call == 1
+              ? _multiToolUseResponse([
+                  ('read-1', 'getSystemInfo', const <String, dynamic>{}),
+                  ('write-1', 'setWifiPassword', const {'password': 'secret'}),
+                ])
+              : _textResponse('done');
+        });
+
+        await controller.sendMessage('Check and change');
+
+        // Batch stays open while the dialog is showing.
+        expect(controller.hasPendingConfirmation, isTrue);
+        expect(_toolResultMessages(controller.messages), isEmpty,
+            reason: 'nothing may be emitted until the batch is complete');
+
+        await controller.confirmPendingAction();
+
+        final results = _toolResultMessages(controller.messages);
+        expect(results, hasLength(1));
+        expect(_partsOf(results.single).map((p) => p.toolUseId),
+            ['read-1', 'write-1'],
+            reason: 'every tool_use in the turn must be answered together');
+      });
+
+      test('answers sibling results when a confirmation is cancelled',
+          () async {
+        var call = 0;
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async {
+          call++;
+          return call == 1
+              ? _multiToolUseResponse([
+                  ('read-1', 'getSystemInfo', const <String, dynamic>{}),
+                  ('write-1', 'setWifiPassword', const {'password': 'secret'}),
+                ])
+              : _textResponse('ok, cancelled');
+        });
+        when(() => mockCommandProvider.execute('getSystemInfo', any()))
+            .thenAnswer(
+                (_) async => RouterCommandResult.success(const {'ok': true}));
+
+        await controller.sendMessage('Check and change');
+        await controller.cancelPendingAction();
+
+        final results = _toolResultMessages(controller.messages);
+        expect(results, hasLength(1));
+        expect(_partsOf(results.single).map((p) => p.toolUseId),
+            ['read-1', 'write-1']);
+        verifyNever(
+            () => mockCommandProvider.execute('setWifiPassword', any()));
+      });
+
+      test('does not drop the first of two confirmation-required tools',
+          () async {
+        var call = 0;
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async {
+          call++;
+          return call == 1
+              ? _multiToolUseResponse([
+                  ('write-1', 'setWifiPassword', const {'password': 'one'}),
+                  ('write-2', 'setWifiPassword', const {'password': 'two'}),
+                ])
+              : _textResponse('done');
+        });
+        when(() => mockCommandProvider.execute(any(), any())).thenAnswer(
+            (_) async => RouterCommandResult.success(const {'ok': true}));
+
+        await controller.sendMessage('Change twice');
+
+        // The first one is what the user is asked about.
+        expect(controller.pendingConfirmation?.params['password'], 'one');
+
+        await controller.confirmPendingAction();
+
+        final parts = _partsOf(_toolResultMessages(controller.messages).single);
+        expect(parts.map((p) => p.toolUseId), ['write-2', 'write-1'],
+            reason: 'the deferred tool is still answered, not silently lost');
+
+        // Only the confirmed one ran; the extra is deferred to a later turn.
+        verify(() => mockCommandProvider.execute('setWifiPassword', any()))
+            .called(1);
+      });
+
+      test('confirming cannot re-enter the loop while siblings still run',
+          () async {
+        // Resolve the read tool only when told to, so the dialog would appear
+        // mid-loop if the controller still notified from inside _executeToolUse.
+        final gate = Completer<RouterCommandResult>();
+        when(() => mockCommandProvider.execute('getSystemInfo', any()))
+            .thenAnswer((_) => gate.future);
+        when(() => mockCommandProvider.execute('setWifiPassword', any()))
+            .thenAnswer(
+                (_) async => RouterCommandResult.success(const {'ok': true}));
+
+        var call = 0;
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async {
+          call++;
+          return call == 1
+              ? _multiToolUseResponse([
+                  ('write-1', 'setWifiPassword', const {'password': 'secret'}),
+                  ('read-1', 'getSystemInfo', const <String, dynamic>{}),
+                ])
+              : _textResponse('done');
+        });
+
+        final pending = controller.sendMessage('Change then check');
+        await Future<void>.delayed(Duration.zero);
+
+        // Write came first, but the dialog must not be offered yet because the
+        // read tool is still in flight.
+        expect(controller.hasPendingConfirmation, isFalse);
+
+        gate.complete(RouterCommandResult.success(const {'ok': true}));
+        await pending;
+
+        expect(controller.hasPendingConfirmation, isTrue);
+      });
+
+      test('retry keeps tool results and does not duplicate the question',
+          () async {
+        var call = 0;
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async {
+          call++;
+          if (call == 1) {
+            return _multiToolUseResponse([
+              ('read-1', 'getSystemInfo', const <String, dynamic>{}),
+            ]);
+          }
+          // The call right after the flush fails, then the retry succeeds.
+          if (call == 2) throw NetworkException('flaky');
+          return _textResponse('Your router is MR7500.');
+        });
+        when(() => mockCommandProvider.execute('getSystemInfo', any()))
+            .thenAnswer((_) async =>
+                RouterCommandResult.success(const {'m': 'MR7500'}));
+
+        await controller.sendMessage('What router do I have?');
+        expect(controller.hasError, isTrue);
+
+        await controller.retry();
+
+        // The real device result must survive — it answers an earlier tool_use.
+        final parts = _partsOf(_toolResultMessages(controller.messages).single);
+        expect(parts.single.result['m'], 'MR7500',
+            reason: 'retry must not destroy a flushed tool result');
+        expect(
+          controller.messages.where((m) => m.isUser && !m.isToolResult).length,
+          1,
+          reason: 'the question must not be asked twice',
+        );
+        // The command already ran; retry resumes rather than re-executing.
+        verify(() => mockCommandProvider.execute('getSystemInfo', any()))
+            .called(1);
+      });
+
+      test('discards a confirmation result when the conversation was cleared',
+          () async {
+        final gate = Completer<RouterCommandResult>();
+        when(() => mockCommandProvider.execute('setWifiPassword', any()))
+            .thenAnswer((_) => gate.future);
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async => _multiToolUseResponse([
+              ('write-1', 'setWifiPassword', const {'password': 'secret'}),
+            ]));
+
+        await controller.sendMessage('Change it');
+        final confirming = controller.confirmPendingAction();
+
+        // User clears the chat while the device request is still in flight.
+        controller.clearConversation();
+        gate.complete(RouterCommandResult.success(const {'ok': true}));
+        await confirming;
+
+        expect(controller.messages, isEmpty,
+            reason: 'a stale result must not be injected into a fresh '
+                'conversation, where it would have no matching tool_use');
+      });
+
+      test('answers already-executed tools when the batch fails part-way',
+          () async {
+        var call = 0;
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async {
+          call++;
+          if (call == 1) {
+            return _multiToolUseResponse([
+              ('read-1', 'getSystemInfo', const <String, dynamic>{}),
+            ]);
+          }
+          throw NetworkException('flaky');
+        });
+        when(() => mockCommandProvider.execute('getSystemInfo', any()))
+            .thenAnswer(
+                (_) async => RouterCommandResult.success(const {'ok': true}));
+
+        await controller.sendMessage('Check');
+
+        expect(controller.hasError, isTrue);
+        final results = _toolResultMessages(controller.messages);
+        expect(results, hasLength(1),
+            reason: 'the executed tool must still be answered so the '
+                'assistant turn has no unanswered tool_use');
+        expect(_partsOf(results.single).single.toolUseId, 'read-1');
+      });
+
+      test('keeps a confirmation that was found before a failure', () async {
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async => _multiToolUseResponse([
+              ('write-1', 'setWifiPassword', const {'password': 'secret'}),
+              ('read-1', 'getSystemInfo', const <String, dynamic>{}),
+            ]));
+        // The sibling read blows up after the confirmation was discovered.
+        when(() => mockCommandProvider.execute('getSystemInfo', any()))
+            .thenThrow(StateError('boom'));
+
+        await controller.sendMessage('Change then check');
+
+        expect(controller.hasPendingConfirmation, isTrue,
+            reason: "the user's write request must not evaporate");
+        expect(controller.pendingConfirmation!.command.name, 'setWifiPassword');
+      });
+
+      test('reports abandoned commands as not executed, not as rendered',
+          () async {
+        var call = 0;
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async {
+          call++;
+          return call == 1
+              ? _multiToolUseResponse([
+                  ('write-1', 'setWifiPassword', const {'password': 'secret'}),
+                ])
+              : _textResponse('done');
+        });
+
+        await controller.sendMessage('Change it');
+        await controller.sendMessage('Actually, never mind');
+
+        final parts = _partsOf(_toolResultMessages(controller.messages).first);
+        expect(parts.single.result['status'], 'not_executed',
+            reason: 'the command never ran — saying "rendered" misleads the '
+                'model into thinking it succeeded');
+      });
+
+      test('fills in unanswered tool_use when the user types instead',
+          () async {
+        var call = 0;
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async {
+          call++;
+          return call == 1
+              ? _multiToolUseResponse([
+                  ('write-1', 'setWifiPassword', const {'password': 'secret'}),
+                ])
+              : _textResponse('done');
+        });
+
+        await controller.sendMessage('Change it');
+        expect(controller.hasPendingConfirmation, isTrue);
+
+        // User ignores the dialog and asks something else instead.
+        await controller.sendMessage('Never mind, what is my model?');
+
+        expect(controller.hasPendingConfirmation, isFalse);
+        final parts = _partsOf(_toolResultMessages(controller.messages).single);
+        expect(parts.map((p) => p.toolUseId), ['write-1'],
+            reason: 'the abandoned tool_use must still be answered');
+      });
+    });
   });
 }
 
@@ -326,3 +688,26 @@ LLMResponse _toolUseResponse(String toolName, Map<String, dynamic> input) {
     ],
   );
 }
+
+/// Build a response containing several tool_use blocks with fixed ids, so tests
+/// can assert on which ids were answered and in what order.
+LLMResponse _multiToolUseResponse(
+  List<(String id, String name, Map<String, dynamic> input)> tools,
+) {
+  return LLMResponse(
+    id: 'resp-${DateTime.now().millisecondsSinceEpoch}',
+    model: 'test-model',
+    content: [
+      for (final (id, name, input) in tools)
+        ToolUseBlock(id: id, name: name, input: input),
+    ],
+  );
+}
+
+/// The tool result messages of a conversation, in order.
+List<ChatMessage> _toolResultMessages(List<ChatMessage> messages) =>
+    messages.where((m) => m.isToolResult).toList();
+
+/// The tool result parts carried by a single tool result message.
+List<ToolResultPart> _partsOf(ChatMessage message) =>
+    (message.content as List<ContentPart>).whereType<ToolResultPart>().toList();


### PR DESCRIPTION
## Summary

Fixes #1191.

The Claude Messages API requires every `tool_use` block in an assistant message to be answered by `tool_result` blocks carried in the **single** user message that immediately follows it. `RouterChatController` emitted one `ChatMessage.toolResult` per result — one user message each — and a confirmation-gated command left its `tool_use` unanswered entirely. Both make the API reject the whole request.

This PR batches results into one message per assistant turn, and fixes six further problems found in the same flow while verifying that change.

## Why the API contract matters here

```json
{"role": "assistant", "content": [
    {"type": "tool_use", "id": "A", "name": "getWanStatus"},
    {"type": "tool_use", "id": "B", "name": "setDmz"}
]}
{"role": "user", "content": [
    {"type": "tool_result", "tool_use_id": "A", "content": "..."},
    {"type": "tool_result", "tool_use_id": "B", "content": "..."}
]}
```

Both results must sit in **one** user message. Order is irrelevant (matching is by `tool_use_id`), but completeness and grouping are not — a violation is rejected wholesale, not partially tolerated.

The old loop produced two consecutive user messages for two tools, and when one tool needed confirmation it emitted the siblings' results and returned, leaving that `tool_use` with no answer at all. `_insertPendingToolResults()` could not repair it: it is only called from `sendMessage()` (so pressing Confirm never reaches it) and it returned early on encountering any existing `tool_result` — which is exactly the state the bug produces.

Low-impact today because there is currently no write command on `dev-2.7.0`. It becomes easy to trigger as soon as write commands land: users naturally say "check my network and turn X off", and the model answers with several tools at once.

## The change

**`lib/ai/orchestrator/router_chat_controller.dart`**

Results accumulate in `_pendingResults` and are flushed as a single `ChatMessage.toolResults` message once the batch is complete. A pending confirmation keeps the batch open across the dialog, so sibling results are held back and flushed together with the write result. Invisible to the user — tool results are never rendered in the chat.

New members:

| Member | Purpose |
|---|---|
| `_pendingResults` | Accumulates the current batch |
| `_conversationGeneration` | Detects that the conversation was reset while work was in flight |
| `_commandsByName` | Command lookup cache (was re-querying the provider per tool) |
| `_flushPendingResults()` | Emits the batch as one message |
| `_completeBatch(generation)` | Flushes only if the generation is still current |
| `_abandonBatch(deferred)` | Winds down a failed batch: answers what ran, keeps a confirmation |
| `_abandonedToolResult(name)` | Distinguishes commands from A2UI components |

Also fixed, all in the same flow:

- **Two confirmation-required commands in one response no longer drop the first.** Only the first is executed; the rest are answered with `status: 'not_executed'` and a reason, so the model asks again in a later turn. Previously the single `_pendingConfirmation` field was overwritten and the first `tool_use` could never be answered — with no user-visible indication.
- **The dialog is surfaced after the tool loop finishes.** `_executeToolUse()` now *reports* a `PendingConfirmation` instead of assigning it and notifying mid-loop, so confirming while siblings are still awaiting can no longer start a second concurrent `_processConversation()`.
- **`retry()` no longer deletes a flushed tool result.** Tool result messages also carry `ChatRole.user`, so "remove the failed user message" destroyed real device data whenever the failure landed on the LLM call *after* a successful flush — the typical retryable case. It now excludes tool results, and resumes the exchange instead of re-asking the question when tools already ran.
- **A confirmation resolving after `clearConversation()` no longer injects an orphan.** The Clear button has no in-flight guard, so a result could arrive after the reset and become the first message of a fresh conversation — a `tool_result` with no preceding `tool_use`, which breaks *every* later request and cannot be repaired by `_insertPendingToolResults()` (it only walks back to the trailing assistant turn). Guarded by the generation counter.
- **A failure mid-batch now answers the tools that did run**, instead of discarding results for commands that already executed against the device, and **keeps a confirmation discovered before the failure** (`deferred` moved out of the `try`, which previously let a write request evaporate with no Retry affordance).
- **Abandoned commands report `not_executed` rather than `rendered`.** The `{'status': 'rendered'}` placeholder is correct for A2UI components but told the model an unexecuted command had succeeded.
- **`handleToolAction()` closes out an unanswered previous turn** rather than leaving `_pendingConfirmation` live while appending its own single-part result.

**`test/ai/orchestrator/router_chat_controller_test.dart`** — new `tool result batching` group, 11 tests, one per problem above plus the `_insertPendingToolResults` path.

**`pubspec.yaml`** — bump `ui_kit_library` / `generative_ui` to `v2.31.0`, which contains the new `ChatMessage.toolResults(List<ToolResultPart>)` factory (UI kit commit `53aaeb80`). That factory is additive: `ChatMessage.toolResult` is untouched, and for a single part both produce identical output.

## Verification

| Check | Result |
|---|---|
| `flutter test test/ai/ test/page/ai_assistant/` | **59/59 pass** (48 pre-existing + 11 new) |
| `./run_tests.sh` (full functional suite) | **3350/3350 pass** |
| `flutter analyze` on changed files | clean |
| `fvm dart format` | 2 files, 0 changed |
| UI kit `generative_ui` package tests | 189/189 pass (7 new for the factory) |

The full suite was run because the UI kit bump spans three minor versions (v2.28.1 → v2.31.0) and affects the whole project, not just the AI module. Verified against the released `v2.31.0` tag, not a local override.

Two pre-existing `prefer_const_literals` infos remain in the test file (lines 136, 184) — present on `dev-2.7.0`, untouched by this PR.

## Notes for reviewers

- `handleToolAction()` is currently unreachable: the A2UI action payload carries `surfaceId` / `sourceComponentId` / `name`, not `toolUseId`, so the view returns early. Its fix is in place for when that wiring is completed.
- Only one confirmation is processed per turn by design. A full confirmation queue was considered and rejected as premature — the current behaviour is explicit (nothing is silently dropped) and avoids firing consecutive dialogs at the user.
- `_pendingResults` ordering follows execution, not `tool_use` order (a confirmed write is appended after its siblings). This is fine — the API matches by `tool_use_id`.
- Prerequisite for #1192 and for opening up write commands.
