### PR TITLE
feat(e2e): add stable identifiers to dialog/CRUD controls (#1172)

### DIFF
--- a/lib/page/admin/views/dialogs/timezone_edit_dialog.dart
+++ b/lib/page/admin/views/dialogs/timezone_edit_dialog.dart
@@ -148,6 +148,7 @@ class _TimezoneListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Semantics(
+      identifier: 'admin-timezone-item-${timezone.timeZoneID}',
       label: '${timezone.friendlyName}, ${timezone.offsetDisplayText}',
       selected: isSelected,
       button: true,

--- a/lib/page/dashboard/views/dialogs/port_forwarding_dialog.dart
+++ b/lib/page/dashboard/views/dialogs/port_forwarding_dialog.dart
@@ -270,13 +270,15 @@ class _PortForwardingDialogState extends State<PortForwardingDialog> {
         ),
       ),
       actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(loc(context).cancel),
+        AppButton.text(
+          identifier: 'pf-single-cancel',
+          label: loc(context).cancel,
+          onTap: () => Navigator.of(context).pop(),
         ),
-        FilledButton(
-          onPressed: _isFormValid(context) ? _submit : null,
-          child: Text(_isEdit ? loc(context).save : loc(context).add),
+        AppButton.text(
+          identifier: 'pf-single-submit',
+          label: _isEdit ? loc(context).save : loc(context).add,
+          onTap: _isFormValid(context) ? _submit : null,
         ),
       ],
     );

--- a/lib/page/instant_privacy/views/instant_privacy_view.dart
+++ b/lib/page/instant_privacy/views/instant_privacy_view.dart
@@ -322,6 +322,7 @@ class InstantPrivacyView extends ConsumerWidget {
             onTap: () => Navigator.of(ctx).pop(false),
           ),
           AppButton.primary(
+            identifier: 'instant-privacy-enable-confirm',
             label: loc(context).enable,
             onTap: () => Navigator.of(ctx).pop(true),
           ),

--- a/lib/page/port_forwarding/views/components/usp_single_port_tab.dart
+++ b/lib/page/port_forwarding/views/components/usp_single_port_tab.dart
@@ -171,6 +171,7 @@ class UspSinglePortTab extends ConsumerWidget {
           onTap: () => context.pop(),
         ),
         AppButton.dangerText(
+          identifier: 'pf-delete-confirm',
           label: loc(context).delete,
           onTap: () => context.pop(true),
         ),

--- a/lib/page/wifi_settings/views/components/wifi_network_card.dart
+++ b/lib/page/wifi_settings/views/components/wifi_network_card.dart
@@ -158,6 +158,7 @@ class WifiNetworkCard extends ConsumerWidget {
       title: loc(context).name,
       contentBuilder: (ctx, setState, onSubmit) => AppTextFormField(
         controller: controller,
+        identifier: 'wifi-ssid-name-input',
         label: loc(context).name,
         onChanged: (_) => setState(() {}),
       ),

--- a/lib/page/wifi_settings/views/components/wifi_quick_setup_card.dart
+++ b/lib/page/wifi_settings/views/components/wifi_quick_setup_card.dart
@@ -113,6 +113,7 @@ class WifiQuickSetupCard extends ConsumerWidget {
       title: loc(context).name,
       contentBuilder: (ctx, setState, onSubmit) => AppTextFormField(
         controller: controller,
+        identifier: 'wifi-ssid-name-input',
         label: loc(context).name,
         onChanged: (_) => setState(() {}),
       ),


### PR DESCRIPTION
## What

Group 2 (write-proof follow-up) of #1172. The list-row trigger hooks
(`pf-add/edit/delete-*`, `wifi-quick-setup`) already shipped in dev-2.7.0, but the
**dialog-internal controls** those rows open still lacked stable E2E anchors, so the
write-proof tests (PrivacyGUI-USP-E2E#9) could only reach them via fragile localized
text. This adds the remaining identifiers.

## Changes

| identifier | control | file |
|---|---|---|
| `instant-privacy-enable-confirm` | Instant Privacy enable-confirm button | `instant_privacy_view.dart` |
| `pf-delete-confirm` | PF delete-confirm button | `usp_single_port_tab.dart` |
| `pf-single-cancel` / `pf-single-submit` | PF single-port dialog actions | `port_forwarding_dialog.dart` |
| `wifi-ssid-name-input` | SSID rename dialogs (network + quick-setup) | `wifi_network_card.dart`, `wifi_quick_setup_card.dart` |
| `admin-timezone-item-${timeZoneID}` | timezone option rows | `timezone_edit_dialog.dart` |

Notes:
- The PF single-port dialog's actions were Material `TextButton`/`FilledButton`
  (can't carry an `identifier`), so they were converted to `AppButton.text` — matching
  the port-range dialog. `pf-single-cancel` added alongside `-submit` for symmetry.
- The SSID rename `_editSsid` exists in **two** components (regular network + quick
  setup); both got the same `wifi-ssid-name-input`.
- Timezone rows keyed by the stable `timeZoneID` (e.g. `admin-timezone-item-PST8`),
  not the localized label or row index (Article XVI §16.3).

## No ui_kit change needed

An earlier concern (issue-body comment) suggested `AppTextField` needed
`excludeSemantics` for typing to reach the controller. Investigated and **retracted**
(linksys/privacyGUI-UI-kit#7, closed): CanvasKit typing into the controller is gated by
the engine's 500ms `GestureMode` debounce and is solved **test-side** (`el.focus()` +
`activeElement` poll + `keyboard.type()`, already in the E2E suite's
`fillInputById`/`focusAndType`). The `identifier` passthrough shipped in ui_kit v2.31.0
is sufficient; no node-placement change is required.

## Verification

- `flutter analyze` on all 6 changed files: clean
- Full functional suite (`./run_tests.sh` scope): 3452 passed / 0 failed
- Affected functional test `timezone_edit_dialog_test.dart`: 16/16 passed
- No widget-signature or behavior change beyond the single-port dialog button-type swap
- Golden diffs on the two visually-affected views are baseline/environment noise
  (baselines are gitignored; the same states fail on unmodified base code) — CI
  regenerates baselines

## Follow-up (E2E side)

PrivacyGUI-USP-E2E#9 has the 4 write-proof tests `test.skip`-ped — unskip + run
`gen:ids` once this lands.

Closes part of #1172 (Group 2 dialog controls).
