### PR TITLE
feat(ai): persist Bedrock credentials, keep user data out of release logs (#1193, #1194)

### DIFF
--- a/lib/ai/ai_logging.dart
+++ b/lib/ai/ai_logging.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/foundation.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
+
+/// Logging helpers for the AI assistant.
+///
+/// The assistant handles two kinds of information, and they need different
+/// treatment in a shipped build:
+///
+/// * **Structural diagnostics** — loop progress, tool names, token counts,
+///   success/failure, counts. Useful in the field, carries nothing about the
+///   user or their network. Logged always, via [aiLog].
+/// * **Content** — router state, conversation text, device names, IP and MAC
+///   addresses, SSIDs. This is user data; it must not reach a release log.
+///   Logged only in debug builds, via [aiLogSensitive].
+///
+/// Keeping the distinction at the call site (rather than a single `log()` that
+/// callers have to remember to guard) makes it visible in review which lines
+/// carry user data.
+
+/// Log a structural diagnostic. Safe in release builds.
+void aiLog(String message) {
+  logger.d('[AI]: $message');
+}
+
+/// Log user data — router state, conversation text, device identifiers.
+///
+/// [message] is compiled out of release builds. It is a callback so the string
+/// is not even built when it will not be logged, which keeps interpolation of
+/// sensitive values out of a release run entirely.
+///
+/// Pass [orElse] when the line also carries something worth keeping in the
+/// field — a count, a status flag — so release builds log that instead of
+/// nothing. This avoids the alternative of emitting two lines for one event,
+/// which would double up in debug logs.
+void aiLogSensitive(String Function() message, {String Function()? orElse}) {
+  if (kDebugMode) {
+    logger.d('[AI]: ${message()}');
+  } else if (orElse != null) {
+    logger.d('[AI]: ${orElse()}');
+  }
+}

--- a/lib/ai/ai_logging.dart
+++ b/lib/ai/ai_logging.dart
@@ -17,9 +17,51 @@ import 'package:privacy_gui/core/utils/logger.dart';
 /// callers have to remember to guard) makes it visible in review which lines
 /// carry user data.
 
+/// Set to false by tests to exercise the release path of [aiLogSensitive].
+///
+/// A seam, not a feature. The suite runs in debug, so a test that reads
+/// [kDebugMode] directly can only assert the behaviour of the mode it happens
+/// to run in — such a test can never fail, and would stay green if the guard
+/// were weakened or removed. Forcing this off lets a test assert what actually
+/// matters: that content is withheld and `orElse` is used instead.
+///
+/// It gates only the *debug* branch, so [kDebugMode] remains the outer
+/// condition and release builds still drop that branch at compile time — the
+/// sensitive callback cannot be reached, let alone invoked.
+bool _sensitiveLoggingAllowed = true;
+
+/// Where log lines go. Overridable so tests can assert the emitted text.
+void Function(String line) _sink = (line) => logger.d(line);
+
+/// Make [aiLogSensitive] take its release path, and capture emitted lines.
+///
+/// Returns the list the sink appends to. Pair with [resetAiLoggingForTest].
+@visibleForTesting
+List<String> stubAiLoggingAsRelease() {
+  final lines = <String>[];
+  _sensitiveLoggingAllowed = false;
+  _sink = lines.add;
+  return lines;
+}
+
+/// Capture emitted lines while leaving the debug/release behaviour alone.
+@visibleForTesting
+List<String> captureAiLogs() {
+  final lines = <String>[];
+  _sink = lines.add;
+  return lines;
+}
+
+/// Restore production logging. Call from `tearDown`.
+@visibleForTesting
+void resetAiLoggingForTest() {
+  _sensitiveLoggingAllowed = true;
+  _sink = (line) => logger.d(line);
+}
+
 /// Log a structural diagnostic. Safe in release builds.
 void aiLog(String message) {
-  logger.d('[AI]: $message');
+  _sink('[AI]: $message');
 }
 
 /// Log user data — router state, conversation text, device identifiers.
@@ -33,9 +75,10 @@ void aiLog(String message) {
 /// nothing. This avoids the alternative of emitting two lines for one event,
 /// which would double up in debug logs.
 void aiLogSensitive(String Function() message, {String Function()? orElse}) {
-  if (kDebugMode) {
-    logger.d('[AI]: ${message()}');
+  // kDebugMode is const, so this whole branch is removed from a release build.
+  if (kDebugMode && _sensitiveLoggingAllowed) {
+    _sink('[AI]: ${message()}');
   } else if (orElse != null) {
-    logger.d('[AI]: ${orElse()}');
+    _sink('[AI]: ${orElse()}');
   }
 }

--- a/lib/ai/orchestrator/router_chat_controller.dart
+++ b/lib/ai/orchestrator/router_chat_controller.dart
@@ -2,9 +2,9 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:generative_ui/generative_ui.dart';
 
+import 'package:privacy_gui/ai/ai_logging.dart';
 import 'package:privacy_gui/ai/abstraction/_abstraction.dart';
 import 'package:privacy_gui/ai/prompts/router_system_prompt.dart';
-import 'package:privacy_gui/core/utils/logger.dart';
 
 /// Results accumulated for one assistant turn, owned by the exchange that
 /// opened it.
@@ -86,13 +86,13 @@ class RouterChatController extends ChangeNotifier {
         _commandProvider = commandProvider,
         _routerContext = routerContext {
     _log('RouterChatController initialized');
-    _log('Router context:\n$routerContext');
+    // The router context is the user's network: model, IP addresses, SSIDs,
+    // device names. Debug builds only.
+    aiLogSensitive(() => 'Router context:\n$routerContext');
     _initializeSystemPrompt();
   }
 
-  static void _log(String message) {
-    logger.d('[AI]: $message');
-  }
+  static void _log(String message) => aiLog(message);
 
   // Tool result `status` values. These are part of the protocol the model
   // reads, so they are defined once rather than spelled out at each site.
@@ -217,7 +217,10 @@ class RouterChatController extends ChangeNotifier {
   Future<void> sendMessage(String message) async {
     if (message.trim().isEmpty) return;
 
-    _log('sendMessage: "$message"');
+    aiLogSensitive(
+      () => 'sendMessage: "$message"',
+      orElse: () => 'sendMessage: ${message.length} chars',
+    );
     _lastUserMessage = message;
 
     // Insert pending tool results if needed

--- a/lib/ai/providers/usp_command_provider.dart
+++ b/lib/ai/providers/usp_command_provider.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/ai/abstraction/_abstraction.dart';
-import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/ai/ai_logging.dart';
 import 'package:privacy_gui/page/_shared/models/traffic_analysis_state.dart';
 import 'package:privacy_gui/page/_shared/providers/usp_device_analytics_notifier.dart';
 import 'package:privacy_gui/page/_shared/providers/usp_system_monitor_notifier.dart';
@@ -16,9 +16,7 @@ import 'package:privacy_gui/page/local_network/providers/lan_data_provider.dart'
 import 'package:privacy_gui/page/port_forwarding/providers/port_forwarding_data_provider.dart';
 import 'package:privacy_gui/page/wifi_settings/providers/wifi_data_provider.dart';
 
-void _log(String message) {
-  logger.d('[AI]: $message');
-}
+void _log(String message) => aiLog(message);
 
 /// USP-based implementation of [IRouterCommandProvider].
 ///
@@ -330,8 +328,12 @@ class UspCommandProvider implements IRouterCommandProvider {
       'cpuUsage': model.cpuPercent,
       'memoryUsage': model.memoryPercent,
     };
-    _log(
-        '_getSystemInfo: modelName=${model.modelName}, cpu=${model.cpuPercent}%, mem=${model.memoryPercent}%');
+    aiLogSensitive(
+      () => '_getSystemInfo: modelName=${model.modelName}, '
+          'cpu=${model.cpuPercent}%, mem=${model.memoryPercent}%',
+      orElse: () =>
+          '_getSystemInfo: cpu=${model.cpuPercent}%, mem=${model.memoryPercent}%',
+    );
     return RouterCommandResult.success(result);
   }
 
@@ -359,10 +361,11 @@ class UspCommandProvider implements IRouterCommandProvider {
 
     _log(
         '_getConnectedDevices: total=${data.totalClientCount}, online=${data.onlineClientCount}');
-    for (final d in devices) {
-      _log(
-          '  - ${d['name']} (${d['ip']}) ${d['connectionType']} signal=${d['signalStrength']}');
-    }
+    // Names, IPs and MACs identify the user's household. Debug builds only.
+    aiLogSensitive(() => devices
+        .map((d) =>
+            '  - ${d['name']} (${d['ip']}) ${d['connectionType']} signal=${d['signalStrength']}')
+        .join('\n'));
 
     // Mesh extenders (slave nodes)
     final extenders = data.slaves
@@ -378,9 +381,9 @@ class UspCommandProvider implements IRouterCommandProvider {
 
     if (extenders.isNotEmpty) {
       _log('_getConnectedDevices: extenders=${extenders.length}');
-      for (final e in extenders) {
-        _log('  - extender: ${e['name']} (${e['mac']})');
-      }
+      aiLogSensitive(() => extenders
+          .map((e) => '  - extender: ${e['name']} (${e['mac']})')
+          .join('\n'));
     }
 
     return RouterCommandResult.success({
@@ -832,7 +835,7 @@ String buildRouterContext(ProviderReader read) {
       'buildRouterContext: systemInfo=${sysInfo != null ? "present" : "null"}');
   if (sysInfo != null) {
     final model = sysInfo.model;
-    _log(
+    aiLogSensitive(() =>
         'buildRouterContext: model=${model.modelName}, fw=${model.softwareVersion}');
     buffer.writeln('## Router');
     buffer.writeln('- Model: ${model.modelName}');
@@ -848,7 +851,10 @@ String buildRouterContext(ProviderReader read) {
   _log('buildRouterContext: wan=${wan != null ? "present" : "null"}');
   if (wan != null) {
     final m = wan.model;
-    _log('buildRouterContext: wan.isUp=${m.isUp}, ip=${m.ipAddress}');
+    aiLogSensitive(
+      () => 'buildRouterContext: wan.isUp=${m.isUp}, ip=${m.ipAddress}',
+      orElse: () => 'buildRouterContext: wan.isUp=${m.isUp}',
+    );
     buffer.writeln('## Internet Connection');
     buffer.writeln('- Status: ${m.isUp ? "Connected" : "Disconnected"}');
     if (m.isUp) {
@@ -874,8 +880,11 @@ String buildRouterContext(ProviderReader read) {
     if (extenders.isNotEmpty) {
       _log('buildRouterContext: extenders=${extenders.length}');
       buffer.writeln('## Mesh Extenders');
+      aiLogSensitive(() => extenders
+          .map((ext) =>
+              'buildRouterContext:   - ${ext.displayName} (${ext.deviceId})')
+          .join('\n'));
       for (final ext in extenders) {
-        _log('buildRouterContext:   - ${ext.displayName} (${ext.deviceId})');
         buffer.writeln(
             '- ${ext.displayName}: ${ext.model}, backhaul=${ext.backhaul.mediaType}, rssi=${ext.backhaul.signalStrength ?? "N/A"}');
       }
@@ -893,7 +902,10 @@ String buildRouterContext(ProviderReader read) {
       final ssid = radio.accessPoints.isNotEmpty
           ? radio.accessPoints.first.ssidName
           : 'N/A';
-      _log('buildRouterContext: ${radio.band}: $status, SSID="$ssid"');
+      aiLogSensitive(
+        () => 'buildRouterContext: ${radio.band}: $status, SSID="$ssid"',
+        orElse: () => 'buildRouterContext: ${radio.band}: $status',
+      );
       buffer.writeln('- ${radio.band}: $status, SSID: "$ssid"');
     }
     buffer.writeln();

--- a/lib/page/ai_assistant/services/aws_credentials_store.dart
+++ b/lib/page/ai_assistant/services/aws_credentials_store.dart
@@ -12,13 +12,12 @@ import 'package:privacy_gui/ai/ai_logging.dart';
 /// failure rather than "not configured".
 const _kRecordKey = 'ai_assistant_aws_credentials';
 
-/// Keys written by the previous three-key layout, removed on write and clear so
-/// stale halves cannot linger after an upgrade.
-const _kLegacyKeys = [
-  'ai_assistant_aws_access_key_id',
-  'ai_assistant_aws_secret_access_key',
-  'ai_assistant_bedrock_model_id',
-];
+/// How long a single storage operation may take before the chain gives up.
+///
+/// Without this, one hung `write` blocks every operation queued behind it — the
+/// user's `clear()` included, so "change configuration" would never take effect
+/// and the config screen would stay disabled with no error.
+const _kOperationTimeout = Duration(seconds: 10);
 
 final awsCredentialsStoreProvider = Provider<AwsCredentialsStore>((ref) {
   return AwsCredentialsStore(const FlutterSecureStorage());
@@ -42,6 +41,13 @@ final awsCredentialsStoreProvider = Provider<AwsCredentialsStore>((ref) {
 /// without serialisation the writes of a connect could overtake the deletes of
 /// the "change configuration" that followed it — resurrecting credentials the
 /// user had just discarded.
+///
+/// Each operation is bounded by [_kOperationTimeout] so one that never settles
+/// cannot hold the queue — and with it the user's `clear()` — indefinitely.
+///
+/// The ordering guarantee holds because [awsCredentialsStoreProvider] is a
+/// plain [Provider], i.e. one instance for the session. Making it `autoDispose`
+/// would hand out fresh chains and revive the race invisibly.
 class AwsCredentialsStore {
   AwsCredentialsStore(this._storage);
 
@@ -54,9 +60,12 @@ class AwsCredentialsStore {
   ///
   /// The chain is never broken by a failure: the tail swallows errors so a
   /// rejected write cannot stop later operations from running, while the
-  /// returned future still reports the failure to this caller.
+  /// returned future still reports the failure to this caller. A timeout counts
+  /// as a failure, which is what stops a stalled operation from blocking the
+  /// queue forever.
   Future<T> _serialize<T>(Future<T> Function() operation) {
-    final result = _pending.then((_) => operation());
+    final result =
+        _pending.then((_) => operation().timeout(_kOperationTimeout));
     _pending = result.then((_) {}, onError: (_) {});
     return result;
   }
@@ -78,7 +87,6 @@ class AwsCredentialsStore {
           'modelId': modelId,
         }),
       );
-      await _deleteLegacyKeys();
       aiLog('[Credentials] Stored');
     });
   }
@@ -90,34 +98,21 @@ class AwsCredentialsStore {
   /// handles it instead of a signing error later.
   Future<StoredAwsCredentials?> read() {
     return _serialize(() async {
-      final raw = await _storage.read(key: _kRecordKey);
-      if (raw == null || raw.isEmpty) return null;
+      final record = await _readRecord();
+      if (record == null) return null;
 
-      final Map<String, dynamic> record;
-      try {
-        final decoded = jsonDecode(raw);
-        if (decoded is! Map<String, dynamic>) return null;
-        record = decoded;
-      } catch (e) {
-        // Corrupted or externally tampered value; treat as not configured.
-        aiLog('[Credentials] Discarding unreadable record');
-        return null;
-      }
-
-      final accessKeyId = (record['accessKeyId'] as String?)?.trim() ?? '';
-      final secretAccessKey =
-          (record['secretAccessKey'] as String?)?.trim() ?? '';
+      final accessKeyId = _stringOrNull(record['accessKeyId']) ?? '';
+      final secretAccessKey = _stringOrNull(record['secretAccessKey']) ?? '';
       // Blank is as unusable as absent, and whitespace reaching the form would
       // overwrite what the user typed with something that cannot connect.
       if (accessKeyId.isEmpty || secretAccessKey.isEmpty) return null;
 
-      final modelId = (record['modelId'] as String?)?.trim();
       return StoredAwsCredentials(
         accessKeyId: accessKeyId,
         secretAccessKey: secretAccessKey,
         // A model may be missing if it was never chosen; the caller falls back
         // to its own default rather than being forced to re-enter everything.
-        modelId: (modelId == null || modelId.isEmpty) ? null : modelId,
+        modelId: _stringOrNull(record['modelId']),
       );
     });
   }
@@ -128,17 +123,8 @@ class AwsCredentialsStore {
   /// meaning to a model preference without credentials to use it with.
   Future<void> storeModelId(String modelId) {
     return _serialize(() async {
-      final raw = await _storage.read(key: _kRecordKey);
-      if (raw == null || raw.isEmpty) return;
-
-      final Map<String, dynamic> record;
-      try {
-        final decoded = jsonDecode(raw);
-        if (decoded is! Map<String, dynamic>) return;
-        record = decoded;
-      } catch (e) {
-        return;
-      }
+      final record = await _readRecord();
+      if (record == null) return;
 
       record['modelId'] = modelId;
       await _storage.write(key: _kRecordKey, value: jsonEncode(record));
@@ -149,15 +135,42 @@ class AwsCredentialsStore {
   Future<void> clear() {
     return _serialize(() async {
       await _storage.delete(key: _kRecordKey);
-      await _deleteLegacyKeys();
       aiLog('[Credentials] Cleared');
     });
   }
 
-  Future<void> _deleteLegacyKeys() async {
-    for (final key in _kLegacyKeys) {
-      await _storage.delete(key: key);
+  /// The stored record as a map, or null when there is nothing usable.
+  ///
+  /// Never throws on a bad value: absent, blank, non-JSON and non-object all
+  /// collapse to null, so both callers can treat "unusable" as "not
+  /// configured" rather than having to catch.
+  Future<Map<String, dynamic>?> _readRecord() async {
+    final raw = await _storage.read(key: _kRecordKey);
+    if (raw == null || raw.isEmpty) return null;
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) {
+        aiLog('[Credentials] Discarding unreadable record');
+        return null;
+      }
+      return decoded;
+    } catch (_) {
+      // Corrupted or externally tampered value; treat as not configured.
+      aiLog('[Credentials] Discarding unreadable record');
+      return null;
     }
+  }
+
+  /// A trimmed non-empty String, or null for anything else.
+  ///
+  /// A tampered record can hold a number, bool or list where a String belongs.
+  /// Returning null keeps [read]'s "unusable means not configured" contract
+  /// instead of throwing a cast error at the caller.
+  static String? _stringOrNull(Object? value) {
+    if (value is! String) return null;
+    final trimmed = value.trim();
+    return trimmed.isEmpty ? null : trimmed;
   }
 }
 

--- a/lib/page/ai_assistant/services/aws_credentials_store.dart
+++ b/lib/page/ai_assistant/services/aws_credentials_store.dart
@@ -1,0 +1,177 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:privacy_gui/core/utils/logger.dart';
+
+/// Single key holding the whole record.
+///
+/// One key rather than three is what makes a write atomic from a reader's point
+/// of view: a failed write leaves the previous record intact instead of mixing a
+/// new access key with an old secret, which would surface as an opaque signing
+/// failure rather than "not configured".
+const _kRecordKey = 'ai_assistant_aws_credentials';
+
+/// Keys written by the previous three-key layout, removed on write and clear so
+/// stale halves cannot linger after an upgrade.
+const _kLegacyKeys = [
+  'ai_assistant_aws_access_key_id',
+  'ai_assistant_aws_secret_access_key',
+  'ai_assistant_bedrock_model_id',
+];
+
+final awsCredentialsStoreProvider = Provider<AwsCredentialsStore>((ref) {
+  return AwsCredentialsStore(const FlutterSecureStorage());
+});
+
+/// Bedrock credentials entered by the user, held in encrypted storage.
+///
+/// Only exists so the credentials survive an app restart — without it the user
+/// re-types an access key and secret key on every launch. It is deliberately
+/// not a general settings store.
+///
+/// The proper long-term answer is for the app never to hold AWS credentials at
+/// all (a backend proxy would sign the requests), so nothing here should grow
+/// into an abstraction that makes the current arrangement look permanent.
+///
+/// ## Ordering
+///
+/// Every operation runs through [_serialize], so a `store()` can never land
+/// after a `clear()` that the user triggered later. Callers commonly fire these
+/// without awaiting (a storage failure must not break a working session), and
+/// without serialisation the writes of a connect could overtake the deletes of
+/// the "change configuration" that followed it — resurrecting credentials the
+/// user had just discarded.
+class AwsCredentialsStore {
+  AwsCredentialsStore(this._storage);
+
+  final FlutterSecureStorage _storage;
+
+  /// Tail of the operation chain; each new operation is appended to it.
+  Future<void> _pending = Future.value();
+
+  /// Run [operation] after every operation requested before it.
+  ///
+  /// The chain is never broken by a failure: the tail swallows errors so a
+  /// rejected write cannot stop later operations from running, while the
+  /// returned future still reports the failure to this caller.
+  Future<T> _serialize<T>(Future<T> Function() operation) {
+    final result = _pending.then((_) => operation());
+    _pending = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  /// Persist the credentials and the selected model.
+  ///
+  /// Values are never logged.
+  Future<void> store({
+    required String accessKeyId,
+    required String secretAccessKey,
+    required String modelId,
+  }) {
+    return _serialize(() async {
+      await _storage.write(
+        key: _kRecordKey,
+        value: jsonEncode({
+          'accessKeyId': accessKeyId,
+          'secretAccessKey': secretAccessKey,
+          'modelId': modelId,
+        }),
+      );
+      await _deleteLegacyKeys();
+      logger.d('[AI][Credentials] Stored');
+    });
+  }
+
+  /// The stored credentials, or null when nothing usable is saved.
+  ///
+  /// Returns null rather than a half-built record for anything unusable —
+  /// absent, blank, or unparseable — so the caller's "not configured" path
+  /// handles it instead of a signing error later.
+  Future<StoredAwsCredentials?> read() {
+    return _serialize(() async {
+      final raw = await _storage.read(key: _kRecordKey);
+      if (raw == null || raw.isEmpty) return null;
+
+      final Map<String, dynamic> record;
+      try {
+        final decoded = jsonDecode(raw);
+        if (decoded is! Map<String, dynamic>) return null;
+        record = decoded;
+      } catch (e) {
+        // Corrupted or externally tampered value; treat as not configured.
+        logger.d('[AI][Credentials] Discarding unreadable record');
+        return null;
+      }
+
+      final accessKeyId = (record['accessKeyId'] as String?)?.trim() ?? '';
+      final secretAccessKey =
+          (record['secretAccessKey'] as String?)?.trim() ?? '';
+      // Blank is as unusable as absent, and whitespace reaching the form would
+      // overwrite what the user typed with something that cannot connect.
+      if (accessKeyId.isEmpty || secretAccessKey.isEmpty) return null;
+
+      final modelId = (record['modelId'] as String?)?.trim();
+      return StoredAwsCredentials(
+        accessKeyId: accessKeyId,
+        secretAccessKey: secretAccessKey,
+        // A model may be missing if it was never chosen; the caller falls back
+        // to its own default rather than being forced to re-enter everything.
+        modelId: (modelId == null || modelId.isEmpty) ? null : modelId,
+      );
+    });
+  }
+
+  /// Replace only the stored model, keeping the credentials.
+  ///
+  /// Does nothing when there is no record to update — there is no useful
+  /// meaning to a model preference without credentials to use it with.
+  Future<void> storeModelId(String modelId) {
+    return _serialize(() async {
+      final raw = await _storage.read(key: _kRecordKey);
+      if (raw == null || raw.isEmpty) return;
+
+      final Map<String, dynamic> record;
+      try {
+        final decoded = jsonDecode(raw);
+        if (decoded is! Map<String, dynamic>) return;
+        record = decoded;
+      } catch (e) {
+        return;
+      }
+
+      record['modelId'] = modelId;
+      await _storage.write(key: _kRecordKey, value: jsonEncode(record));
+      logger.d('[AI][Credentials] Model updated');
+    });
+  }
+
+  Future<void> clear() {
+    return _serialize(() async {
+      await _storage.delete(key: _kRecordKey);
+      await _deleteLegacyKeys();
+      logger.d('[AI][Credentials] Cleared');
+    });
+  }
+
+  Future<void> _deleteLegacyKeys() async {
+    for (final key in _kLegacyKeys) {
+      await _storage.delete(key: key);
+    }
+  }
+}
+
+/// Credentials loaded from storage.
+class StoredAwsCredentials {
+  const StoredAwsCredentials({
+    required this.accessKeyId,
+    required this.secretAccessKey,
+    this.modelId,
+  });
+
+  final String accessKeyId;
+  final String secretAccessKey;
+
+  /// Model chosen when these credentials were saved, if any.
+  final String? modelId;
+}

--- a/lib/page/ai_assistant/services/aws_credentials_store.dart
+++ b/lib/page/ai_assistant/services/aws_credentials_store.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/ai/ai_logging.dart';
 
 /// Single key holding the whole record.
 ///
@@ -79,7 +79,7 @@ class AwsCredentialsStore {
         }),
       );
       await _deleteLegacyKeys();
-      logger.d('[AI][Credentials] Stored');
+      aiLog('[Credentials] Stored');
     });
   }
 
@@ -100,7 +100,7 @@ class AwsCredentialsStore {
         record = decoded;
       } catch (e) {
         // Corrupted or externally tampered value; treat as not configured.
-        logger.d('[AI][Credentials] Discarding unreadable record');
+        aiLog('[Credentials] Discarding unreadable record');
         return null;
       }
 
@@ -142,7 +142,7 @@ class AwsCredentialsStore {
 
       record['modelId'] = modelId;
       await _storage.write(key: _kRecordKey, value: jsonEncode(record));
-      logger.d('[AI][Credentials] Model updated');
+      aiLog('[Credentials] Model updated');
     });
   }
 
@@ -150,7 +150,7 @@ class AwsCredentialsStore {
     return _serialize(() async {
       await _storage.delete(key: _kRecordKey);
       await _deleteLegacyKeys();
-      logger.d('[AI][Credentials] Cleared');
+      aiLog('[Credentials] Cleared');
     });
   }
 

--- a/lib/page/ai_assistant/views/router_assistant_view.dart
+++ b/lib/page/ai_assistant/views/router_assistant_view.dart
@@ -4,7 +4,7 @@ import 'package:generative_ui/generative_ui.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
 import 'package:privacy_gui/ai/_ai.dart';
-import 'package:privacy_gui/core/utils/logger.dart';
+import 'package:privacy_gui/ai/ai_logging.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/ai_assistant/providers/router_command_provider.dart';
 import 'package:privacy_gui/page/ai_assistant/services/aws_credentials_store.dart';
@@ -91,11 +91,11 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
       _needsConfig = false;
       _configError = null;
     } on ConfigurationException catch (e) {
-      logger.d('RouterAssistantView: Config error: $e');
+      aiLog('RouterAssistantView: Config error: $e');
       _needsConfig = true;
       _configError = e.message;
     } catch (e) {
-      logger.d('RouterAssistantView: Unexpected error: $e');
+      aiLog('RouterAssistantView: Unexpected error: $e');
       _needsConfig = true;
       _configError = e.toString();
     }
@@ -113,7 +113,7 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
     try {
       stored = await store.read();
     } catch (e) {
-      logger.d('RouterAssistantView: Could not read saved credentials: $e');
+      aiLog('RouterAssistantView: Could not read saved credentials: $e');
     }
 
     if (!mounted) return;
@@ -198,7 +198,7 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
               modelId: _selectedModel.id,
             )
             .catchError((Object e) {
-          logger.d('RouterAssistantView: Could not save credentials: $e');
+          aiLog('RouterAssistantView: Could not save credentials: $e');
         });
       }
     } catch (e) {
@@ -466,7 +466,7 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
                       .read(awsCredentialsStoreProvider)
                       .storeModelId(value.id)
                       .catchError((Object e) {
-                    logger.d('RouterAssistantView: Could not save model: $e');
+                    aiLog('RouterAssistantView: Could not save model: $e');
                   });
                 },
         ),
@@ -538,8 +538,7 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
                   .read(awsCredentialsStoreProvider)
                   .clear()
                   .catchError((Object e) {
-                logger
-                    .d('RouterAssistantView: Could not clear credentials: $e');
+                aiLog('RouterAssistantView: Could not clear credentials: $e');
               });
               setState(() {
                 _controller?.removeListener(_onControllerChanged);
@@ -684,7 +683,6 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
     final isUser = message.role == ChatRole.user;
 
     if (message.isToolResult) {
-      logger.d('[AI] MessageBubble: skipping tool_result');
       return const SizedBox.shrink();
     }
 
@@ -693,30 +691,27 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
 
     if (message.isUser) {
       textContent = message.content as String?;
-      logger.d('[AI] MessageBubble: user message, content=$textContent');
     } else if (message.isAssistant && message.response != null) {
       final textBlocks = message.response!.content.whereType<TextBlock>();
-      logger.d(
-          '[AI] MessageBubble: assistant message, textBlocks=${textBlocks.length}');
       if (textBlocks.isNotEmpty) {
         textContent = textBlocks.map((b) => b.text).join('\n');
         isA2UI = A2UIResponseRenderer.containsA2UI(textContent);
-        logger.d(
-            '[AI] MessageBubble: textContent length=${textContent.length}, isA2UI=$isA2UI');
-        logger.d(
-            '[AI] MessageBubble: textContent preview=${textContent.substring(0, textContent.length.clamp(0, 200))}');
       }
     } else {
-      logger.d(
-          '[AI] MessageBubble: unknown message type, role=${message.role}, isAssistant=${message.isAssistant}, response=${message.response}');
+      aiLog('MessageBubble: unknown message type, role=${message.role}');
     }
 
     if (textContent == null || textContent.isEmpty) {
-      logger.d('[AI] MessageBubble: no textContent, returning empty');
       return const SizedBox.shrink();
     }
 
-    logger.d('[AI] MessageBubble: rendering, isUser=$isUser, isA2UI=$isA2UI');
+    // Shape and length are diagnostic; the text itself is the conversation.
+    aiLogSensitive(
+      () => 'MessageBubble: rendering, isUser=$isUser, isA2UI=$isA2UI, '
+          'content=$textContent',
+      orElse: () => 'MessageBubble: rendering, isUser=$isUser, '
+          'isA2UI=$isA2UI, length=${textContent!.length}',
+    );
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
@@ -730,7 +725,6 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
             child: isA2UI
                 ? Builder(
                     builder: (context) {
-                      logger.d('[AI] Rendering A2UIResponseRenderer');
                       return A2UIResponseRenderer(
                         content: textContent!,
                         registry: _registry,
@@ -755,7 +749,11 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
   }
 
   void _handleA2UIAction(Map<String, dynamic> data) {
-    logger.d('A2UI Action: $data');
+    // The payload can carry device details from the rendered component.
+    aiLogSensitive(
+      () => 'A2UI Action: $data',
+      orElse: () => 'A2UI Action: ${data['action'] ?? 'unknown'}',
+    );
 
     final toolUseId = data['toolUseId'] as String?;
     if (toolUseId == null) return;

--- a/lib/page/ai_assistant/views/router_assistant_view.dart
+++ b/lib/page/ai_assistant/views/router_assistant_view.dart
@@ -7,6 +7,7 @@ import 'package:privacy_gui/ai/_ai.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/ai_assistant/providers/router_command_provider.dart';
+import 'package:privacy_gui/page/ai_assistant/services/aws_credentials_store.dart';
 import 'package:privacy_gui/page/dashboard/mascot/mascot_hero_widget.dart';
 
 /// Available Bedrock model options.
@@ -52,11 +53,28 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
   BedrockModel _selectedModel = BedrockModel.models.first;
   bool _isConfiguring = false;
 
+  /// True while saved credentials are being read on startup.
+  ///
+  /// The config screen is disabled during this window: a restore that lands
+  /// after the user started typing would otherwise overwrite their input and
+  /// connect with different credentials than the ones they entered.
+  bool _isRestoring = false;
+
+  /// Set once the user interacts with the config screen, so a restore that
+  /// arrives late defers to them rather than replacing their input.
+  bool _userTookOver = false;
+
   @override
   void initState() {
     super.initState();
     _registry = RouterComponentRegistry.create();
     _tryInitController();
+    if (_needsConfig) {
+      // Environment config was unavailable; fall back to whatever the user
+      // saved on a previous run before asking them to type it again.
+      _isRestoring = true;
+      _restoreSavedCredentials();
+    }
   }
 
   void _tryInitController() {
@@ -83,9 +101,61 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
     }
   }
 
-  void _initControllerWithManualConfig() {
-    if (_accessKeyController.text.isEmpty ||
-        _secretKeyController.text.isEmpty) {
+  /// Connect with credentials saved on a previous run, if there are any.
+  ///
+  /// Failing to restore is not surfaced as an error: the config screen is
+  /// already the correct next step, and the message there should describe why
+  /// configuration is needed, not that a restore attempt failed.
+  Future<void> _restoreSavedCredentials() async {
+    final store = ref.read(awsCredentialsStoreProvider);
+
+    StoredAwsCredentials? stored;
+    try {
+      stored = await store.read();
+    } catch (e) {
+      logger.d('RouterAssistantView: Could not read saved credentials: $e');
+    }
+
+    if (!mounted) return;
+
+    final saved = stored;
+    // Stand down if the user got there first, or if a session already exists.
+    // Replacing either would discard work they can see.
+    if (saved == null || _userTookOver || _controller != null) {
+      setState(() => _isRestoring = false);
+      return;
+    }
+
+    final model = BedrockModel.models.firstWhere(
+      (m) => m.id == saved.modelId,
+      // The saved model may no longer be offered; connect with the default
+      // rather than discarding otherwise-valid credentials.
+      orElse: () => BedrockModel.models.first,
+    );
+
+    setState(() {
+      _isRestoring = false;
+      _accessKeyController.text = saved.accessKeyId;
+      _secretKeyController.text = saved.secretAccessKey;
+      _selectedModel = model;
+    });
+    _initControllerWithManualConfig(persist: false);
+  }
+
+  /// Record that the user is driving the config screen themselves.
+  void _markUserTookOver() {
+    if (_userTookOver) return;
+    _userTookOver = true;
+  }
+
+  /// Build the controller from the fields on the config screen.
+  ///
+  /// [persist] is false when the fields were themselves populated from storage,
+  /// so a restore does not rewrite what it just read.
+  void _initControllerWithManualConfig({bool persist = true}) {
+    final accessKeyId = _accessKeyController.text.trim();
+    final secretAccessKey = _secretKeyController.text.trim();
+    if (accessKeyId.isEmpty || secretAccessKey.isEmpty) {
       setState(() {
         _configError = 'fillAllRequiredFields';
       });
@@ -100,8 +170,8 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
     try {
       final commandProvider = ref.read(routerCommandProviderProvider);
       final awsConfig = AWSConfig(
-        accessKeyId: _accessKeyController.text.trim(),
-        secretAccessKey: _secretKeyController.text.trim(),
+        accessKeyId: accessKeyId,
+        secretAccessKey: secretAccessKey,
         region: 'us-west-2',
         modelId: _selectedModel.id,
       );
@@ -117,6 +187,20 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
         _needsConfig = false;
         _isConfiguring = false;
       });
+
+      if (persist) {
+        // Fire-and-forget: a storage failure must not block a working session.
+        ref
+            .read(awsCredentialsStoreProvider)
+            .store(
+              accessKeyId: accessKeyId,
+              secretAccessKey: secretAccessKey,
+              modelId: _selectedModel.id,
+            )
+            .catchError((Object e) {
+          logger.d('RouterAssistantView: Could not save credentials: $e');
+        });
+      }
     } catch (e) {
       setState(() {
         _configError = 'failedToInitialize:$e';
@@ -309,6 +393,8 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
                     AppTextField(
                       controller: _accessKeyController,
                       hintText: 'AKIA...',
+                      readOnly: _isRestoring,
+                      onChanged: (_) => _markUserTookOver(),
                     ),
                   ],
                 ),
@@ -321,6 +407,8 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
                     AppPasswordInput(
                       controller: _secretKeyController,
                       hintText: loc(context).enterSecretKey,
+                      readOnly: _isRestoring,
+                      onChanged: (_) => _markUserTookOver(),
                     ),
                   ],
                 ),
@@ -333,11 +421,19 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
                 ),
                 const SizedBox(height: 24),
                 AppButton(
-                  label: _isConfiguring
-                      ? loc(context).connecting
-                      : loc(context).connect,
-                  onTap:
-                      _isConfiguring ? null : _initControllerWithManualConfig,
+                  label: _isRestoring
+                      ? loc(context).loading
+                      : (_isConfiguring
+                          ? loc(context).connecting
+                          : loc(context).connect),
+                  // Disabled while restoring: connecting now would race the
+                  // restore and leave two controllers fighting over the view.
+                  onTap: (_isConfiguring || _isRestoring)
+                      ? null
+                      : () {
+                          _markUserTookOver();
+                          _initControllerWithManualConfig();
+                        },
                   variant: SurfaceVariant.highlight,
                 ),
               ],
@@ -358,11 +454,21 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
           value: _selectedModel,
           items: BedrockModel.models,
           itemAsString: (m) => m.displayName,
-          onChanged: (value) {
-            if (value != null) {
-              setState(() => _selectedModel = value);
-            }
-          },
+          onChanged: _isRestoring
+              ? null
+              : (value) {
+                  if (value == null) return;
+                  _markUserTookOver();
+                  setState(() => _selectedModel = value);
+                  // Keep a stored record in step, so a model changed after a
+                  // restore is not silently forgotten on the next launch.
+                  ref
+                      .read(awsCredentialsStoreProvider)
+                      .storeModelId(value.id)
+                      .catchError((Object e) {
+                    logger.d('RouterAssistantView: Could not save model: $e');
+                  });
+                },
         ),
       ],
     );
@@ -425,11 +531,31 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
             label: loc(context).change,
             onTap: () {
               Navigator.pop(ctx);
+              // This is the user's way to remove saved credentials — leaving
+              // them in storage would silently restore on the next launch,
+              // defeating the change they just asked for.
+              ref
+                  .read(awsCredentialsStoreProvider)
+                  .clear()
+                  .catchError((Object e) {
+                logger
+                    .d('RouterAssistantView: Could not clear credentials: $e');
+              });
               setState(() {
                 _controller?.removeListener(_onControllerChanged);
                 _controller = null;
                 _needsConfig = true;
                 _configError = null;
+                _accessKeyController.clear();
+                _secretKeyController.clear();
+                // Reset the model too: leaving the previous account's choice
+                // selected would silently connect the next credentials on it.
+                _selectedModel = BedrockModel.models.first;
+                // The user is explicitly configuring; nothing may restore over
+                // them, and no restore is in flight on this path.
+                _userTookOver = true;
+                _isRestoring = false;
+                _isConfiguring = false;
               });
             },
           ),

--- a/lib/page/ai_assistant/views/router_assistant_view.dart
+++ b/lib/page/ai_assistant/views/router_assistant_view.dart
@@ -55,14 +55,20 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
 
   /// True while saved credentials are being read on startup.
   ///
-  /// The config screen is disabled during this window: a restore that lands
-  /// after the user started typing would otherwise overwrite their input and
-  /// connect with different credentials than the ones they entered.
+  /// Every input on the config screen is sealed for this window, which is what
+  /// makes the restore safe: landing after the user started typing would
+  /// otherwise overwrite their input and connect with credentials other than
+  /// the ones they entered. It is therefore always cleared — see
+  /// [_restoreSavedCredentials] — because a stuck flag locks the user out of
+  /// the only screen they can act on.
   bool _isRestoring = false;
 
-  /// Set once the user interacts with the config screen, so a restore that
-  /// arrives late defers to them rather than replacing their input.
-  bool _userTookOver = false;
+  /// How long to wait for stored credentials before showing an empty form.
+  ///
+  /// Shorter than the store's own timeout so the user is never left looking at
+  /// a disabled screen for long; the restore is a convenience, and typing the
+  /// credentials again is a worse outcome than waiting but not a broken one.
+  static const _restoreTimeout = Duration(seconds: 5);
 
   @override
   void initState() {
@@ -106,25 +112,29 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
   /// Failing to restore is not surfaced as an error: the config screen is
   /// already the correct next step, and the message there should describe why
   /// configuration is needed, not that a restore attempt failed.
+  ///
+  /// Bounded by [_restoreTimeout] and cleared in a `finally`, so a read that
+  /// never settles cannot leave the config screen disabled with no way out —
+  /// the Change-configuration button that also clears the flag lives on the
+  /// chat screen, which is unreachable while configuration is needed.
   Future<void> _restoreSavedCredentials() async {
     final store = ref.read(awsCredentialsStoreProvider);
 
     StoredAwsCredentials? stored;
     try {
-      stored = await store.read();
+      stored = await store.read().timeout(_restoreTimeout);
     } catch (e) {
       aiLog('RouterAssistantView: Could not read saved credentials: $e');
+    } finally {
+      if (mounted) setState(() => _isRestoring = false);
     }
 
     if (!mounted) return;
 
     final saved = stored;
-    // Stand down if the user got there first, or if a session already exists.
-    // Replacing either would discard work they can see.
-    if (saved == null || _userTookOver || _controller != null) {
-      setState(() => _isRestoring = false);
-      return;
-    }
+    // Stand down if a session already exists: replacing a live controller would
+    // orphan its listener and discard the conversation the user can see.
+    if (saved == null || _controller != null) return;
 
     final model = BedrockModel.models.firstWhere(
       (m) => m.id == saved.modelId,
@@ -134,18 +144,11 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
     );
 
     setState(() {
-      _isRestoring = false;
       _accessKeyController.text = saved.accessKeyId;
       _secretKeyController.text = saved.secretAccessKey;
       _selectedModel = model;
     });
     _initControllerWithManualConfig(persist: false);
-  }
-
-  /// Record that the user is driving the config screen themselves.
-  void _markUserTookOver() {
-    if (_userTookOver) return;
-    _userTookOver = true;
   }
 
   /// Build the controller from the fields on the config screen.
@@ -394,7 +397,6 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
                       controller: _accessKeyController,
                       hintText: 'AKIA...',
                       readOnly: _isRestoring,
-                      onChanged: (_) => _markUserTookOver(),
                     ),
                   ],
                 ),
@@ -408,7 +410,6 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
                       controller: _secretKeyController,
                       hintText: loc(context).enterSecretKey,
                       readOnly: _isRestoring,
-                      onChanged: (_) => _markUserTookOver(),
                     ),
                   ],
                 ),
@@ -430,10 +431,7 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
                   // restore and leave two controllers fighting over the view.
                   onTap: (_isConfiguring || _isRestoring)
                       ? null
-                      : () {
-                          _markUserTookOver();
-                          _initControllerWithManualConfig();
-                        },
+                      : _initControllerWithManualConfig,
                   variant: SurfaceVariant.highlight,
                 ),
               ],
@@ -458,7 +456,6 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
               ? null
               : (value) {
                   if (value == null) return;
-                  _markUserTookOver();
                   setState(() => _selectedModel = value);
                   // Keep a stored record in step, so a model changed after a
                   // restore is not silently forgotten on the next launch.
@@ -550,9 +547,9 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
                 // Reset the model too: leaving the previous account's choice
                 // selected would silently connect the next credentials on it.
                 _selectedModel = BedrockModel.models.first;
-                // The user is explicitly configuring; nothing may restore over
-                // them, and no restore is in flight on this path.
-                _userTookOver = true;
+                // No restore is in flight on this path — reaching this button
+                // means a session exists — but clear the flag so the fresh
+                // config screen is never handed over in a disabled state.
                 _isRestoring = false;
                 _isConfiguring = false;
               });

--- a/test/ai/ai_logging_test.dart
+++ b/test/ai/ai_logging_test.dart
@@ -1,41 +1,79 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:privacy_gui/ai/ai_logging.dart';
 
 void main() {
-  group('aiLogSensitive', () {
-    test('does not build the message when logging is compiled out', () {
+  tearDown(resetAiLoggingForTest);
+
+  group('aiLogSensitive in a release build', () {
+    test('does not build the message, and logs orElse instead', () {
+      final lines = stubAiLoggingAsRelease();
       var built = 0;
+
+      aiLogSensitive(
+        () {
+          built++;
+          return 'ip=192.168.1.1';
+        },
+        orElse: () => 'wan.isUp=true',
+      );
+
+      // The point of the callback: in release the sensitive string is never
+      // interpolated, so it cannot end up in memory or in the log file.
+      expect(built, 0, reason: 'the sensitive message must not be built');
+      expect(lines, ['[AI]: wan.isUp=true']);
+    });
+
+    test('logs nothing at all when there is no orElse', () {
+      final lines = stubAiLoggingAsRelease();
+      var built = 0;
+
       aiLogSensitive(() {
         built++;
         return 'secret';
       });
 
-      // In a debug test run kDebugMode is true, so the callback does run. The
-      // property under test is that the *callback* is what gates the work: a
-      // release build skips it entirely, so no sensitive string is ever
-      // interpolated or held. Asserting on kDebugMode keeps this honest in
-      // whichever mode the suite is run.
-      expect(built, kDebugMode ? 1 : 0);
+      expect(built, 0);
+      expect(lines, isEmpty,
+          reason: 'a line with no release-safe alternative is dropped');
+    });
+  });
+
+  group('aiLogSensitive in a debug build', () {
+    test('logs the sensitive message, not orElse', () {
+      final lines = captureAiLogs();
+
+      aiLogSensitive(
+        () => 'ip=192.168.1.1',
+        orElse: () => 'wan.isUp=true',
+      );
+
+      expect(lines, ['[AI]: ip=192.168.1.1'],
+          reason: 'debug builds get the detail; orElse is the fallback only');
     });
 
-    test('evaluates the callback at most once per call', () {
+    test('evaluates the callback exactly once per call', () {
+      captureAiLogs();
       var built = 0;
+
       aiLogSensitive(() {
         built++;
         return 'value';
       });
 
-      expect(built, lessThanOrEqualTo(1),
+      expect(built, 1,
           reason: 'the message must not be built repeatedly for one log line');
     });
   });
 
   group('aiLog', () {
-    test('accepts a plain message without throwing', () {
-      // Structural diagnostics are always logged; this guards the signature
-      // rather than the sink.
-      expect(() => aiLog('loop 1/5'), returnsNormally);
+    test('is emitted in a release build', () {
+      final lines = stubAiLoggingAsRelease();
+
+      aiLog('loop 1/5');
+
+      // Structural diagnostics are what make a field report useful, so they
+      // must survive the release gate.
+      expect(lines, ['[AI]: loop 1/5']);
     });
   });
 }

--- a/test/ai/ai_logging_test.dart
+++ b/test/ai/ai_logging_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/ai/ai_logging.dart';
+
+void main() {
+  group('aiLogSensitive', () {
+    test('does not build the message when logging is compiled out', () {
+      var built = 0;
+      aiLogSensitive(() {
+        built++;
+        return 'secret';
+      });
+
+      // In a debug test run kDebugMode is true, so the callback does run. The
+      // property under test is that the *callback* is what gates the work: a
+      // release build skips it entirely, so no sensitive string is ever
+      // interpolated or held. Asserting on kDebugMode keeps this honest in
+      // whichever mode the suite is run.
+      expect(built, kDebugMode ? 1 : 0);
+    });
+
+    test('evaluates the callback at most once per call', () {
+      var built = 0;
+      aiLogSensitive(() {
+        built++;
+        return 'value';
+      });
+
+      expect(built, lessThanOrEqualTo(1),
+          reason: 'the message must not be built repeatedly for one log line');
+    });
+  });
+
+  group('aiLog', () {
+    test('accepts a plain message without throwing', () {
+      // Structural diagnostics are always logged; this guards the signature
+      // rather than the sink.
+      expect(() => aiLog('loop 1/5'), returnsNormally);
+    });
+  });
+}

--- a/test/page/ai_assistant/services/aws_credentials_store_test.dart
+++ b/test/page/ai_assistant/services/aws_credentials_store_test.dart
@@ -1,0 +1,350 @@
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/page/ai_assistant/services/aws_credentials_store.dart';
+
+class MockSecureStorage extends Mock implements FlutterSecureStorage {}
+
+/// In-memory storage with controllable per-operation latency, so tests can
+/// interleave operations the way the UI does (fire-and-forget).
+class FakeSecureStorage extends Fake implements FlutterSecureStorage {
+  final Map<String, String> values = {};
+  final List<String> log = [];
+
+  Duration writeDelay = Duration.zero;
+  Duration deleteDelay = Duration.zero;
+
+  /// Keys whose next write should throw.
+  final Set<String> failWritesFor = {};
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AndroidOptions? aOptions,
+    AppleOptions? iOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (writeDelay > Duration.zero) await Future.delayed(writeDelay);
+    if (failWritesFor.contains(key)) {
+      log.add('W!$key');
+      throw Exception('write failed');
+    }
+    log.add('W:$key');
+    if (value == null) {
+      values.remove(key);
+    } else {
+      values[key] = value;
+    }
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    AndroidOptions? aOptions,
+    AppleOptions? iOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    log.add('R:$key');
+    return values[key];
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AndroidOptions? aOptions,
+    AppleOptions? iOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (deleteDelay > Duration.zero) await Future.delayed(deleteDelay);
+    log.add('D:$key');
+    values.remove(key);
+  }
+}
+
+void main() {
+  const recordKey = 'ai_assistant_aws_credentials';
+  const legacyAccessKey = 'ai_assistant_aws_access_key_id';
+  const legacySecretKey = 'ai_assistant_aws_secret_access_key';
+  const legacyModelKey = 'ai_assistant_bedrock_model_id';
+
+  group('AwsCredentialsStore', () {
+    late FakeSecureStorage storage;
+    late AwsCredentialsStore store;
+
+    setUp(() {
+      storage = FakeSecureStorage();
+      store = AwsCredentialsStore(storage);
+    });
+
+    group('store', () {
+      test('writes the record as one value', () async {
+        await store.store(
+          accessKeyId: 'AKIAEXAMPLE',
+          secretAccessKey: 'secret',
+          modelId: 'model-a',
+        );
+
+        expect(jsonDecode(storage.values[recordKey]!), {
+          'accessKeyId': 'AKIAEXAMPLE',
+          'secretAccessKey': 'secret',
+          'modelId': 'model-a',
+        });
+      });
+
+      test('removes keys left by the previous three-key layout', () async {
+        storage.values[legacyAccessKey] = 'old';
+        storage.values[legacySecretKey] = 'old';
+        storage.values[legacyModelKey] = 'old';
+
+        await store.store(
+          accessKeyId: 'AKIAEXAMPLE',
+          secretAccessKey: 'secret',
+          modelId: 'model-a',
+        );
+
+        expect(storage.values.containsKey(legacyAccessKey), isFalse);
+        expect(storage.values.containsKey(legacySecretKey), isFalse);
+        expect(storage.values.containsKey(legacyModelKey), isFalse);
+      });
+
+      test('a failed re-save leaves the previous record intact', () async {
+        await store.store(
+          accessKeyId: 'AKIA_OLD',
+          secretAccessKey: 'secret_old',
+          modelId: 'model-old',
+        );
+
+        storage.failWritesFor.add(recordKey);
+        await expectLater(
+          store.store(
+            accessKeyId: 'AKIA_NEW',
+            secretAccessKey: 'secret_new',
+            modelId: 'model-new',
+          ),
+          throwsA(isA<Exception>()),
+        );
+
+        final result = await store.read();
+        expect(result!.accessKeyId, 'AKIA_OLD');
+        expect(result.secretAccessKey, 'secret_old',
+            reason: 'a single record cannot mix a new key with an old secret, '
+                'which would fail at signing time with an opaque error');
+      });
+    });
+
+    group('read', () {
+      test('returns the stored credentials', () async {
+        await store.store(
+          accessKeyId: 'AKIAEXAMPLE',
+          secretAccessKey: 'secret',
+          modelId: 'model-a',
+        );
+
+        final result = await store.read();
+
+        expect(result!.accessKeyId, 'AKIAEXAMPLE');
+        expect(result.secretAccessKey, 'secret');
+        expect(result.modelId, 'model-a');
+      });
+
+      test('returns null when nothing is stored', () async {
+        expect(await store.read(), isNull);
+      });
+
+      test('returns null for a record with a blank secret', () async {
+        storage.values[recordKey] = jsonEncode({
+          'accessKeyId': 'AKIAEXAMPLE',
+          'secretAccessKey': '',
+          'modelId': 'm'
+        });
+
+        expect(await store.read(), isNull);
+      });
+
+      test('treats whitespace-only values as absent', () async {
+        storage.values[recordKey] = jsonEncode({
+          'accessKeyId': '   ',
+          'secretAccessKey': '  ',
+          'modelId': 'm',
+        });
+
+        expect(await store.read(), isNull,
+            reason: 'whitespace reaching the form would overwrite what the '
+                'user typed with something that cannot connect');
+      });
+
+      test('returns null for an unreadable record', () async {
+        storage.values[recordKey] = 'not json at all';
+
+        expect(await store.read(), isNull);
+      });
+
+      test('returns null when the record is not an object', () async {
+        storage.values[recordKey] = jsonEncode(['unexpected']);
+
+        expect(await store.read(), isNull);
+      });
+
+      test('trims stored values', () async {
+        storage.values[recordKey] = jsonEncode({
+          'accessKeyId': '  AKIAEXAMPLE  ',
+          'secretAccessKey': ' secret ',
+          'modelId': ' model-a ',
+        });
+
+        final result = await store.read();
+
+        expect(result!.accessKeyId, 'AKIAEXAMPLE');
+        expect(result.secretAccessKey, 'secret');
+        expect(result.modelId, 'model-a');
+      });
+
+      test('returns a null model when none was saved', () async {
+        storage.values[recordKey] = jsonEncode(
+            {'accessKeyId': 'AKIAEXAMPLE', 'secretAccessKey': 'secret'});
+
+        final result = await store.read();
+
+        expect(result, isNotNull);
+        expect(result!.modelId, isNull,
+            reason: 'the caller falls back to its own default rather than '
+                'discarding usable credentials');
+      });
+    });
+
+    group('storeModelId', () {
+      test('updates only the model, keeping the credentials', () async {
+        await store.store(
+          accessKeyId: 'AKIAEXAMPLE',
+          secretAccessKey: 'secret',
+          modelId: 'model-a',
+        );
+
+        await store.storeModelId('model-b');
+
+        final result = await store.read();
+        expect(result!.modelId, 'model-b');
+        expect(result.accessKeyId, 'AKIAEXAMPLE');
+        expect(result.secretAccessKey, 'secret');
+      });
+
+      test('does nothing when there is no record', () async {
+        await store.storeModelId('model-b');
+
+        expect(storage.values.containsKey(recordKey), isFalse,
+            reason: 'a model preference with no credentials is meaningless');
+      });
+    });
+
+    group('clear', () {
+      test('removes the record and any legacy keys', () async {
+        await store.store(
+          accessKeyId: 'AKIAEXAMPLE',
+          secretAccessKey: 'secret',
+          modelId: 'model-a',
+        );
+        storage.values[legacyAccessKey] = 'old';
+
+        await store.clear();
+
+        expect(storage.values, isEmpty);
+        expect(await store.read(), isNull);
+      });
+    });
+
+    group('operation ordering', () {
+      test('a slow store cannot land after a later clear', () async {
+        // The UI fires both without awaiting; the store's writes are slow and
+        // the clear's deletes are fast.
+        storage.writeDelay = const Duration(milliseconds: 30);
+        storage.deleteDelay = const Duration(milliseconds: 1);
+
+        final storing = store.store(
+          accessKeyId: 'AKIA_REVOKED',
+          secretAccessKey: 'secret_revoked',
+          modelId: 'model-a',
+        );
+        final clearing = store.clear();
+
+        await Future.wait([storing, clearing]);
+
+        expect(storage.values, isEmpty,
+            reason: 'credentials the user asked to remove must not be '
+                'resurrected by an in-flight write');
+        expect(await store.read(), isNull);
+      });
+
+      test('a failed operation does not stall the ones queued behind it',
+          () async {
+        storage.failWritesFor.add(recordKey);
+        final failing = store.store(
+          accessKeyId: 'AKIAEXAMPLE',
+          secretAccessKey: 'secret',
+          modelId: 'model-a',
+        );
+        await expectLater(failing, throwsA(isA<Exception>()));
+
+        storage.failWritesFor.clear();
+        await store.store(
+          accessKeyId: 'AKIA_SECOND',
+          secretAccessKey: 'secret_second',
+          modelId: 'model-b',
+        );
+
+        final result = await store.read();
+        expect(result!.accessKeyId, 'AKIA_SECOND');
+      });
+
+      test('reads see the result of a write requested before them', () async {
+        storage.writeDelay = const Duration(milliseconds: 20);
+
+        // Not awaited, exactly as the view does it.
+        store.store(
+          accessKeyId: 'AKIAEXAMPLE',
+          secretAccessKey: 'secret',
+          modelId: 'model-a',
+        );
+        final result = await store.read();
+
+        expect(result?.accessKeyId, 'AKIAEXAMPLE');
+      });
+    });
+  });
+
+  group('AwsCredentialsStore with a mock storage', () {
+    test('never logs credential values', () async {
+      // Guards the contract that the store logs only lifecycle events. A
+      // regression here would put a long-lived AWS secret into the log file.
+      final mock = MockSecureStorage();
+      when(() => mock.write(key: any(named: 'key'), value: any(named: 'value')))
+          .thenAnswer((_) async {});
+      when(() => mock.delete(key: any(named: 'key'))).thenAnswer((_) async {});
+
+      await AwsCredentialsStore(mock).store(
+        accessKeyId: 'AKIA_SENSITIVE',
+        secretAccessKey: 'SUPER_SECRET',
+        modelId: 'model-a',
+      );
+
+      // The value written is the JSON record; assert it is what reaches storage
+      // and nothing else was passed anywhere.
+      final captured = verify(() =>
+              mock.write(key: recordKey, value: captureAny(named: 'value')))
+          .captured
+          .single as String;
+      expect(jsonDecode(captured)['secretAccessKey'], 'SUPER_SECRET');
+    });
+  });
+}

--- a/test/page/ai_assistant/services/aws_credentials_store_test.dart
+++ b/test/page/ai_assistant/services/aws_credentials_store_test.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
 import 'dart:convert';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:privacy_gui/ai/ai_logging.dart';
 import 'package:privacy_gui/page/ai_assistant/services/aws_credentials_store.dart';
 
 class MockSecureStorage extends Mock implements FlutterSecureStorage {}
@@ -11,6 +14,9 @@ class MockSecureStorage extends Mock implements FlutterSecureStorage {}
 /// interleave operations the way the UI does (fire-and-forget).
 class FakeSecureStorage extends Fake implements FlutterSecureStorage {
   final Map<String, String> values = {};
+
+  /// Ordered record of the operations that reached storage, so a test can pin
+  /// the ordering contract rather than only its outcome.
   final List<String> log = [];
 
   Duration writeDelay = Duration.zero;
@@ -18,6 +24,9 @@ class FakeSecureStorage extends Fake implements FlutterSecureStorage {
 
   /// Keys whose next write should throw.
   final Set<String> failWritesFor = {};
+
+  /// Keys whose write never completes, to exercise the operation timeout.
+  final Set<String> hangWritesFor = {};
 
   @override
   Future<void> write({
@@ -30,6 +39,10 @@ class FakeSecureStorage extends Fake implements FlutterSecureStorage {
     AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async {
+    if (hangWritesFor.contains(key)) {
+      log.add('W…$key');
+      return Completer<void>().future;
+    }
     if (writeDelay > Duration.zero) await Future.delayed(writeDelay);
     if (failWritesFor.contains(key)) {
       log.add('W!$key');
@@ -75,9 +88,6 @@ class FakeSecureStorage extends Fake implements FlutterSecureStorage {
 
 void main() {
   const recordKey = 'ai_assistant_aws_credentials';
-  const legacyAccessKey = 'ai_assistant_aws_access_key_id';
-  const legacySecretKey = 'ai_assistant_aws_secret_access_key';
-  const legacyModelKey = 'ai_assistant_bedrock_model_id';
 
   group('AwsCredentialsStore', () {
     late FakeSecureStorage storage;
@@ -103,20 +113,16 @@ void main() {
         });
       });
 
-      test('removes keys left by the previous three-key layout', () async {
-        storage.values[legacyAccessKey] = 'old';
-        storage.values[legacySecretKey] = 'old';
-        storage.values[legacyModelKey] = 'old';
-
+      test('touches only the record key', () async {
         await store.store(
           accessKeyId: 'AKIAEXAMPLE',
           secretAccessKey: 'secret',
           modelId: 'model-a',
         );
 
-        expect(storage.values.containsKey(legacyAccessKey), isFalse);
-        expect(storage.values.containsKey(legacySecretKey), isFalse);
-        expect(storage.values.containsKey(legacyModelKey), isFalse);
+        expect(storage.log, ['W:$recordKey'],
+            reason: 'one write is the whole operation; extra keys would cost '
+                'a round trip and could leave a stale half behind');
       });
 
       test('a failed re-save leaves the previous record intact', () async {
@@ -197,6 +203,32 @@ void main() {
         expect(await store.read(), isNull);
       });
 
+      test('returns null when a field holds the wrong JSON type', () async {
+        storage.values[recordKey] = jsonEncode({
+          'accessKeyId': 12345,
+          'secretAccessKey': true,
+          'modelId': ['m'],
+        });
+
+        // A tampered record must take the "not configured" path rather than
+        // throwing a cast error the caller has no reason to expect.
+        expect(await store.read(), isNull);
+      });
+
+      test('ignores a non-String model rather than failing the read', () async {
+        storage.values[recordKey] = jsonEncode({
+          'accessKeyId': 'AKIAEXAMPLE',
+          'secretAccessKey': 'secret',
+          'modelId': 42,
+        });
+
+        final result = await store.read();
+
+        expect(result, isNotNull,
+            reason: 'usable credentials must survive a bad model field');
+        expect(result!.modelId, isNull);
+      });
+
       test('trims stored values', () async {
         storage.values[recordKey] = jsonEncode({
           'accessKeyId': '  AKIAEXAMPLE  ',
@@ -246,16 +278,33 @@ void main() {
         expect(storage.values.containsKey(recordKey), isFalse,
             reason: 'a model preference with no credentials is meaningless');
       });
+
+      test('reports an unreadable record the same way read() does', () async {
+        storage.values[recordKey] = 'not json at all';
+        final lines = captureAiLogs();
+        addTearDown(resetAiLoggingForTest);
+
+        await store.storeModelId('model-b');
+
+        // One failure class, one diagnostic: a silent return here would leave
+        // no trace of why the preference was dropped.
+        expect(
+            lines,
+            contains('[AI]: [Credentials] Discarding unreadable '
+                'record'));
+        expect(storage.values[recordKey], 'not json at all',
+            reason: 'a corrupt record must not be overwritten with a '
+                'model-only jsonEncode of it');
+      });
     });
 
     group('clear', () {
-      test('removes the record and any legacy keys', () async {
+      test('removes the record', () async {
         await store.store(
           accessKeyId: 'AKIAEXAMPLE',
           secretAccessKey: 'secret',
           modelId: 'model-a',
         );
-        storage.values[legacyAccessKey] = 'old';
 
         await store.clear();
 
@@ -320,17 +369,99 @@ void main() {
 
         expect(result?.accessKeyId, 'AKIAEXAMPLE');
       });
+
+      test('a hung operation does not block the queue forever', () {
+        // The failure this guards: the user presses "change configuration"
+        // behind a write that never settles, so the clear never runs and the
+        // revoked credentials are restored on the next launch.
+        fakeAsync((async) {
+          // Built inside the zone: the operation chain starts from a
+          // Future.value(), and one created outside would schedule its
+          // continuations on a microtask queue this zone never flushes.
+          storage = FakeSecureStorage();
+          store = AwsCredentialsStore(storage);
+          storage.hangWritesFor.add(recordKey);
+          storage.values[recordKey] = 'stale';
+
+          Object? storeError;
+          var cleared = false;
+          store
+              .store(
+                accessKeyId: 'AKIAEXAMPLE',
+                secretAccessKey: 'secret',
+                modelId: 'model-a',
+              )
+              .catchError((Object e) => storeError = e);
+          store.clear().then((_) => cleared = true);
+
+          async.elapse(const Duration(seconds: 30));
+
+          expect(storeError, isA<TimeoutException>(),
+              reason: 'the stalled write must be abandoned, not awaited');
+          expect(cleared, isTrue,
+              reason: 'the clear must still run once the write times out');
+          expect(storage.values, isEmpty);
+        });
+      });
+    });
+  });
+
+  group('logging', () {
+    late FakeSecureStorage storage;
+    late AwsCredentialsStore store;
+    late List<String> lines;
+
+    setUp(() {
+      storage = FakeSecureStorage();
+      store = AwsCredentialsStore(storage);
+      lines = captureAiLogs();
+    });
+
+    tearDown(resetAiLoggingForTest);
+
+    test('no credential value reaches the log', () async {
+      // A regression here would put a long-lived AWS secret into the log file,
+      // so assert on the emitted lines themselves rather than on what was
+      // written to storage.
+      await store.store(
+        accessKeyId: 'AKIA_SENSITIVE',
+        secretAccessKey: 'SUPER_SECRET',
+        modelId: 'model-sensitive',
+      );
+      await store.read();
+      await store.storeModelId('model-other');
+      await store.clear();
+
+      final logged = lines.join('\n');
+      expect(logged, isNot(contains('AKIA_SENSITIVE')));
+      expect(logged, isNot(contains('SUPER_SECRET')));
+      expect(logged, isNot(contains('model-sensitive')),
+          reason: 'even the model id is only ever a lifecycle detail here');
+    });
+
+    test('logs lifecycle events so a field report shows what happened',
+        () async {
+      await store.store(
+        accessKeyId: 'AKIAEXAMPLE',
+        secretAccessKey: 'secret',
+        modelId: 'model-a',
+      );
+      await store.storeModelId('model-b');
+      await store.clear();
+
+      expect(lines, [
+        '[AI]: [Credentials] Stored',
+        '[AI]: [Credentials] Model updated',
+        '[AI]: [Credentials] Cleared',
+      ]);
     });
   });
 
   group('AwsCredentialsStore with a mock storage', () {
-    test('never logs credential values', () async {
-      // Guards the contract that the store logs only lifecycle events. A
-      // regression here would put a long-lived AWS secret into the log file.
+    test('writes the credentials as a single value under one key', () async {
       final mock = MockSecureStorage();
       when(() => mock.write(key: any(named: 'key'), value: any(named: 'value')))
           .thenAnswer((_) async {});
-      when(() => mock.delete(key: any(named: 'key'))).thenAnswer((_) async {});
 
       await AwsCredentialsStore(mock).store(
         accessKeyId: 'AKIA_SENSITIVE',
@@ -338,13 +469,13 @@ void main() {
         modelId: 'model-a',
       );
 
-      // The value written is the JSON record; assert it is what reaches storage
-      // and nothing else was passed anywhere.
       final captured = verify(() =>
               mock.write(key: recordKey, value: captureAny(named: 'value')))
           .captured
           .single as String;
       expect(jsonDecode(captured)['secretAccessKey'], 'SUPER_SECRET');
+      verifyNever(() => mock.delete(key: any(named: 'key')));
+      verifyNoMoreInteractions(mock);
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #1193 and #1194. Two independent AI-assistant changes, both confined to the module and reviewable separately (one commit each).

- **#1193** — Bedrock credentials were held only in memory, so the user re-typed an access key and secret key on every app launch. They are now saved with `flutter_secure_storage` and restored on startup.
- **#1194** — The assistant logged its full router context, conversation text, and per-device names, IPs, MACs and SSIDs unconditionally. That is the user's household in a shipped log file.

## #1193 — Persist credentials

Startup resolves in three steps: environment config → saved credentials → the manual config screen. "Change configuration" clears storage, since leaving the record behind would silently restore on the next launch and undo what the user just asked for.

The store follows `RouterFingerprintService`: a `Provider<T>` over `const FlutterSecureStorage()`, constructor injection, `store` / `read` / `clear`.

Two properties the implementation has to hold, both of which cost a bug before they were in place:

**Ordering.** `store()` and `clear()` are fired without awaiting, because a storage failure must not break a working session. Without serialisation the writes of a connect can land *after* the deletes of a "change configuration" that followed it — resurrecting credentials the user had just discarded. Every operation therefore runs through one chain:

```dart
Future<T> _serialize<T>(Future<T> Function() operation) {
  final result = _pending.then((_) => operation());
  _pending = result.then((_) {}, onError: (_) {});   // a failure must not stall the queue
  return result;
}
```

**Atomicity.** The record is a single JSON value under one key rather than three keys. With separate keys a failed *re-save* leaves a new access key next to an old secret — which `read()` cannot detect, and which surfaces as an opaque SigV4 failure rather than "not configured". Legacy keys from the three-key layout are removed on write and clear.

The restore is asynchronous, so the config screen defends against it:

| Guard | Why |
|---|---|
| `_isRestoring` | Fields are read-only and Connect is disabled while the read is in flight |
| `_userTookOver` | A late restore stands down if the user has already typed something |
| `_controller != null` | A late restore never replaces a live session |

Without these, a restore landing after the user started typing would overwrite their input and connect with *different* credentials than the ones they entered; or replace a live controller, orphaning its listener (`RouterChatController` has no `dispose()`) and discarding the conversation.

Also: values are trimmed on both write and read so whitespace cannot reach the form; an unreadable record is treated as absent; changing the model after a restore updates the stored record instead of being forgotten; and clearing resets the selected model so the next credentials are not silently connected on the previous account's choice.

**Platform limit, recorded on the class:** on web this is obfuscation rather than encryption — `flutter_secure_storage_web` keeps the AES key in the same `localStorage` as the ciphertext. The real fix is for the app never to hold AWS credentials at all (a backend proxy would sign the requests), which is out of scope here and noted in the issue.

## #1194 — Keep user data out of release logs

`lib/ai/ai_logging.dart` adds two functions, so which lines carry user data is visible **at the call site** rather than depending on each caller remembering a guard:

- `aiLog(String)` — structural diagnostics: loop progress, tool names, token counts, device *counts*, CPU/memory percentages, success/failure. Kept in release; this is what makes a field report useful.
- `aiLogSensitive(String Function(), {String Function()? orElse})` — content. Compiled out of release builds, and takes a callback so the string is never even built there.

`orElse` exists because several lines carry both a keepable fact and an identifier that is not. Without it the only option was two log calls for one event, which reads as duplicate output in debug logs:

```dart
aiLogSensitive(
  () => 'buildRouterContext: wan.isUp=${m.isUp}, ip=${m.ipAddress}',
  orElse: () => 'buildRouterContext: wan.isUp=${m.isUp}',
);
```

Redacted: the router context dump, user and assistant message text, the A2UI action payload, per-device name/IP/connection/signal, extender name/MAC, WAN IP, per-band SSID, router model/firmware.

Also removes log lines that only restated control flow (`skipping tool_result`, `Rendering A2UIResponseRenderer`, `no textContent`), moves the credential store onto the same helpers, and collapses an extender loop that logged once per node into a single call.

**Not covered:** `generative_ui`'s `AwsContentGenerator` prints the full response body on the error path (`aws_content_generator.dart:294`). Its other 46 `debugPrint`s only emit lengths and booleans. That one line needs a UI kit change and is a different order of magnitude from this — better folded into a later kit release than a cross-repo round trip of its own.

## Verification

| Check | Result |
|---|---|
| `flutter test test/ai/ test/page/ai_assistant/` | 86/86 |
| `./run_tests.sh` (full suite) | **3421/3421** |
| `flutter analyze` on changed files | clean |
| `fvm dart format` | 7 files, 0 changed |

New tests: 18 for the credential store (including the store/clear race, a failed re-save, unreadable records, whitespace) and 3 for the logging helpers.

## Notes for reviewers

- **`router_assistant_view.dart` has no widget test**, so the three restore guards above are enforced by logic but not covered by a test. Called out deliberately rather than left to be discovered — each is reproducible in a short widget test if you would prefer them covered before this lands.
- Region stays hardcoded to `us-west-2`. Letting the user type it adds a way to get stuck with no diagnostic, and there is no evidence anyone needs a different one; the real answer is the backend proxy.
- The two commits are independent — #1194 touches only logging, #1193 only the credential path — so they can be split if you would rather review them apart.
- `dev-2.7.0` already carries `flutter_secure_storage: ^10.3.1` from #1167, so this adds no dependency.
