### PR TITLE
feat(topology): add stable Semantics identifier to node-detail Details button (#1254)

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -1439,7 +1439,7 @@ Code Review MUST check:
 
 ## Article XVI: E2E Test Hooks (Semantics Identifiers)
 
-**Rationale**: The app is a Flutter CanvasKit web build tested end-to-end with Playwright. CanvasKit renders to a single canvas, so tests can only reach a widget through the Semantics tree it projects to the DOM. When a control has no stable, unique anchor, tests fall back to positional selectors (`.nth()`, row index) that silently break when copy, order, or layout changes. This Article makes the stable anchor a first-class, reviewable property of E2E-critical widgets.
+**Rationale**: The app is a Flutter CanvasKit web build tested end-to-end with Playwright. CanvasKit renders to a single canvas, so tests can only reach a widget through the Semantics tree it projects to the DOM. When a control has no stable, unique anchor, tests fall back to selectors that silently break for reasons unrelated to identity — positional (`.nth()`, row index) when order or layout changes, and accessible-name matching when display copy changes. This Article makes the stable anchor a first-class, reviewable property of every widget on an E2E interaction path.
 
 **Section 16.1: `identifier` is the Preferred E2E Anchor — Not `semanticLabel`**
 
@@ -1475,16 +1475,19 @@ AppIconButton(
 
 **Section 16.2: When an `identifier` Is Required**
 
-An `identifier` MUST be added when, and only when, a control lacks a stable, unique anchor that a test can already reach:
+The test is **interaction path, not anchor quality**. An `identifier` MUST be added to any control that sits on an E2E interaction path — one a spec taps, types into, or reads state from:
 
-* ✅ **Required** — icon-only buttons (`AppIconButton`) whose accessible name is a generic fallback (e.g. "Icon button"), making sibling instances indistinguishable.
-* ✅ **Required** — toggles/switches, and form inputs, that a test must set or read but that carry no unique role+name.
+* ✅ **Required** — any control a spec acts on: buttons (labelled or icon-only), toggles/switches, form inputs, tabs, CRUD row actions, and the entry points into a flow.
 * ✅ **Required** — any control a test currently reaches only via `.nth()` / positional index.
-* ❌ **Not required** — controls already uniquely addressable by role + accessible name, or by stable visible content text (e.g. a labelled `AppButton`, a device row keyed on its name). Do not add redundant identifiers to anchorable controls.
+* ❌ **Not required** — presentational content no spec interacts with: static text, headings, decorative icons, layout containers, and rows a test only reads through their visible text.
 
-**Locale caveat**: "addressable by accessible name" counts as a stable anchor **only while the E2E suite is locked to a single locale**. An accessible name is localized display copy — `getByRole(role, { name: 'Save' })` targets the English string. The current suite has no locale lock (`playwright.config.ts` sets none) and matches localized names directly, so it is implicitly English-only. The moment E2E must run across locales — or the app's default locale changes — such a control is reachable only through copy that varies, which is the same silent-break failure mode this Article exists to kill (locale-triggered rather than layout-triggered). In that case the control moves back to ✅ **Required**: give it an `identifier`. A cross-locale test matrix is therefore a trigger to re-audit every ❌ decision made under this section.
+A labelled `AppButton` on an interaction path is ✅ **Required**. Its accessible name is a stable *anchor* but not a stable *contract*: the name is ARB copy, so a rename silently converts a passing spec into a count-0 timeout — the same failure mode positional selectors have, differently triggered. An `identifier` is the one anchor that is neither positional nor localized.
 
-**Principle**: The `identifier` exists to eliminate selectors that break on things unrelated to identity — positional index, and (under a cross-locale matrix) localized copy. If a control is already stably anchorable *for the locales the suite runs*, adding an `identifier` is noise — Article V (Simplicity) applies.
+**Cost asymmetry — why identifier-first:** the cost of a redundant identifier is one line, no runtime cost, and no a11y cost (unlike a `semanticLabel` slug, an `identifier` is never announced — Rule 16.1.2). The cost of a missing one is a cross-repo round trip: E2E discovers the gap, files an app issue, waits on an app PR and review, then regenerates the selector map. The E2E repo cannot unblock itself. When in doubt, add it.
+
+**Principle**: The `identifier` decouples test identity from everything that legitimately changes without changing identity — position, layout, and copy. Article V (Simplicity) still governs the ❌ case: do not blanket every widget, because a selector map full of never-used entries is noise. Scope by interaction path, not by anchor quality.
+
+**Backwards compatibility (per Article II §2.2)**: this section replaces an earlier rule that treated a labelled `AppButton` as ❌ *not required*, subject to a locale caveat. That caveat is now absorbed by the interaction-path test and removed. The change is **forward-applying**: existing labelled controls without an identifier are not retroactively violations, and no sweep is mandated. Add the hook when a spec next needs the control, or when the surrounding code is touched. A cross-locale matrix is no longer a trigger to re-audit past decisions — under this section the answer no longer depends on the locales the suite runs.
 
 **Section 16.3: Naming Convention**
 
@@ -1520,12 +1523,12 @@ The derivation helper (e.g. `ruleIdentifierKey`) MUST be a pure, unit-tested fun
 **Section 16.5: Code Review Checklist**
 
 Code Review MUST check:
-- ✅ Every E2E-critical control (icon buttons, toggles, targeted inputs, CRUD row actions) has a stable hook — `identifier` where the host widget forwards it (Rule 16.1.1)
+- ✅ Every control on an E2E interaction path — labelled buttons included — has a stable hook: `identifier` where the host widget forwards it (Rule 16.1.1, §16.2)
 - ✅ Where a widget forwards `identifier`, no test slug appears in `semanticLabel`, and no widget carries both an `identifier` and a redundant test-slug `semanticLabel`
 - ✅ A `semanticLabel` test slug appears only where the host widget exposes no `identifier` passthrough (Rule 16.1.2), and such cases are flagged as tech debt to migrate
 - ✅ Identifier values are `kebab-case`, follow `{page}-{control}[-{instance-key}]`, and per-instance keys derive from data (not row index)
 - ✅ Per-instance key derivation is a pure, unit-tested function
-- ✅ No redundant identifier added to a control already anchorable by role+name or stable content text — but any ❌-"not required" call is sound only for the locales the suite runs; a cross-locale matrix re-opens it (16.2 locale caveat)
+- ✅ No identifier added to presentational content no spec interacts with (§16.2 ❌) — but a labelled control on an interaction path is ✅ Required, not redundant
 - ✅ Raw `Semantics` test hooks use `identifier:`, not `label:` (a bare `label` is announced aloud AND invisible to the generator)
 - ✅ Any `semanticLabel`→`identifier` migration — even with an unchanged slug — regenerated the map AND migrated every spec from `getByRole({name})` to `byIdentifier()` (16.4)
 

--- a/lib/page/topology/helpers/node_identifier.dart
+++ b/lib/page/topology/helpers/node_identifier.dart
@@ -20,6 +20,14 @@ String topologySlaveIdentifier(String macSuffix) =>
 String topologyClientIdentifier(String macSuffix) =>
     'topology-node-client-$macSuffix';
 
+/// Identifier for the `Details` action inside the node-detail popup.
+///
+/// Carries no per-instance key: the popup renders in the graph view's
+/// singleton detail panel, so only one instance is ever mounted. See the note
+/// at the call site in `node_detail_popup.dart`.
+const String kTopologyNodeDetailButtonIdentifier =
+    'topology-node-detail-button';
+
 /// Normalizes a MAC / device id to uppercase hex with every separator removed.
 ///
 /// `aa:bb:cc:dd:ee:ff` → `AABBCCDDEEFF`. Any non-hex character (`:`, `-`, `.`,

--- a/lib/page/topology/views/components/node_detail_popup.dart
+++ b/lib/page/topology/views/components/node_detail_popup.dart
@@ -103,6 +103,7 @@ class NodeDetailPopup extends StatelessWidget {
               child: AppButton.text(
                 label: loc(context).details,
                 onTap: onDetailsTap,
+                identifier: 'topology-node-detail-button',
               ),
             ),
           ),

--- a/lib/page/topology/views/components/node_detail_popup.dart
+++ b/lib/page/topology/views/components/node_detail_popup.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
+import 'package:privacy_gui/page/topology/helpers/node_identifier.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:privacy_gui/util/network_utils.dart';
 import 'package:ui_kit_library/ui_kit.dart';
@@ -103,7 +104,15 @@ class NodeDetailPopup extends StatelessWidget {
               child: AppButton.text(
                 label: loc(context).details,
                 onTap: onDetailsTap,
-                identifier: 'topology-node-detail-button',
+                // Fixed slug with no per-instance key — unlike the node
+                // identifiers in node_identifier.dart, which need one because
+                // N nodes coexist in the Semantics tree. This button lives in
+                // the graph view's singleton detail panel (one `_selectedNodeId`
+                // at a time), so it is unique by construction. Wiring this
+                // popup into `TopologyTreeConfiguration.detailBuilder`, which
+                // renders per row, would break that: derive the key from the
+                // node's MAC first (see shortestUniqueMacSuffixes).
+                identifier: kTopologyNodeDetailButtonIdentifier,
               ),
             ),
           ),

