### PR TITLE
refactor(ui): migrate port/service rule dialogs to AppDialog (#1166)

### DIFF
--- a/lib/page/admin/views/dialogs/timezone_edit_dialog.dart
+++ b/lib/page/admin/views/dialogs/timezone_edit_dialog.dart
@@ -148,6 +148,7 @@ class _TimezoneListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Semantics(
+      identifier: 'admin-timezone-item-${timezone.timeZoneID}',
       label: '${timezone.friendlyName}, ${timezone.offsetDisplayText}',
       selected: isSelected,
       button: true,

--- a/lib/page/dashboard/views/dialogs/port_forwarding_dialog.dart
+++ b/lib/page/dashboard/views/dialogs/port_forwarding_dialog.dart
@@ -270,13 +270,15 @@ class _PortForwardingDialogState extends State<PortForwardingDialog> {
         ),
       ),
       actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(loc(context).cancel),
+        AppButton.text(
+          identifier: 'pf-single-cancel',
+          label: loc(context).cancel,
+          onTap: () => Navigator.of(context).pop(),
         ),
-        FilledButton(
-          onPressed: _isFormValid(context) ? _submit : null,
-          child: Text(_isEdit ? loc(context).save : loc(context).add),
+        AppButton.text(
+          identifier: 'pf-single-submit',
+          label: _isEdit ? loc(context).save : loc(context).add,
+          onTap: _isFormValid(context) ? _submit : null,
         ),
       ],
     );

