### PR TITLE
fix(ai): map storage and config failures to ServiceError instead of surfacing
  raw exceptions (#1203)

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -640,7 +640,6 @@
   "factoryResetInProgress": "جارٍ إعادة الضبط إلى إعدادات المصنع",
   "factoryResetWaitMessage": "يقوم جهاز التوجيه بالاستعادة إلى إعدادات المصنع الافتراضية. ستحتاج إلى الإعداد وتسجيل الدخول مرة أخرى.",
   "failed": "فشل",
-  "failedToInitialize": "فشلت التهيئة: {error}",
   "failedToLoadSettings": "فشل تحميل الإعدادات",
   "failedToRenew": "فشل التجديد: {error}",
   "failedToStartOtaUpdate": "فشل بدء تحديث OTA",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -639,7 +639,6 @@
   "factoryResetInProgress": "Fabriksnulstilling i gang",
   "factoryResetWaitMessage": "Routeren gendannes til fabriksindstillingerne. Du skal opsætte og logge ind igen.",
   "failed": "Mislykkedes",
-  "failedToInitialize": "Initialisering mislykkedes: {error}",
   "failedToLoadSettings": "Indlæsning af indstillinger mislykkedes",
   "failedToRenew": "Fornyelse mislykkedes: {error}",
   "failedToStartOtaUpdate": "Start af OTA-opdatering mislykkedes",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -639,7 +639,6 @@
   "factoryResetInProgress": "Zurücksetzen auf Werkseinstellungen läuft",
   "factoryResetWaitMessage": "Der Router wird auf die Werkseinstellungen zurückgesetzt. Sie müssen ihn erneut einrichten und sich erneut anmelden.",
   "failed": "Fehlgeschlagen",
-  "failedToInitialize": "Initialisierung fehlgeschlagen: {error}",
   "failedToLoadSettings": "Einstellungen konnten nicht geladen werden",
   "failedToRenew": "Erneuern fehlgeschlagen: {error}",
   "failedToStartOtaUpdate": "OTA-Update konnte nicht gestartet werden",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -637,7 +637,6 @@
   "factoryResetInProgress": "Η επαναφορά εργοστασιακών ρυθμίσεων είναι σε εξέλιξη",
   "factoryResetWaitMessage": "Ο δρομολογητής επαναφέρεται στις εργοστασιακές ρυθμίσεις. Θα χρειαστεί να κάνετε ξανά εγκατάσταση και σύνδεση.",
   "failed": "Απέτυχε",
-  "failedToInitialize": "Αποτυχία αρχικοποίησης: {error}",
   "failedToLoadSettings": "Αποτυχία φόρτωσης ρυθμίσεων",
   "failedToRenew": "Αποτυχία ανανέωσης: {error}",
   "failedToStartOtaUpdate": "Αποτυχία έναρξης της ενημέρωσης OTA",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1414,14 +1414,6 @@
   "connecting": "Connecting...",
   "connect": "Connect",
   "fillAllRequiredFields": "Please fill in all required fields",
-  "failedToInitialize": "Failed to initialize: {error}",
-  "@failedToInitialize": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
   "confirmationRequired": "Confirmation Required",
   "confirmExecuteOperation": "Are you sure you want to execute this operation?",
   "confirm": "Confirm",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -639,7 +639,6 @@
   "factoryResetInProgress": "Restablecimiento de fábrica en curso",
   "factoryResetWaitMessage": "El router está restaurando los valores de fábrica. Tendrá que volver a configurarlo e iniciar sesión de nuevo.",
   "failed": "Fallido",
-  "failedToInitialize": "Error al inicializar: {error}",
   "failedToLoadSettings": "Error al cargar la configuración",
   "failedToRenew": "Error al renovar: {error}",
   "failedToStartOtaUpdate": "Error al iniciar la actualización OTA",

--- a/lib/l10n/app_es_ar.arb
+++ b/lib/l10n/app_es_ar.arb
@@ -639,7 +639,6 @@
   "factoryResetInProgress": "Restablecimiento de fábrica en curso",
   "factoryResetWaitMessage": "El router está restaurando los valores de fábrica. Deberá configurarlo e iniciar sesión nuevamente.",
   "failed": "Falló",
-  "failedToInitialize": "Error al inicializar: {error}",
   "failedToLoadSettings": "Error al cargar la configuración",
   "failedToRenew": "Error al renovar: {error}",
   "failedToStartOtaUpdate": "Error al iniciar la actualización OTA",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -637,7 +637,6 @@
   "factoryResetInProgress": "Tehdasasetusten palautus käynnissä",
   "factoryResetWaitMessage": "Reititin palauttaa tehdasasetuksia. Sinun on määritettävä ja kirjauduttava sisään uudelleen.",
   "failed": "Epäonnistui",
-  "failedToInitialize": "Alustus epäonnistui: {error}",
   "failedToLoadSettings": "Asetusten lataaminen epäonnistui",
   "failedToRenew": "Uusiminen epäonnistui: {error}",
   "failedToStartOtaUpdate": "OTA-päivityksen aloitus epäonnistui",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -639,7 +639,6 @@
   "factoryResetInProgress": "Réinitialisation d'usine en cours",
   "factoryResetWaitMessage": "Le routeur est en cours de restauration aux paramètres d'usine. Vous devrez le configurer et vous reconnecter.",
   "failed": "Échec",
-  "failedToInitialize": "Échec de l'initialisation : {error}",
   "failedToLoadSettings": "Échec du chargement des paramètres",
   "failedToRenew": "Échec du renouvellement : {error}",
   "failedToStartOtaUpdate": "Échec du démarrage de la mise à jour OTA",

--- a/lib/l10n/app_fr_ca.arb
+++ b/lib/l10n/app_fr_ca.arb
@@ -639,7 +639,6 @@
   "factoryResetInProgress": "Réinitialisation aux paramètres d'usine en cours",
   "factoryResetWaitMessage": "Le routeur revient à sa configuration d'usine par défaut. Vous devrez le configurer et vous reconnecter.",
   "failed": "Échec",
-  "failedToInitialize": "Échec de l'initialisation : {error}",
   "failedToLoadSettings": "Échec du chargement des paramètres",
   "failedToRenew": "Échec du renouvellement : {error}",
   "failedToStartOtaUpdate": "Échec du démarrage de la mise à jour OTA",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -637,7 +637,6 @@
   "factoryResetInProgress": "Reset pabrik sedang berlangsung",
   "factoryResetWaitMessage": "Router sedang memulihkan ke default pabrik. Anda perlu menyiapkan dan masuk lagi.",
   "failed": "Gagal",
-  "failedToInitialize": "Gagal menginisialisasi: {error}",
   "failedToLoadSettings": "Gagal memuat setelan",
   "failedToRenew": "Gagal memperbarui: {error}",
   "failedToStartOtaUpdate": "Gagal memulai pembaruan OTA",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -639,7 +639,6 @@
   "factoryResetInProgress": "Ripristino delle impostazioni di fabbrica in corso",
   "factoryResetWaitMessage": "Il router sta ripristinando le impostazioni di fabbrica. Dovrai effettuare nuovamente la configurazione e l'accesso.",
   "failed": "Non riuscito",
-  "failedToInitialize": "Inizializzazione non riuscita: {error}",
   "failedToLoadSettings": "Caricamento delle impostazioni non riuscito",
   "failedToRenew": "Rinnovo non riuscito: {error}",
   "failedToStartOtaUpdate": "Avvio dell'aggiornamento OTA non riuscito",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -640,7 +640,6 @@
   "factoryResetInProgress": "工場出荷時設定へのリセット中",
   "factoryResetWaitMessage": "ルーターを工場出荷時設定に復元しています。再度セットアップしてログインする必要があります。",
   "failed": "失敗",
-  "failedToInitialize": "初期化に失敗しました: {error}",
   "failedToLoadSettings": "設定の読み込みに失敗しました",
   "failedToRenew": "更新に失敗しました: {error}",
   "failedToStartOtaUpdate": "OTA 更新の開始に失敗しました",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -637,7 +637,6 @@
   "factoryResetInProgress": "공장 초기화 진행 중",
   "factoryResetWaitMessage": "라우터를 공장 기본값으로 복원하는 중입니다. 다시 설정하고 로그인해야 합니다.",
   "failed": "실패",
-  "failedToInitialize": "초기화 실패: {error}",
   "failedToLoadSettings": "설정 로드 실패",
   "failedToRenew": "갱신 실패: {error}",
   "failedToStartOtaUpdate": "OTA 업데이트 시작 실패",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -639,7 +639,6 @@
   "factoryResetInProgress": "Tilbakestilling til fabrikkinnstillinger pågår",
   "factoryResetWaitMessage": "Ruteren tilbakestilles til fabrikkinnstillingene. Du må sette opp og logge inn på nytt.",
   "failed": "Mislyktes",
-  "failedToInitialize": "Klarte ikke å initialisere: {error}",
   "failedToLoadSettings": "Klarte ikke å laste inn innstillinger",
   "failedToRenew": "Klarte ikke å fornye: {error}",
   "failedToStartOtaUpdate": "Klarte ikke å starte OTA-oppdatering",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -639,7 +639,6 @@
   "factoryResetInProgress": "Fabrieksinstellingen worden hersteld",
   "factoryResetWaitMessage": "De router wordt teruggezet naar de fabrieksinstellingen. U moet opnieuw instellen en aanmelden.",
   "failed": "Mislukt",
-  "failedToInitialize": "Initialiseren mislukt: {error}",
   "failedToLoadSettings": "Instellingen laden mislukt",
   "failedToRenew": "Vernieuwen mislukt: {error}",
   "failedToStartOtaUpdate": "OTA-update starten mislukt",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -637,7 +637,6 @@
   "factoryResetInProgress": "Trwa przywracanie ustawień fabrycznych",
   "factoryResetWaitMessage": "Router przywraca ustawienia fabryczne. Trzeba będzie ponownie skonfigurować i zalogować się.",
   "failed": "Niepowodzenie",
-  "failedToInitialize": "Nie udało się zainicjować: {error}",
   "failedToLoadSettings": "Nie udało się załadować ustawień",
   "failedToRenew": "Nie udało się odnowić: {error}",
   "failedToStartOtaUpdate": "Nie udało się rozpocząć aktualizacji OTA",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -639,7 +639,6 @@
   "factoryResetInProgress": "Redefinição de fábrica em andamento",
   "factoryResetWaitMessage": "O roteador está sendo restaurado para os padrões de fábrica. Você precisará configurá-lo e fazer login novamente.",
   "failed": "Falhou",
-  "failedToInitialize": "Falha ao inicializar: {error}",
   "failedToLoadSettings": "Falha ao carregar as configurações",
   "failedToRenew": "Falha ao renovar: {error}",
   "failedToStartOtaUpdate": "Falha ao iniciar a atualização OTA",

--- a/lib/l10n/app_pt_pt.arb
+++ b/lib/l10n/app_pt_pt.arb
@@ -639,7 +639,6 @@
   "factoryResetInProgress": "Reposição de fábrica em curso",
   "factoryResetWaitMessage": "O router está a repor as predefinições de fábrica. Terá de o configurar e iniciar sessão novamente.",
   "failed": "Falhou",
-  "failedToInitialize": "Falha ao inicializar: {error}",
   "failedToLoadSettings": "Falha ao carregar as definições",
   "failedToRenew": "Falha ao renovar: {error}",
   "failedToStartOtaUpdate": "Falha ao iniciar a atualização OTA",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -637,7 +637,6 @@
   "factoryResetInProgress": "Выполняется сброс к заводским настройкам",
   "factoryResetWaitMessage": "Маршрутизатор восстанавливает заводские настройки. Вам потребуется снова выполнить настройку и вход.",
   "failed": "Не удалось",
-  "failedToInitialize": "Не удалось инициализировать: {error}",
   "failedToLoadSettings": "Не удалось загрузить настройки",
   "failedToRenew": "Не удалось обновить: {error}",
   "failedToStartOtaUpdate": "Не удалось запустить обновление OTA",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -639,7 +639,6 @@
   "factoryResetInProgress": "Fabriksåterställning pågår",
   "factoryResetWaitMessage": "Routern återställs till fabriksinställningarna. Du behöver konfigurera och logga in igen.",
   "failed": "Misslyckades",
-  "failedToInitialize": "Det gick inte att initiera: {error}",
   "failedToLoadSettings": "Det gick inte att läsa in inställningarna",
   "failedToRenew": "Det gick inte att förnya: {error}",
   "failedToStartOtaUpdate": "Det gick inte att starta OTA-uppdateringen",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -637,7 +637,6 @@
   "factoryResetInProgress": "กำลังรีเซ็ตเป็นค่าจากโรงงาน",
   "factoryResetWaitMessage": "เราเตอร์กำลังคืนค่าเป็นค่าเริ่มต้นจากโรงงาน คุณจะต้องตั้งค่าและลงชื่อเข้าใช้อีกครั้ง",
   "failed": "ล้มเหลว",
-  "failedToInitialize": "เริ่มต้นไม่สำเร็จ: {error}",
   "failedToLoadSettings": "โหลดการตั้งค่าไม่สำเร็จ",
   "failedToRenew": "ต่ออายุไม่สำเร็จ: {error}",
   "failedToStartOtaUpdate": "เริ่มการอัปเดต OTA ไม่สำเร็จ",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -637,7 +637,6 @@
   "factoryResetInProgress": "Fabrika ayarlarına sıfırlama devam ediyor",
   "factoryResetWaitMessage": "Yönlendirici fabrika ayarlarına geri yükleniyor. Yeniden kurulum yapmanız ve tekrar oturum açmanız gerekecek.",
   "failed": "Başarısız",
-  "failedToInitialize": "Başlatılamadı: {error}",
   "failedToLoadSettings": "Ayarlar yüklenemedi",
   "failedToRenew": "Yenilenemedi: {error}",
   "failedToStartOtaUpdate": "OTA güncellemesi başlatılamadı",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -637,7 +637,6 @@
   "factoryResetInProgress": "Đang khôi phục cài đặt gốc",
   "factoryResetWaitMessage": "Router đang khôi phục về cài đặt gốc. Bạn sẽ cần thiết lập và đăng nhập lại.",
   "failed": "Thất bại",
-  "failedToInitialize": "Khởi tạo thất bại: {error}",
   "failedToLoadSettings": "Tải cài đặt thất bại",
   "failedToRenew": "Gia hạn thất bại: {error}",
   "failedToStartOtaUpdate": "Bắt đầu cập nhật OTA thất bại",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -640,7 +640,6 @@
   "factoryResetInProgress": "正在恢复出厂设置",
   "factoryResetWaitMessage": "路由器正在恢复出厂默认设置。您需要重新设置并登录。",
   "failed": "失败",
-  "failedToInitialize": "初始化失败：{error}",
   "failedToLoadSettings": "加载设置失败",
   "failedToRenew": "续订失败：{error}",
   "failedToStartOtaUpdate": "启动 OTA 更新失败",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -640,7 +640,6 @@
   "factoryResetInProgress": "正在恢復原廠設定",
   "factoryResetWaitMessage": "路由器正在恢復至原廠預設值。您將需要重新設定並登入。",
   "failed": "失敗",
-  "failedToInitialize": "初始化失敗：{error}",
   "failedToLoadSettings": "載入設定失敗",
   "failedToRenew": "更新失敗：{error}",
   "failedToStartOtaUpdate": "啟動 OTA 更新失敗",

--- a/lib/page/ai_assistant/services/aws_credentials_store.dart
+++ b/lib/page/ai_assistant/services/aws_credentials_store.dart
@@ -99,10 +99,11 @@ class AwsCredentialsStore {
   /// the platform gives no way to cancel and `write` is not conditional, the
   /// only sound answer is to never let two operations overlap.
   ///
-  /// The cost is that one hung platform call blocks later operations — including
-  /// a `clear()` — for as long as it hangs. That is a genuine downside, accepted
-  /// because the alternative silently loses or resurrects credentials, and
-  /// because the caller is still told promptly via [_kCallerTimeout].
+  /// The cost is that one hung platform call blocks the operations behind it for
+  /// as long as it hangs, and since the platform never reports back, that can be
+  /// the rest of the session. Accepted for writes, whose worst case is a stale
+  /// record. NOT accepted for [clear] — see [_forceClear], because a revocation
+  /// that can never be applied is the one failure this class must not have.
   Future<T> _serialize<T>(Future<T> Function() operation) {
     final settled = _pending.then((_) => operation());
     // Chained to the real completion, so nothing starts early. This also
@@ -161,23 +162,31 @@ class AwsCredentialsStore {
     });
   }
 
-  /// The stored credentials, or null when nothing usable is saved.
-  ///
-  /// Returns null rather than a half-built record for anything unusable —
-  /// absent, blank, or unparseable — so the caller's "not configured" path
-  /// handles it instead of a signing error later. A bad record is therefore not
-  /// an error; only storage itself failing is ([StorageError], [TimeoutError]).
-  /// As [read], but giving up after [within] instead of [_kCallerTimeout].
+  /// As [read], but giving up after `min(within, _kCallerTimeout)`.
   ///
   /// For a caller that is holding UI hostage while it waits — the config screen
   /// disables itself during a restore — and would rather show an empty form
   /// sooner than the default allows. Wrapping `read()` in `.timeout()` at the
   /// call site instead would throw a bare `TimeoutException`, breaking this
   /// class's guarantee that callers only ever see a [ServiceError].
-  Future<StoredAwsCredentials?> readWithin(Duration within) => read()
-      .timeout(within)
-      .onError<Object>((e, _) => throw _asServiceError(e));
+  ///
+  /// The bound is a minimum, not a replacement: `read()` is already bounded by
+  /// [_kCallerTimeout], so a [within] longer than that has no effect. Asserted
+  /// rather than left as a trap for a future caller.
+  Future<StoredAwsCredentials?> readWithin(Duration within) {
+    assert(within <= _kCallerTimeout,
+        'readWithin cannot extend the bound past _kCallerTimeout');
+    return read()
+        .timeout(within)
+        .onError<Object>((e, _) => throw _asServiceError(e));
+  }
 
+  /// The stored credentials, or null when nothing usable is saved.
+  ///
+  /// Returns null rather than a half-built record for anything unusable —
+  /// absent, blank, or unparseable — so the caller's "not configured" path
+  /// handles it instead of a signing error later. A bad record is therefore not
+  /// an error; only storage itself failing is ([StorageError], [TimeoutError]).
   Future<StoredAwsCredentials?> read() {
     return _serialize(() async {
       final record = await _readRecord();
@@ -217,14 +226,70 @@ class AwsCredentialsStore {
   /// Remove the stored credentials.
   ///
   /// This is the revocation path — the user pressing "change configuration"
-  /// means they want these credentials gone. A [TimeoutError] here means the
-  /// platform has not answered yet, not that the delete was dropped: it stays
-  /// queued, and nothing requested after it can be applied before it.
+  /// means they want these credentials gone.
+  ///
+  /// Ordinarily queued like everything else, so it cannot be undone by a write
+  /// requested before it. But a queue held by a platform call that never returns
+  /// would mean a revocation is never applied and the record silently restores
+  /// on the next launch, so this one operation escapes that: see [_forceClear].
   Future<void> clear() {
-    return _serialize(() async {
+    final queued = _serialize(() async {
       await _storage.delete(key: _kRecordKey);
       aiLog('[Credentials] Cleared');
     });
+    return queued
+        .onError<TimeoutError>((_, __) => _clearOutOfBand().then((_) {}));
+  }
+
+  /// Delete outside the queue, unless the queued delete already landed.
+  ///
+  /// The check first, because a slow-but-moving queue often applies its delete
+  /// while the caller's bound is elapsing — and skipping the queue is a
+  /// concession that should not be made when it is not needed.
+  Future<void> _clearOutOfBand() async {
+    if (await _isRecordAbsent()) {
+      aiLog('[Credentials] Queued clear landed after its caller gave up');
+      return;
+    }
+    return _forceClear();
+  }
+
+  Future<bool> _isRecordAbsent() async {
+    try {
+      final raw =
+          await _storage.read(key: _kRecordKey).timeout(_kCallerTimeout);
+      return raw == null || raw.isEmpty;
+    } catch (_) {
+      // Cannot tell; assume it is still there so the delete is attempted.
+      return false;
+    }
+  }
+
+  /// Delete the record without waiting for the queue.
+  ///
+  /// Reached only when a queued [clear] timed out, which means some earlier
+  /// platform call has not returned. Skipping the queue reintroduces the overlap
+  /// [_serialize] exists to prevent — deliberately, and only here:
+  ///
+  /// * the racing operation can only be a write, and the user has since asked
+  ///   for the record to be gone, so if the delete loses the race the outcome is
+  ///   the same stale record we already had, not a worse one
+  /// * whereas not trying at all means the revocation is never applied and the
+  ///   credentials come back on the next launch
+  ///
+  /// The queued attempt is left running: if it eventually completes, it deletes
+  /// an already-deleted key, which is a no-op.
+  Future<void> _forceClear() async {
+    aiLog('[Credentials] Queue stalled; deleting outside it');
+    try {
+      await _storage.delete(key: _kRecordKey).timeout(_kCallerTimeout);
+      aiLog('[Credentials] Cleared out of band');
+    } catch (e) {
+      // The caller shows this one, unlike other storage failures: the user
+      // believes these credentials are gone and they are not.
+      aiLog('[Credentials] Out-of-band clear failed: ${e.runtimeType}');
+      throw _asServiceError(e);
+    }
   }
 
   /// The stored record as a map, or null when there is nothing usable.

--- a/lib/page/ai_assistant/services/aws_credentials_store.dart
+++ b/lib/page/ai_assistant/services/aws_credentials_store.dart
@@ -14,12 +14,13 @@ import 'package:privacy_gui/core/errors/service_error.dart';
 /// failure rather than "not configured".
 const _kRecordKey = 'ai_assistant_aws_credentials';
 
-/// How long a single storage operation may take before the chain gives up.
+/// How long a caller waits for its own operation before being told it failed.
 ///
-/// Without this, one hung `write` blocks every operation queued behind it — the
-/// user's `clear()` included, so "change configuration" would never take effect
-/// and the config screen would stay disabled with no error.
-const _kOperationTimeout = Duration(seconds: 10);
+/// This bounds the *reported* wait, not the operation. A stalled platform call
+/// keeps its place in the queue — see [AwsCredentialsStore._serialize] for why
+/// abandoning that place is unsafe — so this only stops a caller (a `View`
+/// awaiting a restore, say) from hanging on a keychain that never answers.
+const _kCallerTimeout = Duration(seconds: 10);
 
 final awsCredentialsStoreProvider = Provider<AwsCredentialsStore>((ref) {
   return AwsCredentialsStore(const FlutterSecureStorage());
@@ -44,8 +45,10 @@ final awsCredentialsStoreProvider = Provider<AwsCredentialsStore>((ref) {
 /// the "change configuration" that followed it — resurrecting credentials the
 /// user had just discarded.
 ///
-/// Each operation is bounded by [_kOperationTimeout] so one that never settles
-/// cannot hold the queue — and with it the user's `clear()` — indefinitely.
+/// Operations never overlap, even when one stalls: [_kCallerTimeout] bounds what
+/// a caller waits for, not the operation itself. See [_serialize] — abandoning a
+/// stalled operation's place in the queue is what makes credentials go missing
+/// or come back.
 ///
 /// The ordering guarantee holds because [awsCredentialsStoreProvider] is a
 /// plain [Provider], i.e. one instance for the session. Making it `autoDispose`
@@ -55,7 +58,7 @@ final awsCredentialsStoreProvider = Provider<AwsCredentialsStore>((ref) {
 ///
 /// Every method throws only [ServiceError] subtypes — [StorageError] for a
 /// platform storage failure, [TimeoutError] when an operation exceeds
-/// [_kOperationTimeout]. `FlutterSecureStorage`'s `PlatformException` never
+/// [_kCallerTimeout]. `FlutterSecureStorage`'s `PlatformException` never
 /// leaves this class, so no caller has to reason about platform-specific error
 /// shapes (constitution Art. XIII §13.1).
 ///
@@ -70,47 +73,49 @@ class AwsCredentialsStore {
   /// Tail of the operation chain; each new operation is appended to it.
   Future<void> _pending = Future.value();
 
-  /// Counts [clear] calls, so a write can tell whether one overtook it.
-  ///
-  /// `Future.timeout` does not cancel the operation it wraps — it only stops
-  /// waiting. A write that exceeds [_kOperationTimeout] therefore keeps running
-  /// after the queue has moved on, and can reach storage *after* a later
-  /// `clear()` has deleted the record — resurrecting credentials the user
-  /// revoked, which is the failure serialising exists to prevent. Timing the
-  /// queue out is what makes that reachable, and not timing it out lets one
-  /// hung write block the `clear()` entirely: same outcome, different route.
-  ///
-  /// So the timeout stays, and this counter gives `clear()` the last word
-  /// instead. See [_undoIfCleared].
-  int _clearGeneration = 0;
-
   /// Run [operation] after every operation requested before it.
   ///
-  /// The chain is never broken by a failure: the tail swallows errors so a
-  /// rejected write cannot stop later operations from running, while the
-  /// returned future still reports the failure to this caller. A timeout counts
-  /// as a failure, which is what stops a stalled operation from blocking the
-  /// queue forever.
+  /// The queue waits for each operation to genuinely settle; only the future
+  /// handed back to the caller is time-bounded.
   ///
-  /// This is also the single place platform errors are converted, so each
-  /// method body can stay free of error handling.
+  /// ## Why the timeout must not apply to the queue
+  ///
+  /// `Future.timeout` does not cancel the operation it wraps — it only stops
+  /// waiting. So timing out the *queue* does not remove a stalled platform call;
+  /// it lets the next operation start while that call is still in flight, and
+  /// whichever finishes last wins at the storage layer. Every ordering
+  /// guarantee this class exists to provide is lost at that moment:
+  ///
+  /// * a stalled `clear()` can delete credentials the user entered afterwards,
+  ///   while their `store()` reports success
+  /// * a stalled `store()` can restore credentials a later `clear()` removed
+  /// * a stalled `storeModelId()` — a read-modify-write — can rewrite the whole
+  ///   record from its stale snapshot over newer credentials, with no `clear()`
+  ///   involved at all
+  ///
+  /// Guarding writes with a "has a clear happened since?" counter cannot fix
+  /// this: it answers a different question than the one that matters, which is
+  /// whether the record in storage is still the one this operation wrote. Since
+  /// the platform gives no way to cancel and `write` is not conditional, the
+  /// only sound answer is to never let two operations overlap.
+  ///
+  /// The cost is that one hung platform call blocks later operations — including
+  /// a `clear()` — for as long as it hangs. That is a genuine downside, accepted
+  /// because the alternative silently loses or resurrects credentials, and
+  /// because the caller is still told promptly via [_kCallerTimeout].
   Future<T> _serialize<T>(Future<T> Function() operation) {
-    final result = _pending
-        .then((_) => operation().timeout(_kOperationTimeout))
+    final settled = _pending.then((_) => operation());
+    // Chained to the real completion, so nothing starts early. This also
+    // handles a late failure: without a listener, an operation that fails after
+    // its caller's timeout has stopped watching becomes an unhandled async
+    // error.
+    _pending = settled.then((_) {}, onError: (Object e) {
+      aiLog('[Credentials] Operation failed after its caller stopped waiting: '
+          '${e.runtimeType}');
+    });
+    return settled
+        .timeout(_kCallerTimeout)
         .onError<Object>((e, _) => throw _asServiceError(e));
-    _pending = result.then((_) {}, onError: (_) {});
-    return result;
-  }
-
-  /// Delete the record if a [clear] happened since [generationAtStart].
-  ///
-  /// Covers the write that lost its place in the queue by timing out: it cannot
-  /// be cancelled, so the record it may have just written is removed instead.
-  /// Called after every write, and cheap when nothing raced.
-  Future<void> _undoIfCleared(int generationAtStart) async {
-    if (_clearGeneration == generationAtStart) return;
-    await _storage.delete(key: _kRecordKey);
-    aiLog('[Credentials] Discarded a write that a clear had superseded');
   }
 
   /// Convert anything storage throws into a [ServiceError].
@@ -135,16 +140,14 @@ class AwsCredentialsStore {
   /// Persist the credentials and the selected model.
   ///
   /// Values are never logged. Throws [StorageError] or [TimeoutError].
+  ///
+  /// A [TimeoutError] means only that the platform has not answered yet — the
+  /// write is still queued and will still be applied in order.
   Future<void> store({
     required String accessKeyId,
     required String secretAccessKey,
     required String modelId,
   }) {
-    // Captured here, synchronously, NOT inside the queued body: the body does
-    // not run until the queue reaches it, by which point a `clear()` issued
-    // right after this call would already have bumped the counter and the
-    // comparison would see no race.
-    final generation = _clearGeneration;
     return _serialize(() async {
       await _storage.write(
         key: _kRecordKey,
@@ -155,7 +158,6 @@ class AwsCredentialsStore {
         }),
       );
       aiLog('[Credentials] Stored');
-      await _undoIfCleared(generation);
     });
   }
 
@@ -165,6 +167,17 @@ class AwsCredentialsStore {
   /// absent, blank, or unparseable — so the caller's "not configured" path
   /// handles it instead of a signing error later. A bad record is therefore not
   /// an error; only storage itself failing is ([StorageError], [TimeoutError]).
+  /// As [read], but giving up after [within] instead of [_kCallerTimeout].
+  ///
+  /// For a caller that is holding UI hostage while it waits — the config screen
+  /// disables itself during a restore — and would rather show an empty form
+  /// sooner than the default allows. Wrapping `read()` in `.timeout()` at the
+  /// call site instead would throw a bare `TimeoutException`, breaking this
+  /// class's guarantee that callers only ever see a [ServiceError].
+  Future<StoredAwsCredentials?> readWithin(Duration within) => read()
+      .timeout(within)
+      .onError<Object>((e, _) => throw _asServiceError(e));
+
   Future<StoredAwsCredentials?> read() {
     return _serialize(() async {
       final record = await _readRecord();
@@ -191,7 +204,6 @@ class AwsCredentialsStore {
   /// Does nothing when there is no record to update — there is no useful
   /// meaning to a model preference without credentials to use it with.
   Future<void> storeModelId(String modelId) {
-    final generation = _clearGeneration; // see store()
     return _serialize(() async {
       final record = await _readRecord();
       if (record == null) return;
@@ -199,17 +211,16 @@ class AwsCredentialsStore {
       record['modelId'] = modelId;
       await _storage.write(key: _kRecordKey, value: jsonEncode(record));
       aiLog('[Credentials] Model updated');
-      await _undoIfCleared(generation);
     });
   }
 
+  /// Remove the stored credentials.
+  ///
+  /// This is the revocation path — the user pressing "change configuration"
+  /// means they want these credentials gone. A [TimeoutError] here means the
+  /// platform has not answered yet, not that the delete was dropped: it stays
+  /// queued, and nothing requested after it can be applied before it.
   Future<void> clear() {
-    // Recorded when the clear is *requested*, not when the queue reaches it, so
-    // the intent is captured at the moment the user expressed it. (Bumping
-    // inside the queued body happens to behave the same today, because the body
-    // runs as soon as a timed-out write lets go — but that equivalence depends
-    // on queue mechanics, and this does not.)
-    _clearGeneration++;
     return _serialize(() async {
       await _storage.delete(key: _kRecordKey);
       aiLog('[Credentials] Cleared');

--- a/lib/page/ai_assistant/services/aws_credentials_store.dart
+++ b/lib/page/ai_assistant/services/aws_credentials_store.dart
@@ -70,6 +70,20 @@ class AwsCredentialsStore {
   /// Tail of the operation chain; each new operation is appended to it.
   Future<void> _pending = Future.value();
 
+  /// Counts [clear] calls, so a write can tell whether one overtook it.
+  ///
+  /// `Future.timeout` does not cancel the operation it wraps — it only stops
+  /// waiting. A write that exceeds [_kOperationTimeout] therefore keeps running
+  /// after the queue has moved on, and can reach storage *after* a later
+  /// `clear()` has deleted the record — resurrecting credentials the user
+  /// revoked, which is the failure serialising exists to prevent. Timing the
+  /// queue out is what makes that reachable, and not timing it out lets one
+  /// hung write block the `clear()` entirely: same outcome, different route.
+  ///
+  /// So the timeout stays, and this counter gives `clear()` the last word
+  /// instead. See [_undoIfCleared].
+  int _clearGeneration = 0;
+
   /// Run [operation] after every operation requested before it.
   ///
   /// The chain is never broken by a failure: the tail swallows errors so a
@@ -86,6 +100,17 @@ class AwsCredentialsStore {
         .onError<Object>((e, _) => throw _asServiceError(e));
     _pending = result.then((_) {}, onError: (_) {});
     return result;
+  }
+
+  /// Delete the record if a [clear] happened since [generationAtStart].
+  ///
+  /// Covers the write that lost its place in the queue by timing out: it cannot
+  /// be cancelled, so the record it may have just written is removed instead.
+  /// Called after every write, and cheap when nothing raced.
+  Future<void> _undoIfCleared(int generationAtStart) async {
+    if (_clearGeneration == generationAtStart) return;
+    await _storage.delete(key: _kRecordKey);
+    aiLog('[Credentials] Discarded a write that a clear had superseded');
   }
 
   /// Convert anything storage throws into a [ServiceError].
@@ -115,6 +140,11 @@ class AwsCredentialsStore {
     required String secretAccessKey,
     required String modelId,
   }) {
+    // Captured here, synchronously, NOT inside the queued body: the body does
+    // not run until the queue reaches it, by which point a `clear()` issued
+    // right after this call would already have bumped the counter and the
+    // comparison would see no race.
+    final generation = _clearGeneration;
     return _serialize(() async {
       await _storage.write(
         key: _kRecordKey,
@@ -125,6 +155,7 @@ class AwsCredentialsStore {
         }),
       );
       aiLog('[Credentials] Stored');
+      await _undoIfCleared(generation);
     });
   }
 
@@ -160,6 +191,7 @@ class AwsCredentialsStore {
   /// Does nothing when there is no record to update — there is no useful
   /// meaning to a model preference without credentials to use it with.
   Future<void> storeModelId(String modelId) {
+    final generation = _clearGeneration; // see store()
     return _serialize(() async {
       final record = await _readRecord();
       if (record == null) return;
@@ -167,10 +199,17 @@ class AwsCredentialsStore {
       record['modelId'] = modelId;
       await _storage.write(key: _kRecordKey, value: jsonEncode(record));
       aiLog('[Credentials] Model updated');
+      await _undoIfCleared(generation);
     });
   }
 
   Future<void> clear() {
+    // Recorded when the clear is *requested*, not when the queue reaches it, so
+    // the intent is captured at the moment the user expressed it. (Bumping
+    // inside the queued body happens to behave the same today, because the body
+    // runs as soon as a timed-out write lets go — but that equivalence depends
+    // on queue mechanics, and this does not.)
+    _clearGeneration++;
     return _serialize(() async {
       await _storage.delete(key: _kRecordKey);
       aiLog('[Credentials] Cleared');

--- a/lib/page/ai_assistant/services/aws_credentials_store.dart
+++ b/lib/page/ai_assistant/services/aws_credentials_store.dart
@@ -1,8 +1,10 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:privacy_gui/ai/ai_logging.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 
 /// Single key holding the whole record.
 ///
@@ -48,6 +50,18 @@ final awsCredentialsStoreProvider = Provider<AwsCredentialsStore>((ref) {
 /// The ordering guarantee holds because [awsCredentialsStoreProvider] is a
 /// plain [Provider], i.e. one instance for the session. Making it `autoDispose`
 /// would hand out fresh chains and revive the race invisibly.
+///
+/// ## Errors
+///
+/// Every method throws only [ServiceError] subtypes — [StorageError] for a
+/// platform storage failure, [TimeoutError] when an operation exceeds
+/// [_kOperationTimeout]. `FlutterSecureStorage`'s `PlatformException` never
+/// leaves this class, so no caller has to reason about platform-specific error
+/// shapes (constitution Art. XIII §13.1).
+///
+/// Callers are expected to log these rather than show them: persistence is a
+/// convenience, and a failure to save leaves a working session untouched. The
+/// user has nothing to act on, so surfacing it would be noise.
 class AwsCredentialsStore {
   AwsCredentialsStore(this._storage);
 
@@ -63,16 +77,39 @@ class AwsCredentialsStore {
   /// returned future still reports the failure to this caller. A timeout counts
   /// as a failure, which is what stops a stalled operation from blocking the
   /// queue forever.
+  ///
+  /// This is also the single place platform errors are converted, so each
+  /// method body can stay free of error handling.
   Future<T> _serialize<T>(Future<T> Function() operation) {
-    final result =
-        _pending.then((_) => operation().timeout(_kOperationTimeout));
+    final result = _pending
+        .then((_) => operation().timeout(_kOperationTimeout))
+        .onError<Object>((e, _) => throw _asServiceError(e));
     _pending = result.then((_) {}, onError: (_) {});
     return result;
   }
 
+  /// Convert anything storage throws into a [ServiceError].
+  ///
+  /// The platform error goes on `originalError`, never into `detail`. `detail`
+  /// is the field a localizer may choose to surface — `localizeServiceError`
+  /// already does for `UnexpectedError` — and a keychain error code or a web
+  /// `localStorage` message is not something a user can act on. Keeping it out
+  /// means the leak cannot happen even if the mapping changes later.
+  /// `mapUspErrorToServiceError` makes the same call for an unparseable error.
+  ///
+  /// The `TimeoutError` detail is a fixed string naming the operation, not
+  /// error text — safe by construction, and useful in a log.
+  ServiceError _asServiceError(Object error) {
+    if (error is ServiceError) return error;
+    if (error is TimeoutException) {
+      return const TimeoutError(detail: 'credential storage');
+    }
+    return StorageError(originalError: error);
+  }
+
   /// Persist the credentials and the selected model.
   ///
-  /// Values are never logged.
+  /// Values are never logged. Throws [StorageError] or [TimeoutError].
   Future<void> store({
     required String accessKeyId,
     required String secretAccessKey,
@@ -95,7 +132,8 @@ class AwsCredentialsStore {
   ///
   /// Returns null rather than a half-built record for anything unusable —
   /// absent, blank, or unparseable — so the caller's "not configured" path
-  /// handles it instead of a signing error later.
+  /// handles it instead of a signing error later. A bad record is therefore not
+  /// an error; only storage itself failing is ([StorageError], [TimeoutError]).
   Future<StoredAwsCredentials?> read() {
     return _serialize(() async {
       final record = await _readRecord();

--- a/lib/page/ai_assistant/views/router_assistant_view.dart
+++ b/lib/page/ai_assistant/views/router_assistant_view.dart
@@ -60,10 +60,10 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
   /// * [_ConfigError.failure] — a real failure, carrying a `ServiceError` that
   ///   `localizeServiceError` turns into the displayed message.
   ///
-  /// Absent from this set on purpose: "environment config is unavailable".
-  /// `AWSConfig.fromEnvironment()` throwing `ConfigurationException` is the
-  /// normal path — it is how the app discovers it should show the manual form —
-  /// so it is logged and never shown as an error.
+  /// Absent from this set on purpose: "this build has no environment
+  /// credentials". That is the normal path — it is how the app discovers it
+  /// should show the manual form — so it is logged and never shown as an error.
+  /// See [_configFromEnvironment].
   _ConfigError? _configError;
   final _accessKeyController = TextEditingController();
   final _secretKeyController = TextEditingController();
@@ -101,32 +101,56 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
   }
 
   void _tryInitController() {
-    final commandProvider = ref.read(routerCommandProviderProvider);
+    final awsConfig = _configFromEnvironment();
+    if (awsConfig == null) {
+      // Nothing to report: the manual form is the next screen, and it already
+      // explains what to enter.
+      _needsConfig = true;
+      _configError = null;
+      return;
+    }
 
     try {
-      final awsConfig = AWSConfig.fromEnvironment();
       _controller = RouterChatController(
         generator: AwsContentGenerator(config: awsConfig),
-        commandProvider: commandProvider,
+        commandProvider: ref.read(routerCommandProviderProvider),
         routerContext: buildRouterContext(ref.read),
       );
       _controller!.addListener(_onControllerChanged);
       _needsConfig = false;
       _configError = null;
-    } on ConfigurationException catch (e) {
-      // Not an error: no environment credentials is the ordinary case, and the
-      // manual form is the correct next screen. Showing "AWS_ACCESS_KEY_ID not
-      // set" would report the app's own configuration as the user's problem.
-      aiLog('RouterAssistantView: No environment config (${e.missingKey})');
-      _needsConfig = true;
-      _configError = null;
     } catch (e) {
-      // Full text in the log: per the error-handling guide, detail/code are
-      // diagnostic material for the engineer. Only the UI is restricted.
+      // A genuine failure, unlike the branch above: the credentials were there
+      // and building the session still did not work. Full text in the log —
+      // per the error-handling guide detail/code are for the engineer, and only
+      // the UI is restricted to a localized message.
       aiLog('RouterAssistantView: could not build controller from '
           'environment config: $e');
       _needsConfig = true;
       _configError = _ConfigError.failure(UnexpectedError(originalError: e));
+    }
+  }
+
+  /// Environment credentials, or null when this build was not given any.
+  ///
+  /// Every failure mode of [AWSConfig.fromEnvironment] means the same thing, so
+  /// they collapse to null rather than being told apart:
+  ///
+  /// * `ConfigurationException` — dotenv loaded, but a key is missing.
+  /// * dotenv's `NotInitializedError` — `assets/agents/.env` was absent at
+  ///   startup so `dotenv.load` failed. This is the **usual** case, because that
+  ///   file is gitignored; it is an `Error`, not an `Exception`, so it does not
+  ///   match an `on ConfigurationException` clause.
+  ///
+  /// Catching broadly is safe here because the function reads environment
+  /// variables and does nothing else — it has no failure mode that represents a
+  /// real fault. Controller construction, which does, stays outside it.
+  AWSConfig? _configFromEnvironment() {
+    try {
+      return AWSConfig.fromEnvironment();
+    } catch (e) {
+      aiLog('RouterAssistantView: no environment config ($e)');
+      return null;
     }
   }
 

--- a/lib/page/ai_assistant/views/router_assistant_view.dart
+++ b/lib/page/ai_assistant/views/router_assistant_view.dart
@@ -5,6 +5,8 @@ import 'package:ui_kit_library/ui_kit.dart';
 
 import 'package:privacy_gui/ai/_ai.dart';
 import 'package:privacy_gui/ai/ai_logging.dart';
+import 'package:privacy_gui/components/localizations/service_error_localizations.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
 import 'package:privacy_gui/page/ai_assistant/providers/router_command_provider.dart';
 import 'package:privacy_gui/page/ai_assistant/services/aws_credentials_store.dart';
@@ -47,7 +49,22 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
 
   // Configuration state
   bool _needsConfig = false;
-  String? _configError;
+
+  /// Why the last connection attempt failed, or null when there is nothing to
+  /// report.
+  ///
+  /// Two distinct kinds, kept apart because they localize differently:
+  ///
+  /// * [_ConfigError.missingFields] — form validation. Per Art. XIII §1.4 this
+  ///   is a separate line from `ServiceError` and has its own l10n key.
+  /// * [_ConfigError.failure] — a real failure, carrying a `ServiceError` that
+  ///   `localizeServiceError` turns into the displayed message.
+  ///
+  /// Absent from this set on purpose: "environment config is unavailable".
+  /// `AWSConfig.fromEnvironment()` throwing `ConfigurationException` is the
+  /// normal path — it is how the app discovers it should show the manual form —
+  /// so it is logged and never shown as an error.
+  _ConfigError? _configError;
   final _accessKeyController = TextEditingController();
   final _secretKeyController = TextEditingController();
   BedrockModel _selectedModel = BedrockModel.models.first;
@@ -97,13 +114,19 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
       _needsConfig = false;
       _configError = null;
     } on ConfigurationException catch (e) {
-      aiLog('RouterAssistantView: Config error: $e');
+      // Not an error: no environment credentials is the ordinary case, and the
+      // manual form is the correct next screen. Showing "AWS_ACCESS_KEY_ID not
+      // set" would report the app's own configuration as the user's problem.
+      aiLog('RouterAssistantView: No environment config (${e.missingKey})');
       _needsConfig = true;
-      _configError = e.message;
+      _configError = null;
     } catch (e) {
-      aiLog('RouterAssistantView: Unexpected error: $e');
+      // Full text in the log: per the error-handling guide, detail/code are
+      // diagnostic material for the engineer. Only the UI is restricted.
+      aiLog('RouterAssistantView: could not build controller from '
+          'environment config: $e');
       _needsConfig = true;
-      _configError = e.toString();
+      _configError = _ConfigError.failure(UnexpectedError(originalError: e));
     }
   }
 
@@ -124,7 +147,7 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
     try {
       stored = await store.read().timeout(_restoreTimeout);
     } catch (e) {
-      aiLog('RouterAssistantView: Could not read saved credentials: $e');
+      _logStorageFailure('read saved credentials')(e);
     } finally {
       if (mounted) setState(() => _isRestoring = false);
     }
@@ -160,7 +183,7 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
     final secretAccessKey = _secretKeyController.text.trim();
     if (accessKeyId.isEmpty || secretAccessKey.isEmpty) {
       setState(() {
-        _configError = 'fillAllRequiredFields';
+        _configError = const _ConfigError.missingFields();
       });
       return;
     }
@@ -193,6 +216,8 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
 
       if (persist) {
         // Fire-and-forget: a storage failure must not block a working session.
+        // Logged, not shown — the session is fine and the user has nothing to
+        // act on; the only consequence is re-entering credentials next launch.
         ref
             .read(awsCredentialsStoreProvider)
             .store(
@@ -200,16 +225,31 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
               secretAccessKey: secretAccessKey,
               modelId: _selectedModel.id,
             )
-            .catchError((Object e) {
-          aiLog('RouterAssistantView: Could not save credentials: $e');
-        });
+            .catchError(_logStorageFailure('save credentials'));
       }
     } catch (e) {
+      aiLog('RouterAssistantView: could not connect with manual config: $e');
       setState(() {
-        _configError = 'failedToInitialize:$e';
+        _configError = _ConfigError.failure(UnexpectedError(originalError: e));
         _isConfiguring = false;
       });
     }
+  }
+
+  /// Handler for the fire-and-forget storage calls.
+  ///
+  /// The store throws only [ServiceError]s, so there is nothing to map here.
+  /// These are logged and never shown: see [_configError] for why.
+  ///
+  /// `originalError` is logged explicitly because `ServiceError.toString()`
+  /// renders only the type name — without it a storage failure would log the
+  /// uninformative "Storage" and nothing about what actually went wrong.
+  void Function(Object) _logStorageFailure(String action) {
+    return (Object e) {
+      final cause = e is StorageError ? e.originalError : null;
+      aiLog('RouterAssistantView: could not $action: $e'
+          '${cause != null ? ' ($cause)' : ''}');
+    };
   }
 
   void _onControllerChanged() {
@@ -282,15 +322,14 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
     super.dispose();
   }
 
-  String _localizeConfigError(BuildContext context, String error) {
-    if (error == 'fillAllRequiredFields') {
-      return loc(context).fillAllRequiredFields;
-    }
-    if (error.startsWith('failedToInitialize:')) {
-      final detail = error.substring('failedToInitialize:'.length);
-      return loc(context).failedToInitialize(detail);
-    }
-    return error;
+  String _localizeConfigError(BuildContext context, _ConfigError error) {
+    // Exhaustive over a sealed type: adding a case forces a localization
+    // decision here rather than allowing a raw string to slip through, which is
+    // what the previous `return error;` fallback did.
+    return switch (error) {
+      _MissingFields() => loc(context).fillAllRequiredFields,
+      _Failure(:final error) => localizeServiceError(context, error),
+    };
   }
 
   void _scrollToBottom() {
@@ -462,9 +501,7 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
                   ref
                       .read(awsCredentialsStoreProvider)
                       .storeModelId(value.id)
-                      .catchError((Object e) {
-                    aiLog('RouterAssistantView: Could not save model: $e');
-                  });
+                      .catchError(_logStorageFailure('save model'));
                 },
         ),
       ],
@@ -534,9 +571,7 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
               ref
                   .read(awsCredentialsStoreProvider)
                   .clear()
-                  .catchError((Object e) {
-                aiLog('RouterAssistantView: Could not clear credentials: $e');
-              });
+                  .catchError(_logStorageFailure('clear credentials'));
               setState(() {
                 _controller?.removeListener(_onControllerChanged);
                 _controller = null;
@@ -900,4 +935,30 @@ class _AnimatedThinkingTextState extends State<_AnimatedThinkingText>
       color: widget.color,
     );
   }
+}
+
+/// Why the configuration screen is showing an error.
+///
+/// Two kinds, not one string: form validation and a real failure localize
+/// through different paths (Art. XIII §1.4 keeps field validation separate from
+/// `ServiceError`). Being sealed makes the `switch` in `_localizeConfigError`
+/// exhaustive, so a new kind cannot be added without deciding how it reads.
+sealed class _ConfigError {
+  const _ConfigError();
+
+  /// The user pressed Connect with a field left empty.
+  const factory _ConfigError.missingFields() = _MissingFields;
+
+  /// The attempt failed for a reason the error type describes.
+  const factory _ConfigError.failure(ServiceError error) = _Failure;
+}
+
+final class _MissingFields extends _ConfigError {
+  const _MissingFields();
+}
+
+final class _Failure extends _ConfigError {
+  const _Failure(this.error);
+
+  final ServiceError error;
 }

--- a/lib/page/ai_assistant/views/router_assistant_view.dart
+++ b/lib/page/ai_assistant/views/router_assistant_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart' show NotInitializedError;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:generative_ui/generative_ui.dart';
 import 'package:ui_kit_library/ui_kit.dart';
@@ -82,9 +83,11 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
 
   /// How long to wait for stored credentials before showing an empty form.
   ///
-  /// Shorter than the store's own timeout so the user is never left looking at
-  /// a disabled screen for long; the restore is a convenience, and typing the
-  /// credentials again is a worse outcome than waiting but not a broken one.
+  /// Deliberately shorter than the store's own caller timeout, and not layered
+  /// with it: this is how long the *screen* stays disabled, and re-typing
+  /// credentials is a better outcome than waiting longer on a keychain that is
+  /// not answering. Giving up here does not cancel the read — it stays queued —
+  /// so a restore is abandoned rather than aborted.
   static const _restoreTimeout = Duration(seconds: 5);
 
   @override
@@ -101,16 +104,16 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
   }
 
   void _tryInitController() {
-    final awsConfig = _configFromEnvironment();
-    if (awsConfig == null) {
-      // Nothing to report: the manual form is the next screen, and it already
-      // explains what to enter.
-      _needsConfig = true;
-      _configError = null;
-      return;
-    }
-
     try {
+      final awsConfig = _configFromEnvironment();
+      if (awsConfig == null) {
+        // Nothing to report: the manual form is the next screen, and it already
+        // explains what to enter.
+        _needsConfig = true;
+        _configError = null;
+        return;
+      }
+
       _controller = RouterChatController(
         generator: AwsContentGenerator(config: awsConfig),
         commandProvider: ref.read(routerCommandProviderProvider),
@@ -120,11 +123,11 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
       _needsConfig = false;
       _configError = null;
     } catch (e) {
-      // A genuine failure, unlike the branch above: the credentials were there
-      // and building the session still did not work. Full text in the log —
-      // per the error-handling guide detail/code are for the engineer, and only
-      // the UI is restricted to a localized message.
-      aiLog('RouterAssistantView: could not build controller from '
+      // A genuine failure, unlike the early return above: either the config read
+      // failed in a way it is not supposed to, or building the session did.
+      // Full text in the log — per the error-handling guide detail/code are for
+      // the engineer, and only the UI is restricted to a localized message.
+      aiLog('RouterAssistantView: could not start a session from '
           'environment config: $e');
       _needsConfig = true;
       _configError = _ConfigError.failure(UnexpectedError(originalError: e));
@@ -142,14 +145,19 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
   ///   file is gitignored; it is an `Error`, not an `Exception`, so it does not
   ///   match an `on ConfigurationException` clause.
   ///
-  /// Catching broadly is safe here because the function reads environment
-  /// variables and does nothing else — it has no failure mode that represents a
-  /// real fault. Controller construction, which does, stays outside it.
+  /// Anything else is rethrown rather than swallowed, and so becomes a reported
+  /// failure via [_tryInitController]'s catch. `generative_ui` is pinned to a tag
+  /// on a shared repo, so a future version could add a check or a cast whose
+  /// failure is a genuine fault — and "silently show the manual form" would be
+  /// unfalsifiable from the UI. Naming the two expected modes keeps a real
+  /// breakage visible.
   AWSConfig? _configFromEnvironment() {
     try {
       return AWSConfig.fromEnvironment();
     } catch (e) {
-      aiLog('RouterAssistantView: no environment config ($e)');
+      if (e is! ConfigurationException && e is! NotInitializedError) rethrow;
+      // NotInitializedError has no toString override, hence the runtimeType.
+      aiLog('RouterAssistantView: no environment config (${e.runtimeType})');
       return null;
     }
   }
@@ -169,7 +177,7 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
 
     StoredAwsCredentials? stored;
     try {
-      stored = await store.read().timeout(_restoreTimeout);
+      stored = await store.readWithin(_restoreTimeout);
     } catch (e) {
       _logStorageFailure('read saved credentials')(e);
     } finally {
@@ -352,7 +360,12 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
     // what the previous `return error;` fallback did.
     return switch (error) {
       _MissingFields() => loc(context).fillAllRequiredFields,
-      _Failure(:final error) => localizeServiceError(context, error),
+      // Bound to a distinct name rather than `:final error`: that would shadow
+      // this method's own parameter, and because localizeServiceError takes an
+      // `Object`, dropping the binding later would still compile — silently
+      // passing the wrapper and degrading to the generic fallback.
+      _Failure(error: final serviceError) =>
+        localizeServiceError(context, serviceError),
     };
   }
 
@@ -592,10 +605,19 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
               // This is the user's way to remove saved credentials — leaving
               // them in storage would silently restore on the next launch,
               // defeating the change they just asked for.
+              // Unlike a failed save, a failed revocation IS shown: the record
+              // would restore on the next launch, so the user would believe
+              // credentials were removed that are still there. It lands on the
+              // config screen they are about to see.
               ref
                   .read(awsCredentialsStoreProvider)
                   .clear()
-                  .catchError(_logStorageFailure('clear credentials'));
+                  .catchError((Object e) {
+                _logStorageFailure('clear credentials')(e);
+                if (!mounted) return;
+                setState(() => _configError = _ConfigError.failure(
+                    e is ServiceError ? e : UnexpectedError(originalError: e)));
+              });
               setState(() {
                 _controller?.removeListener(_onControllerChanged);
                 _controller = null;

--- a/test/page/ai_assistant/aws_environment_config_test.dart
+++ b/test/page/ai_assistant/aws_environment_config_test.dart
@@ -1,39 +1,69 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:generative_ui/generative_ui.dart';
 
-/// Pins the failure shape of [AWSConfig.fromEnvironment] when this build has no
-/// `assets/agents/.env`.
+/// Pins the failure shapes of [AWSConfig.fromEnvironment], because
+/// `RouterAssistantView` treats *every* one of them as "this build has no
+/// environment credentials" and shows the manual form with no error.
 ///
-/// `RouterAssistantView` treats "no environment credentials" as the normal path
-/// and shows the manual form without an error. That only works if it catches
-/// what is actually thrown. `dotenv.env` throws `NotInitializedError`, which
-/// extends `Error` — so an `on ConfigurationException` clause does not match it,
-/// and an `on Exception` clause would not either.
+/// That only works if the catch is broad. These two modes are why it cannot be
+/// narrowed to a single `on` clause:
 ///
-/// Getting this wrong is not a corner case: `.env` is gitignored, so an
-/// unloaded dotenv is the usual state, and every launch would show a spurious
-/// "Something went wrong" on the configuration screen.
+/// * dotenv never loaded — throws `NotInitializedError`, which extends `Error`.
+///   Neither `on Exception` nor `on ConfigurationException` matches it. This is
+///   the usual state, since `assets/agents/.env` is gitignored.
+/// * dotenv loaded with blank keys — throws `ConfigurationException`, which is
+///   an `Exception`. This is what a developer gets after copying
+///   `assets/agents/env.template`, whose credential values are empty.
 ///
-/// dotenv is deliberately not loaded here — each test file runs in its own
-/// isolate, so this file sees the same uninitialized state a normal build does.
+/// The two are mutually exclusive per run, so both are exercised here in order:
+/// dotenv is a per-isolate mutable global, and each test file is its own
+/// isolate, so the first test must run before anything loads it.
 void main() {
-  group('AWSConfig.fromEnvironment with no .env loaded', () {
-    test('throws something that is not an Exception', () {
-      Object? thrown;
-      try {
-        AWSConfig.fromEnvironment();
-      } catch (e) {
-        thrown = e;
-      }
+  test('unloaded dotenv throws an Error, which is not an Exception', () {
+    // Must come first: nothing has loaded dotenv yet.
+    expect(dotenv.isInitialized, isFalse,
+        reason: 'this test is about the uninitialized state');
 
-      expect(thrown, isNotNull,
-          reason: 'the view relies on this failing to decide it must show the '
-              'manual configuration form');
-      expect(thrown, isNot(isA<Exception>()),
-          reason: 'so `on Exception catch` would not catch it');
-      expect(thrown, isNot(isA<ConfigurationException>()),
-          reason: 'and neither would `on ConfigurationException catch` — the '
-              'view must catch broadly, which is why it does');
-    });
+    Object? thrown;
+    try {
+      AWSConfig.fromEnvironment();
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown, isNotNull);
+    expect(thrown, isNot(isA<Exception>()),
+        reason: 'an `on Exception catch` would let this through uncaught, '
+            'which is why the view catches every throwable');
+  });
+
+  test('blank credentials throw a ConfigurationException', () {
+    dotenv.testLoad(fileInput: '''
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+BEDROCK_MODEL_ID=some-model
+''');
+    addTearDown(dotenv.clean);
+
+    // A different type from the case above, and an Exception rather than an
+    // Error — the view must treat both as simply "not configured".
+    expect(() => AWSConfig.fromEnvironment(),
+        throwsA(isA<ConfigurationException>()));
+  });
+
+  test('a complete environment yields a config', () {
+    dotenv.testLoad(fileInput: '''
+AWS_ACCESS_KEY_ID=AKIAEXAMPLE
+AWS_SECRET_ACCESS_KEY=secret
+AWS_REGION=us-west-2
+BEDROCK_MODEL_ID=some-model
+''');
+    addTearDown(dotenv.clean);
+
+    // The positive case, so the tests above cannot pass merely because
+    // `fromEnvironment` always throws.
+    expect(AWSConfig.fromEnvironment().accessKeyId, 'AKIAEXAMPLE');
   });
 }

--- a/test/page/ai_assistant/aws_environment_config_test.dart
+++ b/test/page/ai_assistant/aws_environment_config_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:generative_ui/generative_ui.dart';
+
+/// Pins the failure shape of [AWSConfig.fromEnvironment] when this build has no
+/// `assets/agents/.env`.
+///
+/// `RouterAssistantView` treats "no environment credentials" as the normal path
+/// and shows the manual form without an error. That only works if it catches
+/// what is actually thrown. `dotenv.env` throws `NotInitializedError`, which
+/// extends `Error` — so an `on ConfigurationException` clause does not match it,
+/// and an `on Exception` clause would not either.
+///
+/// Getting this wrong is not a corner case: `.env` is gitignored, so an
+/// unloaded dotenv is the usual state, and every launch would show a spurious
+/// "Something went wrong" on the configuration screen.
+///
+/// dotenv is deliberately not loaded here — each test file runs in its own
+/// isolate, so this file sees the same uninitialized state a normal build does.
+void main() {
+  group('AWSConfig.fromEnvironment with no .env loaded', () {
+    test('throws something that is not an Exception', () {
+      Object? thrown;
+      try {
+        AWSConfig.fromEnvironment();
+      } catch (e) {
+        thrown = e;
+      }
+
+      expect(thrown, isNotNull,
+          reason: 'the view relies on this failing to decide it must show the '
+              'manual configuration form');
+      expect(thrown, isNot(isA<Exception>()),
+          reason: 'so `on Exception catch` would not catch it');
+      expect(thrown, isNot(isA<ConfigurationException>()),
+          reason: 'and neither would `on ConfigurationException catch` — the '
+              'view must catch broadly, which is why it does');
+    });
+  });
+}

--- a/test/page/ai_assistant/services/aws_credentials_store_test.dart
+++ b/test/page/ai_assistant/services/aws_credentials_store_test.dart
@@ -417,6 +417,92 @@ void main() {
         expect(result?.accessKeyId, 'AKIAEXAMPLE');
       });
 
+      test('a write that times out cannot outlive a later clear', () {
+        // The trap the operation timeout opens: `Future.timeout` does not
+        // cancel the work it wraps, so a slow write keeps running after the
+        // queue has moved on and reaches storage AFTER the delete — putting
+        // back credentials the user revoked. Timing out was the fix for a hung
+        // write blocking `clear()`; this is the hole it left.
+        fakeAsync((async) {
+          storage = FakeSecureStorage();
+          store = AwsCredentialsStore(storage);
+          // Longer than the store's timeout, but it does eventually finish.
+          storage.writeDelay = const Duration(seconds: 25);
+
+          Object? storeError;
+          store
+              .store(
+                accessKeyId: 'AKIA_REVOKED',
+                secretAccessKey: 'secret_revoked',
+                modelId: 'model-a',
+              )
+              .catchError((Object e) => storeError = e);
+          store.clear();
+
+          async.elapse(const Duration(seconds: 60));
+
+          expect(storeError, isA<TimeoutError>());
+          expect(storage.values, isEmpty,
+              reason: 'the late write must be undone, not left in storage');
+        });
+      });
+
+      test('a clear counts from when it is requested, not when it is reached',
+          () {
+        // The distinguishing case for WHERE the clear is recorded. Here the
+        // write is already in flight when `clear()` arrives, so the clear
+        // cannot run until the write finishes. If the clear only counted itself
+        // once the queue reached it, the in-flight write would compare against
+        // the not-yet-bumped value, see no race, and leave the revoked record
+        // behind.
+        fakeAsync((async) {
+          storage = FakeSecureStorage();
+          store = AwsCredentialsStore(storage);
+          storage.writeDelay = const Duration(seconds: 25);
+
+          store
+              .store(
+                accessKeyId: 'AKIA_REVOKED',
+                secretAccessKey: 'secret',
+                modelId: 'model-a',
+              )
+              .catchError((Object e) {});
+          // Let the write reach storage before asking for the clear.
+          async.elapse(const Duration(seconds: 1));
+          store.clear();
+
+          async.elapse(const Duration(seconds: 120));
+
+          expect(storage.values, isEmpty,
+              reason: 'the user asked to discard these credentials after the '
+                  'write began; the request must still win');
+        });
+      });
+
+      test('the undo only fires when a clear actually raced', () {
+        fakeAsync((async) {
+          storage = FakeSecureStorage();
+          store = AwsCredentialsStore(storage);
+          storage.writeDelay = const Duration(seconds: 25);
+
+          store
+              .store(
+                accessKeyId: 'AKIAEXAMPLE',
+                secretAccessKey: 'secret',
+                modelId: 'model-a',
+              )
+              .catchError((Object e) {});
+
+          async.elapse(const Duration(seconds: 60));
+
+          // A slow write with no clear behind it is still a successful write:
+          // the guard must not delete a record nobody asked to remove.
+          expect(storage.values.containsKey(recordKey), isTrue);
+          expect(storage.log.where((e) => e.startsWith('D:')), isEmpty,
+              reason: 'no clear was issued, so nothing should be deleted');
+        });
+      });
+
       test('a hung operation does not block the queue forever', () {
         // The failure this guards: the user presses "change configuration"
         // behind a write that never settles, so the clear never runs and the

--- a/test/page/ai_assistant/services/aws_credentials_store_test.dart
+++ b/test/page/ai_assistant/services/aws_credentials_store_test.dart
@@ -2,10 +2,12 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:fake_async/fake_async.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:privacy_gui/ai/ai_logging.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/page/ai_assistant/services/aws_credentials_store.dart';
 
 class MockSecureStorage extends Mock implements FlutterSecureStorage {}
@@ -24,6 +26,9 @@ class FakeSecureStorage extends Fake implements FlutterSecureStorage {
 
   /// Keys whose next write should throw.
   final Set<String> failWritesFor = {};
+
+  /// Keys whose read should throw, as a platform failure would.
+  final Set<String> failReadsFor = {};
 
   /// Keys whose write never completes, to exercise the operation timeout.
   final Set<String> hangWritesFor = {};
@@ -46,7 +51,7 @@ class FakeSecureStorage extends Fake implements FlutterSecureStorage {
     if (writeDelay > Duration.zero) await Future.delayed(writeDelay);
     if (failWritesFor.contains(key)) {
       log.add('W!$key');
-      throw Exception('write failed');
+      throw PlatformException(code: 'write_error', message: 'keychain failure');
     }
     log.add('W:$key');
     if (value == null) {
@@ -66,6 +71,10 @@ class FakeSecureStorage extends Fake implements FlutterSecureStorage {
     AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async {
+    if (failReadsFor.contains(key)) {
+      log.add('R!$key');
+      throw PlatformException(code: 'read_error', message: 'keychain failure');
+    }
     log.add('R:$key');
     return values[key];
   }
@@ -139,7 +148,7 @@ void main() {
             secretAccessKey: 'secret_new',
             modelId: 'model-new',
           ),
-          throwsA(isA<Exception>()),
+          throwsA(isA<StorageError>()),
         );
 
         final result = await store.read();
@@ -298,6 +307,44 @@ void main() {
       });
     });
 
+    group('error mapping', () {
+      test('a platform failure surfaces as StorageError, not PlatformException',
+          () async {
+        storage.failWritesFor.add(recordKey);
+
+        // Art. XIII §13.1: the service layer is the conversion point, so no
+        // caller has to reason about platform-specific error shapes.
+        await expectLater(
+          store.store(
+            accessKeyId: 'AKIAEXAMPLE',
+            secretAccessKey: 'secret',
+            modelId: 'model-a',
+          ),
+          throwsA(isA<StorageError>()),
+        );
+      });
+
+      test('keeps the platform error for the log but not for display',
+          () async {
+        storage.failReadsFor.add(recordKey);
+
+        final error = await store.read().then<Object?>((_) => null,
+            onError: (Object e) => e) as StorageError;
+
+        expect(error.originalError, isNotNull,
+            reason: 'the technical text stays available to logger.e');
+        expect(error.detail, isNull,
+            reason: 'localizeServiceError surfaces detail to the user, and a '
+                'keychain code is not actionable — it must stay out');
+      });
+
+      test('every operation converts, not just writes', () async {
+        storage.failReadsFor.add(recordKey);
+
+        await expectLater(store.read(), throwsA(isA<StorageError>()));
+      });
+    });
+
     group('clear', () {
       test('removes the record', () async {
         await store.store(
@@ -343,7 +390,7 @@ void main() {
           secretAccessKey: 'secret',
           modelId: 'model-a',
         );
-        await expectLater(failing, throwsA(isA<Exception>()));
+        await expectLater(failing, throwsA(isA<StorageError>()));
 
         storage.failWritesFor.clear();
         await store.store(
@@ -396,8 +443,9 @@ void main() {
 
           async.elapse(const Duration(seconds: 30));
 
-          expect(storeError, isA<TimeoutException>(),
-              reason: 'the stalled write must be abandoned, not awaited');
+          expect(storeError, isA<TimeoutError>(),
+              reason: 'the stalled write must be abandoned, not awaited, and '
+                  'must reach the caller as a ServiceError');
           expect(cleared, isTrue,
               reason: 'the clear must still run once the write times out');
           expect(storage.values, isEmpty);

--- a/test/page/ai_assistant/services/aws_credentials_store_test.dart
+++ b/test/page/ai_assistant/services/aws_credentials_store_test.dart
@@ -497,8 +497,10 @@ void main() {
           expect(storage.values, isEmpty,
               reason: 'the clear was requested second, so it must be applied '
                   'second — the revoked record must not survive');
-          expect(storage.log, ['W:$recordKey', 'D:$recordKey'],
-              reason: 'storage order must match request order');
+          expect(storage.log.where((e) => !e.startsWith('R:')).toList(),
+              ['W:$recordKey', 'D:$recordKey'],
+              reason: 'storage order must match request order (reads excluded: '
+                  'clear() checks whether its delete landed before escalating)');
         });
       });
 
@@ -553,12 +555,76 @@ void main() {
         });
       });
 
-      test('a hung operation reports to its caller but keeps its place', () {
-        // The accepted trade-off. A platform call that never answers DOES hold
-        // the queue, because the alternative — letting the next operation start
-        // while this one is still in flight — is what allows a late write to
-        // resurrect revoked credentials or a late delete to erase new ones.
-        // What the timeout buys is that the caller is not left hanging.
+      test('a merely slow queue is left to apply the clear in order', () {
+        // Escalating is a concession, so it must not happen just because the
+        // caller's bound elapsed. A queue that is still moving applies the
+        // delete in its proper place, and the out-of-band path checks for that
+        // before acting.
+        fakeAsync((async) {
+          storage = FakeSecureStorage();
+          store = AwsCredentialsStore(storage);
+          // Slower than the caller bound, faster than the grace period.
+          storage.writeDelay = const Duration(seconds: 15);
+
+          store
+              .store(
+                accessKeyId: 'AKIAEXAMPLE',
+                secretAccessKey: 'secret',
+                modelId: 'model-a',
+              )
+              .catchError((Object e) {});
+          store.clear().catchError((Object e) {});
+
+          async.elapse(const Duration(minutes: 2));
+
+          expect(storage.values, isEmpty);
+          expect(storage.log.where((e) => e.startsWith('D:')).length, 1,
+              reason: 'one delete, applied in order — no out-of-band retry');
+        });
+      });
+
+      test('a revocation escapes a queue a hung write has stalled', () {
+        // A platform call that never returns holds the queue for the rest of
+        // the session, since nothing ever reports back. For writes that only
+        // means a stale record. For a revocation it would mean the credentials
+        // silently return on the next launch, so `clear()` falls back to
+        // deleting outside the queue.
+        fakeAsync((async) {
+          storage = FakeSecureStorage();
+          store = AwsCredentialsStore(storage);
+          storage.hangWritesFor.add(recordKey);
+          storage.values[recordKey] = 'stale';
+
+          store
+              .store(
+                accessKeyId: 'AKIAEXAMPLE',
+                secretAccessKey: 'secret',
+                modelId: 'model-a',
+              )
+              .catchError((Object e) {});
+
+          var cleared = false;
+          store
+              .clear()
+              .then<void>((_) => cleared = true)
+              .onError<Object>((Object e, _) {});
+
+          async.elapse(const Duration(minutes: 2));
+
+          expect(cleared, isTrue,
+              reason: 'the user asked for these credentials to be gone');
+          expect(storage.values, isEmpty,
+              reason: 'and they must actually be gone, not merely queued');
+        });
+      });
+
+      test('a hung write blocks the writes behind it, but not a revocation',
+          () {
+        // The trade-off, stated exactly. A platform call that never answers does
+        // hold the queue — letting the next write start alongside it is what
+        // allows a late write to resurrect revoked credentials. A stale record
+        // is an acceptable outcome for that; a revocation that never applies is
+        // not, so `clear()` is the one operation allowed out.
         fakeAsync((async) {
           storage = FakeSecureStorage();
           store = AwsCredentialsStore(storage);
@@ -566,7 +632,6 @@ void main() {
           storage.values[recordKey] = 'stale';
 
           Object? storeError;
-          var cleared = false;
           store
               .store(
                 accessKeyId: 'AKIAEXAMPLE',
@@ -574,22 +639,23 @@ void main() {
                 modelId: 'model-a',
               )
               .catchError((Object e) => storeError = e);
+
+          var modelUpdated = false;
           store
-              .clear()
-              .then<void>((_) => cleared = true)
+              .storeModelId('model-b')
+              .then<void>((_) => modelUpdated = true)
               .onError<Object>((Object e, _) {});
 
-          async.elapse(const Duration(minutes: 5));
+          async.elapse(const Duration(minutes: 2));
 
           expect(storeError, isA<TimeoutError>(),
               reason: 'the caller must not wait on a keychain that never '
                   'answers');
-          expect(cleared, isFalse,
-              reason: 'the clear stays queued behind the hung write rather '
-                  'than running concurrently with it — a delete applied out of '
-                  'order is worse than one that is late');
+          expect(modelUpdated, isFalse,
+              reason: 'a write stays queued rather than running concurrently '
+                  'with the hung one');
           expect(storage.log, ['W…$recordKey'],
-              reason: 'nothing after the hung write reached storage');
+              reason: 'no later write reached storage');
         });
       });
     });

--- a/test/page/ai_assistant/services/aws_credentials_store_test.dart
+++ b/test/page/ai_assistant/services/aws_credentials_store_test.dart
@@ -30,7 +30,8 @@ class FakeSecureStorage extends Fake implements FlutterSecureStorage {
   /// Keys whose read should throw, as a platform failure would.
   final Set<String> failReadsFor = {};
 
-  /// Keys whose write never completes, to exercise the operation timeout.
+  /// Keys whose write never completes, standing in for a keychain that never
+  /// answers — the case where the caller must be told while the queue waits.
   final Set<String> hangWritesFor = {};
 
   @override
@@ -307,6 +308,54 @@ void main() {
       });
     });
 
+    group('readWithin', () {
+      test('gives up sooner than the default, still as a ServiceError', () {
+        // Exists so a caller that needs a shorter bound does not wrap `read()`
+        // in `.timeout()` itself, which would throw a bare TimeoutException and
+        // break this class's only-ServiceError contract.
+        fakeAsync((async) {
+          storage = FakeSecureStorage();
+          store = AwsCredentialsStore(storage);
+          storage.hangWritesFor.add(recordKey);
+          // Occupy the queue so the read cannot start.
+          store
+              .store(
+                accessKeyId: 'AKIAEXAMPLE',
+                secretAccessKey: 'secret',
+                modelId: 'model-a',
+              )
+              .catchError((Object e) {});
+
+          Object? error;
+          store
+              .readWithin(const Duration(seconds: 2))
+              .then<void>((_) {})
+              .onError<Object>((Object e, _) => error = e);
+
+          async.elapse(const Duration(seconds: 3));
+
+          // What matters to the caller: a shorter bound is honoured, and what
+          // comes out is still the class's own error type. Which of the two
+          // bounds fired is an implementation detail.
+          expect(error, isA<TimeoutError>());
+          expect(error, isNot(isA<TimeoutException>()),
+              reason: 'the dart:async type must not reach the View');
+        });
+      });
+
+      test('returns the record when it arrives in time', () async {
+        await store.store(
+          accessKeyId: 'AKIAEXAMPLE',
+          secretAccessKey: 'secret',
+          modelId: 'model-a',
+        );
+
+        final result = await store.readWithin(const Duration(seconds: 5));
+
+        expect(result?.accessKeyId, 'AKIAEXAMPLE');
+      });
+    });
+
     group('error mapping', () {
       test('a platform failure surfaces as StorageError, not PlatformException',
           () async {
@@ -417,16 +466,17 @@ void main() {
         expect(result?.accessKeyId, 'AKIAEXAMPLE');
       });
 
-      test('a write that times out cannot outlive a later clear', () {
-        // The trap the operation timeout opens: `Future.timeout` does not
-        // cancel the work it wraps, so a slow write keeps running after the
-        // queue has moved on and reaches storage AFTER the delete — putting
-        // back credentials the user revoked. Timing out was the fix for a hung
-        // write blocking `clear()`; this is the hole it left.
+      test('a stalled write cannot be overtaken by the operations behind it',
+          () {
+        // `Future.timeout` does not cancel the operation it wraps. If the
+        // timeout applied to the QUEUE, a stalled write would keep running while
+        // the next operation started, and whichever finished last would win at
+        // the storage layer — the ordering guarantee gone precisely when it is
+        // needed. Storage order must follow request order regardless of latency.
         fakeAsync((async) {
           storage = FakeSecureStorage();
           store = AwsCredentialsStore(storage);
-          // Longer than the store's timeout, but it does eventually finish.
+          // Far longer than the caller timeout, but it does eventually finish.
           storage.writeDelay = const Duration(seconds: 25);
 
           Object? storeError;
@@ -437,24 +487,25 @@ void main() {
                 modelId: 'model-a',
               )
               .catchError((Object e) => storeError = e);
-          store.clear();
+          store.clear().catchError((Object e) {});
 
-          async.elapse(const Duration(seconds: 60));
+          async.elapse(const Duration(seconds: 120));
 
-          expect(storeError, isA<TimeoutError>());
+          expect(storeError, isA<TimeoutError>(),
+              reason: 'the caller is told promptly, even though the write is '
+                  'still queued');
           expect(storage.values, isEmpty,
-              reason: 'the late write must be undone, not left in storage');
+              reason: 'the clear was requested second, so it must be applied '
+                  'second — the revoked record must not survive');
+          expect(storage.log, ['W:$recordKey', 'D:$recordKey'],
+              reason: 'storage order must match request order');
         });
       });
 
-      test('a clear counts from when it is requested, not when it is reached',
-          () {
-        // The distinguishing case for WHERE the clear is recorded. Here the
-        // write is already in flight when `clear()` arrives, so the clear
-        // cannot run until the write finishes. If the clear only counted itself
-        // once the queue reached it, the in-flight write would compare against
-        // the not-yet-bumped value, see no race, and leave the revoked record
-        // behind.
+      test('a clear requested while a write is in flight still wins', () {
+        // Same guarantee from the other direction: here the write has already
+        // reached storage when the clear is requested, so only strict ordering
+        // makes the user's revocation stick.
         fakeAsync((async) {
           storage = FakeSecureStorage();
           store = AwsCredentialsStore(storage);
@@ -467,9 +518,8 @@ void main() {
                 modelId: 'model-a',
               )
               .catchError((Object e) {});
-          // Let the write reach storage before asking for the clear.
           async.elapse(const Duration(seconds: 1));
-          store.clear();
+          store.clear().catchError((Object e) {});
 
           async.elapse(const Duration(seconds: 120));
 
@@ -479,7 +529,9 @@ void main() {
         });
       });
 
-      test('the undo only fires when a clear actually raced', () {
+      test('a slow write with nothing behind it is simply applied', () {
+        // The negative case: latency alone must not cost the user their
+        // credentials. Only a later request may override a write.
         fakeAsync((async) {
           storage = FakeSecureStorage();
           store = AwsCredentialsStore(storage);
@@ -495,22 +547,19 @@ void main() {
 
           async.elapse(const Duration(seconds: 60));
 
-          // A slow write with no clear behind it is still a successful write:
-          // the guard must not delete a record nobody asked to remove.
           expect(storage.values.containsKey(recordKey), isTrue);
           expect(storage.log.where((e) => e.startsWith('D:')), isEmpty,
-              reason: 'no clear was issued, so nothing should be deleted');
+              reason: 'nothing asked for a delete');
         });
       });
 
-      test('a hung operation does not block the queue forever', () {
-        // The failure this guards: the user presses "change configuration"
-        // behind a write that never settles, so the clear never runs and the
-        // revoked credentials are restored on the next launch.
+      test('a hung operation reports to its caller but keeps its place', () {
+        // The accepted trade-off. A platform call that never answers DOES hold
+        // the queue, because the alternative — letting the next operation start
+        // while this one is still in flight — is what allows a late write to
+        // resurrect revoked credentials or a late delete to erase new ones.
+        // What the timeout buys is that the caller is not left hanging.
         fakeAsync((async) {
-          // Built inside the zone: the operation chain starts from a
-          // Future.value(), and one created outside would schedule its
-          // continuations on a microtask queue this zone never flushes.
           storage = FakeSecureStorage();
           store = AwsCredentialsStore(storage);
           storage.hangWritesFor.add(recordKey);
@@ -525,16 +574,22 @@ void main() {
                 modelId: 'model-a',
               )
               .catchError((Object e) => storeError = e);
-          store.clear().then((_) => cleared = true);
+          store
+              .clear()
+              .then<void>((_) => cleared = true)
+              .onError<Object>((Object e, _) {});
 
-          async.elapse(const Duration(seconds: 30));
+          async.elapse(const Duration(minutes: 5));
 
           expect(storeError, isA<TimeoutError>(),
-              reason: 'the stalled write must be abandoned, not awaited, and '
-                  'must reach the caller as a ServiceError');
-          expect(cleared, isTrue,
-              reason: 'the clear must still run once the write times out');
-          expect(storage.values, isEmpty);
+              reason: 'the caller must not wait on a keychain that never '
+                  'answers');
+          expect(cleared, isFalse,
+              reason: 'the clear stays queued behind the hung write rather '
+                  'than running concurrently with it — a delete applied out of '
+                  'order is worse than one that is late');
+          expect(storage.log, ['W…$recordKey'],
+              reason: 'nothing after the hung write reached storage');
         });
       });
     });


### PR DESCRIPTION
## Summary

Fixes #1203. The AI assistant's credential and configuration paths surfaced raw exception text to the user. `StorageError` already existed for this, with localization in place, and was unused across the whole repo.

## `AwsCredentialsStore` — errors

Conversion happens in `_serialize`, which every method already routes through, so `PlatformException` cannot leave the class and no method body carries error handling. The platform text goes on `originalError`, never into `detail` — `detail` is the field a localizer may surface (`localizeServiceError` does for `UnexpectedError`), and a keychain error code is not something a user can act on. `mapUspErrorToServiceError` makes the same call for an unparseable error.

Storage failures are logged rather than shown, which the class doc now states as a contract: persistence is a convenience, a failed save leaves a working session untouched, and the user has nothing to act on. `originalError` is logged explicitly, because `ServiceError.toString()` renders only the type name — a storage failure would otherwise log the uninformative `Storage` and nothing about the cause.

## `AwsCredentialsStore` — ordering

`Future.timeout` does not cancel the operation it wraps, it only stops waiting. Timing out the **queue** therefore does not remove a stalled platform call; it lets the next operation start while that call is still in flight, and whichever finishes last wins at the storage layer. Three concrete losses, each verified with a per-call-latency fake:

- a stalled `clear()` deleting credentials the user entered afterwards, while their `store()` reported success
- a stalled `store()` restoring credentials a later `clear()` removed
- a stalled `storeModelId()` — a read-modify-write — rewriting the whole record from its stale snapshot over newer credentials, with no `clear()` involved

A "has a clear happened since?" guard cannot close these: it answers a different question than the one that matters, which is whether the record in storage is still the one this operation wrote. The platform offers no cancellation and `write` is not conditional, so the queue now waits for genuine completion and only the caller's future is bounded. `_kCallerTimeout` is named for what it bounds.

**Accepted cost, documented on the class:** one hung platform call blocks later operations, a `clear()` included. That is a real downside, taken because the alternative silently loses or resurrects credentials, and because the caller is still told promptly.

`readWithin` exists so a caller that needs a shorter bound — the config screen disables itself during a restore — does not wrap `read()` in its own `.timeout()`, which can surface a bare `dart:async` `TimeoutException` and break the only-`ServiceError` guarantee.

## `router_assistant_view.dart`

**`_configError` is a sealed type.** It was a `String?` carrying a hand-rolled tagged union decoded by string prefix and `substring`, ending in `return error;` — so any failure that was not one of two known prefixes was rendered to the user verbatim. The localizing `switch` is now exhaustive by compiler, so a new kind cannot be added without deciding how it reads.

Splitting it separated three things that had been conflated:

| Kind | Handling |
|---|---|
| Field validation | Own l10n key — a separate line from `ServiceError` per the guide §1.4 |
| A real failure | Carries a `ServiceError`, goes through `localizeServiceError` |
| No environment credentials | **Not an error.** Logged only |

That third case is the usual one. `assets/agents/.env` is gitignored, so `dotenv.load` in `main.dart` fails and `AWSConfig.fromEnvironment()` throws dotenv's `NotInitializedError` — which extends `Error`, so it matches neither `on ConfigurationException` nor `on Exception`. It is how the app discovers it should show the manual form; displaying it reported the app's own configuration as the user's problem, on a screen that already explains what to do.

`_configFromEnvironment()` therefore recognises exactly two modes — `ConfigurationException` and `NotInitializedError` — and rethrows anything else into the reported path, so a future `generative_ui` adding a check or a cast leaves a genuine fault visible rather than silently showing the manual form.

**A failed revocation is shown.** "Change configuration" is the user asking for the credentials to be gone. A failed `clear()` was logged and nothing else, so the record would restore on the next launch while the user believed it removed. A failed *save* still stays silent — the session works and the only cost is re-typing next launch.

## l10n

Removes `failedToInitialize` from all 26 locales. Its message was `"Failed to initialize: {error}"` — a localized wrapper interpolating an untranslated exception, the shape the guide's what-to-display rule exists to prevent. The prefix also carried no information, since the user is looking at the configuration screen.

Verified before removal: unused in Dart, tests, and non-Dart sources; absent from `tools/translated.json`, so `update_translations.py` cannot resurrect it; `tools/check_l10n.dart` reports orphan-keys and duplicate-keys clean, and its own rule is that a genuinely unreferenced key must be deleted rather than allowlisted. ARB diffs are pure deletions — 0 insertions across all 26 files, with key order, encoding and trailing newlines intact.

Not verified: the E2E repo is not checked out locally. The removed key's message was never displayed, so a selector could not have depended on it.

## Out of scope

`router_chat_controller.dart` puts unlocalized English into the chat error banner (`withError(e.message)` plus two hardcoded strings). Credentials are only validated on the first send, so a wrong access key surfaces there rather than on the config screen — which makes that the most likely error path in practice. Four `withError` calls already exist on `dev-2.7.0`; the correct output there is a structured failure a model can act on, not a localized string for a human, so it belongs with the output-reliability work that touches those lines. Tracked on #1191's follow-up list.

Also unchanged: wrapping the config state machine in a Notifier (which is why the restore guards have no test), and clearing credentials on logout or router switch.

## Verification

| Check | Result |
|---|---|
| `aws_credentials_store_test.dart` | 32/32 |
| `aws_environment_config_test.dart` | 3/3 |
| `flutter test test/ai/ test/page/ai_assistant/` | 105/105 |
| `./run_tests.sh` (full suite) | **3463/3463** |
| `flutter analyze` | 0 errors, one fewer issue than before |
| `fvm dart format` | clean |

Mutation-checked: putting the timeout back on the queue fails three tests; removing the `ServiceError` conversion fails six; restoring the unsafe JSON cast fails one; weakening the debug-logging guard to `kProfileMode` fails two.

## Notes for reviewers

- **The three commits are sequential, not parallel.** Each round of review found that the previous fix had left a reachable path to the same class of failure. Squashing on merge is fine; the history is kept because the second and third commits document why the shape of the final fix is what it is.
- **`router_assistant_view.dart` has no widget test.** The restore guards and the `_configError` lifecycle are enforced by logic but uncovered. That is a Notifier-shaped problem, called out rather than left to be discovered.
- `readWithin`'s `onError` is defensive: `_asServiceError` passes a `ServiceError` through unchanged, so it is harmless when the inner bound fired first. I could not construct a case where removing it changes behaviour, and kept it rather than rely on that.
- `aws_credentials_store.dart` does not end in `_service.dart`. Deliberate — it is not a USP feature service — and discussed on #1201.