--- a/test/page/topology/views/components/node_detail_popup_identifier_widget_test.dart
+++ b/test/page/topology/views/components/node_detail_popup_identifier_widget_test.dart
@@ -1,0 +1,201 @@
+@Tags(['ui'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/topology/helpers/node_identifier.dart';
+import 'package:privacy_gui/page/topology/views/components/node_detail_popup.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+/// Verifies that the node-detail popup's `Details` button carries the stable
+/// E2E identifier added in issue #1254 and that it is locatable via
+/// [CommonFinders.bySemanticsIdentifier].
+///
+/// This is the fast local proxy for the E2E `byId()` contract (constitution
+/// Article XVI): once the identifier reaches the Semantics tree, the CanvasKit
+/// → `flt-semantics-identifier` DOM projection is a Flutter-runtime guarantee,
+/// so no web round is needed here.
+///
+/// Unlike the node identifiers (`topology_node_identifier_widget_test.dart`),
+/// this hook is a FIXED slug with no per-instance key. That is sound only
+/// because the button renders inside the graph view's singleton detail panel —
+/// `TopologyGraphView._selectedNodeId` is a single `String?`, so tapping
+/// another node replaces the panel rather than adding one. The two render
+/// gates that keep it singular are asserted below, so wiring this popup into
+/// `TopologyTreeConfiguration.detailBuilder` (which renders per row) fails
+/// here rather than as a Playwright strict-mode violation.
+void main() {
+  // Master / slave nodes reach the node-detail page through `deviceId`.
+  const masterMetadata = <String, dynamic>{
+    'deviceId': 'AA:BB:CC:DD:EE:00',
+    'isMaster': true,
+    'model': 'MR7500',
+    'manufacturer': 'Linksys',
+  };
+
+  const slaveMetadata = <String, dynamic>{
+    'deviceId': 'AA:BB:CC:DD:EE:01',
+    'isMaster': false,
+    'model': 'MX2000',
+  };
+
+  // Client nodes carry only `mac` — `UspTopologyBuilder` puts no `deviceId`
+  // in their metadata (usp_topology_builder.dart:202-206).
+  const clientMetadata = <String, dynamic>{
+    'mac': '11:22:33:44:55:01',
+    'hasMultipleInterfaces': false,
+  };
+
+  MeshNode node({
+    required MeshNodeType type,
+    MeshNodeStatus status = MeshNodeStatus.online,
+  }) =>
+      MeshNode(
+        id: 'node-1',
+        name: 'Test Node',
+        type: type,
+        status: status,
+      );
+
+  // Mirrors the production call in usp_topology_view.dart:123-125, which is
+  // the only site that passes `showDetailsButton: true`.
+  Widget wrap(
+    MeshNode target,
+    Map<String, dynamic> metadata, {
+    required bool showDetailsButton,
+  }) {
+    return MaterialApp(
+      theme: AppTheme.create(brightness: Brightness.light),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SizedBox(
+          width: 320,
+          child: Builder(
+            builder: (ctx) => NodeDetailPopup.builder(
+              ctx,
+              target,
+              metadata,
+              showDetailsButton: showDetailsButton,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // Asserted against the literal, not the constant: this is the cross-repo
+  // contract value the E2E selector map is generated from, so a rename must
+  // fail here rather than silently follow the constant.
+  const detailsIdentifier = 'topology-node-detail-button';
+
+  group('Details button identifier', () {
+    test('the contract value is unchanged', () {
+      expect(kTopologyNodeDetailButtonIdentifier, detailsIdentifier);
+    });
+
+    testWidgets('master node with showDetailsButton carries the identifier',
+        (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(wrap(
+        node(type: MeshNodeType.gateway),
+        masterMetadata,
+        showDetailsButton: true,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsIdentifier(detailsIdentifier), findsOneWidget);
+
+      handle.dispose();
+    });
+
+    testWidgets('slave node with showDetailsButton carries the identifier',
+        (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(wrap(
+        node(type: MeshNodeType.extender),
+        slaveMetadata,
+        showDetailsButton: true,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsIdentifier(detailsIdentifier), findsOneWidget);
+
+      handle.dispose();
+    });
+
+    // Gate 1 of 2 (node_detail_popup.dart:98). The dashboard card
+    // (usp_network_topology_card.dart:79-80) and the AI topology section both
+    // rely on this default, so the hook must be absent there.
+    testWidgets('absent when showDetailsButton is not set (the default)',
+        (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(wrap(
+        node(type: MeshNodeType.extender),
+        slaveMetadata,
+        showDetailsButton: false,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsIdentifier(detailsIdentifier), findsNothing);
+
+      handle.dispose();
+    });
+
+    // Gate 2 of 2 (node_detail_popup.dart:98). E2E must therefore assert node
+    // state before locating this hook — an offline node yields count 0.
+    testWidgets('absent when the node is offline', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(wrap(
+        node(type: MeshNodeType.extender, status: MeshNodeStatus.offline),
+        slaveMetadata,
+        showDetailsButton: true,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsIdentifier(detailsIdentifier), findsNothing);
+
+      handle.dispose();
+    });
+
+    // CHARACTERIZATION TEST — documents a latent coupling, NOT a live bug.
+    //
+    // A client node's metadata has no `deviceId` (only `mac`), so
+    // `NodeDetailPopup.builder` (node_detail_popup.dart:36-46) builds a
+    // non-null `onDetailsTap` whose body is a no-op: the `deviceId.isNotEmpty`
+    // guard fails and no navigation happens. The button renders and carries
+    // the identifier regardless.
+    //
+    // Unreachable in production today: `TopologyGraphView._handleNodeTap`
+    // short-circuits client and internet nodes before the detail panel opens
+    // (ui_kit v2.34.5 topology_graph_view.dart:352-355), and all three app
+    // call sites use `NodeDetailTrigger.tap` with no hover path. So a client
+    // node never renders this popup.
+    //
+    // Pinned here because that guard lives in ui_kit, not in this repo: if it
+    // is relaxed, or if this popup is wired into
+    // `TopologyTreeConfiguration.detailBuilder`, E2E gains a locatable button
+    // that does nothing when tapped. Flip to `findsNothing` if the render gate
+    // is ever extended with `deviceId.isNotEmpty`.
+    testWidgets('client node renders the hook despite having no deviceId',
+        (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(wrap(
+        node(type: MeshNodeType.client),
+        clientMetadata,
+        showDetailsButton: true,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsIdentifier(detailsIdentifier), findsOneWidget);
+
+      handle.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## What

Add a stable `Semantics` identifier to the topology node-detail popup's **Details** button so E2E can locate it by a hook instead of its localized label.

```dart
// lib/page/topology/views/components/node_detail_popup.dart
child: AppButton.text(
  label: loc(context).details,
  onTap: onDetailsTap,
  identifier: kTopologyNodeDetailButtonIdentifier,   // ← added
),
```

The value lives in `lib/page/topology/helpers/node_identifier.dart` next to the node identifiers, so the feature keeps one place to scan for its E2E hooks.

## Why

The Details button is the entry point to the node-detail page — on the critical path of the D5a/D5b topology interaction chains. Topology **nodes** already carry stable identifiers (shipped in `#1211` / privacyGUI-UI-kit#9), but this action button *inside* the popup was skipped, so `PrivacyGUI-USP-E2E` has to locate it by `getByRole('button', { name: /Details/i })` — coupling the test to ARB copy. A `details` rename would turn into a count-0 timeout rather than a compile error. This closes that inconsistency.

Framing: implementation completeness, not a new feature — sibling controls in the same chain already carry hooks.

**Article XVI §16.2**: this PR also amends the section it is governed by. The old rule listed a labelled `AppButton` as ❌ not-required, with a locale caveat that moved it back to ✅ required whenever accessible-name matching is unstable across locales — and since an accessible name is always ARB copy, that caveat covered nearly every case the rule excluded. The result was that each labelled control became an argument rather than a lookup: this one-line change carried a paragraph of justification and still drew a review comment saying the cited trigger was not pinned. §16.2 now tests **interaction path, not anchor quality** — a control a spec acts on requires an identifier, labelled or not. Scope stays bounded (presentational content gets no hook), and 16.3 / 16.4 are unchanged. Forward-applying per Article II §2.2: no retroactive violations, no sweep mandated.

## Scope

Three commits:

| Commit | Contents |
|---|---|
| `b3af732` | The identifier itself (1 line) |
| `beb26c3` | Article XVI §16.2 → identifier-first, + rationale/checklist consistency |
| `e1f8138` | Named constant (review W-4) + widget test (review W-1) |

`AppButton.text` already exposes `identifier` (ui_kit_library v2.34.5, `app_button.dart:176` → `Semantics(identifier:)` at `:527`), so **no ui_kit change and no codegen**. Naming follows the existing topology kebab-case family (`topology-node-master` / `-slave-*` / `-client-*`).

## Test coverage

`test/page/topology/views/components/node_detail_popup_identifier_widget_test.dart` — 6 cases. Present for master and slave nodes; **absent** under each of the two render gates (`showDetailsButton` unset, offline node).

The absence cases are the load-bearing ones. Unlike the node identifiers, this slug carries no per-instance key — sound only while the button renders in the graph view's singleton detail panel (`TopologyGraphView._selectedNodeId` is a single `String?`, so tapping another node replaces the panel rather than adding one). Wiring this popup into `TopologyTreeConfiguration.detailBuilder`, which renders per row, now fails locally instead of surfacing as a Playwright strict-mode violation. A comment at the call site says the same.

The sixth case is a **characterization test, not a bug**: a client node's metadata carries no `deviceId` (only `mac`), so `onDetailsTap` is non-null but navigates nowhere. Unreachable today — `TopologyGraphView._handleNodeTap` short-circuits client and internet nodes before the panel opens (ui_kit v2.34.5 `topology_graph_view.dart:352-355`), and all three app call sites use `NodeDetailTrigger.tap` with no hover path. Pinned because that guard lives in ui_kit rather than here.

## Verification

- `dart format --output=none --set-exit-if-changed` → exit 0
- `flutter analyze` (3 changed files) → `No issues found!`
- New test → 6/6 pass
- `flutter test test/page/topology/` → **66/66 pass** (covers the existing consumers of the edited helper)

## Downstream

Once merged, the E2E side is a two-line swap in `P15-topology.spec.ts` (getByRole → byId) plus `gen:ids` picking up the new constant — tracked as verdict 2 in `linksys/PrivacyGUI-USP-E2E#44`. Note for that work: the hook is absent in tree view and on offline nodes, so the spec should pin a desktop viewport and assert node state first.

Refs `#1254`. Split out of `#1208` (node identifiers, already done). Sibling app-hook request: `#1246` (Port Forwarding tabs) — now unambiguously ✅ required under the amended §16.2.
