### PR TITLE
feat(ai): emit the A2UI protocol version in generated messages (requires ui_kit v2.34.4)

### DIFF
--- a/lib/ai/prompts/router_system_prompt.dart
+++ b/lib/ai/prompts/router_system_prompt.dart
@@ -96,6 +96,7 @@ CRITICAL FORMAT RULES:
 1. Each JSON message MUST be on a SINGLE LINE (no line breaks inside JSON)
 2. NO pretty-printing, NO indentation, NO newlines within the JSON object
 3. Two JSON messages total: updateComponents (line 1) + createSurface (line 2)
+4. EVERY message MUST start with "version":"v0.9" as its first field
 
 FORBIDDEN:
 - ❌ Multi-line / pretty-printed JSON
@@ -104,14 +105,14 @@ FORBIDDEN:
 - ❌ Code blocks (```json)
 
 CRITICAL ROOT RULE:
-4. The FIRST component MUST have id="root" — this is MANDATORY for A2UI v0.9
+5. The FIRST component MUST have id="root" — this is MANDATORY for A2UI v0.9
 
 CORRECT FORMAT (exactly 2 lines):
-{"updateComponents":{"surfaceId":"main","components":[{"id":"root","component":"AppCard","childIds":["c"]},{"id":"c","component":"WanSection","wanStatus":"Connected"}]}}
-{"createSurface":{"surfaceId":"main","catalogId":"a2ui://router-assistant/v1"}}
+{"version":"v0.9","updateComponents":{"surfaceId":"main","components":[{"id":"root","component":"AppCard","childIds":["c"]},{"id":"c","component":"WanSection","wanStatus":"Connected"}]}}
+{"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"a2ui://router-assistant/v1"}}
 
 WRONG FORMAT (multi-line JSON breaks the parser):
-{"updateComponents":{
+{"version":"v0.9","updateComponents":{
   "surfaceId":"main",
   "components":[...]
 }}
@@ -120,10 +121,10 @@ WRONG FORMAT (multi-line JSON breaks the parser):
   /// Reminder at the end of the prompt.
   static const _formatReminder = '''
 ⚠️ FINAL FORMAT CHECK:
-- Line 1: {"updateComponents":...} (SINGLE LINE, no newlines inside)
-- Line 2: {"createSurface":...} (SINGLE LINE)
+- Line 1: {"version":"v0.9","updateComponents":...} (SINGLE LINE, no newlines inside)
+- Line 2: {"version":"v0.9","createSurface":...} (SINGLE LINE)
 - NO pretty-printing, NO indentation
-- Start NOW with {"updateComponents":
+- Start NOW with {"version":"v0.9","updateComponents":
 ''';
 
   static const _basePrompt = '''
@@ -138,8 +139,8 @@ When a user asks "how's my network?", you DO NOT write:
   "Your network looks healthy. Internet is connected..."
 
 Instead, you MUST output A2UI JSONL (SINGLE LINE per message, root id="root"):
-{"updateComponents":{"surfaceId":"main","components":[{"id":"root","component":"AppCard","childIds":["c"]},{"id":"c","component":"Column","childIds":["h","wan"]},{"id":"h","component":"SectionHeader","title":"Network"},{"id":"wan","component":"WanSection","wanStatus":"Connected","connectedDevices":3}]}}
-{"createSurface":{"surfaceId":"main","catalogId":"a2ui://router-assistant/v1"}}
+{"version":"v0.9","updateComponents":{"surfaceId":"main","components":[{"id":"root","component":"AppCard","childIds":["c"]},{"id":"c","component":"Column","childIds":["h","wan"]},{"id":"h","component":"SectionHeader","title":"Network"},{"id":"wan","component":"WanSection","wanStatus":"Connected","connectedDevices":3}]}}
+{"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"a2ui://router-assistant/v1"}}
 
 ## Behavior Guidelines
 
@@ -307,6 +308,7 @@ IMPORTANT FOR MULTI-TURN CONVERSATIONS:
 - The client will REPLACE the entire UI with your new updateComponents
 
 ### v0.9 Message Format Changes (from v0.8):
+- EVERY message carries `"version":"v0.9"` as its first field
 - `surfaceUpdate` → `updateComponents`
 - `dataModelUpdate` → `updateDataModel`
 - `beginRendering` → `createSurface` (with required `catalogId`)
@@ -362,16 +364,16 @@ IMPORTANT FOR MULTI-TURN CONVERSATIONS:
 ### Examples (CRITICAL: Each JSON must be on ONE line, first component MUST have id="root")
 
 #### Example 1: Network Summary
-{"updateComponents":{"surfaceId":"main","components":[{"id":"root","component":"AppCard","childIds":["content"]},{"id":"content","component":"Column","childIds":["h1","wan","d1","h2","lan"]},{"id":"h1","component":"SectionHeader","title":"WAN"},{"id":"wan","component":"WanSection","wanStatus":"Connected","connectedDevices":8},{"id":"d1","component":"AppDivider"},{"id":"h2","component":"SectionHeader","title":"LAN"},{"id":"lan","component":"LanSection","ipAddress":"192.168.1.1","subnetMask":"255.255.255.0"}]}}
-{"createSurface":{"surfaceId":"main","catalogId":"a2ui://router-assistant/v1"}}
+{"version":"v0.9","updateComponents":{"surfaceId":"main","components":[{"id":"root","component":"AppCard","childIds":["content"]},{"id":"content","component":"Column","childIds":["h1","wan","d1","h2","lan"]},{"id":"h1","component":"SectionHeader","title":"WAN"},{"id":"wan","component":"WanSection","wanStatus":"Connected","connectedDevices":8},{"id":"d1","component":"AppDivider"},{"id":"h2","component":"SectionHeader","title":"LAN"},{"id":"lan","component":"LanSection","ipAddress":"192.168.1.1","subnetMask":"255.255.255.0"}]}}
+{"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"a2ui://router-assistant/v1"}}
 
 #### Example 2: Single Section
-{"updateComponents":{"surfaceId":"main","components":[{"id":"root","component":"AppCard","childIds":["wan"]},{"id":"wan","component":"WanSection","wanStatus":"Connected","connectedDevices":5}]}}
-{"createSurface":{"surfaceId":"main","catalogId":"a2ui://router-assistant/v1"}}
+{"version":"v0.9","updateComponents":{"surfaceId":"main","components":[{"id":"root","component":"AppCard","childIds":["wan"]},{"id":"wan","component":"WanSection","wanStatus":"Connected","connectedDevices":5}]}}
+{"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"a2ui://router-assistant/v1"}}
 
 #### Example 3: Device List
-{"updateComponents":{"surfaceId":"main","components":[{"id":"root","component":"DeviceListView","devices":[{"name":"iPhone","ip":"192.168.1.101","connectionType":"WiFi 5GHz"}]}]}}
-{"createSurface":{"surfaceId":"main","catalogId":"a2ui://router-assistant/v1"}}
+{"version":"v0.9","updateComponents":{"surfaceId":"main","components":[{"id":"root","component":"DeviceListView","devices":[{"name":"iPhone","ip":"192.168.1.101","connectionType":"WiFi 5GHz"}]}]}}
+{"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"a2ui://router-assistant/v1"}}
 
 ⚠️ CRITICAL: Always INLINE data directly into components. Do NOT use boundPath references.
 ''';

--- a/lib/ai/prompts/router_system_prompt.dart
+++ b/lib/ai/prompts/router_system_prompt.dart
@@ -3,6 +3,19 @@ import 'package:generative_ui/generative_ui.dart';
 /// System prompt template for the Router AI Assistant.
 ///
 /// This defines how the AI should behave and what components it can generate.
+///
+/// ## Upgrading the A2UI protocol version
+///
+/// `v0.9` appears throughout the prompt below — in the message examples, in the
+/// format rules, and in section headings. It is written out rather than
+/// interpolated because these are `const` strings: interpolating would make
+/// every one of them `static final`, losing the compile-time constant that lets
+/// them be assembled without runtime work on each request.
+///
+/// So a protocol upgrade is a deliberate find-and-replace across this file, and
+/// `router_system_prompt_test.dart` is the safety net — it asserts the version
+/// appears on every whole-message example and that the renderer recognises the
+/// shape, so a partial replacement fails rather than silently shipping a mix.
 class RouterSystemPrompt {
   RouterSystemPrompt._();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,11 +59,11 @@ dependencies:
   ui_kit_library:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.34.4
+      ref: v2.34.5
   generative_ui:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.34.4
+      ref: v2.34.5
       path: generative_ui
   flutter_blue_plus: ^1.4.0
   crypto: ^3.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,11 +59,11 @@ dependencies:
   ui_kit_library:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.34.3
+      ref: v2.34.4
   generative_ui:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.34.3
+      ref: v2.34.4
       path: generative_ui
   flutter_blue_plus: ^1.4.0
   crypto: ^3.0.2

--- a/test/ai/prompts/router_system_prompt_test.dart
+++ b/test/ai/prompts/router_system_prompt_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:generative_ui/generative_ui.dart';
 import 'package:privacy_gui/ai/prompts/router_system_prompt.dart';
 
 /// Guards the A2UI envelope the prompt teaches the model to emit.
@@ -14,7 +15,10 @@ void main() {
     late String prompt;
 
     setUp(() {
-      prompt = RouterSystemPrompt.staticPrompt;
+      // `build()` rather than `staticPrompt`: the latter omits the trailing
+      // format reminder, which IS sent to the model and repeats the message
+      // shape. Asserting on the smaller string would leave that copy unguarded.
+      prompt = RouterSystemPrompt.build();
     });
 
     /// Whole-message example lines, i.e. those carrying a message-type key.
@@ -23,6 +27,11 @@ void main() {
     /// are entries inside a message's `components` array and correctly carry no
     /// version of their own.
     List<String> messageExamples(String text) {
+      // The v0.9 message types. Mirrors the set in ui_kit's `_messageStart`
+      // pattern; if the protocol gains a message type, both need it — but the
+      // consequence of drift here is only that a new example goes unchecked,
+      // and the renderer-recognition test below would still catch a shape it
+      // cannot parse.
       const messageKeys = [
         'updateComponents',
         'createSurface',
@@ -56,6 +65,26 @@ void main() {
       // has to appear as a rule.
       expect(prompt, contains('"version":"v0.9"'));
       expect(prompt, contains('EVERY message'));
+    });
+
+    test('the closing reminder shows the versioned shape too', () {
+      // The reminder is the last thing the model reads before generating, so a
+      // stale shape here competes with the rules above it. It is not part of
+      // `staticPrompt`, which is why this asserts against `build()`.
+      expect(prompt, contains('Start NOW with {"version":"v0.9"'),
+          reason: 'the final instruction must not demonstrate the old shape');
+    });
+
+    test('the renderer recognises every example the prompt teaches', () {
+      // The string assertions above cannot catch the failure that matters: the
+      // renderer detects a message by pattern, so a shape the prompt teaches but
+      // the renderer does not recognise is displayed to the user as raw JSONL.
+      // This is the cross-repo contract, asserted here rather than trusted —
+      // it is what makes the ui_kit ref bump verifiable in CI.
+      for (final example in messageExamples(prompt)) {
+        expect(A2UIResponseRenderer.containsA2UI(example), isTrue,
+            reason: 'renderer would treat this as plain text: $example');
+      }
     });
 
     test('each correct-format example stays on one line', () {

--- a/test/ai/prompts/router_system_prompt_test.dart
+++ b/test/ai/prompts/router_system_prompt_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/ai/prompts/router_system_prompt.dart';
+
+/// Guards the A2UI envelope the prompt teaches the model to emit.
+///
+/// The spec requires `"version":"v0.9"` on every message, and the reference
+/// implementation (`a2ui_core`) rejects a message without it rather than
+/// defaulting. Our own renderer tolerates its absence, so nothing in the app
+/// fails if the prompt stops asking for it — the cost would appear only as a
+/// wholesale rejection the first time our output meets a conformant parser.
+/// Hence a test rather than a comment.
+void main() {
+  group('A2UI envelope', () {
+    late String prompt;
+
+    setUp(() {
+      prompt = RouterSystemPrompt.staticPrompt;
+    });
+
+    /// Whole-message example lines, i.e. those carrying a message-type key.
+    ///
+    /// Component-schema snippets (`{"id":…,"component":…}`) are excluded: they
+    /// are entries inside a message's `components` array and correctly carry no
+    /// version of their own.
+    List<String> messageExamples(String text) {
+      const messageKeys = [
+        'updateComponents',
+        'createSurface',
+        'updateDataModel',
+        'deleteSurface',
+      ];
+      return text
+          .split('\n')
+          .where((l) => l.startsWith('{"'))
+          .where((l) => messageKeys.any((k) => l.contains('"$k"')))
+          .toList();
+    }
+
+    test('every message example carries the protocol version', () {
+      final examples = messageExamples(prompt);
+
+      expect(examples, isNotEmpty,
+          reason: 'the prompt must show the model what to emit');
+
+      final missing =
+          examples.where((l) => !l.startsWith('{"version":"v0.9"')).toList();
+
+      expect(missing, isEmpty,
+          reason:
+              'a conformant parser rejects a message with no version, so an '
+              'example without one teaches output that cannot migrate');
+    });
+
+    test('the version requirement is stated, not only demonstrated', () {
+      // Models improvise message shapes the examples do not cover, so the rule
+      // has to appear as a rule.
+      expect(prompt, contains('"version":"v0.9"'));
+      expect(prompt, contains('EVERY message'));
+    });
+
+    test('each correct-format example stays on one line', () {
+      // Pre-existing contract worth pinning here: the version edit rewrote every
+      // example line, and a stray newline inside one would break parsing while
+      // still looking correct in review.
+      //
+      // The prompt also contains a deliberately-WRONG multi-line sample, shown
+      // so the model can recognise the mistake. Excluded by taking only lines
+      // that close their own object — which is exactly the property under test
+      // for the rest.
+      final wellFormed = messageExamples(prompt)
+          .where((l) => l.trimRight().endsWith('}'))
+          .toList();
+
+      expect(wellFormed.length, greaterThanOrEqualTo(8),
+          reason: 'most examples must be single-line; if this drops, the '
+              'exclusion above is hiding a real regression');
+
+      for (final line in wellFormed) {
+        expect(RegExp(r'^\{.*\}$').hasMatch(line.trim()), isTrue,
+            reason: 'one complete JSON object per line: $line');
+      }
+    });
+  });
+}


### PR DESCRIPTION
Fixes #1216.

## Summary

From the #1202 evaluation. Our A2UI output omits the `version` field the spec puts on every message, and the reference implementation does not treat it as optional:

```dart
// a2ui_core-0.1.0/lib/src/core/messages.dart:11-21
if (rawVersion is! String) throw A2uiValidationError(...);
if (rawVersion != 'v0.9') throw A2uiValidationError(...);
```

Nothing breaks today, because our own renderer never reads it. The cost is deferred rather than absent: any move to a conformant parser would begin by rejecting **100%** of our model output, so it would have to start with a prompt change and a fresh round of verifying how reliably the model complies. Paying it now, while it is one field, removes that from every later decision — including the re-evaluation this PR's parent issue schedules for when `genui` reaches 1.0.

## Requires ui_kit v2.34.4

This bump is not cosmetic — the PR does not work without it.

The renderer's message-start pattern required the message key to sit immediately after the opening brace:

```
{"version":"v0.9","updateComponents":…}   → no match
```

`containsA2UI()` would have returned false, the view would have taken its plain-text branch, and **the user would have seen raw JSONL instead of cards**. Nothing throws; there is no test spanning both repos.

Found by reviewing this change before pushing it, and fixed in ui_kit `v2.34.4` first, which is safe to land alone because the tolerance is purely additive. Verified both directions: the old pattern does fail on the new format, and the new pattern accepts messages with and without the field.

## The prompt change

Every whole-message example carries the field, and the format rules plus the v0.9 section state the requirement — models improvise shapes the examples do not cover, so it has to appear as a rule and not only as a demonstration.

**Component-schema snippets are untouched.** They are entries inside a message's `components` array and correctly carry no version of their own. Getting this wrong is easy: my first pass flagged 11 of them, which is what led to the test selecting by message-type key rather than by "line starts with `{`".

**The deliberately-wrong multi-line sample also gained the field**, which sharpens it. It now differs from the correct form in exactly one way — a newline inside the JSON, the mistake it exists to show — instead of two.

## Verification

End-to-end rather than by inspection. All six message examples from the live prompt were run through the real `A2UIResponseRenderer` with the real `RouterComponentRegistry`:

```
E2E examples found: 6
E2E detected=true  (×6)
E2E parse error shown: false
```

and rendering reached our actual components (`AppText` via `ai_info_row.dart`), so detection, parsing and widget construction all complete.

| Check | Result |
|---|---|
| `test/ai/prompts/router_system_prompt_test.dart` | 3/3 |
| `flutter test test/ai/ test/page/ai_assistant/` | 110/110 |
| `./run_tests.sh` (full suite) | **3574/3574** |
| `flutter analyze` | 0 issues |
| ui_kit `generative_ui` package tests | 196/196 |

Mutation-checked in both repos: dropping the field from one prompt example fails a test here; restoring the old regex fails five tests in ui_kit, across both the detection and extraction paths.

## Notes for reviewers

- **The extraction path in ui_kit had no test at all** before v2.34.4 — only `containsA2UI` was covered. That is precisely why the brace-adjacency assumption went unnoticed, and it is now closed with three widget tests that render through the real widget.
- **The test guards the envelope, not the wording.** It selects lines carrying a message-type key, so adding or rewording examples will not make it fail spuriously, and it distinguishes whole messages from component fragments.
- This is forward-compatibility work with **no behavioural change today**. The reason to take it now rather than at migration time is sequencing, not urgency.
- The other actionable item from the #1202 evaluation is tracked as #1217 (streaming). It touches the same prompt and renderer, so this one landing first avoids editing the same lines twice.

