### PR TITLE
fix(dashboard/_shared): size UspInfoRow label from real available width (#1231)

### DIFF
--- a/lib/page/_shared/components/usp_info_row.dart
+++ b/lib/page/_shared/components/usp_info_row.dart
@@ -3,9 +3,13 @@ import 'package:ui_kit_library/ui_kit.dart';
 
 /// A label–value row used throughout the USP Dashboard cards.
 ///
-/// Uses the UI Kit 12-column grid system for responsive label sizing.
-/// [labelColumns] controls how many grid columns the label occupies
-/// (default 2, calculated via `context.colWidth()`).
+/// The label column is sized from the width the row is actually given
+/// (read via a [LayoutBuilder]), not from screen width. [labelColumns]
+/// controls the fraction of a nominal 12-column grid the label occupies
+/// (default 2 of 12). Sizing against the real available width keeps the
+/// value legible when the row lives inside a shrunken card, where a
+/// screen-derived width would over-claim the label column and clip the
+/// value against the card surface with no overflow raised.
 class UspInfoRow extends StatelessWidget {
   final String label;
   final String value;
@@ -22,15 +26,20 @@ class UspInfoRow extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SizedBox(
-            width: context.colWidth(labelColumns),
-            child: AppText.labelLarge(label),
-          ),
-          Expanded(child: AppText.bodyMedium(value)),
-        ],
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final labelWidth = constraints.maxWidth * labelColumns / 12;
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(
+                width: labelWidth,
+                child: AppText.labelLarge(label),
+              ),
+              Expanded(child: AppText.bodyMedium(value)),
+            ],
+          );
+        },
       ),
     );
   }

--- a/lib/page/_shared/components/usp_info_row.dart
+++ b/lib/page/_shared/components/usp_info_row.dart
@@ -1,25 +1,41 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
+/// Fraction of the row the label column may claim.
+///
+/// At the narrowest card realization (191px) this leaves the value ~115px,
+/// enough for the longest common value on one line. The split favours the
+/// value on purpose: per density design §2.10a the label is a name and the
+/// value is the payload, so the label is what yields.
+const double _kLabelShare = 0.4;
+
+/// Ceiling for the label column, so a wide row does not open an absurd
+/// gutter before the value. Sits inside the 130–187px band that the old
+/// screen-derived `context.colWidth(2)` produced across desktop breakpoints,
+/// so rows that were already wide enough keep roughly the column they had.
+const double _kLabelMaxWidth = 150.0;
+
 /// A label–value row used throughout the USP Dashboard cards.
 ///
