### PR TITLE
fix(dashboard): size wifi_status card rows from the row, not the screen (#1251)

### DIFF
--- a/lib/page/_shared/components/usp_info_row.dart
+++ b/lib/page/_shared/components/usp_info_row.dart
@@ -3,19 +3,26 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
-/// Fraction of the row the label column may claim.
+/// Fraction of the row a fixed label column may claim.
 ///
 /// At the narrowest card realization (191px) this leaves the value ~115px,
 /// enough for the longest common value on one line. The split favours the
 /// value on purpose: per density design §2.10a the label is a name and the
 /// value is the payload, so the label is what yields.
-const double _kLabelShare = 0.4;
+///
+/// Public because a second, unrelated module now derives a fixed label column
+/// from the row's real width the same way (`usp_wifi_status_card.dart`'s
+/// Channel row, #1251). Per constitution Article V §5.3 the shared arithmetic
+/// moves out of a single module once a second consumer converges on it — this
+/// is that moment, so the two constants live here (the only current home of
+/// the row-derived label-column rule) rather than being copied.
+const double kUspLabelShare = 0.4;
 
-/// Ceiling for the label column, so a wide row does not open an absurd
+/// Ceiling for a fixed label column, so a wide row does not open an absurd
 /// gutter before the value. Sits inside the 130–187px band that the old
 /// screen-derived `context.colWidth(2)` produced across desktop breakpoints,
 /// so rows that were already wide enough keep roughly the column they had.
-const double _kLabelMaxWidth = 150.0;
+const double kUspLabelMaxWidth = 150.0;
 
 /// A label–value row used throughout the USP Dashboard cards.
 ///
@@ -44,8 +51,8 @@ class UspInfoRow extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: LayoutBuilder(
         builder: (context, constraints) {
-          final labelWidth =
-              math.min(constraints.maxWidth * _kLabelShare, _kLabelMaxWidth);
+          final labelWidth = math.min(
+              constraints.maxWidth * kUspLabelShare, kUspLabelMaxWidth);
           return Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/lib/page/wifi_settings/cards/usp_wifi_status_card.dart
+++ b/lib/page/wifi_settings/cards/usp_wifi_status_card.dart
@@ -80,23 +80,37 @@ class UspWifiStatusCard extends ConsumerWidget {
             display: '${radio.maxBitRate} Mbps',
           ),
           AppGap.md(),
-          Row(
-            children: [
-              SizedBox(
-                width: context.colWidth(2),
-                child: AppText.labelLarge(loc(context).channel),
-              ),
-              Expanded(
-                child: AppText.bodyMedium(
-                    wifiDisplayValue(context, radio.channelDisplay)),
-              ),
-              AppIconButton(
-                icon: AppIcon.font(Icons.edit, size: 18),
-                onTap: isLoading
-                    ? null
-                    : () => _showWifiChannelDialog(context, ref, radio),
-              ),
-            ],
+          // Size the label column from the width THIS ROW is given (via a
+          // LayoutBuilder), not from screen width. `context.colWidth(2)`
+          // answered a page-scale question (122.25px of the 260.5px this card
+          // shrinks to at 601px), over-claiming the row and silently clipping
+          // the value against the card surface with no overflow raised (#1251;
+          // density design §2.2/§2.8). This is the same fix #1231 applied to
+          // UspInfoRow; the row keeps its trailing edit button, so it reuses
+          // that rule's constants rather than the UspInfoRow widget itself.
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final labelWidth = (constraints.maxWidth * kUspLabelShare)
+                  .clamp(0.0, kUspLabelMaxWidth);
+              return Row(
+                children: [
+                  SizedBox(
+                    width: labelWidth,
+                    child: AppText.labelLarge(loc(context).channel),
+                  ),
+                  Expanded(
+                    child: AppText.bodyMedium(
+                        wifiDisplayValue(context, radio.channelDisplay)),
+                  ),
+                  AppIconButton(
+                    icon: AppIcon.font(Icons.edit, size: 18),
+                    onTap: isLoading
+                        ? null
+                        : () => _showWifiChannelDialog(context, ref, radio),
+                  ),
+                ],
+              );
+            },
           ),
           UspInfoRow(
               label: loc(context).bandwidth,
@@ -166,26 +180,41 @@ class UspWifiStatusCard extends ConsumerWidget {
   Widget _buildApRow(BuildContext context, WifiAccessPointUIModel ap) {
     return Padding(
       padding: const EdgeInsets.only(bottom: AppSpacing.sm),
-      child: Row(
-        children: [
-          UspStatusDot(isActive: ap.enable),
-          AppGap.sm(),
-          Expanded(child: AppText.bodyMedium(ap.ssidName)),
-          SizedBox(
-            width: context.colWidth(2),
-            child: AppText.bodySmall(
-              wifiDisplayValue(context, ap.securityMode),
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-          ),
-          SizedBox(
-            width: context.colWidth(1),
-            child: AppText.bodySmall(
-              wifiDisplayValue(context, ap.encryptionMode),
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-          ),
-        ],
+      // The two trailing value columns were sized with `context.colWidth(2)` /
+      // `colWidth(1)` — screen-derived, so inside this 260.5px card at 601px
+      // they claimed 122.25 + 53.13 = 175px (67% of the card) and starved the
+      // SSID Expanded to ~61px. Size them from the width THIS ROW is given
+      // instead (#1251), keeping the SSID the dominant column. Fractions hold
+      // the old ~2:1 security:encryption split; the ceilings keep a wide row
+      // from opening an absurd gutter, matching the row-derived rule from #1231.
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final securityWidth =
+              (constraints.maxWidth * 0.28).clamp(0.0, kUspLabelMaxWidth);
+          final encryptionWidth =
+              (constraints.maxWidth * 0.14).clamp(0.0, kUspLabelMaxWidth / 2);
+          return Row(
+            children: [
+              UspStatusDot(isActive: ap.enable),
+              AppGap.sm(),
+              Expanded(child: AppText.bodyMedium(ap.ssidName)),
+              SizedBox(
+                width: securityWidth,
+                child: AppText.bodySmall(
+                  wifiDisplayValue(context, ap.securityMode),
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+              SizedBox(
+                width: encryptionWidth,
+                child: AppText.bodySmall(
+                  wifiDisplayValue(context, ap.encryptionMode),
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/test/page/wifi_settings/cards/usp_wifi_status_card_legibility_test.dart
+++ b/test/page/wifi_settings/cards/usp_wifi_status_card_legibility_test.dart
@@ -1,0 +1,192 @@
+@Tags(['dashboard-card'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/_shared/models/wifi_radio_ui_model.dart';
+import 'package:privacy_gui/page/wifi_settings/cards/usp_wifi_status_card.dart';
+import 'package:privacy_gui/page/wifi_settings/providers/wifi_data_provider.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import '../../../util/app_test_fonts.dart';
+
+/// Row-legibility regression for [UspWifiStatusCard] (#1251, T13b).
+///
+/// The Channel row and the AP row used `context.colWidth(2)` / `colWidth(1)` to
+/// size fixed columns. That helper is screen-derived: inside the dashboard card
+/// the grid shrinks to 260.5px (span-4 @ 601px, density design §1.6) while
+/// `colWidth` keeps answering a page-scale question, so the fixed columns
+/// over-claimed and the value/SSID was clipped by the card surface's
+/// `Clip.antiAlias` with no `RenderFlex` overflow raised — invisible to the
+/// #1183 gate (§2.8). These assertions therefore live outside the gate.
+///
+/// Every case pumps on a WIDE surface (so a screen-derived width could NOT
+/// coincidentally pass) and constrains only the card to the narrowest width.
+/// Real fonts are loaded so "fits on one line" is measured against real glyphs.
+void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await loadAppFonts();
+  });
+
+  const wideSurface = Size(1400, 900);
+
+  // Narrowest realization of a span-4 card: 260.5px at a 601px screen
+  // (density design §1.6, line 229). Kept as a named constant so the intent is
+  // legible rather than a magic number.
+  const narrowestCardWidth = 260.5;
+
+  WifiData mockWifiData({
+    required String channelDisplay,
+    required List<WifiAccessPointUIModel> aps,
+  }) {
+    // channelDisplay is derived from channel + autoChannelEnable; pick values
+    // that reproduce the desired string. "149 (Auto)" is a realistic worst
+    // case: a 3-digit 5 GHz channel plus the Auto suffix.
+    final parts = channelDisplay.endsWith(' (Auto)');
+    final channel = int.parse(channelDisplay.replaceAll(' (Auto)', '').trim());
+    return WifiData(
+      codegenContext: WifiCodegenContext.empty,
+      radioModels: [
+        WifiRadioUIModel(
+          instancePath: 'Device.WiFi.Radio.1.',
+          band: '5GHz',
+          enable: true,
+          transmitPower: -1,
+          maxBitRate: 4800,
+          channel: channel,
+          autoChannelEnable: parts,
+          channelBandwidth: '80MHz',
+          supportedStandards: '802.11ax',
+          accessPoints: aps,
+        ),
+      ],
+    );
+  }
+
+  Future<void> pumpCard(WidgetTester tester, WifiData data) async {
+    await tester.binding.setSurfaceSize(wideSurface);
+    tester.view.physicalSize = wideSurface;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() async {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: AppTheme.create(
+            brightness: Brightness.light,
+            seedColor: Colors.blue,
+            designThemeBuilder: (c) =>
+                CustomDesignTheme.fromJson({'style': 'flat'}),
+          ),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.topLeft,
+              // The card fills whatever height its content needs, so give it an
+              // unbounded-height slot and only pin the width to the narrowest
+              // realization.
+              child: SizedBox(
+                width: narrowestCardWidth,
+                height: 700,
+                child: UspWifiStatusCard(wifiData: data),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    // The card's tx-power / bit-rate bars use an AppLoader (linear), which
+    // animates indefinitely, so pumpAndSettle never settles. A couple of fixed
+    // pumps are enough to lay the card out for measurement.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+  }
+
+  RenderParagraph paragraphOf(WidgetTester tester, String text) =>
+      tester.renderObject<RenderParagraph>(find.text(text));
+
+  /// One line == its rendered height is no taller than its unbounded-width
+  /// (by definition one-line) height.
+  bool isSingleLine(WidgetTester tester, String text) {
+    final p = paragraphOf(tester, text);
+    return p.size.height <= p.getMinIntrinsicHeight(double.infinity) + 0.5;
+  }
+
+  double labelColumnWidthFor(WidgetTester tester, String labelText) {
+    // The label column is the SizedBox that directly wraps the label text
+    // inside the card. Scope the search to that ancestor chain so we do not
+    // pick up the test's own width wrapper or an icon button's box.
+    final sizedBox = tester.widget<SizedBox>(
+      find
+          .ancestor(
+            of: find.text(labelText),
+            matching: find.byType(SizedBox),
+          )
+          .first,
+    );
+    return sizedBox.width ?? double.infinity;
+  }
+
+  group('Channel row value stays legible at the narrowest card width', () {
+    testWidgets('a 3-digit Auto channel value renders on one line',
+        (tester) async {
+      await pumpCard(
+        tester,
+        mockWifiData(channelDisplay: '149 (Auto)', aps: const []),
+      );
+      // channelDisplay renders as "149 (Auto)".
+      expect(find.text('149 (Auto)'), findsOneWidget);
+      expect(isSingleLine(tester, '149 (Auto)'), isTrue,
+          reason: 'the Channel value must not be clipped/wrapped by an '
+              'over-claiming screen-derived label column');
+    });
+
+    testWidgets('the Channel label column tracks the card, not the screen',
+        (tester) async {
+      // On a 1400px surface, a screen-derived colWidth(2) would be ~330px —
+      // far wider than the 260.5px card. A row-derived column must be a
+      // fraction of the ~228px the row gets, i.e. well under 150px.
+      await pumpCard(
+        tester,
+        mockWifiData(channelDisplay: '6', aps: const []),
+      );
+      final labelColWidth = labelColumnWidthFor(tester, 'Channel');
+      expect(labelColWidth, lessThan(150.0),
+          reason: 'a screen-derived column on a 1400px surface would blow past '
+              'this; a row-derived one stays a fraction of the 260.5px card');
+    });
+  });
+
+  group('AP row keeps the SSID legible at the narrowest card width', () {
+    testWidgets('the SSID renders on one line, not starved by fixed columns',
+        (tester) async {
+      await pumpCard(
+        tester,
+        mockWifiData(
+          channelDisplay: '6',
+          aps: const [
+            WifiAccessPointUIModel(
+              enable: true,
+              ssidName: 'Linksys-Home',
+              securityMode: 'WPA2-Personal',
+              encryptionMode: 'AES',
+            ),
+          ],
+        ),
+      );
+      expect(find.text('Linksys-Home'), findsOneWidget);
+      expect(isSingleLine(tester, 'Linksys-Home'), isTrue,
+          reason: 'the SSID Expanded must keep the dominant share of the row; '
+              'screen-derived colWidth columns starved it to ~61px');
+    });
+  });
+}


### PR DESCRIPTION
## What & why

`[T13b]` Two hand-rolled label/value columns in the `wifi_status` dashboard card
were still sized with the screen-derived `context.colWidth()` helper, so inside
the card (which the grid shrinks to **260.5px** at a 601px screen — span-4, density
design §1.6) the fixed columns over-claimed and the value/SSID was silently
clipped by the card surface's `Clip.antiAlias` with **no `RenderFlex` overflow
raised** — invisible to the #1183 gate (§2.8). This is the second application of
the `doc/dashboard/dashboard_density_design.md` §2.2 rule that #1231 applied to
the shared `UspInfoRow`.

Base is **`gate/1183-overflow-gate`** per the ticket (this epic is consolidated
there while #1248 is the only PR targeting `dev-2.7.0`).

## Measured before the fix (AC1, recorded on the issue)

| site | label/fixed col claims | space left for value/SSID | value needs (1 line) | fits? |
|---|---:|---:|---:|---:|
| Channel row (`:86` `colWidth(2)`) | 122.25px | 98.25px | 115.56px | **NO** |
| AP row (`:175`+`:182`) | 175.4px (2 cols) | ~61px for SSID `Expanded` | — | starved |

`currentMaxColumns` at 601px is 8, so `colWidth(2)` = 122.25px answers a
2/8-of-601px page-scale question unrelated to the 260.5px card.

## The fix

- **Channel row** — row-derived label column via `LayoutBuilder`; keeps its
  trailing edit `AppIconButton`, so it stays a hand-rolled row (not `UspInfoRow`,
  which is label+value only — the component was **not** bent to fit, per
  instruction #2) but reuses that rule's constants.
- **AP row** — the two trailing value columns become row-derived fractions with
  ceilings (holding the old ~2:1 security:encryption split), so the SSID
  `Expanded` keeps the dominant share instead of ~61px.
- `UspInfoRow`'s private `_kLabelShare` / `_kLabelMaxWidth` are promoted to public
  `kUspLabelShare` / `kUspLabelMaxWidth`: a second unrelated module now converges
  on the same row-derived label arithmetic — the Article V §5.3 trigger.

## The three DHCP sites (AC4)

Already converted off `colWidth` by **#1140** on this base branch (annotated
inline: `usp_dhcp_reservations_detail_card.dart:85`,
`usp_dhcp_active_leases_card.dart:110-113`). No change needed; documented on the
issue. `grep -rn colWidth lib/page/dhcp/` shows only the two explanatory comments.

## Verification

- New `usp_wifi_status_card_legibility_test.dart` (tagged `dashboard-card`):
  Channel value + AP SSID single-line at 260.5px; label column tracks the card,
  not the screen — **3/3 green**.
- `usp_info_row_test.dart` (constant rename) — **10/10 green**.
- **dashboard-card overflow gate: 1644 tests, all green**;
  `test/fixtures/known_overflows.json` **unchanged** and the gate count is
  unchanged (this fix moves no coordinate — §2.8: silent clip, not overflow).
- `dart format --set-exit-if-changed .` clean; `flutter analyze` clean.

## Changed files

```
 lib/page/_shared/components/usp_info_row.dart          |  19 ++--
 lib/page/wifi_settings/cards/usp_wifi_status_card.dart | 103 ++++++++++++------
 test/page/wifi_settings/cards/usp_wifi_status_card_legibility_test.dart | +new
```

Refs `#1251` · Parent `#1183`
