### PR TITLE
feat(e2e): add stable identifiers to Advanced Settings entry cards (#1218)

### DIFF
--- a/lib/page/advanced_settings/views/usp_advanced_settings_view.dart
+++ b/lib/page/advanced_settings/views/usp_advanced_settings_view.dart
@@ -67,26 +67,32 @@ class UspAdvancedSettingsView extends StatelessWidget {
   List<AppSectionItemData> _buildItems(BuildContext context) {
     return [
       AppSectionItemData(
+        identifier: 'advanced-settings-internet',
         title: loc(context).internetSettings,
         onTap: () => context.pushNamed(RouteNamed.uspInternetSettings),
       ),
       AppSectionItemData(
+        identifier: 'advanced-settings-local-network',
         title: loc(context).localNetwork,
         onTap: () => context.pushNamed(RouteNamed.uspLocalNetwork),
       ),
       AppSectionItemData(
+        identifier: 'advanced-settings-firewall',
         title: loc(context).firewall,
         onTap: () => context.pushNamed(RouteNamed.uspFirewall),
       ),
       AppSectionItemData(
+        identifier: 'advanced-settings-dmz',
         title: loc(context).dmz,
         onTap: () => context.pushNamed(RouteNamed.uspDmz),
       ),
       AppSectionItemData(
+        identifier: 'advanced-settings-port-forwarding',
         title: loc(context).portForwarding,
         onTap: () => context.pushNamed(RouteNamed.uspPortForwardingDetail),
       ),
       AppSectionItemData(
+        identifier: 'advanced-settings-static-routing',
         title: loc(context).staticRouting,
         onTap: () => context.pushNamed(RouteNamed.uspStaticRouting),
       ),
@@ -95,6 +101,7 @@ class UspAdvancedSettingsView extends StatelessWidget {
 
   Widget _buildCard(AppSectionItemData item) {
     return LayoutBlock(
+      identifier: item.identifier,
       onTap: item.onTap,
       padding: const EdgeInsets.symmetric(
         vertical: AppSpacing.md,

--- a/lib/page/dashboard/views/usp_sliver_dashboard_view.dart
+++ b/lib/page/dashboard/views/usp_sliver_dashboard_view.dart
@@ -290,6 +290,7 @@ class _UspSliverDashboardViewState
 
   Widget _buildOfflineBanner(BuildContext context) {
     return AppCard(
+      identifier: 'dashboard-offline-banner',
       child: InkWell(
         onTap: () {
           context.goNamed(RouteNamed.uspUnifiedDiagnostics);

--- a/lib/page/menu/views/usp_menu_view.dart
+++ b/lib/page/menu/views/usp_menu_view.dart
@@ -144,6 +144,7 @@ class UspMenuView extends ConsumerWidget {
       ),
       if (kDebugMode)
         AppSectionItemData(
+          identifier: 'menu-usp-console',
           title: loc(context).uspConsole,
           description: 'Raw USP CRUD, SSE, subscription & turbo debug tool',
           iconData: Icons.terminal,

--- a/lib/page/support/views/usp_support_view.dart
+++ b/lib/page/support/views/usp_support_view.dart
@@ -141,6 +141,7 @@ class _QuickLinkFooter extends ConsumerWidget {
     final colorScheme = Theme.of(context).colorScheme;
 
     return LayoutBlock(
+      identifier: 'support-visit-linksys',
       onTap: () => gotoOfficialWebUrl(
         linkSupport,
         locale: ref.read(appSettingsProvider).locale,
@@ -190,6 +191,7 @@ class _RemoteAssistanceCard extends ConsumerWidget {
     final credentials = ref.watch(deviceCredentialsProvider);
 
     return LayoutBlock(
+      identifier: 'support-remote-assistance',
       onTap: credentials != null
           ? () =>
               showRemoteAssistanceDialog(context, ref, credentials: credentials)

--- a/test/page/advanced_settings/usp_advanced_settings_identifier_widget_test.dart
+++ b/test/page/advanced_settings/usp_advanced_settings_identifier_widget_test.dart
@@ -1,0 +1,133 @@
+@Tags(['ui'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/advanced_settings/views/usp_advanced_settings_view.dart';
+import 'package:privacy_gui/route/route_model.dart';
+import 'package:privacy_gui/theme/theme_json_config.dart';
+
+import '../../golden_test/golden_framework/mocks/mock_common.dart';
+
+/// Verifies that the Advanced Settings entry cards carry the stable E2E
+/// identifiers added in issue #1218 and that each is locatable via
+/// [CommonFinders.bySemanticsIdentifier].
+///
+/// This is the fast local proxy for the E2E `byId()` contract (constitution
+/// Article XVI): once the identifier reaches the Semantics tree, the CanvasKit
+/// → `flt-semantics-identifier` DOM projection is a Flutter-runtime guarantee,
+/// so no web round is needed here.
+///
+/// Both layout branches are exercised: [UspAdvancedSettingsView] renders a
+/// [Column] of cards on mobile (`_buildMobileList`, width < 600) and a 2-up
+/// grid on desktop (`_buildDesktopGrid`, width > 1240). The identifier wiring
+/// lives in the shared `_buildCard`, but covering both widths proves neither
+/// responsive branch drops the hook.
+void main() {
+  // Fixed E2E hooks assigned to the six entry cards, in list order.
+  const expectedIdentifiers = <String>[
+    'advanced-settings-internet',
+    'advanced-settings-local-network',
+    'advanced-settings-firewall',
+    'advanced-settings-dmz',
+    'advanced-settings-port-forwarding',
+    'advanced-settings-static-routing',
+  ];
+
+  setUpAll(() {
+    // UspTopBar reads package_info during build; stub the platform channel.
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('dev.fluttercommunity.plus/package_info'),
+      (MethodCall methodCall) async {
+        if (methodCall.method == 'getAll') {
+          return <String, dynamic>{
+            'appName': 'PrivacyGUI',
+            'packageName': 'com.linksys.privacygui',
+            'version': '0.0.0',
+            'buildNumber': '0',
+          };
+        }
+        return null;
+      },
+    );
+  });
+
+  // Mirrors the golden framework's shell: ProviderScope + MaterialApp.router so
+  // loc(context) and context.pushNamed resolve inside the view under test.
+  Widget wrap() {
+    final themeConfig = ThemeJsonConfig.defaultConfig();
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        LinksysRoute(
+          path: '/',
+          name: 'test_root',
+          builder: (context, state) => const UspAdvancedSettingsView(),
+        ),
+      ],
+    );
+    return ProviderScope(
+      overrides: commonOverrides(),
+      child: MaterialApp.router(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        theme: themeConfig.createLightTheme(),
+        routerConfig: router,
+      ),
+    );
+  }
+
+  for (final layout in const [
+    (name: 'mobile', size: Size(480, 900)),
+    (name: 'desktop', size: Size(1280, 900)),
+  ]) {
+    group('Advanced Settings entry identifiers in ${layout.name} layout', () {
+      testWidgets('every entry card is locatable by its identifier',
+          (tester) async {
+        final handle = tester.ensureSemantics();
+        tester.view.physicalSize = layout.size;
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(wrap());
+        await tester.pumpAndSettle();
+
+        for (final id in expectedIdentifiers) {
+          expect(
+            find.bySemanticsIdentifier(id),
+            findsOneWidget,
+            reason: 'entry card "$id" must be locatable by identifier',
+          );
+        }
+
+        handle.dispose();
+      });
+
+      testWidgets('the embedded identifier string reads back verbatim',
+          (tester) async {
+        final handle = tester.ensureSemantics();
+        tester.view.physicalSize = layout.size;
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(wrap());
+        await tester.pumpAndSettle();
+
+        final semantics = tester.getSemantics(
+          find.bySemanticsIdentifier('advanced-settings-dmz'),
+        );
+        expect(semantics.identifier, 'advanced-settings-dmz');
+
+        handle.dispose();
+      });
+    });
+  }
+}


### PR DESCRIPTION
Closes #1218

## Summary

The Advanced Settings entry cards (Internet Settings, Local Network, Firewall, DMZ, Port Forwarding, Static Routing) were reachable in E2E only by localized title text (e.g. `getByRole('button', { name: /^DMZ$/ })`) — a positional selector that breaks silently on any ARB copy change and is invisible to `lint:ids`. This threads a stable, screen-reader-silent `identifier` (→ `flt-semantics-identifier`) through each card, per constitution Article XVI.

**Infra was already in place** — `AppSectionItemData`, `LayoutBlock` and `AppCard` all already forward `identifier` to a Semantics node. This PR is pure wiring: additive, no signature changes.

## Changes

**Primary (#1218) — `usp_advanced_settings_view.dart`**

`_buildCard` now passes `item.identifier` to `LayoutBlock`, and each of the six entries gets a fixed kebab-case hook (matching the `menu-*` convention):

| Card | identifier |
|---|---|
| Internet Settings | `advanced-settings-internet` |
| Local Network | `advanced-settings-local-network` |
| Firewall | `advanced-settings-firewall` |
| DMZ | `advanced-settings-dmz` |
| Port Forwarding | `advanced-settings-port-forwarding` |
| Static Routing | `advanced-settings-static-routing` |

**Same-family gap fill** (so no shipping entry/nav card falls back to a title selector):
- `usp_menu_view.dart` — `kDebugMode` USP Console card -> `menu-usp-console`
- `usp_support_view.dart` — visit-linksys + remote-assistance `LayoutBlock` cards -> `support-visit-linksys`, `support-remote-assistance`
- `usp_sliver_dashboard_view.dart` — offline banner `AppCard` -> `dashboard-offline-banner`

## Tests

New widget test `test/page/advanced_settings/usp_advanced_settings_identifier_widget_test.dart` asserts all six `advanced-settings-*` identifiers are locatable via `bySemanticsIdentifier` in **both** responsive branches (mobile `_buildMobileList` / desktop `_buildDesktopGrid`) — the fast local proxy for the E2E `byId()` contract, mirroring the #1208 topology identifier test.

## Verification

- `dart format` — clean (0 changed)
- `flutter analyze` — no issues on the 5 changed files
- New widget test — 4/4 pass (mobile/desktop x {locatable, verbatim readback})
- Full functional suite (`--exclude-tags "golden||loc||ui"`) — 3576/3576 pass
- Goldens unaffected: identifiers are Semantics-only, invisible to rendered pixels

## Follow-ups

- **E2E repo** (`PrivacyGUI-USP-E2E`): migrate P12/P13 `postNav` from the title selector to `byId(IDS.advancedSettings*)`; regenerate `identifiers.generated.ts`.
- **ui_kit**: `AppBadge` exposes no `identifier` (menu ON/OFF status badges are not `byId`-assertable) — tracked in linksys/privacyGUI-UI-kit#11. Out of scope here (requires a ui_kit change).

Same family as #1172 / #1214.