### PR TITLE
fix(dashboard): stack ethernet_ports summary tiles where they cannot fit (#1228)

### DIFF
--- a/doc/dashboard/dashboard_density_design.md
+++ b/doc/dashboard/dashboard_density_design.md
@@ -651,6 +651,52 @@ fail*, and without a stated exit someone will reach for the allowlist mid-fix.
 Forking or patching the dependency is rejected — a vendored patch dies silently
 on the next upgrade.
 
+### 2.12 What the first *rearrangement* taught us (#1228 — implemented)
+
+All 52 coordinates cleared as predicted (278 → 226). #1226/#1233/#1227 all made
+existing rows *give*; this is the first ticket where the row had to be taken
+apart, and three things only showed up in the measurements.
+
+1. **A residual under the gate's tolerance is a silent pass, and the narrowest
+   card produces one.** The gate ignores overflows below 2.0px. At the narrowest
+   realization `ethernet_ports` ever gets — a 191px card, 157px of content — each
+   summary tile's row has **50.69px** for chrome that costs **52px** (a 40px
+   status disc plus a 12px gap). Constraining the text is therefore not a fix
+   *and not a failure either*: the text column goes to zero, the row still
+   overflows by **1.31px**, and the gate goes green on a tile that renders no
+   label at all. The reflex from the three preceding tickets — wrap the label in
+   `Flexible`/`Expanded` and move on — would have produced exactly that. **Check
+   the row's fixed cost against the available width before choosing "make the
+   text give"**; where fixed cost alone exceeds it, the arrangement has to change.
+2. **Rearranging spends vertical budget the gate cannot see.** `ethernet_ports`
+   gives its content a **121px** viewport (measured at both narrow
+   realizations). Stacking the two tiles at the standard 12px padding needs 136px
+   — it clears every coordinate and slices the second tile by 15px, because
+   `DashboardCardTemplate` scrolls rather than clips, so nothing overflows and
+   the gate cannot tell. Stacking therefore tightens the tile padding to 8px
+   (2 × 56 + 8 = 120px). Generalisation for the remaining Track A tickets: a fix
+   that changes a card's *arrangement* must be measured against the content
+   viewport, not only against the gate.
+3. **The port list's initially-visible sliver is a measured, accepted loss —
+   and #1228's AC5 is not met by this ticket.** The port `Wrap` needs 514px (min)
+   / 318px (preferred) against that 121px viewport, so it required scrolling
+   before this change and after it; the port *labels and speeds* sat below the
+   viewport bottom already (wrap top 137 + a 38px glyph = 175, labels from ~183,
+   viewport ends at 178). What changed is the glyph row: stacking moves the wrap
+   from y=137 to y=193, so the 41px of port glyphs that were visible without
+   scrolling become 0px — at the two narrow realizations only, desktop untouched.
+   The loss is forced, not chosen: preserving 41px needs 64px back, which even a
+   disc-less stacked pair (2 × 52px) cannot return. So AC5 ("port state remains
+   readable at the narrowest clean width") is unreachable by *any* arrangement of
+   the summary tiles; it needs a compact port list, which is #1240's job. Track B
+   inherits it rather than #1228 claiming it.
+
+The AC that *is* gate-invisible and satisfiable — the two tiles being a matched
+pair — plus the label-legibility floor are covered by
+`test/page/dashboard/views/components/ethernet_ports_summary_readability_test.dart`,
+tagged `dashboard-card` so it gates; each of its four groups was verified to fail
+under a mutation of the code it guards (the mutations are tabulated in the file).
+
 ---
 
 ## Part 3 — Deferred
@@ -705,7 +751,7 @@ addition — it changes no card's rendering until a threshold is declared.
 | #1226 | `traffic_analysis` legend row (§2.10) — **implemented** | 49 |
 | #1233 | The other six legend rows (§1.1, §2.10a) — **implemented** | 132 |
 | #1227 | Shared blocks made overflow-safe (§2.6, §2.6a) — **implemented** | 101 |
-| #1228 | `ethernet_ports` ×2 sites | 52 |
+| #1228 | `ethernet_ports` ×2 sites (§2.12) — **implemented** | 52 |
 | #1229 | `wifi_performance` ×2 sites | 45 |
 | #1230 | `firewall_overview` own sites (§2.11) | 48 |
 | #1234 | `system_status` remaining ×3 sites | 34 |
@@ -733,7 +779,7 @@ one deviation from the legend shape.
 | #1231 | `usp_info_row` reads real width (§2.8) — fixes silent truncation, clears 0 |
 | #1232 | Density plumbing (§2.1, §2.4, §2.6) — the one ticket needing red-first tests |
 | #1239 | Popup form + dialog reuse (§2.1) |
-| #1240 | Per-card thresholds and compact forms (§2.4, §2.5) — split after fit widths settle |
+| #1240 | Per-card thresholds and compact forms (§2.4, §2.5) — split after fit widths settle; inherits #1228's port-list readability AC (§2.12) |
 
 #1240 waits on all of Track A: thresholds are meaningless while fit widths are
 still moving, and the point of the layout fixes is to lower them. **Re-measure

--- a/lib/page/local_network/cards/usp_ethernet_ports_card.dart
+++ b/lib/page/local_network/cards/usp_ethernet_ports_card.dart
@@ -9,6 +9,29 @@ import 'package:privacy_gui/page/_shared/components/dashboard_card_template.dart
 import 'package:privacy_gui/page/dashboard/views/dialogs/ethernet_port_detail_dialog.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
+/// Content width below which the two summary tiles stack instead of sitting side
+/// by side.
+///
+/// Derived, not chosen. Each tile spends a fixed 76px on chrome — 24px of
+/// [LayoutBlock] padding, the 40px status disc, and the 12px gap after it — and
+/// the source-locale labels need 96px (`Disconnected` measures 95.4px at
+/// `titleSmall`, `LAN connected` 89.4px). Two of those plus the 8px between them
+/// is 352px.
+///
+/// Below that, side by side is measurably worse than stacked rather than merely
+/// tighter. At the narrowest width the grid ever yields — a 191px card, 157px of
+/// content — each tile's row has **50.7px** for a disc and gap that cost 52px, so
+/// the text column is squeezed to zero and the row *still* overflows by 1.3px.
+/// That is under the gate's 2px tolerance, so constraining the text alone would
+/// have passed the gate while rendering no label at all (#1228). Stacked, the
+/// same card gives each label 81px, and 288px gives it 178px.
+///
+/// This threshold only decides *readability*: [_SummaryTile] is overflow-safe at
+/// any width on its own, so getting it wrong costs an ellipsis, never an
+/// overflow. It is a local degradation, not a form selection — Track B (#1240)
+/// may later replace it with a declared `normalAbove` threshold.
+const double _kSideBySideMinWidth = 352;
+
 class UspEthernetPortsCard extends ConsumerWidget {
   final List<EthernetPortUIModel>? ports;
 
@@ -33,79 +56,21 @@ class UspEthernetPortsCard extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           // Summary tiles - WAN first
-          Row(
-            children: [
-              Expanded(
-                child: LayoutBlock(
-                  padding: const EdgeInsets.all(AppSpacing.md),
-                  child: Row(
-                    children: [
-                      Container(
-                        width: 40,
-                        height: 40,
-                        decoration: BoxDecoration(
-                          color: colorScheme.primary.withValues(alpha: 0.15),
-                          shape: BoxShape.circle,
-                        ),
-                        child: AppIcon.font(
-                          Icons.public,
-                          color: colorScheme.primary,
-                          size: 20,
-                        ),
-                      ),
-                      AppGap.md(),
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          AppText.titleSmall(wanConnected > 0
-                              ? loc(context).connected
-                              : loc(context).disconnected),
-                          AppText.bodySmall(
-                            'WAN',
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              AppGap.sm(),
-              Expanded(
-                child: LayoutBlock(
-                  padding: const EdgeInsets.all(AppSpacing.md),
-                  child: Row(
-                    children: [
-                      Container(
-                        width: 40,
-                        height: 40,
-                        decoration: BoxDecoration(
-                          color: (appColors?.semanticSuccess ?? Colors.green)
-                              .withValues(alpha: 0.15),
-                          shape: BoxShape.circle,
-                        ),
-                        child: AppIcon.font(
-                          Icons.lan,
-                          color: appColors?.semanticSuccess ?? Colors.green,
-                          size: 20,
-                        ),
-                      ),
-                      AppGap.md(),
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          AppText.titleSmall('$lanConnected'),
-                          AppText.bodySmall(
-                            loc(context).lanConnected,
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ],
+          _SummaryTiles(
+            wan: _TileSpec(
+              icon: Icons.public,
+              accent: colorScheme.primary,
+              title: wanConnected > 0
+                  ? loc(context).connected
+                  : loc(context).disconnected,
+              subtitle: 'WAN',
+            ),
+            lan: _TileSpec(
+              icon: Icons.lan,
+              accent: appColors?.semanticSuccess ?? Colors.green,
+              title: '$lanConnected',
+              subtitle: loc(context).lanConnected,
+            ),
           ),
           AppGap.lg(),
           // Port icons
@@ -113,6 +78,126 @@ class UspEthernetPortsCard extends ConsumerWidget {
             spacing: AppSpacing.xl,
             runSpacing: AppSpacing.lg,
             children: ports.map((p) => _PortItem(port: p)).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// What one summary tile shows. The four values travel together everywhere, so
+/// they are one type rather than four parameters repeated per tile.
+class _TileSpec {
+  const _TileSpec({
+    required this.icon,
+    required this.accent,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final IconData icon;
+  final Color accent;
+  final String title;
+  final String subtitle;
+}
+
+/// Lays the WAN and LAN summary tiles out side by side, or stacks them once the
+/// card is narrower than [_kSideBySideMinWidth].
+///
+/// The two tiles are a matched pair — same chrome, same treatment — so they are
+/// one widget rendered twice from [_TileSpec] rather than two copies of the same
+/// markup, and no change can reach one without the other (#1228).
+class _SummaryTiles extends StatelessWidget {
+  const _SummaryTiles({required this.wan, required this.lan});
+
+  final _TileSpec wan;
+  final _TileSpec lan;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth >= _kSideBySideMinWidth) {
+          return Row(
+            children: [
+              Expanded(child: _SummaryTile(spec: wan)),
+              AppGap.sm(),
+              Expanded(child: _SummaryTile(spec: lan)),
+            ],
+          );
+        }
+        // Stacked, the pair has to fit the height the card gives its content —
+        // measured at **121px** for this card's 3 rows, at both narrow
+        // realizations. Two tiles at the standard 12px padding are 136px and cut
+        // the second one off, so stacking tightens the padding to 8px: 2 × 56 +
+        // 8 = 120px, and both tiles stay whole. Stretch keeps each one
+        // full-width; the height beyond the viewport scrolls rather than clips,
+        // so this cannot trade right-overflows for bottom ones (#1228).
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _SummaryTile(spec: wan, compact: true),
+            AppGap.sm(),
+            _SummaryTile(spec: lan, compact: true),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// One summary tile: a coloured status disc, then a value over its label.
+///
+/// Overflow-safe at any width regardless of the arrangement above it. The disc
+/// keeps its 40px design size and the text is what yields, because the disc's
+/// colour and glyph are the only things identifying which port group the tile
+/// describes, while a clipped `Disconnec…` still reads as a state (#1228).
+class _SummaryTile extends StatelessWidget {
+  const _SummaryTile({required this.spec, this.compact = false});
+
+  final _TileSpec spec;
+
+  /// Trades 4px of padding per side for vertical budget when stacked; see
+  /// [_SummaryTiles].
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final icon = spec.icon;
+    final accent = spec.accent;
+
+    return LayoutBlock(
+      padding: EdgeInsets.all(compact ? AppSpacing.sm : AppSpacing.md),
+      child: Row(
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: accent.withValues(alpha: 0.15),
+              shape: BoxShape.circle,
+            ),
+            child: AppIcon.font(icon, color: accent, size: 20),
+          ),
+          AppGap.md(),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                AppText.titleSmall(
+                  spec.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                AppText.bodySmall(
+                  spec.subtitle,
+                  color: colorScheme.onSurfaceVariant,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
           ),
         ],
       ),

--- a/lib/page/local_network/cards/usp_ethernet_ports_card.dart
+++ b/lib/page/local_network/cards/usp_ethernet_ports_card.dart
@@ -163,9 +163,11 @@ class _SummaryTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Colour ownership splits on whether the value differs per tile: [accent]
+    // does (one is `colorScheme.primary`, the other `semanticSuccess` from an
+    // extension), so it travels in the spec; the subtitle colour is the same for
+    // both tiles, so it is resolved here and stays out of the spec.
     final colorScheme = Theme.of(context).colorScheme;
-    final icon = spec.icon;
-    final accent = spec.accent;
 
     return LayoutBlock(
       padding: EdgeInsets.all(compact ? AppSpacing.sm : AppSpacing.md),
@@ -175,10 +177,10 @@ class _SummaryTile extends StatelessWidget {
             width: 40,
             height: 40,
             decoration: BoxDecoration(
-              color: accent.withValues(alpha: 0.15),
+              color: spec.accent.withValues(alpha: 0.15),
               shape: BoxShape.circle,
             ),
-            child: AppIcon.font(icon, color: accent, size: 20),
+            child: AppIcon.font(spec.icon, color: spec.accent, size: 20),
           ),
           AppGap.md(),
           Expanded(

--- a/test/fixtures/known_overflows.json
+++ b/test/fixtures/known_overflows.json
@@ -7,8 +7,6 @@
     "connected_devices|min|0": ["*"],
     "connected_devices|preferred|0": ["el"],
     "device_info|min|0": ["el", "ru"],
-    "ethernet_ports|min|0": ["*"],
-    "ethernet_ports|preferred|0": ["*"],
     "firewall_overview|min|0": [
       "ar", "el", "es", "es_AR", "fi", "fr", "fr_CA", "id", "nb", "pl",
       "pt", "pt_PT", "ru", "tr", "vi"

--- a/test/page/dashboard/views/components/ethernet_ports_summary_readability_test.dart
+++ b/test/page/dashboard/views/components/ethernet_ports_summary_readability_test.dart
@@ -95,10 +95,28 @@ void main() {
 
   /// The card's own content viewport — the shorter of the two scroll views in
   /// the tree (the pump harness wraps the whole card in one as well).
+  ///
+  /// The count is asserted rather than assumed. Picking "the shortest" out of an
+  /// empty finder would return [Rect.largest], and every visibility assertion
+  /// below would then pass against an infinite viewport — the failure mode is a
+  /// silently green test, not a red one, so it has to be caught here. Two is the
+  /// exact expected number: one from the harness, one from
+  /// `DashboardCardTemplate`. If the template stops scrolling its content, or
+  /// anything inside the card starts, this fails loudly and the reader learns
+  /// which assumption broke.
   Rect contentViewport(WidgetTester tester) {
     final finder = find.byType(SingleChildScrollView);
+    final count = finder.evaluate().length;
+    expect(
+      count,
+      2,
+      reason: 'expected exactly two scroll views — the pump harness and the '
+          'card content. Found $count, so "the shortest" no longer identifies '
+          'the card\'s own viewport and these measurements are meaningless.',
+    );
+
     var best = Rect.largest;
-    for (var i = 0; i < finder.evaluate().length; i++) {
+    for (var i = 0; i < count; i++) {
       final r = tester.getRect(finder.at(i));
       if (r.height < best.height) best = r;
     }
@@ -164,6 +182,16 @@ void main() {
 
     // Locales whose labels exceed the budget at these widths, so the label fills
     // whatever it is given and its box measures the budget itself.
+    //
+    // Three locales, not all 26, and that is deliberate: a locale whose label
+    // *fits* measures its own text width, not the budget, so it cannot detect a
+    // shrinking budget at all — adding the other 23 would add 23 tests that pass
+    // for the wrong reason. `el`/`nl`/`fi` are the three longest `connected` /
+    // `disconnected` / `lanConnected` renderings at `titleSmall`+`bodySmall`,
+    // measured 2026-08-12 against the current ARB set. Overflow safety for all
+    // 26 is the gate's job (the `"*"` wildcard); this group measures legibility
+    // only. If `AppLocalizations.supportedLocales` or those three strings
+    // change, re-measure which locales overflow the budget.
     for (final tag in ['el', 'nl', 'fi']) {
       for (final wc in narrowCases) {
         testWidgets(

--- a/test/page/dashboard/views/components/ethernet_ports_summary_readability_test.dart
+++ b/test/page/dashboard/views/components/ethernet_ports_summary_readability_test.dart
@@ -1,0 +1,229 @@
+@Tags(['dashboard-card'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
+import 'package:privacy_gui/page/dashboard/models/display_mode.dart';
+import 'package:privacy_gui/page/dashboard/models/usp_widget_specs.dart';
+
+import '../../../../util/app_test_fonts.dart';
+import '../../../../util/dashboard/dashboard_card_probe.dart';
+
+/// Ethernet Ports summary-tile readability (#1228).
+///
+/// ## Why this file exists alongside the #1183 gate
+///
+/// #1228 clears 52 coordinates by letting the two summary tiles stack once the
+/// card is too narrow to hold them side by side. Everything that makes that the
+/// *right* fix is invisible to the gate, which only knows whether a row fits:
+///
+///   - Constraining the text alone would have satisfied the gate while showing
+///     no label at all. At the narrowest realization each tile's row has 50.7px
+///     for a 40px disc and a 12px gap, so the text column is squeezed to zero and
+///     the row still overflows by 1.3px — under the gate's 2px tolerance.
+///   - Stacking at the standard 12px tile padding fits the gate equally well
+///     while cutting the second tile in half: the pair is 136px against the
+///     121px the card gives its content.
+///   - "The two tiles stay visually consistent with each other — they are a
+///     matched pair" (ticket AC) is a claim about two subtrees being identical,
+///     which no overflow measurement can make.
+///
+/// So each group below asserts on the rendered tree. Each was run against a
+/// mutation of the code it guards, and each fired:
+///
+///   | mutation                                  | what failed                  |
+///   |-------------------------------------------|------------------------------|
+///   | `compact` padding dropped (always 12px)   | tiles fully visible (2)      |
+///   | `_kSideBySideMinWidth` 352 → 0            | legible share @min (3), stack (2) |
+///   | LAN tile given `flex: 2` and no `compact` | matched pair (3)             |
+///   | `_kSideBySideMinWidth` 352 → 600          | side by side @desktop (1)    |
+///
+/// Nothing here re-measures overflow — that is the gate's job, and both
+/// `ethernet_ports` keys are gone from `known_overflows.json`.
+///
+/// Tagged `dashboard-card` so it gates PRs: `run_tests.sh` excludes
+/// `golden||loc||ui`, so a `ui`-tagged test here would block nothing.
+void main() {
+  setUpAll(() async {
+    // Real fonts: under the Ahem block font every glyph is one square em, so
+    // what does and does not fit — and therefore what ellipsizes — is fiction.
+    await loadAppFonts();
+  });
+
+  const cardId = 'ethernet_ports';
+  final spec = UspWidgetSpecs.all.firstWhere((s) => s.id == cardId);
+  final heightRows = spec.getConstraints(DisplayMode.normal).minHeightRows;
+
+  /// Pumps the card at one width, as the gate does — one pump, real fonts.
+  Future<void> pumpAt(
+    WidgetTester tester, {
+    required CardWidthCase widthCase,
+    required Locale locale,
+  }) =>
+      probeCardOverflow(
+        tester,
+        cardId: cardId,
+        widthCase: widthCase,
+        cardHeightRows: heightRows,
+        tabIndex: 0,
+        locale: locale,
+      );
+
+  /// The width cases the gate measures: the narrowest realization of the card's
+  /// min and preferred spans. Sourced from the same helper the gate uses, so
+  /// this test cannot drift from the widths that are actually enforced.
+  final narrowCases = widthCasesFor(spec);
+
+  /// A mainstream desktop realization — 1440px screen, the card's default span.
+  final desktopCase = CardWidthCase(
+    screenWidth: 1440,
+    cardWidth: cardWidthAt(1440, 6),
+    columnSpan: 6,
+    label: 'desktop',
+  );
+
+  /// The two summary tiles, in order (WAN, LAN). They are the card's only
+  /// [LayoutBlock]s.
+  List<Rect> tileRects(WidgetTester tester) {
+    final finder = find.byType(LayoutBlock);
+    return [
+      for (var i = 0; i < finder.evaluate().length; i++)
+        tester.getRect(finder.at(i)),
+    ];
+  }
+
+  /// The card's own content viewport — the shorter of the two scroll views in
+  /// the tree (the pump harness wraps the whole card in one as well).
+  Rect contentViewport(WidgetTester tester) {
+    final finder = find.byType(SingleChildScrollView);
+    var best = Rect.largest;
+    for (var i = 0; i < finder.evaluate().length; i++) {
+      final r = tester.getRect(finder.at(i));
+      if (r.height < best.height) best = r;
+    }
+    return best;
+  }
+
+  group('both summary tiles stay whole where the card is narrow (#1228)', () {
+    // The vertical budget is the point. A tile that overflows nothing but is
+    // sliced by the viewport has not been fixed, and the gate cannot tell the
+    // difference because the template scrolls rather than clips.
+    for (final wc in narrowCases) {
+      testWidgets('@${wc.label} ${wc.widthKey}px both tiles are fully visible',
+          (tester) async {
+        await pumpAt(tester, widthCase: wc, locale: const Locale('en'));
+
+        final viewport = contentViewport(tester);
+        final tiles = tileRects(tester);
+
+        expect(tiles.length, 2,
+            reason: 'expected exactly the WAN and LAN tiles');
+        for (var i = 0; i < tiles.length; i++) {
+          expect(
+            tiles[i].bottom,
+            lessThanOrEqualTo(viewport.bottom),
+            reason:
+                'tile $i ends at ${tiles[i].bottom} but the card only shows '
+                'content down to ${viewport.bottom}. The stacked pair must fit '
+                'the ${viewport.height}px the card gives its content — that is '
+                'why stacking tightens the tile padding (#1228).',
+          );
+        }
+      });
+    }
+  });
+
+  group('the tiles are a matched pair (#1228)', () {
+    // The two tiles used to be two copies of the same markup, so they could
+    // drift. They are now one widget rendered from two specs; this pins the
+    // consequence rather than the implementation.
+    for (final wc in [...narrowCases, desktopCase]) {
+      testWidgets('@${wc.label} ${wc.widthKey}px the tiles are the same size',
+          (tester) async {
+        await pumpAt(tester, widthCase: wc, locale: const Locale('el'));
+
+        final tiles = tileRects(tester);
+        expect(tiles.length, 2);
+        expect(tiles[0].width, closeTo(tiles[1].width, 0.01),
+            reason: 'the WAN and LAN tiles must be the same width');
+        expect(tiles[0].height, closeTo(tiles[1].height, 0.01),
+            reason: 'the WAN and LAN tiles must be the same height — equal '
+                'padding and an equal disc');
+      });
+    }
+  });
+
+  group('the state label keeps a legible share of the tile (#1228)', () {
+    // 46px is measured, not chosen: it is the narrowest text column in which any
+    // shipped locale renders both of a tile's labels in full (`zh`, 45.6px). A
+    // label with less than that is being truncated for no gain, which is exactly
+    // what side by side does at the narrowest width — 0px of text, and the row
+    // still over by 1.3px.
+    const minLegibleTextPx = 46.0;
+
+    // Locales whose labels exceed the budget at these widths, so the label fills
+    // whatever it is given and its box measures the budget itself.
+    for (final tag in ['el', 'nl', 'fi']) {
+      for (final wc in narrowCases) {
+        testWidgets(
+            '@${wc.label} ${wc.widthKey}px $tag label gets '
+            '>= ${minLegibleTextPx.toInt()}px', (tester) async {
+          await pumpAt(tester, widthCase: wc, locale: Locale(tag));
+
+          final labels = find.descendant(
+            of: find.byType(LayoutBlock).first,
+            matching: find.byType(Text),
+          );
+          expect(labels.evaluate(), isNotEmpty,
+              reason: 'the WAN tile rendered no text at all');
+
+          final widest = [
+            for (var i = 0; i < labels.evaluate().length; i++)
+              tester.getRect(labels.at(i)).width,
+          ].reduce((a, b) => a > b ? a : b);
+
+          expect(
+            widest,
+            greaterThanOrEqualTo(minLegibleTextPx),
+            reason: 'the WAN tile gives its longest label only '
+                '${widest.toStringAsFixed(1)}px. Below ${minLegibleTextPx.toInt()}px '
+                'no shipped locale renders a tile label in full, so the tile is '
+                'clean but says nothing (#1228).',
+          );
+        });
+      }
+    }
+  });
+
+  group('side by side survives where it fits (#1228)', () {
+    // The stacking is a narrow-width degradation, not a redesign: mainstream
+    // desktop keeps the original arrangement. A threshold raised past the
+    // desktop realization would fail here.
+    testWidgets('@desktop ${desktopCase.widthKey}px the tiles share a row',
+        (tester) async {
+      await pumpAt(tester, widthCase: desktopCase, locale: const Locale('el'));
+
+      final tiles = tileRects(tester);
+      expect(tiles.length, 2);
+      expect(tiles[0].top, closeTo(tiles[1].top, 0.01),
+          reason: 'at ${desktopCase.widthKey}px the tiles must still sit side '
+              'by side, not stacked');
+      expect(tiles[1].left, greaterThan(tiles[0].right),
+          reason: 'the LAN tile must start after the WAN tile ends');
+    });
+
+    for (final wc in narrowCases) {
+      testWidgets('@${wc.label} ${wc.widthKey}px the tiles stack',
+          (tester) async {
+        await pumpAt(tester, widthCase: wc, locale: const Locale('el'));
+
+        final tiles = tileRects(tester);
+        expect(tiles.length, 2);
+        expect(tiles[1].top, greaterThanOrEqualTo(tiles[0].bottom),
+            reason: 'at ${wc.widthKey}px side by side leaves the text column '
+                '0px, so the tiles must stack (#1228)');
+      });
+    }
+  });
+}


### PR DESCRIPTION
Closes #1228. Targets `gate/1183-overflow-gate` so it can be reviewed on its own before joining #1248.

Clears the **52** allowlisted coordinates attributed to this card's two summary tiles — the allowlist goes **278 → 226** (19 keys). Attribution before the change confirmed the ticket's claim exactly: 99 incidents over 52 coordinates, every one from `usp_ethernet_ports_card.dart:41` and `:77`, all right-side. Attribution after the change: **0**.

## Why the obvious fix is not a fix here

The three preceding tickets all made an existing row *give* — wrap the label in `Flexible`/`Expanded`, done. That reflex fails on this card, and it fails **silently**:

| | measured |
|---|---|
| narrowest realization the grid yields | 191px card → 157px content |
| width each tile's row gets | **50.69px** |
| that row's fixed chrome (40px disc + 12px gap) | **52px** |
| residual after squeezing the text to zero | **1.31px** |
| gate tolerance | **2.0px** |

So constraining the text alone would have passed the gate while rendering **no label at all**. The arrangement had to change instead.

## What changed

- Below **352px** of content width the two tiles stack instead of sitting side by side. 352 is derived, not chosen: 2 × (76px chrome + 96px for the source-locale labels) + 8px between them. It only decides readability — the tile is overflow-safe at any width on its own, so a wrong threshold costs an ellipsis, never an overflow.
- Stacking also tightens tile padding from 12px to 8px. The card gives its content **121px**; two tiles at 12px need 136px and the second one gets sliced *without overflowing anything*, because `DashboardCardTemplate` scrolls rather than clips. At 8px the pair is 120px and both tiles stay whole.
- The two tiles were literal copies of the same markup. They are now one widget rendered from a `_TileSpec` pair, so no change can reach one without the other.

## Known trade-off (measured, and it is a regression at two widths)

The port list needed scrolling at these widths **before and after** — its `Wrap` wants 514px (min) / 318px (preferred) against the 121px viewport — and the port labels/speeds already sat below the viewport bottom (wrap top 137 + a 38px glyph = 175; labels from ~183; viewport ends at 178).

What this PR does change: stacking moves the glyph row from y=137 to y=193, so the **41px of port glyphs that were visible without scrolling become 0px** — at the two narrow realizations only, desktop untouched. Preserving that sliver needs 64px back, which even a disc-less stacked pair (2 × 52px) cannot return. Hence the ticket's AC "port state (up/down, speed) remains readable at the narrowest clean width" is **unreachable by any arrangement of the summary tiles** and passes to #1240 (Track B, compact port list). Recorded in the design doc rather than quietly dropped.

## Tests

New `test/page/dashboard/views/components/ethernet_ports_summary_readability_test.dart`, tagged `dashboard-card` so it gates (`run_tests.sh` excludes `golden||loc||ui`). It covers only what the gate cannot see, and each group was run against a mutation of the code it guards:

| mutation | what failed |
|---|---|
| `compact` padding dropped (always 12px) | tiles fully visible (2) |
| `_kSideBySideMinWidth` 352 → 0 | legible share @min (3), stack (2) |
| LAN tile given `flex: 2` and no `compact` | matched pair (3) |
| `_kSideBySideMinWidth` 352 → 600 | side by side @desktop (1) |

## Verification

- overflow gate: **1644/1644** pass, with both `ethernet_ports` keys deleted from `known_overflows.json`
- `./run_tests.sh`: **5063** pass
- `flutter test --tags ui`: **60** pass
- readability test: **14** pass
- `card_ethernet_ports` golden (600×200): pass — 600px is above the threshold, so side by side is unchanged
- `flutter analyze`: 0 issues in both changed files

Screenshots were dumped and inspected at min/preferred/desktop for `en`/`el`/`ru`/`zh` (`el` is the worst locale at 185.9px of labels): both tiles whole, WAN label complete, LAN label ellipsized at min; desktop identical to before.

Design doc: §2.12 added, Track A ledger marks #1228 implemented, #1240 records the inherited AC.