--- a/lib/page/dashboard/views/dialogs/port_forwarding_dialog.dart
+++ b/lib/page/dashboard/views/dialogs/port_forwarding_dialog.dart
@@ -186,88 +186,85 @@ class _PortForwardingDialogState extends State<PortForwardingDialog> {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
-      title: Text(_isEdit
+    return AppDialog(
+      title: AppText.titleLarge(_isEdit
           ? loc(context).editPortForwarding
           : loc(context).addPortForwarding),
-      content: SingleChildScrollView(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            AppTextField(
-              controller: _descController,
-              focusNode: _descFocus,
-              identifier: 'pf-single-description',
-              hintText: loc(context).description,
-              errorText: _errors['description'],
-              onChanged: (_) => _onInputChanged(),
-            ),
-            AppGap.lg(),
-            AppTextField(
-              controller: _extPortController,
-              focusNode: _extPortFocus,
-              identifier: 'pf-single-external-port',
-              hintText: loc(context).externalPort,
-              keyboardType: TextInputType.number,
-              errorText: _errors['externalPort'],
-              onChanged: (_) => _onInputChanged(),
-            ),
-            AppGap.lg(),
-            AppTextField(
-              controller: _intPortController,
-              focusNode: _intPortFocus,
-              identifier: 'pf-single-internal-port',
-              hintText: loc(context).internalPort,
-              keyboardType: TextInputType.number,
-              errorText: _errors['internalPort'],
-              onChanged: (_) => _onInputChanged(),
-            ),
-            AppGap.lg(),
-            AppSelectAutoComplete(
-              options: widget.deviceOptions,
+      scrollable: true,
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AppTextField(
+            controller: _descController,
+            focusNode: _descFocus,
+            identifier: 'pf-single-description',
+            hintText: loc(context).description,
+            errorText: _errors['description'],
+            onChanged: (_) => _onInputChanged(),
+          ),
+          AppGap.lg(),
+          AppTextField(
+            controller: _extPortController,
+            focusNode: _extPortFocus,
+            identifier: 'pf-single-external-port',
+            hintText: loc(context).externalPort,
+            keyboardType: TextInputType.number,
+            errorText: _errors['externalPort'],
+            onChanged: (_) => _onInputChanged(),
+          ),
+          AppGap.lg(),
+          AppTextField(
+            controller: _intPortController,
+            focusNode: _intPortFocus,
+            identifier: 'pf-single-internal-port',
+            hintText: loc(context).internalPort,
+            keyboardType: TextInputType.number,
+            errorText: _errors['internalPort'],
+            onChanged: (_) => _onInputChanged(),
+          ),
+          AppGap.lg(),
+          AppSelectAutoComplete(
+            options: widget.deviceOptions,
+            controller: _intClientController,
+            onSelected: (_) => _validate(context),
+            child: AppTextField(
               controller: _intClientController,
-              onSelected: (_) => _validate(context),
-              child: AppTextField(
-                controller: _intClientController,
-                focusNode: _intClientFocus,
-                identifier: 'pf-single-internal-ip',
-                hintText: loc(context).internalIpHint,
-                errorText: _errors['internalClient'],
-                onChanged: (_) => _onInputChanged(),
+              focusNode: _intClientFocus,
+              identifier: 'pf-single-internal-ip',
+              hintText: loc(context).internalIpHint,
+              errorText: _errors['internalClient'],
+              onChanged: (_) => _onInputChanged(),
+            ),
+          ),
+          AppGap.lg(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              AppText.bodyMedium(loc(context).protocol),
+              SegmentedButton<String>(
+                segments: [
+                  ButtonSegment(value: 'TCP', label: Text(loc(context).tcp)),
+                  ButtonSegment(value: 'UDP', label: Text(loc(context).udp)),
+                  ButtonSegment(value: 'Both', label: Text(loc(context).both)),
+                ],
+                selected: {_protocol},
+                onSelectionChanged: (v) => setState(() => _protocol = v.first),
               ),
-            ),
-            AppGap.lg(),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                AppText.bodyMedium(loc(context).protocol),
-                SegmentedButton<String>(
-                  segments: [
-                    ButtonSegment(value: 'TCP', label: Text(loc(context).tcp)),
-                    ButtonSegment(value: 'UDP', label: Text(loc(context).udp)),
-                    ButtonSegment(
-                        value: 'Both', label: Text(loc(context).both)),
-                  ],
-                  selected: {_protocol},
-                  onSelectionChanged: (v) =>
-                      setState(() => _protocol = v.first),
-                ),
-              ],
-            ),
-            AppGap.lg(),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                AppText.bodyMedium(loc(context).enabled),
-                AppSwitch(
-                  identifier: 'pf-single-enabled',
-                  value: _enabled,
-                  onChanged: (value) => setState(() => _enabled = value),
-                ),
-              ],
-            ),
-          ],
-        ),
+            ],
+          ),
+          AppGap.lg(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              AppText.bodyMedium(loc(context).enabled),
+              AppSwitch(
+                identifier: 'pf-single-enabled',
+                value: _enabled,
+                onChanged: (value) => setState(() => _enabled = value),
+              ),
+            ],
+          ),
+        ],
       ),
       actions: [
         AppButton.text(

--- a/lib/page/instant_privacy/views/instant_privacy_view.dart
+++ b/lib/page/instant_privacy/views/instant_privacy_view.dart
@@ -322,6 +322,7 @@ class InstantPrivacyView extends ConsumerWidget {
             onTap: () => Navigator.of(ctx).pop(false),
           ),
           AppButton.primary(
+            identifier: 'instant-privacy-enable-confirm',
             label: loc(context).enable,
             onTap: () => Navigator.of(ctx).pop(true),
           ),

--- a/lib/page/ipv6_port_service/views/dialogs/ipv6_port_service_rule_dialog.dart
+++ b/lib/page/ipv6_port_service/views/dialogs/ipv6_port_service_rule_dialog.dart
@@ -129,86 +129,87 @@ class _Ipv6PortServiceRuleDialogState extends State<Ipv6PortServiceRuleDialog> {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
-      title: Text(_isEdit ? loc(context).editRule : loc(context).addRule),
-      content: SingleChildScrollView(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            AppTextField(
-              controller: _descriptionController,
-              focusNode: _descriptionFocus,
-              identifier: 'ipv6-rule-description',
-              hintText: loc(context).ruleName,
-              errorText: _errors['description'],
+    return AppDialog(
+      title: AppText.titleLarge(
+          _isEdit ? loc(context).editRule : loc(context).addRule),
+      scrollable: true,
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AppTextField(
+            controller: _descriptionController,
+            focusNode: _descriptionFocus,
+            identifier: 'ipv6-rule-description',
+            hintText: loc(context).ruleName,
+            errorText: _errors['description'],
+            onChanged: (_) => _onInputChanged(),
+          ),
+          AppGap.lg(),
+          AppSelectAutoComplete(
+            options: widget.deviceOptions,
+            controller: _ipv6Controller,
+            onSelected: (_) => _validate(),
+            child: AppTextField(
+              controller: _ipv6Controller,
+              focusNode: _ipv6Focus,
+              identifier: 'ipv6-rule-address',
+              hintText: loc(context).ipv6AddressSearchHint,
+              errorText: _errors['ipv6Address'],
               onChanged: (_) => _onInputChanged(),
             ),
-            AppGap.lg(),
-            AppSelectAutoComplete(
-              options: widget.deviceOptions,
-              controller: _ipv6Controller,
-              onSelected: (_) => _validate(),
-              child: AppTextField(
-                controller: _ipv6Controller,
-                focusNode: _ipv6Focus,
-                identifier: 'ipv6-rule-address',
-                hintText: loc(context).ipv6AddressSearchHint,
-                errorText: _errors['ipv6Address'],
-                onChanged: (_) => _onInputChanged(),
+          ),
+          AppGap.lg(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              AppText.bodyMedium(loc(context).protocol),
+              SegmentedButton<String>(
+                segments: UspIpv6PortServiceService.protocolOptions
+                    .map(
+                        (name) => ButtonSegment(value: name, label: Text(name)))
+                    .toList(),
+                selected: {_protocol},
+                onSelectionChanged: (v) => setState(() => _protocol = v.first),
               ),
-            ),
-            AppGap.lg(),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                AppText.bodyMedium(loc(context).protocol),
-                SegmentedButton<String>(
-                  segments: UspIpv6PortServiceService.protocolOptions
-                      .map((name) =>
-                          ButtonSegment(value: name, label: Text(name)))
-                      .toList(),
-                  selected: {_protocol},
-                  onSelectionChanged: (v) =>
-                      setState(() => _protocol = v.first),
-                ),
-              ],
-            ),
-            AppGap.lg(),
-            AppRangeInput(
-              startController: _startPortController,
-              endController: _endPortController,
-              startFocusNode: _startPortFocus,
-              endFocusNode: _endPortFocus,
-              startLabel: loc(context).startPort,
-              endLabel: loc(context).endPort,
-              startIdentifier: 'ipv6-rule-start-port',
-              endIdentifier: 'ipv6-rule-end-port',
-              errorText: _errors['startPort'] ?? _errors['endPort'],
-              onChanged: (_, __) => _onInputChanged(),
-            ),
-            AppGap.lg(),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                AppText.bodyMedium(loc(context).enabled),
-                AppSwitch(
-                  identifier: 'ipv6-rule-enabled',
-                  value: _enabled,
-                  onChanged: (value) => setState(() => _enabled = value),
-                ),
-              ],
-            ),
-          ],
-        ),
+            ],
+          ),
+          AppGap.lg(),
+          AppRangeInput(
+            startController: _startPortController,
+            endController: _endPortController,
+            startFocusNode: _startPortFocus,
+            endFocusNode: _endPortFocus,
+            startLabel: loc(context).startPort,
+            endLabel: loc(context).endPort,
+            startIdentifier: 'ipv6-rule-start-port',
+            endIdentifier: 'ipv6-rule-end-port',
+            errorText: _errors['startPort'] ?? _errors['endPort'],
+            onChanged: (_, __) => _onInputChanged(),
+          ),
+          AppGap.lg(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              AppText.bodyMedium(loc(context).enabled),
+              AppSwitch(
+                identifier: 'ipv6-rule-enabled',
+                value: _enabled,
+                onChanged: (value) => setState(() => _enabled = value),
+              ),
+            ],
+          ),
+        ],
       ),
       actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(loc(context).cancel),
