### PR TITLE
feat(ai): show which step of a multi-round wait is in flight (#1220)

### DIFF
--- a/lib/ai/orchestrator/router_chat_controller.dart
+++ b/lib/ai/orchestrator/router_chat_controller.dart
@@ -6,6 +6,12 @@ import 'package:privacy_gui/ai/ai_logging.dart';
 import 'package:privacy_gui/ai/abstraction/_abstraction.dart';
 import 'package:privacy_gui/ai/prompts/router_system_prompt.dart';
 
+/// Most LLM round-trips one exchange may take before it is cut off.
+///
+/// A fuse against a model that keeps requesting data instead of answering, not
+/// a budget the user is meant to feel.
+const int _maxLoops = 5;
+
 /// Results accumulated for one assistant turn, owned by the exchange that
 /// opened it.
 ///
@@ -144,6 +150,22 @@ class RouterChatController extends ChangeNotifier {
   /// Whether the controller is currently loading.
   bool get isLoading => _state.isLoading;
 
+  /// Which round-trip of the current exchange is in flight, or 0 when idle.
+  ///
+  /// Exists so the view can say something true while the user waits. A single
+  /// question can take several LLM calls — each round asks for data the previous
+  /// round revealed it needed — and the intermediate responses are invisible
+  /// (they carry only `tool_use`, which is not for the user to read). Without
+  /// this the wait is indistinguishable from a hang.
+  int get currentRound => _currentRound;
+  int _currentRound = 0;
+
+  /// The most rounds one exchange may take before it is cut off.
+  ///
+  /// Exposed so the view can show progress relative to a known bound rather
+  /// than an open-ended counter.
+  static const int maxRounds = _maxLoops;
+
   /// Whether there's an error.
   bool get hasError => _state.hasError;
 
@@ -246,6 +268,21 @@ class RouterChatController extends ChangeNotifier {
   /// - Detecting confirmation requirements
   /// - Looping for multi-turn tool use
   Future<void> _processConversation() async {
+    // Wrapped rather than guarded inline: the body has eleven exit paths, and
+    // clearing the round at each one is the kind of bookkeeping that gets
+    // forgotten when a twelfth is added. A `finally` here covers every return
+    // and every throw, without reindenting the body.
+    try {
+      await _runConversation();
+    } finally {
+      if (_currentRound != 0) {
+        _currentRound = 0;
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<void> _runConversation() async {
     // This exchange owns its own batch, stamped with the generation it belongs
     // to. Every await below is a point where the user can reset the
     // conversation; because results live on the batch rather than in shared
@@ -266,13 +303,17 @@ class RouterChatController extends ChangeNotifier {
     if (_isStale(batch)) return;
 
     var loopCount = 0;
-    const maxLoops = 5;
+    const maxLoops = _maxLoops;
 
     _log(
         '_processConversation: starting loop (${tools.length} tools available)');
 
     while (loopCount < maxLoops) {
       loopCount++;
+      // Published before the call so the view can describe the wait it is
+      // about to sit through, not the one that just ended.
+      _currentRound = loopCount;
+      notifyListeners();
       _log('_processConversation: loop $loopCount/$maxLoops');
 
       // Declared outside the try so the catch blocks can still surface a

--- a/lib/ai/orchestrator/router_chat_controller.dart
+++ b/lib/ai/orchestrator/router_chat_controller.dart
@@ -6,12 +6,6 @@ import 'package:privacy_gui/ai/ai_logging.dart';
 import 'package:privacy_gui/ai/abstraction/_abstraction.dart';
 import 'package:privacy_gui/ai/prompts/router_system_prompt.dart';
 
-/// Most LLM round-trips one exchange may take before it is cut off.
-///
-/// A fuse against a model that keeps requesting data instead of answering, not
-/// a budget the user is meant to feel.
-const int _maxLoops = 5;
-
 /// Results accumulated for one assistant turn, owned by the exchange that
 /// opened it.
 ///
@@ -160,11 +154,12 @@ class RouterChatController extends ChangeNotifier {
   int get currentRound => _currentRound;
   int _currentRound = 0;
 
-  /// The most rounds one exchange may take before it is cut off.
+  /// Most LLM round-trips one exchange may take before it is cut off.
   ///
-  /// Exposed so the view can show progress relative to a known bound rather
-  /// than an open-ended counter.
-  static const int maxRounds = _maxLoops;
+  /// A fuse against a model that keeps requesting data instead of answering,
+  /// not a budget the user is meant to feel. Exposed so the view can show
+  /// progress against a known bound rather than an open-ended counter.
+  static const int maxRounds = 5;
 
   /// Whether there's an error.
   bool get hasError => _state.hasError;
@@ -303,7 +298,7 @@ class RouterChatController extends ChangeNotifier {
     if (_isStale(batch)) return;
 
     var loopCount = 0;
-    const maxLoops = _maxLoops;
+    const maxLoops = maxRounds;
 
     _log(
         '_processConversation: starting loop (${tools.length} tools available)');
@@ -845,6 +840,12 @@ class RouterChatController extends ChangeNotifier {
     _totalOutputTokens = 0;
     _totalCacheReadTokens = 0;
     _totalCacheWriteTokens = 0;
+
+    // A clear is a forced end to the exchange, so the round must read idle from
+    // this notification onward. The `finally` in _processConversation also
+    // clears it, but not until the in-flight call yields — leaving a frame where
+    // the view sees `isLoading == false` alongside a non-zero round.
+    _currentRound = 0;
 
     // Refresh router context
     _initializeSystemPrompt();

--- a/lib/page/ai_assistant/views/router_assistant_view.dart
+++ b/lib/page/ai_assistant/views/router_assistant_view.dart
@@ -714,6 +714,7 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
                       _AnimatedThinkingText(
                         color:
                             theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                        round: _controller?.currentRound ?? 0,
                       ),
                     ],
                   ),
@@ -917,7 +918,17 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
 class _AnimatedThinkingText extends StatefulWidget {
   final Color color;
 
-  const _AnimatedThinkingText({required this.color});
+  /// Which round-trip is in flight, or 0 when that is not known.
+  ///
+  /// Shown because the phrases below are decoration — they rotate on a timer and
+  /// say nothing about progress. A single question can take several rounds while
+  /// the assistant fetches what it needs, and those intermediate responses are
+  /// never rendered, so without this the wait looks identical to a hang.
+  /// Suppressed on the first round: "1" alongside a spinner tells the user
+  /// nothing they cannot already see.
+  final int round;
+
+  const _AnimatedThinkingText({required this.color, this.round = 0});
 
   static const _phrases = [
     'Thinking',
@@ -976,8 +987,13 @@ class _AnimatedThinkingTextState extends State<_AnimatedThinkingText>
   Widget build(BuildContext context) {
     final phrase = _AnimatedThinkingText._phrases[_phraseIndex];
     final dots = '.' * _dotCount;
+    // Digits only, so no new localized string is needed — and the label stays
+    // correct if the tool list is reorganised later.
+    final step = widget.round > 1
+        ? ' (${widget.round}/${RouterChatController.maxRounds})'
+        : '';
     return AppText.body(
-      '$phrase$dots',
+      '$phrase$dots$step',
       color: widget.color,
     );
   }

--- a/lib/page/ai_assistant/views/router_assistant_view.dart
+++ b/lib/page/ai_assistant/views/router_assistant_view.dart
@@ -715,6 +715,7 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
                         color:
                             theme.colorScheme.onSurface.withValues(alpha: 0.7),
                         round: _controller?.currentRound ?? 0,
+                        totalRounds: RouterChatController.maxRounds,
                       ),
                     ],
                   ),
@@ -928,7 +929,15 @@ class _AnimatedThinkingText extends StatefulWidget {
   /// nothing they cannot already see.
   final int round;
 
-  const _AnimatedThinkingText({required this.color, this.round = 0});
+  /// The bound [round] counts against, so the widget does not have to know
+  /// where that number comes from.
+  final int totalRounds;
+
+  const _AnimatedThinkingText({
+    required this.color,
+    this.round = 0,
+    this.totalRounds = 0,
+  });
 
   static const _phrases = [
     'Thinking',
@@ -989,8 +998,11 @@ class _AnimatedThinkingTextState extends State<_AnimatedThinkingText>
     final dots = '.' * _dotCount;
     // Digits only, so no new localized string is needed — and the label stays
     // correct if the tool list is reorganised later.
-    final step = widget.round > 1
-        ? ' (${widget.round}/${RouterChatController.maxRounds})'
+    // Read live from the widget on every build: copying either value into State
+    // would freeze the display at whatever round was current when this widget
+    // was first created.
+    final step = widget.round > 1 && widget.totalRounds > 0
+        ? ' (${widget.round}/${widget.totalRounds})'
         : '';
     return AppText.body(
       '$phrase$dots$step',

--- a/test/ai/orchestrator/router_chat_controller_test.dart
+++ b/test/ai/orchestrator/router_chat_controller_test.dart
@@ -231,6 +231,7 @@ void main() {
 
         expect(controller.messages, isEmpty);
         expect(controller.hasPendingConfirmation, isFalse);
+        expect(controller.currentRound, 0);
         expect(controller.hasError, isFalse);
       });
     });
@@ -345,6 +346,82 @@ void main() {
         expect(controller.currentRound, 0,
             reason: 'an idle controller must not claim a round is running, or '
                 'the view keeps showing progress after the answer');
+      });
+
+      test('reads idle immediately when cleared mid-call', () async {
+        // A clear is a forced end. The `finally` also resets, but not until the
+        // in-flight call yields — so without an explicit reset the view sees
+        // `isLoading == false` next to a non-zero round for a frame.
+        final gate = Completer<LLMResponse>();
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+            )).thenAnswer((_) => gate.future);
+
+        final pending = controller.sendMessage('hi');
+        await Future<void>.delayed(Duration.zero);
+        expect(controller.currentRound, 1, reason: 'a round is in flight');
+
+        controller.clearConversation();
+
+        expect(controller.currentRound, 0,
+            reason: 'the view must not report a round after a clear');
+        expect(controller.isLoading, isFalse);
+
+        gate.complete(_textResponse('late'));
+        await pending;
+        expect(controller.currentRound, 0);
+      });
+
+      test('clears the round after a confirmation is answered', () async {
+        // The confirmation flow re-enters the loop, so it has its own exit paths
+        // through the same wrapper. Both outcomes must land back at idle.
+        when(() => mockGenerator.generateWithHistory(
+                  any(),
+                  tools: any(named: 'tools'),
+                  systemPromptParts: any(named: 'systemPromptParts'),
+                ))
+            .thenAnswer((_) async =>
+                _toolUseResponse('setWifiPassword', {'password': 'secret123'}));
+
+        await controller.sendMessage('change my wifi password');
+        expect(controller.hasPendingConfirmation, isTrue);
+
+        when(() => mockCommandProvider.execute('setWifiPassword', any()))
+            .thenAnswer((_) async => RouterCommandResult.success(const {}));
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+            )).thenAnswer((_) async => _textResponse('Done.'));
+
+        await controller.confirmPendingAction();
+
+        expect(controller.currentRound, 0);
+      });
+
+      test('clears the round after a confirmation is cancelled', () async {
+        when(() => mockGenerator.generateWithHistory(
+                  any(),
+                  tools: any(named: 'tools'),
+                  systemPromptParts: any(named: 'systemPromptParts'),
+                ))
+            .thenAnswer((_) async =>
+                _toolUseResponse('setWifiPassword', {'password': 'secret123'}));
+
+        await controller.sendMessage('change my wifi password');
+        expect(controller.hasPendingConfirmation, isTrue);
+
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+            )).thenAnswer((_) async => _textResponse('No problem.'));
+
+        await controller.cancelPendingAction();
+
+        expect(controller.currentRound, 0);
       });
 
       test('clears the round even when the exchange fails', () async {

--- a/test/ai/orchestrator/router_chat_controller_test.dart
+++ b/test/ai/orchestrator/router_chat_controller_test.dart
@@ -309,6 +309,59 @@ void main() {
     // follows it.
     // =========================================================================
 
+    group('round reporting', () {
+      test('is 0 while idle', () {
+        expect(controller.currentRound, 0);
+      });
+
+      test('reports the round in flight, and clears when the answer arrives',
+          () async {
+        // Two rounds: the model asks for data, then answers with it. The view
+        // shows this so a multi-round wait is distinguishable from a hang.
+        final roundsSeen = <int>[];
+        controller.addListener(() => roundsSeen.add(controller.currentRound));
+
+        var call = 0;
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+            )).thenAnswer((_) async {
+          call++;
+          return call == 1
+              ? _toolUseResponse('getSystemInfo', {})
+              : _textResponse('Your router is a TestRouter.');
+        });
+        when(() => mockCommandProvider.execute('getSystemInfo', any()))
+            .thenAnswer((_) async =>
+                RouterCommandResult.success(const {'model': 'TestRouter'}));
+
+        await controller.sendMessage('what router is this?');
+
+        expect(roundsSeen, contains(1),
+            reason: 'the first round must be published');
+        expect(roundsSeen, contains(2),
+            reason: 'a second round means the assistant needed data first');
+        expect(controller.currentRound, 0,
+            reason: 'an idle controller must not claim a round is running, or '
+                'the view keeps showing progress after the answer');
+      });
+
+      test('clears the round even when the exchange fails', () async {
+        // The reset lives in a `finally`, because the body has many exits and
+        // a stuck counter would leave the view describing work that has stopped.
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+            )).thenThrow(Exception('network down'));
+
+        await controller.sendMessage('hello');
+
+        expect(controller.currentRound, 0);
+      });
+    });
+
     group('tool result batching', () {
       test('answers parallel read tools in one message', () async {
         when(() => mockCommandProvider.execute(any(), any())).thenAnswer(


### PR DESCRIPTION
Fixes #1220.

## Summary

While the assistant works, the loading bubble cycles `Thinking / Analyzing / Processing …`. Those phrases are driven by a timer — they rotate at a fixed interval whether progress is being made or not.

That is fine for a short wait, and misleading for the common one: a single question often takes **several LLM round-trips**, the assistant asking for data before it can answer. Those intermediate responses are never rendered (a message with no `TextBlock` returns `SizedBox.shrink()`, and they carry only `tool_use`). So a multi-round wait is indistinguishable from a hang.

The controller already knew which round it was on and simply never said so. It now publishes it, and the bubble reads `Thinking… (2/5)`.

## Decisions worth reviewing

**Suppressed on round one.** A `(1/5)` next to a spinner tells the user nothing they cannot already see; showing it would add noise to the case that is already fine.

**Digits only — no new l10n keys.** The alternative, naming the tool in flight ("Checking connected devices…"), reads better but costs 15 keys × 26 locales *and* goes stale the moment the tool list is reorganised (mainline 2-2). The round number stays correct through that.

**`_processConversation` is now a thin wrapper around `_runConversation`.** Only so a `finally` can clear the round. The body has **eleven exit paths**; clearing at each is the bookkeeping that gets forgotten when a twelfth is added, and a stuck counter would leave the view reporting work that has stopped. Wrapping avoids reindenting a method whose extraction is tracked separately — the body is byte-for-byte unchanged.

## Why not streaming

This came out of investigating #1217, where I measured whether streaming would address the same complaint. It would not, and the reasoning is recorded there. The short version: the prompt requires the whole component tree in one message (measured at 186–531 characters, so a few hundred milliseconds), and the rounds that make a wait long carry **no renderable content at all** — so streaming has nothing to show during exactly the slow case.

What the user lacks is not partial output. It is whether anything is still happening.

#1217 is now blocked on mainline 2-1, which will make the output incremental and give streaming something to render.

## Verification

| Check | Result |
|---|---|
| `test/ai/orchestrator/router_chat_controller_test.dart` | 35/35 |
| `flutter test test/ai/ test/page/ai_assistant/` | 115/115 |
| `./run_tests.sh` (full suite) | **3579/3579** |
| `flutter analyze` | 0 issues on changed lines |

Three tests added: idle reports 0, a two-round exchange publishes both rounds and returns to 0, and a **failed** exchange still resets. Mutation-checked: removing the reset fails two tests, not publishing the round fails one.

## Notes for reviewers

- **The view-side display logic has no test.** The round arithmetic lives in the controller where it is covered, but the "only show when `round > 1`" condition and the `(2/5)` formatting are in `_AnimatedThinkingText` — enforced by logic, not by a test. This repo has no widget-test infrastructure for this view; called out as a deliberate trade-off rather than left to be discovered.
- Two `prefer_const_literals` infos in the test file are pre-existing (`git blame` → `f75a4ff6`, #995) and not touched here.
- `maxRounds` is exposed on the controller so the view shows progress against a known bound rather than an open-ended counter. The underlying `_maxLoops` was a local `const` inside the loop; it is now a file-level constant so both the loop and the getter cite one source.
