### PR TITLE
fix(statistics/traffic-monitor): Wrap the Monitor legend row so totals never overflow (#1252)

### DIFF
--- a/lib/page/statistics/views/sections/stats_traffic_monitor_section.dart
+++ b/lib/page/statistics/views/sections/stats_traffic_monitor_section.dart
@@ -87,42 +87,88 @@ class StatsTrafficMonitorSection extends ConsumerWidget {
           ),
         ),
         AppGap.sm(),
-        Row(
+        // Legend + totals.
+        //
+        // DEGRADATION SHAPE (#1252, the twin of #1226's dashboard card) \u2014 this
+        // row is a near-duplicate of the Traffic Analysis Monitor legend, so it
+        // takes the identical treatment (design \u00a72.10, \u00a72.10a):
+        //
+        //  1. A `Wrap`, not a `Row` + `Spacer`. At every width where the content
+        //     fits it renders exactly as before: one run, `spaceBetween` puts the
+        //     legend left and the totals right, which is what the `Spacer` did.
+        //     When it does not fit, the totals drop to a second line instead of
+        //     overflowing. The chart above is `Expanded`, so it yields the height
+        //     (\u00a72.10a point 3: this is the unstated precondition #1226 relied on;
+        //     unlike Network Health's fixed-height gauge, this chart yields).
+        //  2. The legend yields before anything else \u2014 its labels are `Flexible`
+        //     with a one-line ellipsis. A legend keys a chart that is already
+        //     colour-coded, so a clipped label still communicates; each dot+label
+        //     pair stays glued together so a label never separates from the
+        //     colour it explains.
+        //  3. The byte totals never shrink: no `Flexible`, no ellipsis, so they
+        //     keep their intrinsic width and wrap as a unit. They are the card's
+        //     content, not chrome \u2014 an ellipsis lands mid-number and a half-shown
+        //     statistic misinforms in a way a missing one does not.
+        Wrap(
+          alignment: WrapAlignment.spaceBetween,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          spacing: AppSpacing.lg,
+          runSpacing: AppSpacing.xs,
           children: [
-            StatsLegendDot(color: colorScheme.primary),
-            AppGap.xs(),
-            AppText.labelSmall(loc(context).upload),
-            AppGap.lg(),
-            StatsLegendDot(color: colorScheme.secondary),
-            AppGap.xs(),
-            AppText.labelSmall(loc(context).download),
-            const Spacer(),
-            if (wan != null) ...[
-              // Icons, not U+2191/U+2193 characters \u2014 matches the dashboard's
-              // Traffic Analysis card, which draws the same two directions with
-              // Icons.arrow_upward/downward.
-              AppIcon.font(
-                Icons.arrow_upward,
-                size: 12,
-                color: colorScheme.onSurfaceVariant,
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                StatsLegendDot(color: colorScheme.primary),
+                AppGap.xs(),
+                Flexible(
+                  child: AppText.labelSmall(
+                    loc(context).upload,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                AppGap.lg(),
+                StatsLegendDot(color: colorScheme.secondary),
+                AppGap.xs(),
+                Flexible(
+                  child: AppText.labelSmall(
+                    loc(context).download,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+            if (wan != null)
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // Icons, not U+2191/U+2193 characters \u2014 matches the dashboard's
+                  // Traffic Analysis card, which draws the same two directions
+                  // with Icons.arrow_upward/downward.
+                  AppIcon.font(
+                    Icons.arrow_upward,
+                    size: 12,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  AppGap.xs(),
+                  AppText.labelSmall(
+                    UspFormatters.formatBytes(wan.totalBytesSent),
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  AppGap.md(),
+                  AppIcon.font(
+                    Icons.arrow_downward,
+                    size: 12,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  AppGap.xs(),
+                  AppText.labelSmall(
+                    UspFormatters.formatBytes(wan.totalBytesReceived),
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ],
               ),
-              AppGap.xs(),
-              AppText.labelSmall(
-                UspFormatters.formatBytes(wan.totalBytesSent),
-                color: colorScheme.onSurfaceVariant,
-              ),
-              AppGap.md(),
-              AppIcon.font(
-                Icons.arrow_downward,
-                size: 12,
-                color: colorScheme.onSurfaceVariant,
-              ),
-              AppGap.xs(),
-              AppText.labelSmall(
-                UspFormatters.formatBytes(wan.totalBytesReceived),
-                color: colorScheme.onSurfaceVariant,
-              ),
-            ],
           ],
         ),
       ],

--- a/test/page/statistics/views/sections/stats_traffic_monitor_legend_test.dart
+++ b/test/page/statistics/views/sections/stats_traffic_monitor_legend_test.dart
@@ -200,12 +200,29 @@ void main() {
     // `['B/s', 'KB/s', 'MB/s', 'GB/s']`, so the two speed tiles above the chart
     // and every y-axis label also contain a `B`, and a `contains('B')` count
     // stays satisfied even with both totals deleted.
-    final wanSnapshot =
-        testTrafficWithHistory.history.last.interfaces[TrafficInterface.wan]!;
-    final totalsLabels = <String, int>{
-      'sent': wanSnapshot.totalBytesSent,
-      'received': wanSnapshot.totalBytesReceived,
-    }.map((kind, bytes) => MapEntry(kind, UspFormatters.formatBytes(bytes)));
+    /// The formatted totals the widget must render, read from the same fixture
+    /// it is pumped with.
+    ///
+    /// Resolved inside each test rather than at group level: a fixture that
+    /// stopped carrying a `wan` snapshot would make the lookup throw while the
+    /// group body is still being built, which reports as a load failure for the
+    /// whole file instead of naming the fixture. Loud either way, but only one of
+    /// the two says what to fix.
+    String totalFor(String kind) {
+      final wan =
+          testTrafficWithHistory.history.last.interfaces[TrafficInterface.wan];
+      expect(
+        wan,
+        isNotNull,
+        reason:
+            'testTrafficWithHistory must carry a wan snapshot — the section '
+            'renders totals only when it does, so without one these tests would '
+            'assert against a legend that never had any',
+      );
+      final bytes =
+          kind == 'sent' ? wan!.totalBytesSent : wan!.totalBytesReceived;
+      return UspFormatters.formatBytes(bytes);
+    }
 
     /// True if a [Flexible] (or [Expanded], its subclass) sits between the total
     /// and the legend [Wrap] — i.e. the total can be squeezed below its
@@ -213,6 +230,11 @@ void main() {
     bool canShrink(Finder totalFinder) {
       var flexed = false;
       totalFinder.evaluate().single.visitAncestorElements((ancestor) {
+        // Stop at the `Wrap`: it is the layout that decides this total's width,
+        // so a `Flexible` above it constrains the whole legend row, not the
+        // total within the row. Reaching the `Wrap` means "nothing between here
+        // and the layout can squeeze it", which is the property under test — not
+        // "not found yet".
         if (ancestor.widget is Wrap) return false;
         if (ancestor.widget is Flexible) {
           flexed = true;
@@ -223,21 +245,22 @@ void main() {
       return flexed;
     }
 
-    for (final entry in totalsLabels.entries) {
+    for (final kind in ['sent', 'received']) {
       testWidgets(
-        'the ${entry.key} total is whole and unshrinkable at the narrowest width',
+        'the $kind total is whole and unshrinkable at the narrowest width',
         (tester) async {
+          final expected = totalFor(kind);
           await overflowsAt(
             tester: tester,
             screenWidth: 320.0,
             locale: const Locale('de'),
           );
 
-          final finder = find.text(entry.value);
+          final finder = find.text(expected);
           expect(
             finder,
             findsOneWidget,
-            reason: 'the ${entry.key} byte total (${entry.value}) must survive '
+            reason: 'the $kind byte total ($expected) must survive '
                 'the degradation — the `Wrap` moves it to a second line, it may '
                 'not discard it',
           );
@@ -246,19 +269,18 @@ void main() {
           expect(
             text.overflow,
             isNot(TextOverflow.ellipsis),
-            reason: 'the ${entry.key} total must never ellipsize: an ellipsis '
+            reason: 'the $kind total must never ellipsize: an ellipsis '
                 'lands mid-number',
           );
           expect(
             text.maxLines,
             isNull,
-            reason: 'the ${entry.key} total must not be line-capped',
+            reason: 'the $kind total must not be line-capped',
           );
           expect(
             canShrink(finder),
             isFalse,
-            reason:
-                'the ${entry.key} total must not be a flex child — it keeps '
+            reason: 'the $kind total must not be a flex child — it keeps '
                 'its intrinsic width and the whole totals group wraps instead',
           );
         },

--- a/test/page/statistics/views/sections/stats_traffic_monitor_legend_test.dart
+++ b/test/page/statistics/views/sections/stats_traffic_monitor_legend_test.dart
@@ -6,8 +6,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:privacy_gui/l10n/gen/app_localizations.dart';
 import 'package:privacy_gui/localization/fallback_font_resolver.dart';
+import 'package:privacy_gui/page/_shared/models/traffic_analysis_state.dart';
+import 'package:privacy_gui/page/_shared/utils/usp_formatters.dart';
 import 'package:privacy_gui/page/statistics/views/sections/stats_traffic_monitor_section.dart';
 import 'package:privacy_gui/theme/theme_json_config.dart';
+import 'package:ui_kit_library/ui_kit.dart';
 
 import '../../../../golden_test/golden_framework/mocks/mock_dashboard_cards.dart';
 import '../../../../golden_test/page/dashboard/cards/fixtures/cards_test_data.dart';
@@ -36,6 +39,23 @@ import '../../../../util/overflow_probe.dart';
 ///
 /// Tagged `dashboard-card` so it gates PRs — `run_tests.sh` excludes
 /// `golden||loc||ui`, and a `ui`-tagged regression test would not block anything.
+///
+/// ## Mutation ledger
+///
+/// Every group here was shown to fail under a mutation of the code it guards —
+/// an overflow test that cannot fail is worse than no test, because it reports
+/// the shape as pinned (precedent: `dashboard_legend_readability_test.dart`).
+///
+///   | mutation                                       | what failed              |
+///   |------------------------------------------------|--------------------------|
+///   | `Wrap` reverted to the pre-fix `Row` + `Spacer` | no overflow @288px (4)   |
+///   | totals wrapped in `Flexible` + 1-line ellipsis  | totals legible (2)       |
+///   | totals wrapped in `Flexible` only               | totals legible (2)       |
+///   | both totals replaced by `SizedBox.shrink()`     | totals legible (2)       |
+///
+/// The pre-fix mutation leaves the totals group green, which is correct: under
+/// `Row` + `Spacer` the totals are still whole and unflexed, they merely
+/// overflow — that is the other group's job. The two groups are independent.
 void main() {
   setUpAll(() async {
     // Real fonts: text widths — and therefore overflow — are meaningless under
@@ -43,24 +63,17 @@ void main() {
     await loadAppFonts();
   });
 
-  /// The page margin `AppLayoutConfig.margin(width)` applies at each breakpoint.
-  /// Mirrors ui_kit `app_layout_config.dart`; the Statistics page pads each
-  /// section by `context.layoutMargin` on both edges
-  /// (`usp_statistics_view.dart:86`).
-  double pageMarginFor(double screenWidth) {
-    if (screenWidth > 1680) return 352.0;
-    if (screenWidth > 1440) return 256.0;
-    if (screenWidth > 1240) return 200.0; // D1: the big-margin regime.
-    if (screenWidth > 905) return 24.0;
-    if (screenWidth > 600) return 32.0;
-    return 16.0;
-  }
-
   /// The width a single Statistics section renders to on a [screenWidth] screen:
   /// full content width minus the page margin on both edges. The section card's
   /// own padding then reduces this further, exactly as in production.
+  ///
+  /// The margin comes from ui_kit's own [AppLayoutConfig.margin] rather than a
+  /// copy of its breakpoint table: the Statistics page pads each section by
+  /// `context.layoutMargin` (`usp_statistics_view.dart:86`), which is that same
+  /// function. A local copy is correct only until ui_kit moves a breakpoint, and
+  /// then this test measures the wrong widths and still passes.
   double sectionWidthFor(double screenWidth) =>
-      screenWidth - pageMarginFor(screenWidth) * 2;
+      screenWidth - AppLayoutConfig.margin(screenWidth) * 2;
 
   final baseTheme = ThemeJsonConfig.defaultConfig().createLightTheme();
 
@@ -175,32 +188,81 @@ void main() {
   });
 
   group('byte totals stay legible (#1252)', () {
-    testWidgets('both totals are still rendered at the narrowest width',
-        (tester) async {
-      // The legend is a key to the chart, but the byte totals are the section's
-      // actual content — degrading the layout must not drop them. The `Wrap`
-      // moves them to a second line; it must not clip or discard them.
-      await overflowsAt(
-        tester: tester,
-        screenWidth: 320.0,
-        locale: const Locale('de'),
-      );
+    // The legend keys a chart that is already colour-coded, so a clipped legend
+    // label still communicates. The byte totals are the section's content: an
+    // ellipsis lands mid-number, and a half-shown statistic misinforms in a way
+    // a missing one does not (§2.10a point 2). So the AC is not "the totals are
+    // somewhere in the tree" — it is that they are present, unellipsized, and
+    // not flex children that could shrink.
+    //
+    // Located by their exact formatted values, derived from the same fixture the
+    // widget renders. A substring test cannot work here: `_formatSpeed` uses
+    // `['B/s', 'KB/s', 'MB/s', 'GB/s']`, so the two speed tiles above the chart
+    // and every y-axis label also contain a `B`, and a `contains('B')` count
+    // stays satisfied even with both totals deleted.
+    final wanSnapshot =
+        testTrafficWithHistory.history.last.interfaces[TrafficInterface.wan]!;
+    final totalsLabels = <String, int>{
+      'sent': wanSnapshot.totalBytesSent,
+      'received': wanSnapshot.totalBytesReceived,
+    }.map((kind, bytes) => MapEntry(kind, UspFormatters.formatBytes(bytes)));
 
-      // The two totals are formatted byte counts; find them by the AppIcon
-      // arrows that precede each so the assertion does not depend on the exact
-      // formatted value. testTrafficWithHistory carries a non-null WAN snapshot,
-      // so both totals must be present.
-      final texts = find.byType(Text).evaluate().map((e) {
-        final w = e.widget as Text;
-        return w.data ?? w.textSpan?.toPlainText() ?? '';
-      }).toList();
-      final byteTotals = texts.where((t) => t.contains('B')).toList();
-      expect(
-        byteTotals.length,
-        greaterThanOrEqualTo(2),
-        reason: 'both byte totals (sent + received) must survive degradation — '
-            'they are content, not chrome. Found: $texts',
+    /// True if a [Flexible] (or [Expanded], its subclass) sits between the total
+    /// and the legend [Wrap] — i.e. the total can be squeezed below its
+    /// intrinsic width.
+    bool canShrink(Finder totalFinder) {
+      var flexed = false;
+      totalFinder.evaluate().single.visitAncestorElements((ancestor) {
+        if (ancestor.widget is Wrap) return false;
+        if (ancestor.widget is Flexible) {
+          flexed = true;
+          return false;
+        }
+        return true;
+      });
+      return flexed;
+    }
+
+    for (final entry in totalsLabels.entries) {
+      testWidgets(
+        'the ${entry.key} total is whole and unshrinkable at the narrowest width',
+        (tester) async {
+          await overflowsAt(
+            tester: tester,
+            screenWidth: 320.0,
+            locale: const Locale('de'),
+          );
+
+          final finder = find.text(entry.value);
+          expect(
+            finder,
+            findsOneWidget,
+            reason: 'the ${entry.key} byte total (${entry.value}) must survive '
+                'the degradation — the `Wrap` moves it to a second line, it may '
+                'not discard it',
+          );
+
+          final text = tester.widget<Text>(finder);
+          expect(
+            text.overflow,
+            isNot(TextOverflow.ellipsis),
+            reason: 'the ${entry.key} total must never ellipsize: an ellipsis '
+                'lands mid-number',
+          );
+          expect(
+            text.maxLines,
+            isNull,
+            reason: 'the ${entry.key} total must not be line-capped',
+          );
+          expect(
+            canShrink(finder),
+            isFalse,
+            reason:
+                'the ${entry.key} total must not be a flex child — it keeps '
+                'its intrinsic width and the whole totals group wraps instead',
+          );
+        },
       );
-    });
+    }
   });
 }

--- a/test/page/statistics/views/sections/stats_traffic_monitor_legend_test.dart
+++ b/test/page/statistics/views/sections/stats_traffic_monitor_legend_test.dart
@@ -1,0 +1,206 @@
+@Tags(['dashboard-card'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/localization/fallback_font_resolver.dart';
+import 'package:privacy_gui/page/statistics/views/sections/stats_traffic_monitor_section.dart';
+import 'package:privacy_gui/theme/theme_json_config.dart';
+
+import '../../../../golden_test/golden_framework/mocks/mock_dashboard_cards.dart';
+import '../../../../golden_test/page/dashboard/cards/fixtures/cards_test_data.dart';
+import '../../../../util/app_test_fonts.dart';
+import '../../../../util/overflow_probe.dart';
+
+/// Overflow tests for the Statistics-page Traffic Monitor legend row (#1252).
+///
+/// ## Why this file exists
+///
+/// `StatsTrafficMonitorSection`'s legend is a near-duplicate of the dashboard
+/// Traffic Analysis Monitor legend that #1226 fixed
+/// (`usp_traffic_analysis_card.dart`): two dot+label pairs, then two byte
+/// totals, laid out with a `Row` + `Spacer`. `Spacer` is an `Expanded`, so it
+/// absorbs slack while the content fits and collapses to zero when it does not,
+/// at which point the unconstrained content takes its full intrinsic width and
+/// overflows on the right.
+///
+/// Unlike the dashboard card, this section is **not** in `UspWidgetSpecs.all`,
+/// so the #1183 overflow gate never scans it — there is no ratchet entry and no
+/// gate failure. This is prophylactic work justified by the #1226 measurement
+/// of the identical shape. The AC is therefore a measurement of the row itself,
+/// not "N gate coordinates removed": these tests pin the chosen shape (`Wrap`
+/// with `spaceBetween`) clean at the narrow widths the Statistics page produces,
+/// in the widest locales, and verify the byte totals are never dropped.
+///
+/// Tagged `dashboard-card` so it gates PRs — `run_tests.sh` excludes
+/// `golden||loc||ui`, and a `ui`-tagged regression test would not block anything.
+void main() {
+  setUpAll(() async {
+    // Real fonts: text widths — and therefore overflow — are meaningless under
+    // the Ahem block font.
+    await loadAppFonts();
+  });
+
+  /// The page margin `AppLayoutConfig.margin(width)` applies at each breakpoint.
+  /// Mirrors ui_kit `app_layout_config.dart`; the Statistics page pads each
+  /// section by `context.layoutMargin` on both edges
+  /// (`usp_statistics_view.dart:86`).
+  double pageMarginFor(double screenWidth) {
+    if (screenWidth > 1680) return 352.0;
+    if (screenWidth > 1440) return 256.0;
+    if (screenWidth > 1240) return 200.0; // D1: the big-margin regime.
+    if (screenWidth > 905) return 24.0;
+    if (screenWidth > 600) return 32.0;
+    return 16.0;
+  }
+
+  /// The width a single Statistics section renders to on a [screenWidth] screen:
+  /// full content width minus the page margin on both edges. The section card's
+  /// own padding then reduces this further, exactly as in production.
+  double sectionWidthFor(double screenWidth) =>
+      screenWidth - pageMarginFor(screenWidth) * 2;
+
+  final baseTheme = ThemeJsonConfig.defaultConfig().createLightTheme();
+
+  /// Pumps the real [StatsTrafficMonitorSection] once at [screenWidth] with the
+  /// section sized to the width the page gives it, mirroring how the section
+  /// lays out inside the scrollable Statistics tab, and returns the RenderFlex
+  /// overflows beyond a 2px tolerance (the gate's own tolerance).
+  ///
+  /// One pump per call: Flutter reports a given RenderFlex's overflow only once
+  /// per render-object lifetime, so a second pump in the same test would report
+  /// a genuinely overflowing width as clean.
+  Future<List<OverflowIncident>> overflowsAt({
+    required WidgetTester tester,
+    required double screenWidth,
+    required Locale locale,
+  }) async {
+    final surface = Size(screenWidth, 900.0);
+    final sectionWidth = sectionWidthFor(screenWidth);
+
+    var theme = baseTheme;
+    final cjkFallback = FallbackFontResolver.prefixedFallbackFor(locale);
+    if (cjkFallback != null) {
+      theme = theme.copyWith(
+        textTheme: theme.textTheme.apply(fontFamilyFallback: cjkFallback),
+      );
+    }
+
+    return runWithOverflowCollection((sink) async {
+      await tester.binding.setSurfaceSize(surface);
+      tester.view.physicalSize = surface;
+      tester.view.devicePixelRatio = 1.0;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: cardOverrides(
+            trafficAnalysisState: testTrafficWithHistory,
+          ),
+          child: MaterialApp(
+            locale: locale,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            theme: theme,
+            builder: (context, child) => MediaQuery(
+              data: MediaQuery.of(context).copyWith(disableAnimations: true),
+              child: child ?? const SizedBox.shrink(),
+            ),
+            home: Scaffold(
+              body: SingleChildScrollView(
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: SizedBox(
+                    width: sectionWidth,
+                    child: const StatsTrafficMonitorSection(),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await settleIgnoringAnimations(tester);
+      return sink.where((i) => i.pixels > 2.0).toList();
+    });
+  }
+
+  /// The Statistics page is a single-column scroll list, so a section spans the
+  /// full content width. These are the narrow realizations that matter:
+  ///
+  /// - 1241px screen: the D1 desktop-large pinch. The 200px page margins open
+  ///   just above 1240px, so a 1241px screen yields a *narrower* section
+  ///   (841px) than a 1240px one (1192px) — the same regime that broke the
+  ///   dashboard twin (density design §D1).
+  /// - 905px tablet: 32px margins, 841px section.
+  /// - 601px: the tablet floor (32px margins), 537px section.
+  /// - 320px: the framework's narrowest supported screen (density design §2.3),
+  ///   16px margins, 288px section — the absolute worst case for this row.
+  const narrowScreens = <double>[1241.0, 905.0, 601.0, 320.0];
+
+  group('legend + totals row is clean (#1252)', () {
+    // The widest upload/download locales measured for the #1226 twin: `fr`
+    // ("Téléchargement"/"Téléversement"), plus de/fi/ru which were worst at the
+    // narrowest realization. If the row is clean in English but not in these,
+    // the fix relies on English being short.
+    for (final tag in ['fr', 'de', 'fi', 'ru']) {
+      for (final screen in narrowScreens) {
+        testWidgets(
+          'no overflow at ${sectionWidthFor(screen).toStringAsFixed(0)}px '
+          'section (${screen.toStringAsFixed(0)}px screen) in $tag',
+          (tester) async {
+            final locale = AppLocalizations.supportedLocales.firstWhere((l) {
+              final t = l.countryCode == null || l.countryCode!.isEmpty
+                  ? l.languageCode
+                  : '${l.languageCode}_${l.countryCode}';
+              return t == tag;
+            });
+            final overflows = await overflowsAt(
+              tester: tester,
+              screenWidth: screen,
+              locale: locale,
+            );
+            expect(
+              overflows,
+              isEmpty,
+              reason: 'Traffic Monitor legend overflows in $tag at a '
+                  '${screen.toStringAsFixed(0)}px screen '
+                  '(${sectionWidthFor(screen).toStringAsFixed(0)}px section): '
+                  '${overflows.join(', ')}',
+            );
+          },
+        );
+      }
+    }
+  });
+
+  group('byte totals stay legible (#1252)', () {
+    testWidgets('both totals are still rendered at the narrowest width',
+        (tester) async {
+      // The legend is a key to the chart, but the byte totals are the section's
+      // actual content — degrading the layout must not drop them. The `Wrap`
+      // moves them to a second line; it must not clip or discard them.
+      await overflowsAt(
+        tester: tester,
+        screenWidth: 320.0,
+        locale: const Locale('de'),
+      );
+
+      // The two totals are formatted byte counts; find them by the AppIcon
+      // arrows that precede each so the assertion does not depend on the exact
+      // formatted value. testTrafficWithHistory carries a non-null WAN snapshot,
+      // so both totals must be present.
+      final texts = find.byType(Text).evaluate().map((e) {
+        final w = e.widget as Text;
+        return w.data ?? w.textSpan?.toPlainText() ?? '';
+      }).toList();
+      final byteTotals = texts.where((t) => t.contains('B')).toList();
+      expect(
+        byteTotals.length,
+        greaterThanOrEqualTo(2),
+        reason: 'both byte totals (sent + received) must survive degradation — '
+            'they are content, not chrome. Found: $texts',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`StatsTrafficMonitorSection`'s legend row (`stats_traffic_monitor_section.dart:90`)
is a near-duplicate of the dashboard Traffic Analysis Monitor legend that #1226
(`2505c016`) fixed: two dot+label pairs, then two byte totals, laid out with a
`Row` + `Spacer`. `Spacer` is an `Expanded`, so it absorbs slack while the
content fits and collapses to zero when it does not — at which point the
unconstrained content takes its full intrinsic width and overflows on the right.
#1249 (finding S-B-3) only applied the icon half of #1226's fix here.

This applies the identical #1226 treatment: a `Wrap` with `spaceBetween` in
place of `Row` + `Spacer` (design §2.10, §2.10a).

## What changed

- `lib/page/statistics/views/sections/stats_traffic_monitor_section.dart` —
  `Row` + `const Spacer()` → `Wrap(alignment: spaceBetween)` of two inner
  `Row(mainAxisSize: min)` groups (legend, totals). Legend labels become
  `Flexible` + one-line ellipsis; the byte totals get no `Flexible`, no
  `maxLines`, no ellipsis and wrap as a unit.
- `test/page/statistics/views/sections/stats_traffic_monitor_legend_test.dart`
  (new) — pins the shape, tagged `dashboard-card` so it gates PRs, in the style
  of `usp_traffic_analysis_card_legend_test.dart`.

## Why this shape (design §2.10a)

- **Height budget verified.** The chart above the legend is `Expanded` inside
  the section card's fixed 280px slot, so it yields the height for the extra
  `Wrap` run. This is *not* Network Health's fixed-120px-gauge counter-example
  where `Wrap` traded right-overflow for bottom-overflow — here the height is
  genuinely available.
- **`Flexible` is load-bearing.** A `Row` hands non-flex children unbounded
  width, so wrapping alone fixes nothing; the legend labels must become flex
  children to give. Each dot+label pair stays glued in its own `Row` so a label
  never separates from the colour it explains.
- **Byte totals never ellipsize or shrink.** They are the card's content, not
  chrome — an ellipsis lands mid-number and a half-shown statistic misinforms in
  a way a missing one does not. Only bare series names may ellipsize.

## Not covered by the overflow gate

This section is on the Statistics page, not a dashboard card, so it is absent
from `UspWidgetSpecs.all` (the #1183 gate's 18-id scan domain). There is no
ratchet entry to clear and no gate failure to fix — this is prophylactic work
justified by the #1226 measurement of the identical shape. `test/fixtures/known_overflows.json`
is **unchanged**, as the AC requires.

## Acceptance criteria — measured evidence

Measured with the new test (real fonts loaded, 2px tolerance). The row was clean
at the wider realizations (841px / 537px sections) and broke only at the
narrowest the Statistics page produces — a 288px section on the framework's
320px floor (density design §2.3), in the widest locales:

| locale | before        | after |
|--------|---------------|-------|
| `fr`   | +228.0px right | clean |
| `de`   | +39.0px right  | clean |
| `ru`   | +25.0px right  | clean |
| `fi`   | +5.5px right   | clean |

- [x] Measured: row's overflow at the narrowest width before/after, in the
  widest locales (`de`, `ru`, `fi`, `fr`)
- [x] The byte totals never ellipsize and never shrink (no `Flexible`/`maxLines`/
  ellipsis; test pins that both totals survive the degradation)
- [x] The widget above the row is confirmed to yield height (the chart is
  `Expanded`) — `Wrap` accepted, no right→bottom overflow trade
- [x] A test pins the chosen shape, in the style of
  `usp_traffic_analysis_card_legend_test.dart`
- [x] `test/fixtures/known_overflows.json` unchanged

## Local verification

```
fvm flutter analyze  lib/.../stats_traffic_monitor_section.dart \
                     test/.../stats_traffic_monitor_legend_test.dart
  → No issues found!

fvm dart format --output=none --set-exit-if-changed .
  → Formatted 1123 files (0 changed)   # CI Quality & Logic gate passes

fvm flutter test test/page/statistics/views/sections/stats_traffic_monitor_legend_test.dart
  → All tests passed!   (17 tests; verified RED on the old Row+Spacer first)
```

Refs #1252, #1183