-/// The label column is sized from the width the row is actually given
-/// (read via a [LayoutBuilder]), not from screen width. [labelColumns]
-/// controls the fraction of a nominal 12-column grid the label occupies
-/// (default 2 of 12). Sizing against the real available width keeps the
-/// value legible when the row lives inside a shrunken card, where a
-/// screen-derived width would over-claim the label column and clip the
-/// value against the card surface with no overflow raised.
+/// The label column is sized from the width the row is actually given (read
+/// via a [LayoutBuilder]), never from screen width: inside a shrunken card
+/// the two are unrelated, and a screen-derived column over-claims and clips
+/// the value against the card surface without raising an overflow.
+///
+/// Degradation follows the shape settled in #1226 and applied in #1233 — the
+/// label yields first with a one-line ellipsis, while the value never shrinks
+/// and never ellipsizes. A clipped label is still recoverable from context; a
+/// half-shown value misinforms.
 class UspInfoRow extends StatelessWidget {
   final String label;
   final String value;
-  final int labelColumns;
 
   const UspInfoRow({
     super.key,
     required this.label,
     required this.value,
-    this.labelColumns = 2,
   });
 
   @override
@@ -28,13 +44,18 @@ class UspInfoRow extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: LayoutBuilder(
         builder: (context, constraints) {
-          final labelWidth = constraints.maxWidth * labelColumns / 12;
+          final labelWidth =
+              math.min(constraints.maxWidth * _kLabelShare, _kLabelMaxWidth);
           return Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               SizedBox(
                 width: labelWidth,
-                child: AppText.labelLarge(label),
+                child: AppText.labelLarge(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
               Expanded(child: AppText.bodyMedium(value)),
             ],

--- a/test/page/_shared/components/usp_info_row_test.dart
+++ b/test/page/_shared/components/usp_info_row_test.dart
@@ -46,7 +46,11 @@ void main() {
     await tester.binding.setSurfaceSize(wideSurface);
     tester.view.physicalSize = wideSurface;
     tester.view.devicePixelRatio = 1.0;
-    addTearDown(() => tester.binding.setSurfaceSize(null));
+    addTearDown(() async {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+      await tester.binding.setSurfaceSize(null);
+    });
 
     await tester.pumpWidget(
       MaterialApp(

--- a/test/page/_shared/components/usp_info_row_test.dart
+++ b/test/page/_shared/components/usp_info_row_test.dart
@@ -1,0 +1,105 @@
+@Tags(['ui'])
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/_shared/components/usp_info_row.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+final _testTheme = AppTheme.create(
+  brightness: Brightness.light,
+  seedColor: Colors.blue,
+  designThemeBuilder: (c) => CustomDesignTheme.fromJson({'style': 'flat'}),
+);
+
+/// White-box tests for [UspInfoRow] label sizing (#1231, T13).
+///
+/// The label column must be sized from the width the ROW is actually given,
+/// not from the screen width. Inside a shrunken dashboard card the two are
+/// unrelated: a screen-derived label over-claims the column and the value is
+/// silently clipped by the card surface with no RenderFlex overflow raised.
+/// These tests pin the fix by pumping the row inside a narrow box on a WIDE
+/// surface — the exact case where the old `context.colWidth()` misbehaved.
+void main() {
+  /// Pumps a single [UspInfoRow] constrained to [rowWidth] on a wide surface,
+  /// so the label sizing can only be correct if it reads the row's own width.
+  Future<void> pumpRow(
+    WidgetTester tester, {
+    required double rowWidth,
+    String label = 'IP Address',
+    String value = '192.168.1.100',
+  }) async {
+    await tester.binding.setSurfaceSize(const Size(1400, 800));
+    tester.view.physicalSize = const Size(1400, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: _testTheme,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: rowWidth,
+              child: UspInfoRow(label: label, value: value),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// The label lives in the first [SizedBox] inside the [UspInfoRow]'s Row.
+  double labelBoxWidth(WidgetTester tester) {
+    final sizedBox = tester.widget<SizedBox>(
+      find.descendant(
+        of: find.byType(UspInfoRow),
+        matching: find.byType(SizedBox),
+      ),
+    );
+    return sizedBox.width!;
+  }
+
+  testWidgets('label column is 2/12 of the ROW width, not the screen width',
+      (tester) async {
+    // On a 1400px screen, the old screen-derived colWidth(2) would produce a
+    // label far wider than 2/12 of a 191px card. The fix ties it to the row.
+    const rowWidth = 191.0;
+    await pumpRow(tester, rowWidth: rowWidth);
+
+    final labelWidth = labelBoxWidth(tester);
+    expect(labelWidth, closeTo(rowWidth * 2 / 12, 0.5),
+        reason: 'label column must be derived from the 191px row, not 1400px');
+  });
+
+  testWidgets('label column shrinks proportionally with the given row width',
+      (tester) async {
+    await pumpRow(tester, rowWidth: 191.0);
+    final narrow = labelBoxWidth(tester);
+
+    await pumpRow(tester, rowWidth: 600.0);
+    final wide = labelBoxWidth(tester);
+
+    // Screen never changed (1400px). If sizing were screen-derived, narrow and
+    // wide would be identical. They must differ, and scale ~4:1 with the width.
+    expect(wide, greaterThan(narrow));
+    expect(wide / narrow, closeTo(600.0 / 191.0, 0.05));
+  });
+
+  testWidgets('value keeps the remaining width so it is legible, not clipped',
+      (tester) async {
+    const rowWidth = 191.0;
+    await pumpRow(tester, rowWidth: rowWidth, value: '255.255.255.255');
+
+    final labelWidth = labelBoxWidth(tester);
+    // The Expanded value gets everything the label leaves — the majority of the
+    // card at the narrowest realization (~5/6 of the row), rather than being
+    // squeezed to a few pixels the way a screen-sized label would have left it.
+    final valueRegion = rowWidth - labelWidth;
+    expect(valueRegion, greaterThan(rowWidth * 0.5),
+        reason: 'value must retain more than half the row to stay legible');
+  });
+}

--- a/test/page/_shared/components/usp_info_row_test.dart
+++ b/test/page/_shared/components/usp_info_row_test.dart
@@ -1,41 +1,61 @@
-@Tags(['ui'])
+@Tags(['dashboard-card'])
+library;
+
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:privacy_gui/l10n/gen/app_localizations.dart';
 import 'package:privacy_gui/page/_shared/components/usp_info_row.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
-final _testTheme = AppTheme.create(
-  brightness: Brightness.light,
-  seedColor: Colors.blue,
-  designThemeBuilder: (c) => CustomDesignTheme.fromJson({'style': 'flat'}),
-);
+import '../../../util/app_test_fonts.dart';
 
-/// White-box tests for [UspInfoRow] label sizing (#1231, T13).
+/// Behavioural tests for [UspInfoRow] label sizing (#1231, T13).
 ///
 /// The label column must be sized from the width the ROW is actually given,
 /// not from the screen width. Inside a shrunken dashboard card the two are
 /// unrelated: a screen-derived label over-claims the column and the value is
-/// silently clipped by the card surface with no RenderFlex overflow raised.
-/// These tests pin the fix by pumping the row inside a narrow box on a WIDE
-/// surface — the exact case where the old `context.colWidth()` misbehaved.
+/// silently clipped by the card surface with no RenderFlex overflow raised —
+/// which is why the overflow gate cannot see this class of bug and these
+/// assertions have to exist separately.
+///
+/// Every case pumps on a WIDE surface and constrains only the row, so a
+/// screen-derived width cannot accidentally pass.
+///
+/// Real fonts are loaded on purpose. Under the default test font every glyph
+/// is a fixed-width block, so "does this text fit on one line" would be
+/// measured against fictional widths and the fit assertions below would be
+/// meaningless.
+///
+/// Tagged `dashboard-card`, not `ui`: `run_tests.sh` excludes `ui`, so a `ui`
+/// tag here would keep the regression this file guards out of the PR gate.
 void main() {
-  /// Pumps a single [UspInfoRow] constrained to [rowWidth] on a wide surface,
-  /// so the label sizing can only be correct if it reads the row's own width.
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await loadAppFonts();
+  });
+
+  const wideSurface = Size(1400, 800);
+
   Future<void> pumpRow(
     WidgetTester tester, {
     required double rowWidth,
     String label = 'IP Address',
-    String value = '192.168.1.100',
+    String value = '255.255.255.255',
   }) async {
-    await tester.binding.setSurfaceSize(const Size(1400, 800));
-    tester.view.physicalSize = const Size(1400, 800);
+    await tester.binding.setSurfaceSize(wideSurface);
+    tester.view.physicalSize = wideSurface;
     tester.view.devicePixelRatio = 1.0;
     addTearDown(() => tester.binding.setSurfaceSize(null));
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: _testTheme,
+        theme: AppTheme.create(
+          brightness: Brightness.light,
+          seedColor: Colors.blue,
+          designThemeBuilder: (c) =>
+              CustomDesignTheme.fromJson({'style': 'flat'}),
+        ),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
@@ -52,54 +72,99 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  /// The label lives in the first [SizedBox] inside the [UspInfoRow]'s Row.
-  double labelBoxWidth(WidgetTester tester) {
-    final sizedBox = tester.widget<SizedBox>(
+  RenderParagraph paragraphOf(WidgetTester tester, String text) =>
+      tester.renderObject<RenderParagraph>(find.text(text));
+
+  /// Whether the text rendered on a single line — the honest measure of "did
+  /// this wrap". Compares the height it actually got against the height it
+  /// takes at unbounded width, which is by definition one line.
+  bool isSingleLine(WidgetTester tester, String text) {
+    final paragraph = paragraphOf(tester, text);
+    final oneLine = paragraph.getMinIntrinsicHeight(double.infinity);
+    return paragraph.size.height <= oneLine + 0.5;
+  }
+
+  double labelColumnWidth(WidgetTester tester) {
+    final box = tester.widget<SizedBox>(
       find.descendant(
         of: find.byType(UspInfoRow),
         matching: find.byType(SizedBox),
       ),
     );
-    return sizedBox.width!;
+    return box.width!;
   }
 
-  testWidgets('label column is 2/12 of the ROW width, not the screen width',
-      (tester) async {
-    // On a 1400px screen, the old screen-derived colWidth(2) would produce a
-    // label far wider than 2/12 of a 191px card. The fix ties it to the row.
-    const rowWidth = 191.0;
-    await pumpRow(tester, rowWidth: rowWidth);
+  group('the label column is derived from the row, not the screen', () {
+    testWidgets('a narrower row yields a narrower label column',
+        (tester) async {
+      // The surface is 1400px in both pumps. Were the column screen-derived,
+      // these two would be identical.
+      await pumpRow(tester, rowWidth: 191);
+      final narrow = labelColumnWidth(tester);
 
-    final labelWidth = labelBoxWidth(tester);
-    expect(labelWidth, closeTo(rowWidth * 2 / 12, 0.5),
-        reason: 'label column must be derived from the 191px row, not 1400px');
+      await pumpRow(tester, rowWidth: 300);
+      final wider = labelColumnWidth(tester);
+
+      expect(narrow, lessThan(wider),
+          reason: 'label column must track the row width, not the surface');
+    });
+
+    testWidgets('the column stops growing once it is wide enough',
+        (tester) async {
+      // Without a ceiling a wide row opens an ever-growing gutter before the
+      // value. Asserted as "equal at two wide widths" rather than against the
+      // constant, so the test pins the behaviour and not the number.
+      await pumpRow(tester, rowWidth: 600);
+      final atSixHundred = labelColumnWidth(tester);
+
+      await pumpRow(tester, rowWidth: 900);
+      final atNineHundred = labelColumnWidth(tester);
+
+      expect(atNineHundred, equals(atSixHundred));
+    });
   });
 
-  testWidgets('label column shrinks proportionally with the given row width',
-      (tester) async {
-    await pumpRow(tester, rowWidth: 191.0);
-    final narrow = labelBoxWidth(tester);
+  group('the value is the payload — it never wraps at a real card width', () {
+    // 191px and 288px are the narrowest and the common realizations the
+    // overflow gate pumps for dashboard cards.
+    for (final rowWidth in <double>[191, 288, 480]) {
+      testWidgets('value renders on one line at ${rowWidth.toInt()}px',
+          (tester) async {
+        await pumpRow(tester, rowWidth: rowWidth);
+        expect(isSingleLine(tester, '255.255.255.255'), isTrue,
+            reason: 'the value must not be squeezed into a wrapped column');
+      });
+    }
 
-    await pumpRow(tester, rowWidth: 600.0);
-    final wide = labelBoxWidth(tester);
-
-    // Screen never changed (1400px). If sizing were screen-derived, narrow and
-    // wide would be identical. They must differ, and scale ~4:1 with the width.
-    expect(wide, greaterThan(narrow));
-    expect(wide / narrow, closeTo(600.0 / 191.0, 0.05));
+    testWidgets('value is not ellipsized either', (tester) async {
+      // Guards the other half of the degradation shape: the value must never
+      // grow a maxLines/ellipsis, because a half-shown statistic misinforms in
+      // a way a clipped label does not.
+      await pumpRow(tester, rowWidth: 191);
+      expect(paragraphOf(tester, '255.255.255.255').didExceedMaxLines, isFalse);
+    });
   });
 
-  testWidgets('value keeps the remaining width so it is legible, not clipped',
-      (tester) async {
-    const rowWidth = 191.0;
-    await pumpRow(tester, rowWidth: rowWidth, value: '255.255.255.255');
+  group('the label yields first, by ellipsis rather than by wrapping', () {
+    testWidgets('a label that fits stays on one line at 288px', (tester) async {
+      // Regression guard: sizing the column as a flat fraction of the row gave
+      // the label 48px here, wrapping "IP Address" onto a second line and
+      // doubling the row height at a width the product actually ships.
+      await pumpRow(tester, rowWidth: 288);
+      expect(isSingleLine(tester, 'IP Address'), isTrue);
+      expect(paragraphOf(tester, 'IP Address').didExceedMaxLines, isFalse);
+    });
 
-    final labelWidth = labelBoxWidth(tester);
-    // The Expanded value gets everything the label leaves — the majority of the
-    // card at the narrowest realization (~5/6 of the row), rather than being
-    // squeezed to a few pixels the way a screen-sized label would have left it.
-    final valueRegion = rowWidth - labelWidth;
-    expect(valueRegion, greaterThan(rowWidth * 0.5),
-        reason: 'value must retain more than half the row to stay legible');
+    testWidgets('a label too long for the column ellipsizes, never wraps',
+        (tester) async {
+      const long = 'Operating Frequency Band';
+      await pumpRow(tester, rowWidth: 191, label: long, value: '5 GHz');
+
+      expect(isSingleLine(tester, long), isTrue,
+          reason: 'a wrapped label grows the row without adding information');
+      expect(paragraphOf(tester, long).didExceedMaxLines, isTrue,
+          reason: 'this label cannot fit — it must be visibly truncated');
+      expect(isSingleLine(tester, '5 GHz'), isTrue);
+    });
   });
 }

--- a/test/page/_shared/components/usp_info_row_test.dart
+++ b/test/page/_shared/components/usp_info_row_test.dart
@@ -150,14 +150,22 @@ void main() {
   });
 
   group('the label yields first, by ellipsis rather than by wrapping', () {
-    testWidgets('a label that fits stays on one line at 288px', (tester) async {
-      // Regression guard: sizing the column as a flat fraction of the row gave
-      // the label 48px here, wrapping "IP Address" onto a second line and
-      // doubling the row height at a width the product actually ships.
-      await pumpRow(tester, rowWidth: 288);
-      expect(isSingleLine(tester, 'IP Address'), isTrue);
-      expect(paragraphOf(tester, 'IP Address').didExceedMaxLines, isFalse);
-    });
+    // A common label must survive intact at every width the grid produces.
+    // 288px is the regression guard: a flat 2/12 of the row gave the label 48px
+    // there, wrapping "IP Address" onto a second line and doubling the row
+    // height at a width the product actually ships. 191px is the tightest case
+    // the constants have to clear — the column is 76.4px against a 74.6px
+    // label, so this test is what stops _kLabelShare from being tuned down
+    // without noticing the label starts truncating.
+    for (final rowWidth in <double>[191, 288, 480]) {
+      testWidgets(
+          'a common label is neither wrapped nor truncated at '
+          '${rowWidth.toInt()}px', (tester) async {
+        await pumpRow(tester, rowWidth: rowWidth);
+        expect(isSingleLine(tester, 'IP Address'), isTrue);
+        expect(paragraphOf(tester, 'IP Address').didExceedMaxLines, isFalse);
+      });
+    }
 
     testWidgets('a label too long for the column ellipsizes, never wraps',
         (tester) async {


### PR DESCRIPTION
Closes #1231. Parent #1183.

Stacked on #1249 → #1248 → `dev-2.7.0`. **Review those first.**

> **This body replaces the original.** The original's central claim ("Behavior
> is preserved at normal widths") was wrong, and its verification numbers were
> measured 11 commits behind its own declared base. Both are corrected below,
> and the extra commits that fix the regression are the reason this PR grew.
> See the measurement comment for the full table.

## The bug this PR started from is real

`UspInfoRow` — the shared label–value row used across USP dashboard cards and
several settings pages — sized its label column with
`context.colWidth(labelColumns)`, which ui_kit derives from **screen** width
(`layout_extensions.dart`), not from the width the row is actually given. Inside
a shrunken dashboard card the two are unrelated.

Because the structure is `SizedBox` + `Expanded`, a compressed value never
raises a `RenderFlex` overflow, so the text is silently clipped by the card
surface's `Clip.antiAlias`. Users see cut-off text; the overflow gate sees
nothing. That is why this needs its own assertions and contributes zero
coordinates to `known_overflows.json`.

## The first fix traded the bug for a narrower one

Replacing `colWidth(2)` with `constraints.maxWidth * labelColumns / 12` keeps a
fraction that was **calibrated against the screen** and applies it to a
card-sized row. At a 1400px screen 2/12 is ~150px — enough for one line. Inside
a 288px row it is 48px, narrower than the 74.6px `"IP Address"` needs.

Measured with real fonts at a fixed 1400px surface (line height 20px):

| row width | `colWidth(2)` (before) | `maxWidth*2/12` (first fix) | this PR |
|---|---|---|---|
| 191, short label | 150 fits / value 41 → **3 lines** / h60 | 31.8 → **3 lines** / value fits / h60 | 76.4 fits / 114.6 fits / **h20** |
| 191, long label | 150 → 2 lines / h40 | 31.8 → **8 lines** / **h160** | ellipsized 1 line / **h20** |
| **288** | 150 fits / 138 fits / **h20** | 48 → **2 lines** / **h40** | 115.2 fits / 172.8 fits / **h20** |
| 480 | 150 fits / h20 | 80 fits / h20 | 150 fits / h20 |
| 900 | 150 fits / h20 | 150 fits / h20 | 150 fits / h20 |

288px is a **regression against the code it replaced**, at a width the product
ships. So "behavior is preserved at normal widths" was the opposite of true: the
first fix helped 191px and broke 288px.

## What this PR settles on

Keep a fraction — sibling rows must share a column width so their values line
up, which intrinsic sizing would break — but recalibrate it to the row and cap
it:

- `_kLabelShare = 0.4` — the label may claim 40% of the row. At 191px that is
  76.4px, which `"IP Address"` (74.6px) fits, leaving the value 114.6px for a
  108.6px address.
- `_kLabelMaxWidth = 150.0` — so a wide row does not open a growing gutter
  before the value. Sits inside the 130–187px band `colWidth(2)` produced across
  desktop breakpoints (measured: 360→156, 480→216, 600→276, 768→164, 1024→142.7,
  1280→130, 1440→156.7, 1920→186 — note it is **not monotonic** in screen
  width), so rows that were already wide enough keep roughly the column they had.

Apply the degradation shape settled in #1226 and applied in #1233 while here:
the label takes `maxLines: 1` + ellipsis, the value takes neither. A clipped
label is recoverable from context; a half-shown statistic misinforms.

**Removed the `labelColumns` parameter.** No consumer ever passed it — verified
across all nine call sites. It was Speculative Generality, and it was also the
vehicle for the miscalibration.

No layout scope wrapper is introduced (design of record §2.2).

## The test file was rewritten, and it now actually runs

Two independent problems:

- It was tagged **`@Tags(['ui'])`**, which `run_tests.sh` excludes
  (`--exclude-tags="golden||loc||ui"`), so it **never ran in the PR gate**. Now
  `dashboard-card`, which does gate.
- Its assertions were geometric — `SizedBox.width`, "value area > half the row"
  — which cannot see whether the text *fits*. A 48px column passes "label is
  2/12 of the row" while wrapping the label onto two lines.

It now measures rendered line count (paragraph height vs. its height at
unbounded width) and loads **real fonts**: without `loadAppFonts()` every glyph
is a fixed-width block, so every "does this fit" answer is fiction. 10 tests,
and **3 of them fail against the first fix's implementation** — verified by
reverting the widget and re-running. The two that stay green are exactly the
part the first fix got right (row-derived, not screen-derived).

Also fixed a leak the round-1 review caught: `pumpRow` set `surfaceSize`,
`physicalSize` and `devicePixelRatio` but reset only the first, leaving a
1400x800 view at DPR 1.0 for every later test in the process. (The review cited
`dhcp_card_test_harness.dart` for the pattern — that file does not exist — but
the leak itself was real.)

## Acceptance criteria

- [x] Label column sized from the row's given width, not screen width
- [x] At ~191px the value keeps >half the row and renders on one line — pinned
      by test, not by golden
- [x] No layout scope wrapper introduced
- [x] All nine consumers unchanged and analyze clean; `labelColumns` confirmed
      dead before removal
- [x] `test/fixtures/known_overflows.json` **unchanged** — this component
      contributes zero baseline coordinates
- [x] #1231's AC "verified by eye or golden" is met by neither: golden baselines
      are gitignored (`.gitignore:92`) and this project runs no pixel diff, so
      golden cannot verify anything here. Substituted measurement + assertions,
      which is strictly stronger. See #1241.

## Verification

```
$ fvm flutter test test/page/_shared/components/usp_info_row_test.dart
  10/10 passed          (3 fail against the pre-fix widget — mutation-checked)

$ fvm flutter test --tags dashboard-card
  1710/1710 passed      (1700 inherited from #1249, + 10 new; fixture untouched)

$ ./run_tests.sh
  5049/5049 passed

$ fvm dart format / fvm flutter analyze <2 changed files>
  clean / No issues found
```

The original body reported `+1493 -151` for the gate. That number was measured
against a merge-base of `c3e40e0b`, **11 commits behind the declared base** —
before `9b848994` rebuilt the overflow baseline from measurement. It described a
tree that no longer exists. This branch has since been merged up to its base and
re-measured.

## Known limits

- The 191px case clears by **1.8px** (76.4px column, 74.6px label). That is
  inside the ±2px tolerance the overflow gate itself allows for mac-vs-ubuntu
  rasterizer differences, so it is conceivable this ellipsizes on CI and not
  locally. It is now pinned by a test at all three widths, so it would fail
  loudly rather than ship a silently truncated label — but reviewers should know
  the margin is thin, and widening `_kLabelShare` past ~0.43 would push the
  *value* under its own floor instead. 191px simply does not have room for both
  with comfort.
- Non-English locales with longer labels will ellipsize at 191px. That is the
  intended degradation, not an oversight — but it is asserted only for one
  synthetic long label, not swept across all 26 locales.
- No consumer-level render test (round-1 review W-4). The nine call sites are
  covered only in that the dashboard ones now run through the overflow gate.
- `labelColumnWidth()` finds the `SizedBox` by type — white-box, and it breaks
  if the sizing mechanism is refactored. Kept because the alternative measures
  nothing useful; flagged so the next person is not surprised.
- `pumpRow` is a third near-identical pump harness in this suite (round-1 review
  W-3). Not consolidated here; that is a suite-wide change and does not belong
  in a fix PR.
