### PR TITLE
chore(deps): bump ui_kit_library / generative_ui to v2.34.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,11 +59,11 @@ dependencies:
   ui_kit_library:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.31.0
+      ref: v2.34.3
   generative_ui:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.31.0
+      ref: v2.34.3
       path: generative_ui
   flutter_blue_plus: ^1.4.0
   crypto: ^3.0.2


### PR DESCRIPTION
## Summary
- Bump `ui_kit_library` and `generative_ui` git ref from `v2.31.0` to `v2.34.3` to pick up the latest UI Kit changes.

## Changes
- `pubspec.yaml`: both `ui_kit_library` and `generative_ui` now pin `ref: v2.34.3`.
- `pubspec.lock` already resolved to `v2.34.3` (commit `d4e64fe`) on the base branch; this aligns `pubspec.yaml` with it.

## Verification
- `flutter pub get`: resolves both packages from git tag `v2.34.3` ✅
- `flutter analyze`: 0 errors / 0 warnings (only pre-existing info-level lints in test/tools) ✅
- `./run_tests.sh`: **3,545 / 3,545 functional tests pass**, 0 failed, 0 skipped ✅

## Notes
- Golden / loc / ui-tagged tests are excluded by `run_tests.sh` and were not run here. Given the bump crosses several patch versions and touches input widgets, a visual pass (`--tags golden`) is recommended before merge if concerned about layout regressions.