### PR TITLE
feat(cloud): route client-side RA requests through router /cloud proxy on local builds (#1179)

### DIFF
--- a/lib/constants/cloud_const.dart
+++ b/lib/constants/cloud_const.dart
@@ -47,6 +47,12 @@ const kSessionInfo =
     '/v1/guardians/remote-assistances/sessions/$kVarRASessionId';
 const kCreatePin = '/v1/guardians/remote-assistances/sessions/pin';
 
+/// Path prefix for the router's reverse proxy to cloud (same-origin), used only
+/// for client-side RA requests on a local web build so the browser avoids CORS.
+/// NOTE: exact prefix NOT YET CONFIRMED by firmware — single point of change.
+/// Must NOT end with a trailing slash (endpoints already start with '/').
+const kProxyPrefix = '/cloud';
+
 // Client type id/secret
 final kClientTypeId = clientTypeID;
 final kClientSecret = clientTypeSecret;

--- a/lib/constants/cloud_const.dart
+++ b/lib/constants/cloud_const.dart
@@ -49,7 +49,8 @@ const kCreatePin = '/v1/guardians/remote-assistances/sessions/pin';
 
 /// Path prefix for the router's reverse proxy to cloud (same-origin), used only
 /// for client-side RA requests on a local web build so the browser avoids CORS.
-/// NOTE: exact prefix NOT YET CONFIRMED by firmware — single point of change.
+/// Verified end-to-end against QA + Production + router FW (see issue #1179);
+/// kept as a single point of change should the FW prefix ever move.
 /// Must NOT end with a trailing slash (endpoints already start with '/').
 const kProxyPrefix = '/cloud';
 

--- a/lib/core/cloud/cloud_host_resolver.dart
+++ b/lib/core/cloud/cloud_host_resolver.dart
@@ -1,0 +1,47 @@
+import 'package:privacy_gui/constants/_constants.dart';
+
+/// Resolves the URL **base** (scheme + host [+ port], plus proxy prefix when
+/// proxying) to prepend to a Guardian API endpoint.
+///
+/// When the web app is served from the router itself (local build), the browser
+/// origin is the router's LAN address. Client-side Remote Assistance requests
+/// that hit the cloud host directly are blocked by CORS, so they are instead
+/// routed through the router's reverse proxy ([kProxyPrefix]) to stay
+/// same-origin. CA-side requests (support agent, cloud-hosted portal) must
+/// always go direct to the cloud host.
+///
+/// Selection rule:
+/// - CA-side → always direct cloud.
+/// - Client-side → router proxy **iff** this is a local build AND the origin is
+///   resolvable; otherwise direct cloud (safe fallback).
+///
+/// [originGetter] and [isLocal] are injected so the resolver is unit-testable
+/// without a browser. The defaults ([_emptyOrigin] and [BuildConfig.isLocal])
+/// deterministically resolve to the cloud base in the unit-test environment.
+class CloudHostResolver {
+  /// Returns the current browser origin (scheme+host+port), e.g.
+  /// `https://192.168.1.1`. Empty when unavailable (non-web / not resolvable).
+  final String Function() _originGetter;
+
+  /// Whether this build is a local (router-hosted) build.
+  final bool Function() _isLocal;
+
+  CloudHostResolver({
+    String Function()? originGetter,
+    bool Function()? isLocal,
+  })  : _originGetter = originGetter ?? _emptyOrigin,
+        _isLocal = isLocal ?? BuildConfig.isLocal;
+
+  static String _emptyOrigin() => '';
+
+  /// Direct cloud base — always `https://<cloudBase>`.
+  String get _cloudBase => 'https://${cloudEnvironmentConfig[kCloudBase]}';
+
+  /// URL base to prepend to a Guardian endpoint.
+  String resolve({required bool forCA}) {
+    if (forCA || !_isLocal()) return _cloudBase;
+    final origin = _originGetter();
+    if (origin.isEmpty) return _cloudBase; // fallback: never break on no origin
+    return '$origin$kProxyPrefix'; // e.g. https://192.168.1.1/cloud
+  }
+}

--- a/lib/core/cloud/guardian_api_client.dart
+++ b/lib/core/cloud/guardian_api_client.dart
@@ -9,10 +9,11 @@ import 'package:privacy_gui/core/cloud/http/linksys_http_client.dart';
 import 'package:privacy_gui/core/cloud/model/guardians_remote_assistance.dart';
 import 'package:privacy_gui/core/cloud/model/error_response.dart';
 import 'package:privacy_gui/core/utils/extension.dart';
+import 'package:privacy_gui/core/utils/ip_getter/ip_getter.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 
 final guardianApiClientProvider = Provider((ref) => GuardianApiClient(
-      hostResolver: CloudHostResolver(originGetter: () => Uri.base.origin),
+      hostResolver: CloudHostResolver(originGetter: getCloudOrigin),
     ));
 
 /// API client for Guardian Remote Assistance services.

--- a/lib/core/cloud/guardian_api_client.dart
+++ b/lib/core/cloud/guardian_api_client.dart
@@ -4,13 +4,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:privacy_gui/constants/_constants.dart';
+import 'package:privacy_gui/core/cloud/cloud_host_resolver.dart';
 import 'package:privacy_gui/core/cloud/http/linksys_http_client.dart';
 import 'package:privacy_gui/core/cloud/model/guardians_remote_assistance.dart';
 import 'package:privacy_gui/core/cloud/model/error_response.dart';
 import 'package:privacy_gui/core/utils/extension.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 
-final guardianApiClientProvider = Provider((ref) => GuardianApiClient());
+final guardianApiClientProvider = Provider((ref) => GuardianApiClient(
+      hostResolver: CloudHostResolver(originGetter: () => Uri.base.origin),
+    ));
 
 /// API client for Guardian Remote Assistance services.
 ///
@@ -23,12 +26,25 @@ final guardianApiClientProvider = Provider((ref) => GuardianApiClient());
 /// 2. **CA (support agent)**: Authorization header with session token
 class GuardianApiClient {
   final LinksysHttpClient _http;
+  final CloudHostResolver _hostResolver;
 
-  GuardianApiClient({LinksysHttpClient? httpClient})
-      : _http = httpClient ?? LinksysHttpClient();
+  GuardianApiClient({
+    LinksysHttpClient? httpClient,
+    CloudHostResolver? hostResolver,
+  })  : _http = httpClient ?? LinksysHttpClient(),
+        _hostResolver = hostResolver ?? CloudHostResolver();
 
-  String _buildUrl(String endpoint, {Map<String, String>? args}) {
-    String url = 'https://${cloudEnvironmentConfig[kCloudBase]}$endpoint';
+  /// Builds an absolute URL for a Guardian [endpoint].
+  ///
+  /// [forCA] selects the host base: CA-side requests always target the cloud
+  /// host directly; client-side requests may be routed through the router's
+  /// reverse proxy on local builds. See [CloudHostResolver].
+  String _buildUrl(
+    String endpoint, {
+    Map<String, String>? args,
+    required bool forCA,
+  }) {
+    String url = '${_hostResolver.resolve(forCA: forCA)}$endpoint';
     args?.forEach((key, value) => url = url.replaceFirst(key, value));
     return url;
   }
@@ -65,7 +81,9 @@ class GuardianApiClient {
     }
 
     logger.d('[Guardian] Fetching new device token');
-    final url = Uri.parse(_buildUrl(kDeviceToken)).replace(queryParameters: {
+    // Client-side (device owner) request → may proxy through the router.
+    final url = Uri.parse(_buildUrl(kDeviceToken, forCA: false))
+        .replace(queryParameters: {
       'serialNumber': serialNumber,
       'macAddress': macAddress,
       'uuid': deviceUUID.toUpperCase(),
@@ -213,7 +231,11 @@ class GuardianApiClient {
     String? serialNumber,
     String? sessionToken,
   }) async {
-    final url = Uri.parse(_buildUrl(endpoint, args: args));
+    // CA-side requests authenticate with a session token and must always hit
+    // the cloud host directly; deriving forCA here keeps it in lock-step with
+    // the auth-header branch below (no drift possible).
+    final forCA = sessionToken != null;
+    final url = Uri.parse(_buildUrl(endpoint, args: args, forCA: forCA));
     final headers = Map<String, String>.from(_defaultHeaders);
 
     if (sessionToken != null) {

--- a/lib/core/utils/ip_getter/get_local_ip.dart
+++ b/lib/core/utils/ip_getter/get_local_ip.dart
@@ -20,3 +20,8 @@ String getLocalIp(ProviderReader read) =>
 
 String getFullLocation(ProviderReader read) =>
     throw UnsupportedError('[Platform ERROR] Get Full Location');
+
+/// Browser origin (scheme + host [+ port]), e.g. `https://192.168.1.1`.
+/// Empty on non-web, where there is no browser origin and CORS does not apply.
+/// Unlike [getLocalIp] (host only), this preserves the scheme for same-origin.
+String getCloudOrigin() => '';

--- a/lib/core/utils/ip_getter/mobile_get_local_ip.dart
+++ b/lib/core/utils/ip_getter/mobile_get_local_ip.dart
@@ -6,3 +6,7 @@ String getLocalIp(ProviderReader read) => '';
 
 String getFullLocation(ProviderReader read) =>
     throw UnsupportedError('[Platform ERROR] Get Full Location');
+
+/// No browser origin on mobile and CORS does not apply → empty string, so the
+/// cloud host resolver falls back to the direct cloud base.
+String getCloudOrigin() => '';

--- a/lib/core/utils/ip_getter/web_get_local_ip.dart
+++ b/lib/core/utils/ip_getter/web_get_local_ip.dart
@@ -5,3 +5,5 @@ import 'get_local_ip.dart';
 String getLocalIp(ProviderReader read) => window.location.host;
 
 String getFullLocation(ProviderReader read) => window.location.toString();
+
+String getCloudOrigin() => window.location.origin;

--- a/test/core/cloud/cloud_host_resolver_test.dart
+++ b/test/core/cloud/cloud_host_resolver_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/constants/_constants.dart';
+import 'package:privacy_gui/core/cloud/cloud_host_resolver.dart';
+
+void main() {
+  // Assert against the configured cloud base (not a hardcoded domain) so the
+  // test is independent of the active CloudEnvironment.
+  final cloudBase = 'https://${cloudEnvironmentConfig[kCloudBase]}';
+
+  group('CloudHostResolver', () {
+    test('local build + client → router proxy base', () {
+      final resolver = CloudHostResolver(
+        isLocal: () => true,
+        originGetter: () => 'https://192.168.1.1',
+      );
+
+      expect(
+          resolver.resolve(forCA: false), 'https://192.168.1.1$kProxyPrefix');
+    });
+
+    test('local build + CA → cloud base (origin ignored)', () {
+      final resolver = CloudHostResolver(
+        isLocal: () => true,
+        originGetter: () => 'https://192.168.1.1',
+      );
+
+      expect(resolver.resolve(forCA: true), cloudBase);
+    });
+
+    test('local build + empty origin → cloud base (fallback)', () {
+      final resolver = CloudHostResolver(
+        isLocal: () => true,
+        originGetter: () => '',
+      );
+
+      expect(resolver.resolve(forCA: false), cloudBase);
+    });
+
+    test('non-local build + client → cloud base', () {
+      final resolver = CloudHostResolver(
+        isLocal: () => false,
+        originGetter: () => 'https://192.168.1.1',
+      );
+
+      expect(resolver.resolve(forCA: false), cloudBase);
+    });
+
+    test('origin with port is preserved', () {
+      final resolver = CloudHostResolver(
+        isLocal: () => true,
+        originGetter: () => 'https://192.168.1.1:8443',
+      );
+
+      expect(
+        resolver.resolve(forCA: false),
+        'https://192.168.1.1:8443$kProxyPrefix',
+      );
+    });
+
+    test('http origin scheme is preserved (not forced to https)', () {
+      final resolver = CloudHostResolver(
+        isLocal: () => true,
+        originGetter: () => 'http://192.168.1.1',
+      );
+
+      expect(resolver.resolve(forCA: false), 'http://192.168.1.1$kProxyPrefix');
+    });
+
+    test('default constructor → cloud base (deterministic in test env)', () {
+      // Defaults: origin empty + BuildConfig.isLocal (false under force=none).
+      final resolver = CloudHostResolver();
+
+      expect(resolver.resolve(forCA: false), cloudBase);
+      expect(resolver.resolve(forCA: true), cloudBase);
+    });
+  });
+}

--- a/test/core/cloud/cloud_host_resolver_test.dart
+++ b/test/core/cloud/cloud_host_resolver_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:privacy_gui/constants/_constants.dart';
 import 'package:privacy_gui/core/cloud/cloud_host_resolver.dart';
+import 'package:privacy_gui/core/utils/ip_getter/ip_getter.dart';
 
 void main() {
   // Assert against the configured cloud base (not a hardcoded domain) so the
@@ -72,6 +73,27 @@ void main() {
 
       expect(resolver.resolve(forCA: false), cloudBase);
       expect(resolver.resolve(forCA: true), cloudBase);
+    });
+  });
+
+  group('getCloudOrigin (platform stub) → resolver integration', () {
+    // Tests run on the Dart VM, which selects the non-web (stub/mobile)
+    // implementation. It MUST return '' — never call Uri.base.origin, which
+    // throws a StateError on a file: URI. This locks in the non-web crash fix.
+    test('returns empty string on non-web', () {
+      expect(getCloudOrigin(), isEmpty);
+    });
+
+    test('local build + non-web origin → falls back to cloud base (no throw)',
+        () {
+      // Emulates a mobile .local build: isLocal() true, but getCloudOrigin()
+      // yields '' → resolver must fall back to the cloud base without throwing.
+      final resolver = CloudHostResolver(
+        isLocal: () => true,
+        originGetter: getCloudOrigin,
+      );
+
+      expect(resolver.resolve(forCA: false), cloudBase);
     });
   });
 }

--- a/test/core/cloud/guardian_api_client_test.dart
+++ b/test/core/cloud/guardian_api_client_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/constants/_constants.dart';
+import 'package:privacy_gui/core/cloud/cloud_host_resolver.dart';
+import 'package:privacy_gui/core/cloud/guardian_api_client.dart';
+import 'package:privacy_gui/core/cloud/http/linksys_http_client.dart';
+
+import '../../mocks/test_data/remote_assistance_test_data.dart';
+
+class MockLinksysHttpClient extends Mock implements LinksysHttpClient {}
+
+class FakeUri extends Fake implements Uri {}
+
+/// Verifies that [GuardianApiClient] assembles request URLs against the correct
+/// host base: client-side requests go through the router proxy on a local
+/// build, while CA-side requests always target the cloud host directly.
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeUri());
+  });
+
+  const routerOrigin = 'https://192.168.1.1';
+  final cloudBase = 'https://${cloudEnvironmentConfig[kCloudBase]}';
+
+  late MockLinksysHttpClient mockHttp;
+  late GuardianApiClient client;
+
+  setUp(() {
+    mockHttp = MockLinksysHttpClient();
+    // Simulate a local (router-hosted) build so client-side requests proxy.
+    client = GuardianApiClient(
+      httpClient: mockHttp,
+      hostResolver: CloudHostResolver(
+        isLocal: () => true,
+        originGetter: () => routerOrigin,
+      ),
+    );
+  });
+
+  /// Captures the [Uri] passed to a mocked verb without hitting the network.
+  Uri capturedGetUri() =>
+      verify(() => mockHttp.get(captureAny(), headers: any(named: 'headers')))
+          .captured
+          .single as Uri;
+
+  Uri capturedPostUri() =>
+      verify(() => mockHttp.post(captureAny(), headers: any(named: 'headers')))
+          .captured
+          .single as Uri;
+
+  Uri capturedDeleteUri() => verify(
+          () => mockHttp.delete(captureAny(), headers: any(named: 'headers')))
+      .captured
+      .single as Uri;
+
+  group('client-side requests → router proxy', () {
+    test('getSessions targets proxy base', () async {
+      when(() => mockHttp.get(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async => http.Response('{"content":[]}', 200));
+
+      await client.getSessions(
+        linksysToken: RemoteAssistanceTestData.testDeviceToken,
+        serialNumber: RemoteAssistanceTestData.testSerialNumber,
+      );
+
+      expect(
+          capturedGetUri().toString(), '$routerOrigin$kProxyPrefix$kSessions');
+    });
+
+    test('getSessionInfo targets proxy base with session id substituted',
+        () async {
+      when(() => mockHttp.get(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async => http.Response('{}', 200));
+
+      await client.getSessionInfo(
+        linksysToken: RemoteAssistanceTestData.testDeviceToken,
+        sessionId: RemoteAssistanceTestData.testSessionId,
+        serialNumber: RemoteAssistanceTestData.testSerialNumber,
+      );
+
+      final expected = '$routerOrigin$kProxyPrefix'
+          '${kSessionInfo.replaceFirst(kVarRASessionId, RemoteAssistanceTestData.testSessionId)}';
+      expect(capturedGetUri().toString(), expected);
+    });
+
+    test('createPin targets proxy base', () async {
+      when(() => mockHttp.post(any(), headers: any(named: 'headers')))
+          .thenAnswer(
+              (_) async => http.Response('{"id":"s1","pin":"1234"}', 200));
+
+      await client.createPin(
+        linksysToken: RemoteAssistanceTestData.testDeviceToken,
+        serialNumber: RemoteAssistanceTestData.testSerialNumber,
+      );
+
+      expect(capturedPostUri().toString(),
+          '$routerOrigin$kProxyPrefix$kCreatePin');
+    });
+
+    test('deleteSession targets proxy base with session id substituted',
+        () async {
+      when(() => mockHttp.delete(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async => http.Response('', 200));
+
+      await client.deleteSession(
+        linksysToken: RemoteAssistanceTestData.testDeviceToken,
+        sessionId: RemoteAssistanceTestData.testSessionId,
+        serialNumber: RemoteAssistanceTestData.testSerialNumber,
+      );
+
+      final expected = '$routerOrigin$kProxyPrefix'
+          '${kSessionInfo.replaceFirst(kVarRASessionId, RemoteAssistanceTestData.testSessionId)}';
+      expect(capturedDeleteUri().toString(), expected);
+    });
+  });
+
+  group('CA-side requests → cloud (bypass proxy even on local build)', () {
+    test('getSessionInfoForCA targets cloud base', () async {
+      when(() => mockHttp.get(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async => http.Response('{}', 200));
+
+      await client.getSessionInfoForCA(
+        sessionToken: RemoteAssistanceTestData.testSessionToken,
+        sessionId: RemoteAssistanceTestData.testSessionId,
+      );
+
+      final expected = '$cloudBase'
+          '${kSessionInfo.replaceFirst(kVarRASessionId, RemoteAssistanceTestData.testSessionId)}';
+      expect(capturedGetUri().toString(), expected);
+    });
+
+    test('deleteSessionForCA targets cloud base', () async {
+      when(() => mockHttp.delete(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async => http.Response('', 200));
+
+      await client.deleteSessionForCA(
+        sessionToken: RemoteAssistanceTestData.testSessionToken,
+        sessionId: RemoteAssistanceTestData.testSessionId,
+      );
+
+      final expected = '$cloudBase'
+          '${kSessionInfo.replaceFirst(kVarRASessionId, RemoteAssistanceTestData.testSessionId)}';
+      expect(capturedDeleteUri().toString(), expected);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Restores the 1.x behavior of routing **client-side** Remote Assistance requests through the router's `/cloud` reverse proxy on local builds, so they stay **same-origin** and avoid the CORS `Failed to fetch` that occurs when the web app is served from the router itself (origin = router LAN IP).

Closes #1179.

## Changes

- **`kProxyPrefix` constant** (`cloud_const.dart`) — single point of change for the FW proxy prefix (`/cloud`).
- **`CloudHostResolver`** (`core/cloud/cloud_host_resolver.dart`) — client-side + local build → router `/cloud` proxy base; CA-side or non-local build → direct cloud base, with a safe fallback to the cloud host when the origin is unresolvable.
- **`GuardianApiClient`** — injects the resolver and threads `forCA` through `_buildUrl`/`_request`, derived from `sessionToken != null` so it stays in lock-step with the auth-header branch. **CA-side requests always target the cloud host directly**, even on a local build (the CA portal is cloud-hosted and must never be proxied).
- **Platform-safe `getCloudOrigin()`** (`core/utils/ip_getter/`) — web returns `window.location.origin`; non-web (mobile/stub) returns `''` so the resolver falls back to the cloud base. `Uri.base.origin` throws a `StateError` on the `file:` URI used by the Dart VM / non-web runtime, so this avoids a non-web crash.

## Compatibility

- **Non-local builds are byte-for-byte identical to today.**
- CA-side flow unchanged — always hits the cloud host directly.

## Verification (see #1179)

- **QA + Production `guardian.tools`** now accept the `/cloud` prefix (no longer return the SPA `index.html`); the Host/prefix coupling is resolved cloud-side.
- **End-to-end through the router FW `/cloud` proxy**, with a real device SN, returns `200 application/json` carrying a real `linksysToken` — same-origin, no redirect, no CORS.

> Note: a local nginx dev-proxy must forward `/cloud` over `https` (`proxy_pass https://<router-ip>; proxy_ssl_verify off;`) — an `http` upstream triggers a cached `308 → https` redirect and a cross-origin failure. This is a local dev-proxy artifact only; it does not affect the app or FW.

## Tests

- `test/core/cloud/cloud_host_resolver_test.dart` — resolver routing + local-build fallback coverage.
- `test/core/cloud/guardian_api_client_test.dart` — client-side vs CA-side URL construction (incl. CA bypasses proxy even on local build).
