### PR TITLE
feat(e2e): stable topology node identifiers for E2E location (#1208)

### DIFF
--- a/lib/page/topology/helpers/node_identifier.dart
+++ b/lib/page/topology/helpers/node_identifier.dart
@@ -1,0 +1,73 @@
+/// Pure helpers that build stable, data-derived E2E `identifier` values for
+/// topology nodes (constitution Article XVI §16.3).
+///
+/// Node identifiers are consumed by the E2E suite via `byIdentifier()` against
+/// the CanvasKit Semantics tree, so they MUST be stable across
+/// quality% / renderer / view-mode / node order and independent of the human
+/// label. Per-instance keys are derived from the node's MAC (never a row
+/// index), reduced to the shortest suffix that stays unique within the graph.
+library;
+
+/// Identifier for the master / gateway node. There is exactly one per topology,
+/// so it carries no per-instance key.
+const String kTopologyMasterIdentifier = 'topology-node-master';
+
+/// Composes the slave / extender node identifier from a MAC suffix key.
+String topologySlaveIdentifier(String macSuffix) =>
+    'topology-node-slave-$macSuffix';
+
+/// Composes the client node identifier from a MAC suffix key.
+String topologyClientIdentifier(String macSuffix) =>
+    'topology-node-client-$macSuffix';
+
+/// Normalizes a MAC / device id to uppercase hex with every separator removed.
+///
+/// `aa:bb:cc:dd:ee:ff` → `AABBCCDDEEFF`. Any non-hex character (`:`, `-`, `.`,
+/// whitespace, …) is stripped, so callers may pass raw `deviceId` / `mac`
+/// values without pre-cleaning them.
+String normalizeMac(String raw) =>
+    raw.toUpperCase().replaceAll(RegExp('[^0-9A-F]'), '');
+
+/// Maps each input MAC / id to the shortest hex suffix that is unique within
+/// the group, keeping the derived identifier short yet collision-free.
+///
+/// - Inputs are normalized via [normalizeMac] (separators stripped, uppercased).
+/// - A single group-wide suffix length is used, starting at [minLength]
+///   (default 4) and growing in steps of [step] (default 2, MAC-octet aligned)
+///   until every suffix in the group is distinct. One shared length keeps the
+///   result deterministic and independent of input order.
+/// - Genuine duplicates (two inputs that normalize identically) cannot be
+///   disambiguated; both fall back to the full normalized value.
+///
+/// The returned map is keyed by the ORIGINAL input string (exactly as passed),
+/// so callers can look up by `slave.deviceId` / `client.mac` directly. Empty
+/// and duplicate inputs are tolerated.
+Map<String, String> shortestUniqueMacSuffixes(
+  Iterable<String> macs, {
+  int minLength = 4,
+  int step = 2,
+}) {
+  final originals = macs.toList();
+  if (originals.isEmpty) return const {};
+
+  final normalized = {for (final m in originals) m: normalizeMac(m)};
+  final maxLen =
+      normalized.values.fold<int>(0, (a, s) => s.length > a ? s.length : a);
+
+  String suffixOf(String s, int len) =>
+      s.length <= len ? s : s.substring(s.length - len);
+
+  // Grow a single group-wide length until all suffixes are distinct.
+  for (var len = minLength; len < maxLen; len += step) {
+    final suffixes = normalized.values.map((s) => suffixOf(s, len)).toList();
+    if (suffixes.toSet().length == suffixes.length) {
+      return {
+        for (final entry in normalized.entries)
+          entry.key: suffixOf(entry.value, len),
+      };
+    }
+  }
+
+  // Full normalized value: covers the capped length and genuine-duplicate case.
+  return normalized;
+}

--- a/lib/page/topology/helpers/usp_topology_builder.dart
+++ b/lib/page/topology/helpers/usp_topology_builder.dart
@@ -7,6 +7,7 @@ import 'package:privacy_gui/page/_shared/models/client_device.dart'
     hide ConnectionType;
 import 'package:privacy_gui/page/_shared/models/mesh_network.dart';
 import 'package:privacy_gui/page/_shared/models/system_info_ui_model.dart';
+import 'package:privacy_gui/page/topology/helpers/node_identifier.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
 /// Builds a [MeshTopology] from USP dashboard state for [AppTopology] widget.
@@ -35,6 +36,7 @@ class UspTopologyBuilder {
     );
     nodes.add(MeshNode(
       id: gatewayId,
+      identifier: kTopologyMasterIdentifier,
       name:
           master.displayName.isNotEmpty ? master.displayName : info.gatewayName,
       type: MeshNodeType.gateway,
@@ -95,6 +97,12 @@ class UspTopologyBuilder {
           'backhaulParentDeviceId: ${slave.backhaul.parentNodeId}');
     }
 
+    // Stable, data-derived E2E identifier keys (Article XVI §16.3): shortest
+    // MAC suffix that stays unique within each node group, independent of the
+    // display label / node order.
+    final slaveIdKeys =
+        shortestUniqueMacSuffixes(meshNetwork.slaves.map((s) => s.deviceId));
+
     // Slave nodes
     for (final slave in meshNetwork.slaves) {
       final extenderId = 'extender-${slave.deviceId}';
@@ -111,6 +119,7 @@ class UspTopologyBuilder {
       final extenderIconName = routerIconTestByModel(modelNumber: slave.model);
       nodes.add(MeshNode(
         id: extenderId,
+        identifier: topologySlaveIdentifier(slaveIdKeys[slave.deviceId] ?? ''),
         name: slave.displayName,
         type: MeshNodeType.extender,
         status: MeshNodeStatus.online,
@@ -148,6 +157,8 @@ class UspTopologyBuilder {
     }
 
     // Client devices — use allClients which includes master + slave clients
+    final clientIdKeys =
+        shortestUniqueMacSuffixes(meshNetwork.allClients.map((c) => c.mac));
     for (final client in meshNetwork.allClients) {
       final clientId = 'client-${client.mac}';
       final isEthernet = !client.isWifi;
@@ -178,6 +189,7 @@ class UspTopologyBuilder {
 
       nodes.add(MeshNode(
         id: clientId,
+        identifier: topologyClientIdentifier(clientIdKeys[client.mac] ?? ''),
         name: client.displayName,
         type: MeshNodeType.client,
         status:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,11 +59,11 @@ dependencies:
   ui_kit_library:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.31.0
+      ref: v2.34.2
   generative_ui:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.31.0
+      ref: v2.34.2
       path: generative_ui
   flutter_blue_plus: ^1.4.0
   crypto: ^3.0.2

--- a/test/page/topology/helpers/node_identifier_test.dart
+++ b/test/page/topology/helpers/node_identifier_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/topology/helpers/node_identifier.dart';
+
+void main() {
+  group('normalizeMac', () {
+    test('strips colons and uppercases', () {
+      expect(normalizeMac('aa:bb:cc:dd:ee:ff'), 'AABBCCDDEEFF');
+    });
+
+    test('strips dashes, dots and whitespace', () {
+      expect(normalizeMac('aa-bb-cc-dd-ee-ff'), 'AABBCCDDEEFF');
+      expect(normalizeMac('aabb.ccdd.eeff'), 'AABBCCDDEEFF');
+      expect(normalizeMac(' AA BB CC DD EE FF '), 'AABBCCDDEEFF');
+    });
+
+    test('drops any non-hex character', () {
+      expect(normalizeMac('AA:BB:CC:DD:EE:ZZ'), 'AABBCCDDEE');
+    });
+
+    test('empty input yields empty', () {
+      expect(normalizeMac(''), '');
+    });
+  });
+
+  group('identifier composers', () {
+    test('master identifier is a fixed, key-less string', () {
+      expect(kTopologyMasterIdentifier, 'topology-node-master');
+    });
+
+    test('slave / client composers prepend the correct prefix', () {
+      expect(topologySlaveIdentifier('EEFF'), 'topology-node-slave-EEFF');
+      expect(topologyClientIdentifier('9C1D'), 'topology-node-client-9C1D');
+    });
+  });
+
+  group('shortestUniqueMacSuffixes', () {
+    test('empty input yields empty map', () {
+      expect(shortestUniqueMacSuffixes(const []), isEmpty);
+    });
+
+    test('uses the last 4 hex chars when that is already unique', () {
+      final result = shortestUniqueMacSuffixes([
+        'AA:BB:CC:DD:E1:11',
+        'AA:BB:CC:DD:E2:22',
+      ]);
+      expect(result['AA:BB:CC:DD:E1:11'], 'E111');
+      expect(result['AA:BB:CC:DD:E2:22'], 'E222');
+    });
+
+    test('map is keyed by the original (un-normalized) input', () {
+      const input = 'aa:bb:cc:dd:ee:ff';
+      final result = shortestUniqueMacSuffixes([input]);
+      expect(result.containsKey(input), isTrue);
+      expect(result[input], 'EEFF');
+    });
+
+    test('extends suffix length group-wide on last-4 collision', () {
+      // Both share suffix "EEFF" at length 4 → must grow to length 6.
+      final result = shortestUniqueMacSuffixes([
+        'AA:BB:CC:11:EE:FF',
+        'AA:BB:CC:22:EE:FF',
+      ]);
+      expect(result['AA:BB:CC:11:EE:FF'], '11EEFF');
+      expect(result['AA:BB:CC:22:EE:FF'], '22EEFF');
+      // Single shared length: every suffix has the same length.
+      final lengths = result.values.map((s) => s.length).toSet();
+      expect(lengths, {6});
+    });
+
+    test('all resulting suffixes are unique for distinct inputs', () {
+      final macs = [
+        'AA:BB:CC:DD:EE:01',
+        'AA:BB:CC:DD:EE:02',
+        'AA:BB:CC:DD:EE:03',
+        '11:22:33:44:55:66',
+      ];
+      final result = shortestUniqueMacSuffixes(macs);
+      expect(result.length, macs.length);
+      expect(result.values.toSet().length, macs.length);
+    });
+
+    test('genuine duplicates collapse to the full normalized value', () {
+      final result = shortestUniqueMacSuffixes([
+        'AA:BB:CC:DD:EE:FF',
+        'aa-bb-cc-dd-ee-ff', // same MAC, different formatting
+      ]);
+      // Cannot be disambiguated → both fall back to full normalized value.
+      expect(result['AA:BB:CC:DD:EE:FF'], 'AABBCCDDEEFF');
+      expect(result['aa-bb-cc-dd-ee-ff'], 'AABBCCDDEEFF');
+    });
+
+    test('result is independent of input order', () {
+      final a = shortestUniqueMacSuffixes([
+        'AA:BB:CC:11:EE:FF',
+        'AA:BB:CC:22:EE:FF',
+      ]);
+      final b = shortestUniqueMacSuffixes([
+        'AA:BB:CC:22:EE:FF',
+        'AA:BB:CC:11:EE:FF',
+      ]);
+      expect(a['AA:BB:CC:11:EE:FF'], b['AA:BB:CC:11:EE:FF']);
+      expect(a['AA:BB:CC:22:EE:FF'], b['AA:BB:CC:22:EE:FF']);
+    });
+
+    test('MAC shorter than min length is returned whole', () {
+      final result = shortestUniqueMacSuffixes(['A:B']); // normalizes to "AB"
+      expect(result['A:B'], 'AB');
+    });
+  });
+}

--- a/test/page/topology/helpers/topology_node_identifier_widget_test.dart
+++ b/test/page/topology/helpers/topology_node_identifier_widget_test.dart
@@ -1,0 +1,135 @@
+@Tags(['ui'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/core/utils/oui_lookup.dart';
+import 'package:privacy_gui/page/topology/helpers/usp_topology_builder.dart';
+import 'package:privacy_gui/page/_shared/models/system_info_ui_model.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import '../../../mocks/test_data/devices_test_data.dart';
+
+/// Verifies that the `identifier` values populated by [UspTopologyBuilder]
+/// (issue #1208) are embedded into the Semantics tree and locatable via
+/// [CommonFinders.bySemanticsIdentifier] in BOTH view modes.
+///
+/// This is the fast local proxy for the E2E `byIdentifier()` contract — the
+/// CanvasKit → `flt-semantics-identifier` DOM projection is a Flutter-runtime
+/// guarantee once the identifier exists, so it needs no web round here.
+///
+/// Coverage note: from ui_kit `v2.34.2`, identifier ownership sits on the
+/// node-dispatch seam (not per-renderer), so EVERY node type — master, slave
+/// AND client — carries its identifier in both graph and tree view,
+/// independent of which renderer the registry happens to dispatch.
+void main() {
+  const sysInfo = SystemInfoUIModel(
+    manufacturer: 'Linksys',
+    modelName: 'MR7500',
+    hardwareVersion: '1.0',
+    serialNumber: 'SN123456',
+    softwareVersion: '1.0.16.26013014',
+    uptime: 3600,
+    totalMemory: 512000,
+    freeMemory: 256000,
+    cpuUsage: 25,
+  );
+
+  setUpAll(() {
+    OuiLookup.initializeForTesting(const {
+      '112233': 'Test Vendor',
+      'AABBCC': 'Linksys',
+    });
+  });
+
+  tearDownAll(OuiLookup.reset);
+
+  // Mirrors the production config in usp_topology_view.dart: animation path on.
+  Widget wrap(MeshTopology topology, TopologyViewMode mode) {
+    return MaterialApp(
+      theme: AppTheme.create(brightness: Brightness.light),
+      home: Scaffold(
+        body: SizedBox(
+          width: 1200,
+          height: 900,
+          child: AppTopology(
+            topology: topology,
+            viewMode: mode,
+            clientVisibility: ClientVisibility.always,
+            nodeRendererRegistry: NodeRendererRegistry.unified,
+            enableAnimation: true,
+            interactive: false,
+            treeConfig: TopologyTreeConfiguration(
+              titleBuilder: (node) => node.name,
+              subtitleBuilder: (node) => node.extra ?? '',
+              preferAnimationNode: true,
+              expanded: true,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // Every node type (master + slave + client) must be locatable by identifier
+  // in BOTH view modes — the core #1208 requirement, guaranteed by the ui_kit
+  // v2.34.2 node-dispatch seam.
+  for (final mode in [TopologyViewMode.graph, TopologyViewMode.tree]) {
+    group('node identifiers locatable in ${mode.name} view', () {
+      testWidgets('master, every slave and every client carry an identifier',
+          (tester) async {
+        final handle = tester.ensureSemantics();
+
+        final topology = UspTopologyBuilder.buildFromMeshNetwork(
+          meshNetwork: DevicesTestData.createMultiSlaveMeshNetwork(),
+          info: sysInfo,
+        );
+
+        await tester.pumpWidget(wrap(topology, mode));
+        await tester.pump(const Duration(milliseconds: 500));
+
+        // Master locatable by its fixed identifier.
+        expect(
+            find.bySemanticsIdentifier('topology-node-master'), findsOneWidget);
+
+        // Each slave locatable by its data-derived identifier
+        // (slaveMac1 = ...EE:01, slaveMac2 = ...EE:02 → unique at 4 hex).
+        expect(find.bySemanticsIdentifier('topology-node-slave-EE01'),
+            findsOneWidget);
+        expect(find.bySemanticsIdentifier('topology-node-slave-EE02'),
+            findsOneWidget);
+
+        // Each client locatable by its data-derived identifier
+        // (client MACs 11:22:33:44:55:0X → unique at 4 hex).
+        expect(find.bySemanticsIdentifier('topology-node-client-5501'),
+            findsOneWidget);
+        expect(find.bySemanticsIdentifier('topology-node-client-5503'),
+            findsOneWidget);
+        expect(find.bySemanticsIdentifier('topology-node-client-5504'),
+            findsOneWidget);
+
+        handle.dispose();
+      });
+
+      testWidgets('the embedded identifier string reads back verbatim',
+          (tester) async {
+        final handle = tester.ensureSemantics();
+
+        final topology = UspTopologyBuilder.buildFromMeshNetwork(
+          meshNetwork: DevicesTestData.createSingleNodeNetwork(),
+          info: sysInfo,
+        );
+
+        await tester.pumpWidget(wrap(topology, mode));
+        await tester.pump(const Duration(milliseconds: 500));
+
+        final semantics = tester.getSemantics(
+          find.bySemanticsIdentifier('topology-node-master'),
+        );
+        expect(semantics.identifier, 'topology-node-master');
+
+        handle.dispose();
+      });
+    });
+  }
+}

--- a/test/page/topology/helpers/usp_topology_builder_test.dart
+++ b/test/page/topology/helpers/usp_topology_builder_test.dart
@@ -551,5 +551,113 @@ void main() {
         expect(link.linkQuality, LinkQuality.unknown);
       });
     });
+
+    // =========================================================================
+    // E2E Semantics identifiers (Article XVI §16.3) — data-derived, stable,
+    // decoupled from the human display label.
+    // =========================================================================
+
+    group('E2E node identifiers', () {
+      test('master node carries the fixed, key-less identifier', () {
+        final topology = UspTopologyBuilder.buildFromMeshNetwork(
+          meshNetwork: DevicesTestData.createSingleNodeNetwork(),
+          info: sysInfo,
+        );
+
+        final gateway =
+            topology.nodes.firstWhere((n) => n.type == MeshNodeType.gateway);
+        expect(gateway.identifier, 'topology-node-master');
+      });
+
+      test('slave / client identifiers embed the MAC suffix key', () {
+        final topology = UspTopologyBuilder.buildFromMeshNetwork(
+          meshNetwork: DevicesTestData.createMultiSlaveMeshNetwork(),
+          info: sysInfo,
+        );
+
+        // slaveMac1 = AA:BB:CC:DD:EE:01, slaveMac2 = ...EE:02 → unique at 4.
+        final slaves =
+            topology.nodes.where((n) => n.type == MeshNodeType.extender);
+        expect(
+          slaves.map((n) => n.identifier),
+          containsAll(
+              <String>['topology-node-slave-EE01', 'topology-node-slave-EE02']),
+        );
+
+        // client MACs 11:22:33:44:55:0X → unique at 4.
+        final clients =
+            topology.nodes.where((n) => n.type == MeshNodeType.client);
+        for (final client in clients) {
+          expect(client.identifier, startsWith('topology-node-client-'));
+        }
+      });
+
+      test('every node identifier is present and unique across the graph', () {
+        final topology = UspTopologyBuilder.buildFromMeshNetwork(
+          meshNetwork: DevicesTestData.createMultiSlaveMeshNetwork(),
+          info: sysInfo,
+        );
+
+        final ids = topology.nodes.map((n) => n.identifier).toList();
+        expect(ids.every((id) => id != null && id.isNotEmpty), isTrue);
+        expect(ids.toSet().length, ids.length,
+            reason: 'identifiers must be unique per node');
+      });
+
+      test('identifier is decoupled from the display label', () {
+        // Two nodes with identical display names must still get distinct
+        // identifiers (identity comes from the MAC, not the label).
+        final network = DevicesTestData.createMeshNetwork(
+          master: DevicesTestData.createMaster(hostName: 'Living Room'),
+          slave: DevicesTestData.createWifiSlave(
+            deviceId: DevicesTestData.slaveMac1,
+            hostName: 'Living Room',
+          ),
+        );
+
+        final topology = UspTopologyBuilder.buildFromMeshNetwork(
+          meshNetwork: network,
+          info: sysInfo,
+        );
+
+        final gateway =
+            topology.nodes.firstWhere((n) => n.type == MeshNodeType.gateway);
+        final slave =
+            topology.nodes.firstWhere((n) => n.type == MeshNodeType.extender);
+        expect(gateway.name, slave.name); // labels collide
+        expect(gateway.identifier, isNot(slave.identifier)); // ids do not
+      });
+
+      test('identifier is stable regardless of client signal quality', () {
+        // Same node, different quality% → identifier must not change.
+        final strong = UspTopologyBuilder.buildFromMeshNetwork(
+          meshNetwork: DevicesTestData.createSingleNodeNetwork(
+            masterClients: [
+              DevicesTestData.createWifiClient(
+                mac: DevicesTestData.clientMac1,
+                wifi: DevicesTestData.createExcellentSignal(),
+              ),
+            ],
+          ),
+          info: sysInfo,
+        );
+        final weak = UspTopologyBuilder.buildFromMeshNetwork(
+          meshNetwork: DevicesTestData.createSingleNodeNetwork(
+            masterClients: [
+              DevicesTestData.createWifiClient(
+                mac: DevicesTestData.clientMac1,
+                wifi: DevicesTestData.createPoorSignal(),
+              ),
+            ],
+          ),
+          info: sysInfo,
+        );
+
+        String clientId(MeshTopology t) => t.nodes
+            .firstWhere((n) => n.type == MeshNodeType.client)
+            .identifier!;
+        expect(clientId(strong), clientId(weak));
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

Populate a stable, data-derived Semantics `identifier` on every topology `MeshNode` so the E2E suite can locate nodes via `byIdentifier()` instead of the fragile display-label heuristic.

Closes #1208. Depends on UI-kit#9 (`MeshNode.identifier` + node-dispatch seam), landed in `ui_kit_library` **v2.34.2**.

## Changes

- Bump `ui_kit_library` + `generative_ui` ref `v2.31.0` → `v2.34.2`.
- Add `node_identifier.dart`: a pure, unit-tested helper (constitution Article XVI §16.3) computing the shortest MAC suffix that stays unique within each node group; it grows group-wide (`4 → 6 → full`) on collision and is order-independent.
- `UspTopologyBuilder` sets `identifier` at all three `MeshNode` construction sites:
  | Node | Identifier | Source |
  |------|-----------|--------|
  | master | `topology-node-master` | fixed, single per topology |
  | slave | `topology-node-slave-<suffix>` | `deviceId` |
  | client | `topology-node-client-<suffix>` | `mac` |
- Additive only: the human label / name / a11y text are unchanged.

## Why the ui_kit v2.34.2 dependency

From v2.34.2, identifier ownership sits on the **node-dispatch seam** rather than per-renderer, so every node type carries its identifier in both graph and tree view regardless of which renderer the registry dispatches — including tree-view clients, which the `.unified` registry otherwise renders without a dedicated tree builder.

## Identifier scheme (Article XVI §16.3)

Per-instance keys are **data-derived, not positional** — the MAC suffix means an identifier stays stable across node reordering and signal-quality changes, satisfying the issue's "stable across node order" requirement. The derivation helper is pure and unit-tested.

## Tests

- `node_identifier_test`: normalization, last-4 default, collision extension, uniqueness, order-independence, genuine-duplicate fallback.
- `usp_topology_builder_test`: identifier value, cross-graph uniqueness, label decoupling, stability across signal quality.
- `topology_node_identifier_widget_test`: `bySemanticsIdentifier` locates master, every slave and every client in **both** graph and tree view.

## Verification

- `dart format --set-exit-if-changed` — clean
- `flutter analyze` — 0 error / 0 warning on changed files
- `./run_tests.sh` — 3491 tests passing
- `flutter test --tags ui` (widget test) — passing