### PR TITLE
fix(usp): resolve #1184 back-fill regressions — conditional tunnel fetch, IPv6 partial SET, table/wildcard log noise

### DIFF
--- a/lib/core/usp/errors/usp_error.dart
+++ b/lib/core/usp/errors/usp_error.dart
@@ -140,7 +140,7 @@ UspError? parseUspError(Object error) {
 /// | code | meaning                          | → ServiceError          |
 /// |------|----------------------------------|-------------------------|
 /// | 7004 | parameter not writable           | InvalidInputError       |
-/// | 7005 | invalid parameter name           | InvalidInputError       |
+/// | 7005 | invalid parameter name¹          | InvalidInputError       |
 /// | 7006 | invalid parameter value          | InvalidInputError       |
 /// | 7026 | parameter (path) not found       | ResourceNotFoundError   |
 /// | 7027 | object not found                 | ResourceNotFoundError   |
@@ -148,6 +148,15 @@ UspError? parseUspError(Object error) {
 /// | 9005 | bbfdm: invalid/unimplemented param | ResourceNotFoundError |
 /// | 9007 | bbfdm: (resource not found)      | ResourceNotFoundError   |
 /// | 9008 | bbfdm: non-writable parameter    | InvalidInputError       |
+///
+/// ¹ 7005 has a second, broker-level meaning on OBUSPA: an atomic SET
+/// (`allow_partial=false`) that spans more than one USP micro-service is
+/// rejected with 7005 "Allow partial=false not supported across more than one
+/// USP Service". This is NOT an invalid parameter name — it is a cross-service
+/// atomicity limit. The fix is on the caller (pass `allowPartial: true` for
+/// multi-service SETs), not this mapping; InvalidInputError remains a reasonable
+/// surface if it ever reaches here. See `_saveIpv6Settings` in
+/// usp_internet_settings_service.dart.
 ///
 /// ### Source 3 — Dart codegen (`lib/generated/*.g.dart`), NOT from Rust
 ///

--- a/lib/core/usp/services/usp_client.dart
+++ b/lib/core/usp/services/usp_client.dart
@@ -297,14 +297,16 @@ class UspClient {
           '${_prettyMap(rawMap)}');
 
       if (rawMap.isEmpty) {
-        if (isWildcardOnlyRequest(paths)) {
-          // A wildcard GET (e.g. Device.Firewall.DMZ.*) is expanded by the
-          // router across the discovered instances of a multi-instance table.
-          // When that table has zero instances the response is legitimately
-          // empty — the generated model iterates the (empty) instance set and
-          // returns an empty list, so this is a normal "no rows" outcome, not
-          // a fault. Log it at debug so it does not drown real warnings.
-          logger.d('$_tag$label GET empty (wildcard table, no instances): '
+        if (isTableQueryOnlyRequest(paths)) {
+          // A table query — a wildcard GET (e.g. Device.Firewall.DMZ.*) or an
+          // object/table path (e.g. Device.IP.Interface.1.IPv6Address.) — is
+          // expanded by the router across the discovered instances of a
+          // multi-instance table. When that table has zero instances the
+          // response is legitimately empty — the generated model iterates the
+          // (empty) instance set and returns an empty list, so this is a normal
+          // "no rows" outcome, not a fault. Log it at debug so it does not
+          // drown real warnings.
+          logger.d('$_tag$label GET empty (table query, no instances): '
               '$paths');
         } else {
           // At least one concrete path was requested — an empty response there
@@ -365,7 +367,7 @@ class UspClient {
       result[entry.key] = _coerceValue(entry.key, entry.value);
     }
     for (final path in paths) {
-      if (path.contains('*') || path.endsWith('.')) continue;
+      if (_isTableExpandedPath(path)) continue;
       if (!result.containsKey(path)) {
         onMissingPath?.call(path);
       }
@@ -373,18 +375,30 @@ class UspClient {
     return result;
   }
 
-  /// Whether every requested path is a wildcard query (contains '*').
+  /// Whether a requested path is one the router expands into concrete instance
+  /// paths, so the requested key itself never appears verbatim in the response.
   ///
-  /// A wildcard GET targets a multi-instance table and the router expands it
-  /// across the discovered instances. When that table has zero instances the
-  /// response is legitimately empty (the generated model returns an empty
-  /// list), so an empty response to a wildcard-only request is a normal
-  /// "no rows" outcome rather than a fault. Callers use this to decide whether
-  /// an empty GET response deserves a warning. An empty [paths] list is not a
-  /// wildcard request.
+  /// Two shapes qualify, and they must be treated identically everywhere:
+  /// - a wildcard search path (contains '*', e.g. Device.Firewall.DMZ.*)
+  /// - an object/table path (ends in '.', e.g. Device.IP.Interface.1.IPv6Address.)
+  ///
+  /// Both target a multi-instance set; an absent requested key is expected, not
+  /// missing, and an empty response means the set has zero rows — not a fault.
+  static bool _isTableExpandedPath(String path) =>
+      path.contains('*') || path.endsWith('.');
+
+  /// Whether every requested path is a table query the router expands
+  /// (see [_isTableExpandedPath]).
+  ///
+  /// When such a query hits a table with zero instances the response is
+  /// legitimately empty (the generated model returns an empty list), so an
+  /// empty response to a table-query-only request is a normal "no rows"
+  /// outcome rather than a fault. Callers use this to decide whether an empty
+  /// GET response deserves a warning. An empty [paths] list is not a table
+  /// query.
   @visibleForTesting
-  static bool isWildcardOnlyRequest(List<String> paths) =>
-      paths.isNotEmpty && paths.every((p) => p.contains('*'));
+  static bool isTableQueryOnlyRequest(List<String> paths) =>
+      paths.isNotEmpty && paths.every(_isTableExpandedPath);
 
   /// Coerce a raw string value from USP into the appropriate Dart type.
   /// - "true" / "false" →bool (any path)

--- a/lib/core/usp/services/usp_client.dart
+++ b/lib/core/usp/services/usp_client.dart
@@ -297,15 +297,37 @@ class UspClient {
           '${_prettyMap(rawMap)}');
 
       if (rawMap.isEmpty) {
-        logger.w('$_tag$label GET response EMPTY for paths: $paths');
+        if (isWildcardOnlyRequest(paths)) {
+          // A wildcard GET (e.g. Device.Firewall.DMZ.*) is expanded by the
+          // router across the discovered instances of a multi-instance table.
+          // When that table has zero instances the response is legitimately
+          // empty — the generated model iterates the (empty) instance set and
+          // returns an empty list, so this is a normal "no rows" outcome, not
+          // a fault. Log it at debug so it does not drown real warnings.
+          logger.d('$_tag$label GET empty (wildcard table, no instances): '
+              '$paths');
+        } else {
+          // At least one concrete path was requested — an empty response there
+          // is genuinely unexpected and worth a warning.
+          logger.w('$_tag$label GET response EMPTY for paths: $paths');
+        }
+        // Every requested path is absent, but the single warning above already
+        // says so. Skip the per-path missing warnings (they would just repeat
+        // the same paths — e.g. 9 lines for lan_network_info's concrete GET).
+        return normalizeGetResponse(paths, rawMap);
       }
 
-      return normalizeGetResponse(
-        paths,
-        rawMap,
-        onMissingPath: (path) =>
-            logger.w('$_tag$label GET missing path in response: "$path"'),
-      );
+      // Non-empty (possibly partial) response: collect any absent concrete
+      // leaves and emit ONE aggregated warning rather than one per path, so a
+      // genuine partial-response warning is not diluted into a wall of lines.
+      final missing = <String>[];
+      final normalized =
+          normalizeGetResponse(paths, rawMap, onMissingPath: missing.add);
+      if (missing.isNotEmpty) {
+        logger.w('$_tag$label GET missing ${missing.length} path(s) in '
+            'response: $missing');
+      }
+      return normalized;
     } catch (e) {
       sw.stop();
       final label = _idLabel(id);
@@ -327,9 +349,11 @@ class UspClient {
   ///    is the `?? ''` on each codegen assignment). Leaving the key absent lets
   ///    the required-leaf contract fire as designed (#1184).
   ///
-  /// Wildcard search paths (containing '*') are expanded by the router into
-  /// concrete instance paths, so the original wildcard path won't appear in the
-  /// response — those are skipped by the missing-path warning.
+  /// Wildcard search paths (containing '*') and object/table paths (ending in
+  /// '.', e.g. Device.IP.Interface.1.IPv6Address.) are expanded by the router
+  /// into concrete instance paths, so the original requested key never appears
+  /// in the response. Both are skipped by the missing-path warning — only a
+  /// requested *concrete leaf* that is absent is genuinely missing.
   @visibleForTesting
   static Map<String, dynamic> normalizeGetResponse(
     List<String> paths,
@@ -341,13 +365,26 @@ class UspClient {
       result[entry.key] = _coerceValue(entry.key, entry.value);
     }
     for (final path in paths) {
-      if (path.contains('*')) continue;
+      if (path.contains('*') || path.endsWith('.')) continue;
       if (!result.containsKey(path)) {
         onMissingPath?.call(path);
       }
     }
     return result;
   }
+
+  /// Whether every requested path is a wildcard query (contains '*').
+  ///
+  /// A wildcard GET targets a multi-instance table and the router expands it
+  /// across the discovered instances. When that table has zero instances the
+  /// response is legitimately empty (the generated model returns an empty
+  /// list), so an empty response to a wildcard-only request is a normal
+  /// "no rows" outcome rather than a fault. Callers use this to decide whether
+  /// an empty GET response deserves a warning. An empty [paths] list is not a
+  /// wildcard request.
+  @visibleForTesting
+  static bool isWildcardOnlyRequest(List<String> paths) =>
+      paths.isNotEmpty && paths.every((p) => p.contains('*'));
 
   /// Coerce a raw string value from USP into the appropriate Dart type.
   /// - "true" / "false" →bool (any path)

--- a/lib/page/instant_safety/services/instant_safety_service.dart
+++ b/lib/page/instant_safety/services/instant_safety_service.dart
@@ -46,6 +46,13 @@ class UspInstantSafetyService {
   Future<void> save(SafeBrowsingType type) async {
     try {
       final dnsValue = dnsValueForType(type);
+      // Uses the default allow_partial=false (atomic). Safe here because this
+      // SET touches a single USP micro-service (DHCPv4.Server.Pool DNSServers).
+      // The OBUSPA broker only rejects atomic SETs that span more than one
+      // service with 7005 — see _saveIpv6Settings in
+      // usp_internet_settings_service.dart, which must relax this. Keep this SET
+      // single-service; if it ever grows to touch another service, switch to
+      // allowPartial: true.
       final result = await LanNetworkInfo.update(_usp, dnsServers: dnsValue);
       final parsed = UspResultParser.parseSetResult(result);
       switch (parsed) {

--- a/lib/page/instant_safety/services/instant_safety_service.dart
+++ b/lib/page/instant_safety/services/instant_safety_service.dart
@@ -46,13 +46,10 @@ class UspInstantSafetyService {
   Future<void> save(SafeBrowsingType type) async {
     try {
       final dnsValue = dnsValueForType(type);
-      // Uses the default allow_partial=false (atomic). Safe here because this
-      // SET touches a single USP micro-service (DHCPv4.Server.Pool DNSServers).
-      // The OBUSPA broker only rejects atomic SETs that span more than one
-      // service with 7005 — see _saveIpv6Settings in
-      // usp_internet_settings_service.dart, which must relax this. Keep this SET
-      // single-service; if it ever grows to touch another service, switch to
-      // allowPartial: true.
+      // Single-service SET → the default atomic allow_partial is safe here. If
+      // this ever adds a param from another USP service, switch to
+      // allowPartial: true — OBUSPA rejects cross-service atomic SETs with 7005
+      // (see usp_error.dart).
       final result = await LanNetworkInfo.update(_usp, dnsServers: dnsValue);
       final parsed = UspResultParser.parseSetResult(result);
       switch (parsed) {

--- a/lib/page/internet_settings/services/usp_internet_settings_service.dart
+++ b/lib/page/internet_settings/services/usp_internet_settings_service.dart
@@ -131,15 +131,22 @@ class UspInternetSettingsService {
         .toList();
 
     // Resolve server address from the tunnel that fetchSettings' phase 2 loaded
-    // for this connection type. The tunnel is non-null by contract: pptp always
-    // fetches GRE.Tunnel.1, l2tp always fetches L2TPv2.Tunnel.1 (both concrete
-    // paths the firmware guarantees exist once LowerLayers references them). If
-    // that contract were ever violated, GreTunnel/L2tpTunnel.fetch would already
-    // have thrown 9998 upstream, so `!` here documents the invariant rather than
-    // guarding a reachable null.
+    // for this connection type. gre/l2tp are nullable because DHCP/Static/PPPoE
+    // WANs pass null — but on the pptp/l2tp branches the tunnel is non-null by
+    // contract: phase 2 fetched the matching tunnel, and GreTunnel/L2tpTunnel
+    // .fetch throws 9998 upstream if the concrete row is absent. The throw
+    // documents that invariant with a diagnosable message instead of a bare `!`
+    // NPE (which would surface only as "Null check operator used on a null
+    // value" with no context).
     final serverAddress = switch (connectionType) {
-      UspWanConnectionType.pptp => gre!.remoteEndpoints,
-      UspWanConnectionType.l2tp => l2tp!.remoteEndpoints,
+      UspWanConnectionType.pptp => (gre ??
+              (throw StateError('PPTP WAN but GRE tunnel absent — '
+                  'fetchSettings phase-2 contract violated')))
+          .remoteEndpoints,
+      UspWanConnectionType.l2tp => (l2tp ??
+              (throw StateError('L2TP WAN but L2TPv2 tunnel absent — '
+                  'fetchSettings phase-2 contract violated')))
+          .remoteEndpoints,
       _ => '',
     };
 

--- a/lib/page/internet_settings/services/usp_internet_settings_service.dart
+++ b/lib/page/internet_settings/services/usp_internet_settings_service.dart
@@ -46,28 +46,45 @@ class UspInternetSettingsService {
   // Fetch
   // ---------------------------------------------------------------------------
 
-  /// Fetch WAN, IPv6, PPP, VLAN, and tunnel settings in parallel.
+  /// Fetch WAN, IPv6, PPP, and VLAN settings in parallel, then the tunnel that
+  /// the resolved connection type actually uses.
   Future<InternetSettingsFetchResult> fetchSettings() async {
     try {
+      // Phase 1 — always needed, fetched in parallel.
       final results = await Future.wait([
         WanSettings.fetch(_usp),
         Ipv6Settings.fetch(_usp),
         PppInterface.fetch(_usp),
         VlanTermination.fetch(_usp),
-        GreTunnel.fetch(_usp),
-        L2tpTunnel.fetch(_usp),
         _fetchHostName(),
       ]);
       final wan = results[0] as WanSettings;
       final ipv6 = results[1] as Ipv6Settings;
       final ppp = results[2] as PppInterface;
       final vlan = results[3] as VlanTermination;
-      final gre = results[4] as GreTunnel;
-      final l2tp = results[5] as L2tpTunnel;
-      final hostName = results[6] as String;
+      final hostName = results[4] as String;
 
       final pppInstance = ppp.items.isNotEmpty ? ppp.items.first : null;
       final vlanInstance = vlan.items.isNotEmpty ? vlan.items.first : null;
+
+      // Phase 2 — tunnel is connection-type-specific. A DHCP/PPPoE/Static WAN
+      // has zero GRE/L2TP tunnel instances, so fetching them would trip the
+      // generated required-leaf check (code 9998) on an absent Tunnel.1. Only
+      // fetch the tunnel the current connection type actually uses.
+      final connectionType = UspWanConnectionType.fromRawFields(
+        addressingType: wan.addressingType,
+        lowerLayers: pppInstance?.lowerLayers ?? '',
+      );
+      GreTunnel? gre;
+      L2tpTunnel? l2tp;
+      switch (connectionType) {
+        case UspWanConnectionType.pptp:
+          gre = await GreTunnel.fetch(_usp);
+        case UspWanConnectionType.l2tp:
+          l2tp = await L2tpTunnel.fetch(_usp);
+        default:
+          break;
+      }
 
       return InternetSettingsFetchResult(
         form: _buildForm(wan, ipv6, pppInstance, vlanInstance, gre, l2tp),
@@ -101,8 +118,8 @@ class UspInternetSettingsService {
     Ipv6Settings ipv6,
     PppInterfaceInstance? ppp,
     VlanTerminationInstance? vlan,
-    GreTunnel gre,
-    L2tpTunnel l2tp,
+    GreTunnel? gre,
+    L2tpTunnel? l2tp,
   ) {
     // Split comma-separated DNS into 3 fields
     final dnsParts = wan.dnsServers
@@ -119,8 +136,8 @@ class UspInternetSettingsService {
 
     // Resolve server address from the appropriate tunnel
     final serverAddress = switch (connectionType) {
-      UspWanConnectionType.pptp => gre.remoteEndpoints,
-      UspWanConnectionType.l2tp => l2tp.remoteEndpoints,
+      UspWanConnectionType.pptp => gre?.remoteEndpoints ?? '',
+      UspWanConnectionType.l2tp => l2tp?.remoteEndpoints ?? '',
       _ => '',
     };
 

--- a/lib/page/internet_settings/services/usp_internet_settings_service.dart
+++ b/lib/page/internet_settings/services/usp_internet_settings_service.dart
@@ -87,7 +87,8 @@ class UspInternetSettingsService {
       }
 
       return InternetSettingsFetchResult(
-        form: _buildForm(wan, ipv6, pppInstance, vlanInstance, gre, l2tp),
+        form: _buildForm(
+            wan, ipv6, pppInstance, vlanInstance, gre, l2tp, connectionType),
         readOnlyInfo: _buildReadOnlyInfo(wan, pppInstance, hostName),
         pppInstancePath: pppInstance?.instancePath,
         vlanInstancePath: vlanInstance?.instancePath,
@@ -120,6 +121,7 @@ class UspInternetSettingsService {
     VlanTerminationInstance? vlan,
     GreTunnel? gre,
     L2tpTunnel? l2tp,
+    UspWanConnectionType connectionType,
   ) {
     // Split comma-separated DNS into 3 fields
     final dnsParts = wan.dnsServers
@@ -128,16 +130,16 @@ class UspInternetSettingsService {
         .where((s) => s.isNotEmpty)
         .toList();
 
-    final lowerLayers = ppp?.lowerLayers ?? '';
-    final connectionType = UspWanConnectionType.fromRawFields(
-      addressingType: wan.addressingType,
-      lowerLayers: lowerLayers,
-    );
-
-    // Resolve server address from the appropriate tunnel
+    // Resolve server address from the tunnel that fetchSettings' phase 2 loaded
+    // for this connection type. The tunnel is non-null by contract: pptp always
+    // fetches GRE.Tunnel.1, l2tp always fetches L2TPv2.Tunnel.1 (both concrete
+    // paths the firmware guarantees exist once LowerLayers references them). If
+    // that contract were ever violated, GreTunnel/L2tpTunnel.fetch would already
+    // have thrown 9998 upstream, so `!` here documents the invariant rather than
+    // guarding a reachable null.
     final serverAddress = switch (connectionType) {
-      UspWanConnectionType.pptp => gre?.remoteEndpoints ?? '',
-      UspWanConnectionType.l2tp => l2tp?.remoteEndpoints ?? '',
+      UspWanConnectionType.pptp => gre!.remoteEndpoints,
+      UspWanConnectionType.l2tp => l2tp!.remoteEndpoints,
       _ => '',
     };
 

--- a/lib/page/internet_settings/services/usp_internet_settings_service.dart
+++ b/lib/page/internet_settings/services/usp_internet_settings_service.dart
@@ -134,19 +134,23 @@ class UspInternetSettingsService {
     // for this connection type. gre/l2tp are nullable because DHCP/Static/PPPoE
     // WANs pass null — but on the pptp/l2tp branches the tunnel is non-null by
     // contract: phase 2 fetched the matching tunnel, and GreTunnel/L2tpTunnel
-    // .fetch throws 9998 upstream if the concrete row is absent. The throw
-    // documents that invariant with a diagnosable message instead of a bare `!`
-    // NPE (which would surface only as "Null check operator used on a null
-    // value" with no context).
+    // .fetch throws 9998 upstream (caught in fetchSettings → ServiceErrorView)
+    // if the concrete Tunnel.1 row is absent, so _buildForm is never reached
+    // with a null tunnel on the matching branch. The asserts document that
+    // invariant in dev; the `?? ''` keeps the (release-only, contract-violating)
+    // fallback graceful — an empty serverAddress fails form validation, which
+    // prompts the user to re-enter rather than surfacing a bare NPE.
+    assert(
+      connectionType != UspWanConnectionType.pptp || gre != null,
+      'PPTP WAN but GRE tunnel absent — fetchSettings phase-2 contract violated',
+    );
+    assert(
+      connectionType != UspWanConnectionType.l2tp || l2tp != null,
+      'L2TP WAN but L2TPv2 tunnel absent — fetchSettings phase-2 contract violated',
+    );
     final serverAddress = switch (connectionType) {
-      UspWanConnectionType.pptp => (gre ??
-              (throw StateError('PPTP WAN but GRE tunnel absent — '
-                  'fetchSettings phase-2 contract violated')))
-          .remoteEndpoints,
-      UspWanConnectionType.l2tp => (l2tp ??
-              (throw StateError('L2TP WAN but L2TPv2 tunnel absent — '
-                  'fetchSettings phase-2 contract violated')))
-          .remoteEndpoints,
+      UspWanConnectionType.pptp => gre?.remoteEndpoints ?? '',
+      UspWanConnectionType.l2tp => l2tp?.remoteEndpoints ?? '',
       _ => '',
     };
 

--- a/lib/page/internet_settings/services/usp_internet_settings_service.dart
+++ b/lib/page/internet_settings/services/usp_internet_settings_service.dart
@@ -556,6 +556,13 @@ class UspInternetSettingsService {
     UspInternetSettingsForm original,
     UspInternetSettingsForm edited,
   ) async {
+    // IPv6 settings span three USP services (IP.Interface, DHCPv6.Client,
+    // IPv6rd.InterfaceSetting). The OBUSPA broker rejects an atomic SET
+    // (allow_partial=false) that touches more than one service — it returns
+    // 7005 "Allow partial=false not supported across more than one USP
+    // Service", failing the whole save. A cross-service SET cannot be atomic on
+    // this router, so allow partial application; _handleSetResult still surfaces
+    // any per-parameter failure as a UspPartialFailureError.
     _handleSetResult(await Ipv6Settings.update(
       _usp,
       ipv6Enabled: _diff(original.ipv6Enabled, edited.ipv6Enabled),
@@ -566,6 +573,7 @@ class UspInternetSettingsService {
           _diff(original.ipv6rdIpv4MaskLength, edited.ipv6rdIpv4MaskLength),
       ipv6rdBorderRelay:
           _diff(original.ipv6rdBorderRelay, edited.ipv6rdBorderRelay),
+      allowPartial: true,
     ));
   }
 

--- a/test/core/usp/services/usp_client_normalize_response_test.dart
+++ b/test/core/usp/services/usp_client_normalize_response_test.dart
@@ -77,6 +77,24 @@ void main() {
       expect(missing, isEmpty);
     });
 
+    test(
+        'trailing-dot object/table request paths never trigger a missing-path '
+        'warning', () {
+      final missing = <String>[];
+      // A path ending in '.' is an object/table GET (e.g. IPv6Address.); the
+      // router expands it into instance paths, so the requested key itself is
+      // absent from the response and must NOT be reported as missing.
+      UspClient.normalizeGetResponse(
+        ['Device.IP.Interface.1.IPv6Address.'],
+        <String, String?>{
+          'Device.IP.Interface.1.IPv6Address.1.IPAddress': '::1',
+        },
+        onMissingPath: missing.add,
+      );
+
+      expect(missing, isEmpty);
+    });
+
     test('absent concrete path invokes onMissingPath; present one does not',
         () {
       final missing = <String>[];
@@ -92,6 +110,74 @@ void main() {
       );
 
       expect(missing, ['Device.DHCPv4.Server.Pool.1.MinAddress']);
+    });
+
+    test(
+        'onMissingPath collects every absent concrete leaf so the caller can '
+        'emit a single aggregated warning', () {
+      // Underpins _rawGet's aggregation: a partial response with several
+      // absent leaves must surface all of them through the callback, so the
+      // caller logs one "missing N paths" line instead of one line per path.
+      final missing = <String>[];
+      UspClient.normalizeGetResponse(
+        [
+          'Device.DHCPv4.Server.Pool.1.MinAddress', // absent
+          'Device.DHCPv4.Server.Pool.1.MaxAddress', // absent
+          'Device.DHCPv4.Server.Pool.1.LeaseTime', // absent
+          'Device.DHCPv4.Server.Pool.1.Enable', // present
+        ],
+        <String, String?>{
+          'Device.DHCPv4.Server.Pool.1.Enable': '1',
+        },
+        onMissingPath: missing.add,
+      );
+
+      expect(missing, [
+        'Device.DHCPv4.Server.Pool.1.MinAddress',
+        'Device.DHCPv4.Server.Pool.1.MaxAddress',
+        'Device.DHCPv4.Server.Pool.1.LeaseTime',
+      ]);
+    });
+  });
+
+  group('UspClient.isWildcardOnlyRequest — empty-GET log classification', () {
+    // An empty GET response to a wildcard-only request means a multi-instance
+    // table has zero rows (a normal outcome), so _rawGet logs it at debug
+    // instead of warn. This seam is what that decision is pinned on, because
+    // _rawGet itself is not unit-testable (see the file header).
+    test('all-wildcard request is classified as wildcard-only', () {
+      expect(
+        UspClient.isWildcardOnlyRequest([
+          'Device.Firewall.DMZ.*.Enable',
+          'Device.NAT.PortMapping.*.Protocol',
+        ]),
+        isTrue,
+      );
+    });
+
+    test('a single concrete path makes the request NOT wildcard-only', () {
+      expect(
+        UspClient.isWildcardOnlyRequest([
+          'Device.Firewall.DMZ.*.Enable', // wildcard
+          'Device.GRE.Tunnel.1.RemoteEndpoints', // concrete → must still warn
+        ]),
+        isFalse,
+      );
+    });
+
+    test('all-concrete request is NOT wildcard-only', () {
+      expect(
+        UspClient.isWildcardOnlyRequest(
+          ['Device.GRE.Tunnel.1.RemoteEndpoints'],
+        ),
+        isFalse,
+      );
+    });
+
+    test('an empty path list is NOT treated as a wildcard-only request', () {
+      // Nothing was requested — an empty response is not a "no rows" table
+      // outcome, so it should not be silently downgraded.
+      expect(UspClient.isWildcardOnlyRequest(const []), isFalse);
     });
   });
 

--- a/test/core/usp/services/usp_client_normalize_response_test.dart
+++ b/test/core/usp/services/usp_client_normalize_response_test.dart
@@ -140,14 +140,16 @@ void main() {
     });
   });
 
-  group('UspClient.isWildcardOnlyRequest — empty-GET log classification', () {
-    // An empty GET response to a wildcard-only request means a multi-instance
+  group('UspClient.isTableQueryOnlyRequest — empty-GET log classification', () {
+    // An empty GET response to a table-query-only request means a multi-instance
     // table has zero rows (a normal outcome), so _rawGet logs it at debug
-    // instead of warn. This seam is what that decision is pinned on, because
-    // _rawGet itself is not unit-testable (see the file header).
-    test('all-wildcard request is classified as wildcard-only', () {
+    // instead of warn. A table query is either a wildcard ('*') OR an
+    // object/table path (trailing '.') — both are expanded by the router. This
+    // seam is what that decision is pinned on, because _rawGet itself is not
+    // unit-testable (see the file header).
+    test('all-wildcard request is classified as table-query-only', () {
       expect(
-        UspClient.isWildcardOnlyRequest([
+        UspClient.isTableQueryOnlyRequest([
           'Device.Firewall.DMZ.*.Enable',
           'Device.NAT.PortMapping.*.Protocol',
         ]),
@@ -155,9 +157,35 @@ void main() {
       );
     });
 
-    test('a single concrete path makes the request NOT wildcard-only', () {
+    test(
+        'all trailing-dot object/table request is classified as '
+        'table-query-only', () {
+      // Regression guard: a trailing-dot object GET (e.g. IPv6Address.) is also
+      // router-expanded, so an empty response is a normal zero-row outcome and
+      // must NOT emit a spurious "GET response EMPTY" warning. Before the fix
+      // isWildcardOnlyRequest only matched '*', so this returned false.
       expect(
-        UspClient.isWildcardOnlyRequest([
+        UspClient.isTableQueryOnlyRequest([
+          'Device.IP.Interface.1.IPv6Address.',
+          'Device.IP.Interface.1.IPv6Prefix.',
+        ]),
+        isTrue,
+      );
+    });
+
+    test('a mix of wildcard and trailing-dot paths is table-query-only', () {
+      expect(
+        UspClient.isTableQueryOnlyRequest([
+          'Device.Firewall.DMZ.*.Enable', // wildcard
+          'Device.IP.Interface.1.IPv6Address.', // trailing-dot table
+        ]),
+        isTrue,
+      );
+    });
+
+    test('a single concrete path makes the request NOT table-query-only', () {
+      expect(
+        UspClient.isTableQueryOnlyRequest([
           'Device.Firewall.DMZ.*.Enable', // wildcard
           'Device.GRE.Tunnel.1.RemoteEndpoints', // concrete → must still warn
         ]),
@@ -165,19 +193,19 @@ void main() {
       );
     });
 
-    test('all-concrete request is NOT wildcard-only', () {
+    test('all-concrete request is NOT table-query-only', () {
       expect(
-        UspClient.isWildcardOnlyRequest(
+        UspClient.isTableQueryOnlyRequest(
           ['Device.GRE.Tunnel.1.RemoteEndpoints'],
         ),
         isFalse,
       );
     });
 
-    test('an empty path list is NOT treated as a wildcard-only request', () {
+    test('an empty path list is NOT treated as a table-query-only request', () {
       // Nothing was requested — an empty response is not a "no rows" table
       // outcome, so it should not be silently downgraded.
-      expect(UspClient.isWildcardOnlyRequest(const []), isFalse);
+      expect(UspClient.isTableQueryOnlyRequest(const []), isFalse);
     });
   });
 

--- a/test/page/instant_setup/services/pnp_service_test.dart
+++ b/test/page/instant_setup/services/pnp_service_test.dart
@@ -93,15 +93,14 @@ void main() {
       if (paths.any((p) => p.contains('VLANTermination'))) {
         return vlanResponse;
       }
+      // PnP setup never configures a PPTP/L2TP WAN, so connectionType is never
+      // PPTP/L2TP and Phase-2 fetches no tunnel. A tunnel GET here means an
+      // unconditional fetch regressed — fail fast instead of returning empty.
       if (paths.any((p) => p.contains('GRE.Tunnel'))) {
-        return <String, dynamic>{
-          'Device.GRE.Tunnel.1.RemoteEndpoints': '',
-        };
+        throw StateError('Unexpected GRE.Tunnel GET in PnP fetch');
       }
       if (paths.any((p) => p.contains('L2TPv2.Tunnel'))) {
-        return <String, dynamic>{
-          'Device.L2TPv2.Tunnel.1.RemoteEndpoints': '',
-        };
+        throw StateError('Unexpected L2TPv2.Tunnel GET in PnP fetch');
       }
       return {};
     });
@@ -306,15 +305,13 @@ void main() {
         if (paths.any((p) => p.contains('VLANTermination'))) {
           return vlanExistingResponse;
         }
+        // PPPoE connection → no tunnel fetch in Phase-2; a tunnel GET is a
+        // regression (unconditional fetch).
         if (paths.any((p) => p.contains('GRE.Tunnel'))) {
-          return <String, dynamic>{
-            'Device.GRE.Tunnel.1.RemoteEndpoints': '',
-          };
+          throw StateError('Unexpected GRE.Tunnel GET in PnP PPPoE fetch');
         }
         if (paths.any((p) => p.contains('L2TPv2.Tunnel'))) {
-          return <String, dynamic>{
-            'Device.L2TPv2.Tunnel.1.RemoteEndpoints': '',
-          };
+          throw StateError('Unexpected L2TPv2.Tunnel GET in PnP PPPoE fetch');
         }
         return {};
       });
@@ -377,15 +374,13 @@ void main() {
         if (paths.any((p) => p.contains('VLANTermination'))) {
           return vlanDisabledResponse;
         }
+        // PPPoE connection → no tunnel fetch in Phase-2; a tunnel GET is a
+        // regression (unconditional fetch).
         if (paths.any((p) => p.contains('GRE.Tunnel'))) {
-          return <String, dynamic>{
-            'Device.GRE.Tunnel.1.RemoteEndpoints': '',
-          };
+          throw StateError('Unexpected GRE.Tunnel GET in PnP PPPoE fetch');
         }
         if (paths.any((p) => p.contains('L2TPv2.Tunnel'))) {
-          return <String, dynamic>{
-            'Device.L2TPv2.Tunnel.1.RemoteEndpoints': '',
-          };
+          throw StateError('Unexpected L2TPv2.Tunnel GET in PnP PPPoE fetch');
         }
         return {};
       });

--- a/test/page/instant_setup/services/pnp_service_test.dart
+++ b/test/page/instant_setup/services/pnp_service_test.dart
@@ -202,14 +202,14 @@ void main() {
       // - Ipv6Settings._resolveInstance() + fetch() = 2 calls
       // - PppInterface.fetch() = 1 call
       // - VlanTermination.fetch() = 1 call
-      // - GreTunnel.fetch() = 1 call
-      // - L2tpTunnel.fetch() = 1 call
       // - _fetchHostName() (Device.DeviceInfo.HostName) = 1 call
+      // No GRE/L2TP fetch: tunnels are fetched only for the pptp/l2tp
+      // connection types, not for Static IP.
       // saveAll:
       // - WanStaticIp.updateOrdered() → _resolveInstance() = 1 call
       // - Ipv6Settings.update() → _resolveInstance() = 1 call
-      // Total = 11 get calls
-      verify(() => mockUsp.get(any())).called(11);
+      // Total = 9 get calls
+      verify(() => mockUsp.get(any())).called(9);
 
       // Verify setOrdered was called for Static IP mode switch
       final capturedOrdered = verify(() => mockUsp.setOrdered(captureAny(),
@@ -246,13 +246,14 @@ void main() {
       await service.saveIspSettings(config);
 
       // Verify fetchSettings + saveAll get calls:
-      // fetchSettings: 9 calls (WanSettings x2, Ipv6 x2, PPP, VLAN, GRE, L2TP,
-      //   _fetchHostName = Device.DeviceInfo.HostName)
+      // fetchSettings: 7 calls (WanSettings x2, Ipv6 x2, PPP, VLAN,
+      //   _fetchHostName = Device.DeviceInfo.HostName). No GRE/L2TP fetch:
+      //   tunnels are fetched only for the pptp/l2tp connection types.
       // saveAll:
       // - WanPppoe.update() → _resolveInstance() = 1 call
       // - Ipv6Settings.update() → _resolveInstance() = 1 call
-      // Total = 11 get calls
-      verify(() => mockUsp.get(any())).called(11);
+      // Total = 9 get calls
+      verify(() => mockUsp.get(any())).called(9);
 
       // Verify PppInterface.add was called (new PPP instance created)
       final addCaptures = verify(() => mockUsp.add(captureAny())).captured;

--- a/test/page/internet_settings/services/usp_internet_settings_service_test.dart
+++ b/test/page/internet_settings/services/usp_internet_settings_service_test.dart
@@ -949,6 +949,44 @@ void main() {
       expect(result.form.serverAddress, equals('l2tp.example.com'));
       expect(result.form.pppUsername, equals('l2tpuser'));
     });
+
+    test(
+        'DHCP WAN fetch issues NO GRE/L2TP tunnel GET (#1184 regression guard)',
+        () async {
+      // The load-bearing regression this PR fixes. GreTunnel/L2tpTunnel are
+      // generated with concrete paths (Device.GRE.Tunnel.1.*), so — now that
+      // #1198 removed _rawGet's null back-fill — fetching them on a DHCP WAN
+      // (zero tunnel instances) fires the codegen required-leaf check (9998).
+      // Phase-2 must fetch ONLY the tunnel the connectionType uses; a DHCP WAN
+      // must fetch none. If someone reverts the conditional fetch to an
+      // unconditional one, a tunnel path appears here and this fails.
+      final handler = createFetchMockHandler(); // default DHCP WAN
+      when(() => mockUsp.get(any())).thenAnswer((invocation) async {
+        final paths = invocation.positionalArguments[0] as List<String>;
+        return handler(paths);
+      });
+
+      final result = await service.fetchSettings();
+      expect(result.form.connectionType, equals(UspWanConnectionType.dhcp));
+
+      // Directly assert intent (not just the handler's fail-fast): no GET this
+      // fetch issued touched a GRE or L2TPv2 tunnel path.
+      final allRequestedPaths = verify(() => mockUsp.get(captureAny()))
+          .captured
+          .cast<List<String>>()
+          .expand((paths) => paths)
+          .toList();
+      expect(
+        allRequestedPaths,
+        isNot(contains(contains('GRE.Tunnel'))),
+        reason: 'DHCP WAN must not fetch the GRE tunnel',
+      );
+      expect(
+        allRequestedPaths,
+        isNot(contains(contains('L2TPv2.Tunnel'))),
+        reason: 'DHCP WAN must not fetch the L2TPv2 tunnel',
+      );
+    });
   });
 
   group('renewDhcpLease', () {

--- a/test/page/internet_settings/services/usp_internet_settings_service_test.dart
+++ b/test/page/internet_settings/services/usp_internet_settings_service_test.dart
@@ -71,15 +71,6 @@ const _l2tpResponse = <String, dynamic>{
   'Device.L2TPv2.Tunnel.1.RemoteEndpoints': 'l2tp.example.com',
 };
 
-// Test data — GRE/L2TP empty
-const _greEmptyResponse = <String, dynamic>{
-  'Device.GRE.Tunnel.1.RemoteEndpoints': '',
-};
-
-const _l2tpEmptyResponse = <String, dynamic>{
-  'Device.L2TPv2.Tunnel.1.RemoteEndpoints': '',
-};
-
 // Test data — PPP empty (no instances)
 const _pppEmptyResponse = <String, dynamic>{};
 
@@ -118,8 +109,12 @@ Map<String, dynamic> Function(List<String>) createFetchMockHandler({
   Map<String, dynamic> wanResponse = _wanResponse,
   Map<String, dynamic> pppResponse = _pppResponse,
   Map<String, dynamic> vlanResponse = _vlanResponse,
-  Map<String, dynamic> greResponse = _greEmptyResponse,
-  Map<String, dynamic> l2tpResponse = _l2tpEmptyResponse,
+  // Tunnel responses default to null: a tunnel GET is only expected when the
+  // resolved connectionType is PPTP/L2TP (Phase-2 conditional fetch). A test
+  // exercising that path passes the matching response explicitly; any other
+  // tunnel GET is a regression (unconditional fetch) and fails fast below.
+  Map<String, dynamic>? greResponse,
+  Map<String, dynamic>? l2tpResponse,
 }) {
   return (List<String> paths) {
     // Alias resolution (must be checked first)
@@ -129,12 +124,18 @@ Map<String, dynamic> Function(List<String>) createFetchMockHandler({
     if (paths.any((p) => p.contains('IP.Interface.*.Alias'))) {
       return _ipAliasResponse;
     }
-    // Tunnel fetches
+    // Tunnel fetches — fail fast if requested without an expected response, so
+    // a regression re-introducing an unconditional GRE/L2TP fetch cannot pass
+    // silently on empty tunnel data.
     if (paths.any((p) => p.contains('GRE.Tunnel'))) {
-      return greResponse;
+      return greResponse ??
+          (throw StateError('Unexpected GRE.Tunnel GET: Phase-2 must only '
+              'fetch the tunnel matching connectionType (paths: $paths)'));
     }
     if (paths.any((p) => p.contains('L2TPv2.Tunnel'))) {
-      return l2tpResponse;
+      return l2tpResponse ??
+          (throw StateError('Unexpected L2TPv2.Tunnel GET: Phase-2 must only '
+              'fetch the tunnel matching connectionType (paths: $paths)'));
     }
     // Other fetches
     if (paths.any((p) => p.contains('AddressingType'))) {
@@ -237,11 +238,13 @@ void main() {
         if (paths.any((p) => p.contains('IP.Interface.*.Alias'))) {
           return _ipAliasResponse;
         }
+        // This test's PPP instance is empty → connectionType is not PPTP/L2TP,
+        // so Phase-2 fetches no tunnel. A tunnel GET here is a regression.
         if (paths.any((p) => p.contains('GRE.Tunnel'))) {
-          return _greEmptyResponse;
+          throw StateError('Unexpected GRE.Tunnel GET in DNS-split test');
         }
         if (paths.any((p) => p.contains('L2TPv2.Tunnel'))) {
-          return _l2tpEmptyResponse;
+          throw StateError('Unexpected L2TPv2.Tunnel GET in DNS-split test');
         }
         if (paths.any((p) => p.contains('AddressingType'))) return wanWith3Dns;
         if (paths.any((p) => p.contains('IPv6Enable'))) return _ipv6Response;
@@ -904,11 +907,12 @@ void main() {
       final wanIpcp = Map<String, dynamic>.from(_wanResponse);
       wanIpcp['Device.IP.Interface.2.IPv4Address.1.AddressingType'] = 'IPCP';
 
+      // Only GRE is expected; leaving l2tpResponse null asserts (via the
+      // handler's fail-fast) that a PPTP connection never fetches L2TP.
       final handler = createFetchMockHandler(
         wanResponse: wanIpcp,
         pppResponse: _pppPptpResponse,
         greResponse: _greResponse,
-        l2tpResponse: _l2tpEmptyResponse,
       );
       when(() => mockUsp.get(any())).thenAnswer((invocation) async {
         final paths = invocation.positionalArguments[0] as List<String>;
@@ -927,10 +931,11 @@ void main() {
       final wanIpcp = Map<String, dynamic>.from(_wanResponse);
       wanIpcp['Device.IP.Interface.2.IPv4Address.1.AddressingType'] = 'IPCP';
 
+      // Only L2TP is expected; leaving greResponse null asserts (via the
+      // handler's fail-fast) that an L2TP connection never fetches GRE.
       final handler = createFetchMockHandler(
         wanResponse: wanIpcp,
         pppResponse: _pppL2tpResponse,
-        greResponse: _greEmptyResponse,
         l2tpResponse: _l2tpResponse,
       );
       when(() => mockUsp.get(any())).thenAnswer((invocation) async {

--- a/test/page/internet_settings/services/usp_internet_settings_service_test.dart
+++ b/test/page/internet_settings/services/usp_internet_settings_service_test.dart
@@ -987,6 +987,37 @@ void main() {
         reason: 'DHCP WAN must not fetch the L2TPv2 tunnel',
       );
     });
+
+    test(
+        'PPTP WAN with absent GRE Tunnel.1 row surfaces a ServiceError (not a crash)',
+        () async {
+      // Companion to the DHCP guard: the item-1 residual-risk path. If the
+      // firmware classifies the WAN as PPTP but has not provisioned
+      // Device.GRE.Tunnel.1 (LowerLayers references it but the row is absent),
+      // Phase-2's GreTunnel.fetch hits the codegen required-leaf check (9998).
+      // That must surface as a mapped ServiceError (→ ServiceErrorView), NOT an
+      // uncaught StateError / NPE — this is the reachable-error contract #1184
+      // is about. An empty greResponse omits the required RemoteEndpoints leaf.
+      final wanIpcp = Map<String, dynamic>.from(_wanResponse);
+      wanIpcp['Device.IP.Interface.2.IPv4Address.1.AddressingType'] = 'IPCP';
+
+      final handler = createFetchMockHandler(
+        wanResponse: wanIpcp,
+        pppResponse: _pppPptpResponse,
+        greResponse: const {}, // Tunnel.1 row absent → 9998 upstream
+      );
+      when(() => mockUsp.get(any())).thenAnswer((invocation) async {
+        final paths = invocation.positionalArguments[0] as List<String>;
+        return handler(paths);
+      });
+
+      await expectLater(
+        service.fetchSettings(),
+        throwsA(isA<ServiceError>()),
+        reason: 'absent Tunnel.1 must map to a ServiceError, not escape as a '
+            'StateError or NPE',
+      );
+    });
   });
 
   group('renewDhcpLease', () {

--- a/test/page/internet_settings/services/usp_internet_settings_service_test.dart
+++ b/test/page/internet_settings/services/usp_internet_settings_service_test.dart
@@ -334,6 +334,46 @@ void main() {
       );
     });
 
+    test('IPv6 save uses allowPartial (cross-USP-service SET cannot be atomic)',
+        () async {
+      // IPv6 settings span IP.Interface, DHCPv6.Client and IPv6rd.Interface-
+      // Setting. The OBUSPA broker rejects an atomic SET (allow_partial=false)
+      // touching more than one service with 7005, failing the whole save.
+      // Regression guard for that: the IPv6 SET must be sent with allowPartial.
+      final original = UspInternetSettingsForm(
+        connectionType: UspWanConnectionType.dhcp,
+        ipv6Enabled: true,
+        dhcpv6Enabled: true,
+      );
+      final edited = original.copyWith(
+        ipv6Enabled: false,
+        dhcpv6Enabled: false,
+      );
+
+      await service.saveAll(original, edited);
+
+      // Find the SET carrying IPv6/DHCPv6 params and assert it passed
+      // allowPartial: true (not the default false that triggers 7005).
+      final captured = verify(
+        () => mockUsp.set(
+          captureAny(),
+          allowPartial: captureAny(named: 'allowPartial'),
+        ),
+      ).captured;
+      var found = false;
+      for (var i = 0; i < captured.length; i += 2) {
+        final params = captured[i] as Map<String, dynamic>;
+        final allowPartial = captured[i + 1] as bool;
+        if (params.keys
+            .any((k) => k.contains('IPv6') || k.contains('DHCPv6'))) {
+          found = true;
+          expect(allowPartial, isTrue,
+              reason: 'IPv6 SET must use allowPartial to avoid 7005');
+        }
+      }
+      expect(found, isTrue, reason: 'an IPv6 SET should have been issued');
+    });
+
     test('adds PPP instance when switching to PPPoE without existing instance',
         () async {
       when(() => mockUsp.add(any())).thenAnswer((_) async => {


### PR DESCRIPTION
Closes #1184.

## Summary

Follow-up to #1198, which removed `_rawGet`'s global back-fill to make the codegen required-leaf (9998) check reachable again. That correct fix exposed three latent regressions and two long-standing log-noise bugs on live routers. This PR fixes all of them.

## What changed

### 1. Conditional WAN tunnel fetch — fixes false 9998 on absent GRE/L2TP tunnels
`GreTunnel` / `L2tpTunnel` are generated with **concrete** paths (`Device.GRE.Tunnel.1.*`), so with the back-fill gone their required leaves fire 9998 whenever the tunnel is absent — which is the normal case for DHCP/Static/PPPoE WANs.

Fixed by a two-phase fetch in `UspInternetSettingsService`: phase 1 fetches the always-present sources in parallel and derives the connection type; phase 2 fetches **only** the tunnel that the connection type actually uses (GRE for PPTP, L2TP for L2TP), and nothing for the others.

**Firmware contract dependency (PPTP/L2TP):** the phase-2 tunnel fetch trusts the firmware contract — a PPTP WAN guarantees `Device.GRE.Tunnel.1.*` and an L2TP WAN guarantees `Device.L2TPv2.Tunnel.1.*` exist once `PPP.Interface.LowerLayers` references them. If that contract were ever broken, `GreTunnel`/`L2tpTunnel.fetch` throws 9998 before the form is built (surfaced as a `ServiceError`), rather than being masked. This is a deliberate trade-off: we do not swallow the tunnel-absent case for PPTP/L2TP.

**Cost note:** PPTP/L2TP WANs now pay one extra serialized round trip (phase 2 runs after phase 1 resolves the connection type). DHCP/Static/PPPoE WANs are unaffected — they fetch no tunnel at all.

### 2. IPv6 settings SET now uses `allow_partial=true` — fixes 7005 save failure
IPv6 settings span three USP micro-services (`IP.Interface`, `DHCPv6.Client`, `IPv6rd.InterfaceSetting`). The OBUSPA broker rejects an atomic SET (`allow_partial=false`) that touches more than one service, returning **7005 "Allow partial=false not supported across more than one USP Service"** and failing the entire save.

A cross-service SET cannot be atomic on this router, so the IPv6 save now passes `allowPartial: true`. `_handleSetResult` still surfaces any per-parameter failure as a `UspPartialFailureError`, so nothing is silently swallowed.

### 3. Stop false "missing / empty" GET warnings for table & wildcard queries
Two false-positive log warnings on healthy routers:
- **Empty multi-instance tables** (table-query-only GETs with zero rows) logged `GET response EMPTY` at `warn`. Now classified via `isTableQueryOnlyRequest` and logged at `debug` — a zero-row table is a normal outcome.
- **Trailing-dot object/table GETs** (e.g. `...IPv6Address.`) were reported as missing paths, because the router expands them into instance paths and never echoes the requested key. Now skipped like wildcards. Wildcard (`*`) and trailing-dot (`.`) paths share one `_isTableExpandedPath` predicate.
- Per-path missing warnings are **aggregated** into one `missing N path(s)` line instead of flooding one line per absent leaf.

## Tests
- `usp_client_normalize_response_test.dart`: added `isTableQueryOnlyRequest` classification group (wildcard, trailing-dot, mixed, concrete-negative), trailing-dot skip, and aggregation-collection tests.
- `usp_internet_settings_service_test.dart`:
  - IPv6-carrying SET is issued with `allowPartial: true`.
  - **#1184 regression guard**: a DHCP WAN fetch issues NO GRE/L2TP tunnel GET (asserted directly on the captured GET paths, independent of the mock handler's fail-fast).
  - PPTP/L2TP fetch tests pass only the active tunnel response; the mock fail-fasts if the inactive tunnel is ever fetched.
- `pnp_service_test.dart`: updated GET-call counts for the conditional tunnel fetch (11 → 9 for PPPoE / Static IP); mock fail-fasts on unexpected tunnel GET.
- `flutter analyze` clean; full functional suite green.

## Review follow-ups (PR #1219)
- **Item 6 (DRY):** `connectionType` is derived once in `fetchSettings` and passed into `_buildForm`.
- **Item 1 (HIGH):** removed the misleading `?? ''` dead-code fallback in the PPTP/L2TP branches; see the firmware-contract note above.
- **Item 3:** added the explicit DHCP-WAN "no tunnel GET" regression guard.
- **Item 4:** documented the cross-service `allow_partial` invariant at the `instant_safety_service` single-service SET site.
- **Item 5:** noted 7005's second, broker-level meaning in the `usp_error.dart` fault-code table.

## Notes
The `ipv6settings` YAML contract currently matches live router state, so its concrete `.1.` paths are intentionally left as-is (contract holds; no speculative change).