+        AppButton.text(
+          identifier: 'ipv6-rule-cancel',
+          label: loc(context).cancel,
+          onTap: () => Navigator.of(context).pop(),
         ),
-        FilledButton(
-          onPressed: _isFormValid ? _submit : null,
-          child: Text(_isEdit ? loc(context).save : loc(context).add),
+        AppButton.text(
+          identifier: 'ipv6-rule-submit',
+          label: _isEdit ? loc(context).save : loc(context).add,
+          onTap: _isFormValid ? _submit : null,
         ),
       ],
     );

--- a/lib/page/port_forwarding/views/components/usp_single_port_tab.dart
+++ b/lib/page/port_forwarding/views/components/usp_single_port_tab.dart
@@ -171,6 +171,7 @@ class UspSinglePortTab extends ConsumerWidget {
           onTap: () => context.pop(),
         ),
         AppButton.dangerText(
+          identifier: 'pf-delete-confirm',
           label: loc(context).delete,
           onTap: () => context.pop(true),
         ),

--- a/lib/page/wifi_settings/views/components/wifi_network_card.dart
+++ b/lib/page/wifi_settings/views/components/wifi_network_card.dart
@@ -158,6 +158,7 @@ class WifiNetworkCard extends ConsumerWidget {
       title: loc(context).name,
       contentBuilder: (ctx, setState, onSubmit) => AppTextFormField(
         controller: controller,
+        identifier: 'wifi-ssid-name-input',
         label: loc(context).name,
         onChanged: (_) => setState(() {}),
       ),

--- a/lib/page/wifi_settings/views/components/wifi_quick_setup_card.dart
+++ b/lib/page/wifi_settings/views/components/wifi_quick_setup_card.dart
@@ -113,6 +113,7 @@ class WifiQuickSetupCard extends ConsumerWidget {
       title: loc(context).name,
       contentBuilder: (ctx, setState, onSubmit) => AppTextFormField(
         controller: controller,
+        identifier: 'wifi-ssid-name-input',
         label: loc(context).name,
         onChanged: (_) => setState(() {}),
       ),


### PR DESCRIPTION
## Summary

Migrates the port-forwarding and IPv6 port-service rule dialogs from raw
Material `AlertDialog` to the UI Kit `AppDialog` pattern, closing the
tech-debt tracked in #1166.

## Stacking note

> ⚠️ **This PR is stacked on #1205** (`feat/1172-e2e-dialog-identifiers`),
> not on `dev-2.7.0` directly. The `port_forwarding_dialog` action buttons
> were already migrated to `AppButton.text` in #1205; basing on that branch
> avoids touching the same lines and conflicting.
>
> **After #1205 merges into `dev-2.7.0`, re-target this PR's base to
> `dev-2.7.0`.** GitHub will recompute the diff automatically.

## Changes

- **`port_forwarding_dialog.dart`**: `AlertDialog` → `AppDialog`, title
  `Text()` → `AppText.titleLarge`, dropped `SingleChildScrollView` in favor
  of `scrollable: true`. Action buttons were already `AppButton.text`
  (from #1205), left untouched.
- **`ipv6_port_service_rule_dialog.dart`**: same dialog-shell migration,
  plus action buttons `TextButton`/`FilledButton` → `AppButton.text` (new
  identifiers `ipv6-rule-cancel` / `ipv6-rule-submit`).
- The third dialog from the original issue (`port_range_forwarding_dialog`)
  already used `AppDialog` and is **not** part of this PR.

## Behavior preserved

- Focus-loss validation, `_isFormValid` / `_hasRequiredInput` submit gating,
  and all E2E `identifier`s remain intact.
- Callers already used `showAppDialog` — no caller changes needed.
- Remaining raw `Text()` is only `SegmentedButton.ButtonSegment.label`
  (Material API requires a `Widget`).

## Issue description drift (heads-up)

Issue #1166's acceptance criteria are partly stale:
- The **third dialog** (`port_range_forwarding_dialog`) is already done.
- **`semanticLabel`s were replaced by `identifier`s** in #1172/#1205, so the
  "preserve semanticLabels" criterion should read "preserve identifiers".

## E2E SSOT follow-up (Article XVI §16.4)

Two new identifiers (`ipv6-rule-cancel`, `ipv6-rule-submit`) are added. The
E2E selector map is derived from app source — regenerate it (`npm run gen:ids`
in the e2e repo) and migrate any spec that located the IPv6 dialog cancel/submit
via `getByRole({name})` to `byIdentifier()`.

## Testing

- `flutter analyze`: no issues.
- Golden tests (both pages): 44/44 pass; baselines regenerated locally, all
  interaction flows (open / input / validate / submit) render without error.
  Baselines are gitignored, so no golden files are committed.
- Functional provider/service tests: 94/94 pass.

Closes #1166