### PR TITLE
fix(dashboard): wrap the wifi_performance legend rows, and localize the channel readout the Channels tab was hiding behind (#1229, #1266)

### DIFF
--- a/doc/dashboard/dashboard_density_design.md
+++ b/doc/dashboard/dashboard_density_design.md
@@ -129,6 +129,55 @@ added to it.**
 
 **Axis split**: 464 right-only, 63 bottom-only, 33 both.
 
+#### Track A's four remaining card-own tickets reduce to four shapes across six sites (#1234–#1237, measured before implementation)
+
+**Method.** §1.1's `fullLog` attribution, re-run at per-line resolution over the
+four cards of #1234 / #1236 / #1237 (`system_status`, `lan_info`, `device_info`,
+`time_settings`). 112 incidents → the 84 allowlisted coordinates those three
+tickets own; adding #1235's 3 makes 87.
+
+| Shape | Sites | Worst | Tickets |
+|---|---|---:|---|
+| "View details" footer — `AppDivider` + `Row(mainAxisAlignment: end)` + `Semantics`/`InkWell` | `usp_system_status_card.dart:118`, `usp_device_info_card.dart:140` | +5.2px | **#1234 + #1236** |
+| Hero inner row — `Row` inside `Expanded(Column(start, [titleLarge, AppGap.xxs, Row]))` | `usp_lan_info_card.dart:56`, `usp_time_settings_card.dart:108` | +102 / +67px | **#1236 + #1237** |
+| Twin gauges — `Expanded(Row(spaceEvenly, [AppGauge(size: 100) ×2]))` | `usp_system_status_card.dart:196` | +43px | #1234 |
+| Legend row — `_LegendDot` ×2 + `Spacer` + refresh chrome | `usp_system_status_card.dart:218` | +107px | #1234 |
+
+**Two of the four shapes straddle ticket boundaries.** The footer is
+near-identical code in two files (`_buildStatisticsFooter` / `_buildNodeDetailFooter`),
+and the hero inner row is the same idiom in two more — and that idiom alone is
+**48 of the 84 coordinates**. Split across separate branches, each shape gets its
+fix invented twice and #1245's de-duplication inventory grows by two more entries.
+This is the #1249 situation again (§2.10a), so the four are best done as one
+branch with a commit per shape.
+
+**`system_status`'s 26 widest coordinates have two causes each, so neither site
+clears them alone.** The exact decomposition of #1234's 34:
+
+- `min|0` tab 0, all 26 locales — caused by **both** `:196` and `:218`; `el`/`ru`
+  additionally by `:118`
+- `min|0` tabs 1–3, `el`+`ru` — 6, `:118`
+- `preferred|0`, `fr`+`fr_CA` — 2, `:218`
+
+So `:196` alone clears 0 and `:218` alone clears 0; the pair clears 26; adding
+`:118` clears all 34. Expect zero allowlist movement until both gauge-row and
+legend-row fixes are in — the same trap §2.6a's shared-plus-card-own coordinates
+set, one file down.
+
+**`AppGauge`'s centre is fixable at the call site — no ui_kit change, so no
+Article XIV question.** `AppGauge` renders
+`SizedBox(width: size, height: size, child: Stack(alignment: center, children: [CustomPaint, …, centerBuilder(…)]))`.
+The centre is a *non-positioned* `Stack` child, so it receives loose `size × size`
+constraints and the overflowing `Column(mainAxisSize: min, …)` is the app's own
+closure. This holds for both #1235's `network_health` gauge (`size: 120`) and
+`system_status._buildGauge` (`size: 100`), which is why #1235's 3 coordinates are
+a cheap add-on to #1234 rather than a separate ui_kit conversation.
+
+> Sequencing note: these four tickets, #1229 and #1266 all edit
+> `test/fixtures/known_overflows.json` and this file. Until #1229/#1266's PR
+> merges, branch the four-ticket work from *its* head rather than from the epic
+> gate branch, or the fixture conflicts.
+
 ### 1.2 Fit width — the narrowest width at which each card is clean
 
 **Method.** Card width was driven directly through a 14-rung ladder

--- a/doc/dashboard/dashboard_density_design.md
+++ b/doc/dashboard/dashboard_density_design.md
@@ -1,6 +1,6 @@
 # Dashboard Card Density — Design Decisions
 
-**Last Updated: 2026-08-12** · Follow-up to #1183 · Status: **agreed; tickets #1225–#1240 published; #1225 + #1226 + #1233 implemented (not yet merged), rest not started**
+**Last Updated: 2026-08-13** · Follow-up to #1183 · Status: **agreed; tickets #1225–#1240 published; #1225 + #1226 + #1233 + #1227 + #1228 + #1229 implemented (not yet merged), rest not started. Allowlist 560 → 181.**
 
 ## Purpose
 
@@ -102,15 +102,27 @@ batching leverage actually is.
 > `:118` (8) + `:218` where those are the coordinate's only remaining cause. So
 > the pattern is really eight rows, and #1234 finishes it.
 
-The private colour-dot widget is additionally duplicated **verbatim in four
-files** (the three above plus `device_analytics`). De-duplicating it, or
-extracting a shared legend entry, would be a **new shared widget** and therefore
-needs approval under Article XIV — so the fix is applied in place, and the
-extraction raised separately rather than blocking on that conversation. That
-raise is **#1245**, filed after #1233; it carries the constraint #1233 measured,
-namely that any shared entry must express the ellipsize-vs-soft-wrap distinction
-per label kind (§2.10a point 2) and must not absorb the WAN/LAN row, which
-deviates for a reason (§2.10a point 3).
+> Re-measured again during #1229: `wifi_performance`'s two sites (`:190` Signal,
+> `:275` Speed) are this same shape, and they are that card's **entire** 45
+> coordinates. So the pattern is **ten rows across four files, 181 + 45 = 226
+> coordinates — 40% of the whole baseline** (not to be confused with the
+> allowlist standing at 226 just before #1229; the two numbers coincide by
+> accident), and it is the only structure in this epic that
+> accounts for a plurality of it. §1.1's greedy table hides `:275` as well as the
+> other nine: it credits `:190` with 33 and never names the Speed tab at all
+> (see §2.10b for why a "×2 sites" ticket still needs its own attribution run).
+
+The private colour-dot widget is additionally duplicated **verbatim in five
+files** (the three above plus `device_analytics` and, per #1229,
+`wifi_performance`). De-duplicating it, or extracting a shared legend entry,
+would be a **new shared widget** and therefore needs approval under Article XIV —
+so the fix is applied in place, and the extraction raised separately rather than
+blocking on that conversation. That raise is **#1245**, filed after #1233; it
+carries the constraint #1233 measured, namely that any shared entry must express
+the ellipsize-vs-soft-wrap distinction per label kind (§2.10a point 2) and must
+not absorb the WAN/LAN row, which deviates for a reason (§2.10a point 3).
+**#1245's inventory is written against four files and needs `wifi_performance`
+added to it.**
 
 **Blocked on a dependency we do not own — 45 coordinates (8%)**: fl_chart 19
 (`firewall_overview`), ui_kit `AppListTile` 26 (`connected_devices`).
@@ -634,6 +646,75 @@ from a row that truncated its content to nothing. They are covered by
 tagged `dashboard-card` so it gates; each of its three groups was verified to
 fail under a mutation of the code it guards.
 
+### 2.10b What the eighth and ninth replications taught us (#1229 — implemented)
+
+All 45 coordinates cleared as predicted (226 → 181). By this point the shape is
+routine — the interesting findings are about *method*, not about legends.
+
+1. **A "×N sites" scope still needs its own attribution run.** §1.1's greedy
+   cover is greedy: it credits each coordinate to one site, so it named
+   `:190` (33) and never mentioned the Speed tab's legend at all. The remaining
+   12 were only located by re-running §1.1's method scoped to this card, which
+   returned an unambiguous split — `:190` → 33, `:275` → 12, no coordinate
+   needing both, total exactly 45. Inferring the second site from the ticket
+   title would have been a guess with a 12-coordinate blast radius.
+2. **Same shape, same fix, different cause — and the locale footprint says
+   which.** `:190` (four entries, 261px) overflows in `en` too: it is
+   *geometry*-bound, and `ru` missed by 149px. `:275` (two entries) overflows
+   only in the long-translation locales (`es`, `fr`, `pt_PT`, `ru`, `tr`): it is
+   *translation-length*-bound. The distinction is free to read off the allowlist
+   — an `["*"]` entry means the card is too narrow for the content in any
+   language, a locale list means the layout is fine and one translation is long
+   — and it predicts which sites will regress when a string changes versus when
+   spacing changes.
+3. **§2.10a point 3's precondition was checked here, not assumed.** The
+   `Expanded` above both rows holds a `ListView`/`AppBarChart`, so it yields the
+   height a second run costs. Confirmed by re-running attribution after the fix:
+   **0 incidents at any site, any tab, any locale** — no bottom-overflow was
+   traded in, which is the exact failure Network Health's fixed 120px gauge
+   produced. Measured, because the shape's cost is paid in a currency the gate
+   only sometimes charges for.
+4. **The mutation that validates a readability test must itself be run against
+   the gate.** #1233 and #1228 recorded "verified to fail under a mutation"; that
+   is necessary but not sufficient. Here the *obvious* mutation — revert `Wrap` to
+   a bare `Row` — turns out to be **invisible to the readability test and caught
+   by the gate** (33 failures): a `Row` hands non-flex children unbounded width,
+   so the inner `Flexible` never binds, every label paints full-width, and the
+   *outer* row overflows. The genuinely gate-invisible regression is the one that
+   *succeeds* at fitting: keep the single `Row` and wrap each entry in
+   `Flexible`. Every tier name then ellipsizes to a stub — in `en`, not just the
+   long translations — and all **157** `wifi_performance` gate cases stay green.
+   That is the shape a well-meaning "just make it fit" edit lands on. **Rule for
+   the remaining Track A tickets: run each candidate mutation against the gate as
+   well: if the gate already fails it, the mutation proves nothing about the
+   readability test and a different one is needed.**
+
+The gate-invisible ACs are covered by
+`test/page/dashboard/views/components/wifi_performance_readability_test.dart`,
+tagged `dashboard-card` so it gates; its three groups were verified to fail under
+the mutations tabulated in the file, each with its gate result beside it.
+
+**AC4 was already true before this ticket, and is now pinned rather than earned.**
+"Per-band metrics stay distinguishable at the narrowest clean width" is about the
+Channels tab, which contributed none of the 45 and which #1229 does not modify. At
+the 261px narrowest realization both bands show band, channel, bandwidth, client
+count and SNR with nothing clipped. It is asserted anyway, because "already clean"
+is not "checked" and nothing else in the suite would notice a later fix collapsing
+those rows.
+
+Two observations left deliberately unfixed:
+
+- `_ChannelsTab`'s two per-radio rows use the same unconstrained shape this epic
+  keeps fixing (`Row` + `Spacer`, non-flex `AppText`), and measure clean only by
+  about **48px** of headroom. That is the #1258 situation exactly — hardening a
+  site that is not currently failing — so it belongs there, not in a ratchet
+  ticket whose contract is a coordinate count.
+- The channel readout is **data**-dependent, not translation-dependent:
+  `Ch 197 (Auto) · 320MHz` on a tri-band router is materially wider than the
+  mock's two-radio output. No amount of locale sweeping reaches it, so that
+  headroom is unmeasured rather than measured-safe — a limit of the gate's fixed
+  mock, worth stating where the 48px figure is quoted.
+
 ### 2.11 fl_chart's 19 coordinates get a primary plan and a documented fallback
 
 `firewall_overview`'s 19 coordinates originate inside fl_chart
@@ -752,7 +833,7 @@ addition — it changes no card's rendering until a threshold is declared.
 | #1233 | The other six legend rows (§1.1, §2.10a) — **implemented** | 132 |
 | #1227 | Shared blocks made overflow-safe (§2.6, §2.6a) — **implemented** | 101 |
 | #1228 | `ethernet_ports` ×2 sites (§2.12) — **implemented** | 52 |
-| #1229 | `wifi_performance` ×2 sites | 45 |
+| #1229 | `wifi_performance` ×2 sites (§2.10b) — **implemented** | 45 |
 | #1230 | `firewall_overview` own sites (§2.11) | 48 |
 | #1234 | `system_status` remaining ×3 sites | 34 |
 | #1236 | `lan_info` + `device_info` card-own | 29 |

--- a/doc/dashboard/dashboard_density_design.md
+++ b/doc/dashboard/dashboard_density_design.md
@@ -807,10 +807,24 @@ that height the donut is visually useless whether or not it reports an overflow,
 "shrink the donut to fit" would silence the gate without fixing anything. Deciding
 what the tab drops at that density (the donut, or the whole tab becoming
 scrollable like the Signal tab's `ListView`) is a density decision, and it is not
-verifiable at all until the gate can express a second data profile. **Filed
-against the #1235 shape rather than fixed here; recorded because the fix does trade
-a right-overflow for a bottom-overflow on that unshipped profile, which is exactly
-the trade §2.10a point 3 warns about.**
+verifiable at all until the gate can express a second data profile.
+
+**Filed as #1267**, which pairs the density decision with the gate change that
+makes it measurable: an `overrides` parameter on `buildDashboardCardApp()` /
+`kitchenSinkOverrides()` plus a tri-band fixture. It is deliberately *not* folded
+into #1235 — same family (fixed-size gauge in an `Expanded` that cannot pay), but
+different axis (vertical vs horizontal), different trigger (data vs translation
+length) and different visibility (invisible until #1267's Part 1 lands vs 3 live
+coordinates), and #1235's acceptance criteria are executable ratchet claims that an
+unverifiable AC would make unclosable. Recorded here because the #1266 fix does
+trade a right-overflow for a bottom-overflow on that unshipped profile, which is
+exactly the trade §2.10a point 3 warns about.
+
+Note also what #1267's Part 1 costs: adding a second profile to the sweep across
+all 18 cards doubles 1644 cases and will surface coordinates nobody has looked at
+— an allowlist *addition*, against the ratchet's direction. Which is why the sweep
+shape (opt-in per card / second allowlist keyed by profile / one allowlist) is an
+explicit decision in that ticket rather than an implementation detail.
 
 ### 2.11 fl_chart's 19 coordinates get a primary plan and a documented fallback
 

--- a/doc/dashboard/dashboard_density_design.md
+++ b/doc/dashboard/dashboard_density_design.md
@@ -702,7 +702,9 @@ count and SNR with nothing clipped. It is asserted anyway, because "already clea
 is not "checked" and nothing else in the suite would notice a later fix collapsing
 those rows.
 
-Two observations left deliberately unfixed:
+Two observations were left deliberately unfixed here, and **both were wrong** —
+#1266 (§2.10c) measured them and inverted the conclusion. They are quoted rather
+than deleted because the way they were wrong is the finding:
 
 - `_ChannelsTab`'s two per-radio rows use the same unconstrained shape this epic
   keeps fixing (`Row` + `Spacer`, non-flex `AppText`), and measure clean only by
@@ -714,6 +716,101 @@ Two observations left deliberately unfixed:
   mock's two-radio output. No amount of locale sweeping reaches it, so that
   headroom is unmeasured rather than measured-safe — a limit of the gate's fixed
   mock, worth stating where the 48px figure is quoted.
+
+The 48px was real and the reasoning from it was not: it was measured with `'Ch '`,
+a hardcoded English abbreviation, in the row. The abbreviation *was* the bug, and
+it was concealing the geometry problem rather than the row not having one. "Clean
+by 48px" and "hardening a site that is not currently failing" both describe a
+string that was never going to ship.
+
+### 2.10c An English abbreviation was hiding a geometry problem (#1266 — implemented)
+
+#1229 left the Channels tab alone on the strength of the two bullets above.
+Localizing `'Ch '` to the existing `channel` ARB key — which was already
+translated in all 26 locales, so this was a one-line change with no ARB work —
+turns the tab's band/channel row into **3 gate coordinates on the fixture the gate
+actually ships**:
+
+| locale | `channel` | 261px (min) | 288px (preferred) |
+|--------|-----------|-------------|-------------------|
+| `tr`   | `Channel (Kanal)` (15 chars) | +4.1px, +41.0px | +14.0px |
+| `th`   | `ช่องสัญญาณ`   | +17.0px         | clean   |
+| other 24 | — | clean | clean |
+
+So the two halves cannot be separated, and the *ordering* is the point:
+
+- **Localizing alone runs the ratchet backwards.** It adds 3 coordinates to a
+  mechanism whose entire purpose (§2.9) is that the count only falls. It would
+  have to be booked as an allowlist *addition*, which nothing in Part 4 permits.
+- **Hardening alone is gate-invisible.** With `'Ch '` in place the row is clean
+  everywhere, so the `Wrap` changes no coordinate and the gate cannot tell whether
+  it worked. That is the #1258 shape, and it is why #1229's bullet reached for
+  #1258.
+- **Together they are self-verifying**: the localization supplies the failure the
+  hardening has to clear, on the shipped fixture, at both widths. Net coordinate
+  change **0**, and the honest string ships. This is the #1249 bundling precedent
+  (ratchet work travels together), not the #1258 one.
+
+Four further findings, all about method:
+
+1. **An abbreviation in `lib/` is a measurement hazard, not just an i18n bug.**
+   Any hardcoded English string makes every width measurement at that site
+   optimistic by however much the translation is longer, and the gate reports the
+   optimistic number in all 26 locales — a locale sweep cannot find a string that
+   never varies. Worth a grep pass over the remaining Track A sites: an
+   abbreviation is the one defect this epic's instrument is structurally blind to.
+2. **Two `testWifiData` fixtures exist and only one reaches the gate.** The
+   dashboard gate reads `test/golden_test/page/dashboard/cards/fixtures/`
+   `cards_test_data.dart` (via `kitchenSinkOverrides()`); the Statistics page reads
+   `test/golden_test/page/statistics/fixtures/statistics_test_data.dart`. Editing
+   the latter and re-running the gate produces a confident, meaningless "clean".
+   Caught only by dumping the rendered `Text` list and noticing the added radio was
+   absent. **Rule: when a measurement depends on fixture data, verify the render
+   contains the data, not just that the verdict is green.**
+3. **`WrapAlignment.spaceBetween` is a silent no-op under loose width
+   constraints.** `RenderWrap` sizes itself to its widest run, so
+   `freeMainAxisSpace` is 0 and there is nothing to distribute; the second child
+   lands one `spacing` gap after the first instead of at the right edge. The
+   enclosing `Column` must hand it a tight width
+   (`CrossAxisAlignment.stretch`) for `spaceBetween` to reproduce what a `Spacer`
+   did. This is a **pure visual regression that overflows nothing**, so the gate
+   passes all 157 cases either way — it is pinned in the readability test instead.
+   **This applies retroactively: #1226's and #1233's `spaceBetween` legends should
+   be checked for the same precondition, since a shrink-wrapped legend is
+   indistinguishable from a correct one in a green gate.**
+4. **Attribution scoped the fix to one of the two rows.** Regexing
+   `usp_wifi_performance_card.dart:(\d+)` over `OverflowIncident.fullLog`
+   attributed every single incident — both fixtures, all locales, both widths — to
+   the band/channel row, and none to the clients/SNR/loader row below it (whose
+   `Expanded` loader already binds). §1.1's method at per-line resolution, and it
+   halved the change: #1229's bullet had assumed "two per-radio rows" needed the
+   same treatment.
+
+**Tri-band data: what the fix costs on a profile the gate cannot produce.** The
+gate's data domain is one hardcoded profile — `testRadios` is 2 radios, 2-digit
+channels, `160MHz` widest — and `buildDashboardCardApp()` takes no overrides, so no
+card can be measured against different data without editing the fixture. Measured
+by temporarily adding a third tri-band radio (`Channel 233 (Auto) · 320MHz`) and
+reverting:
+
+| | before #1266 (`'Ch '`) | localized, old `Row` | localized + `Wrap` (shipped) |
+|---|---|---|---|
+| 2 radios (the gate's fixture) | clean | 3 coordinates | **clean, 26 locales × both widths** |
+| 3 radios, tri-band | clean | `en` +8.3px, plus `fi`, `ja` and the two above | one **+9.0px bottom** (`tr` @261 only) |
+
+The remaining tri-band incident is not the band/channel row: it is the donut's
+centre label at `:575`, squeezed once three two-run blocks have taken enough of the
+column that its `Expanded` no longer fits the label's two lines. That is §2.10a
+point 3's failure mode — the same
+fixed-size-gauge-in-an-`Expanded` shape as #1235's `network_health` gauge — and at
+that height the donut is visually useless whether or not it reports an overflow, so
+"shrink the donut to fit" would silence the gate without fixing anything. Deciding
+what the tab drops at that density (the donut, or the whole tab becoming
+scrollable like the Signal tab's `ListView`) is a density decision, and it is not
+verifiable at all until the gate can express a second data profile. **Filed
+against the #1235 shape rather than fixed here; recorded because the fix does trade
+a right-overflow for a bottom-overflow on that unshipped profile, which is exactly
+the trade §2.10a point 3 warns about.**
 
 ### 2.11 fl_chart's 19 coordinates get a primary plan and a documented fallback
 
@@ -834,6 +931,7 @@ addition — it changes no card's rendering until a threshold is declared.
 | #1227 | Shared blocks made overflow-safe (§2.6, §2.6a) — **implemented** | 101 |
 | #1228 | `ethernet_ports` ×2 sites (§2.12) — **implemented** | 52 |
 | #1229 | `wifi_performance` ×2 sites (§2.10b) — **implemented** | 45 |
+| #1266 | `wifi_performance` Channels tab: localize `'Ch '` + harden (§2.10c) — **implemented** | 0 (net) |
 | #1230 | `firewall_overview` own sites (§2.11) | 48 |
 | #1234 | `system_status` remaining ×3 sites | 34 |
 | #1236 | `lan_info` + `device_info` card-own | 29 |
@@ -842,6 +940,11 @@ addition — it changes no card's rendering until a threshold is declared.
 | #1238 | `connected_devices` card-own (§2.6) | 1 |
 
 Ceiling **515 / 560**. The other 45 are the dependency-blocked ones (§1.1).
+
+#1266 is in this track despite clearing nothing: it is the only entry that *adds*
+coordinates (3, by localizing a hardcoded string) and removes them again in the
+same change. It belongs here rather than in Track B because the ratchet is what
+constrains it — see §2.10c for why the two halves cannot ship separately.
 
 #1225 lands first — not because it re-baselines (it does not, §1.6) but so that
 the invariant holds by construction and any future shift is attributable. #1226

--- a/lib/page/wifi_settings/cards/usp_wifi_performance_card.dart
+++ b/lib/page/wifi_settings/cards/usp_wifi_performance_card.dart
@@ -447,14 +447,53 @@ class _ChannelsTab extends StatelessWidget {
 
             return LayoutBlock(
               child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+                // `stretch`, not `start`, and it is load-bearing for the `Wrap`
+                // below: a `Wrap` under loose width constraints shrink-wraps to
+                // its widest run, which leaves `spaceBetween` zero free space to
+                // distribute — the alignment silently becomes a no-op and the
+                // channel string sits one `spacing` gap after the band instead of
+                // at the block's right edge. `stretch` hands both rows a tight
+                // width, so `spaceBetween` reproduces what the old `Spacer` did.
+                // (The second row is unaffected: its `Expanded` loader already
+                // forced full width.)
+                crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  Row(
+                  // Band + channel. The #1226 shape, and `spaceBetween` is what
+                  // makes it a drop-in: with both children on one run a `Wrap`
+                  // spaces them to the edges exactly as the old `Spacer` did, so
+                  // nothing moves at the widths where the row already fit.
+                  //
+                  // Neither side yields, because neither is chrome: `band` is the
+                  // block's identity and the channel string is composed data
+                  // (§2.10a point 2 — an ellipsis landing inside `320MHz`
+                  // misinforms in a way a wrapped line does not). So both keep
+                  // their intrinsic width and the row spends a second run.
+                  //
+                  // Why this changed now, when the row shipped clean for months:
+                  // `'Ch '` was a hardcoded English abbreviation, and it was
+                  // hiding a geometry problem rather than not having one. With
+                  // the real `channel` key the old `Row` overflowed at the 261px
+                  // card in `th` (+17.0px) and `tr` (+4.1/+41.0px, and +14.0px
+                  // even at the *preferred* 288px width), on the two-radio
+                  // fixture the gate ships. Given a third tri-band radio —
+                  // `Ch 233 (Auto) · 320MHz`, which the gate's fixture cannot
+                  // produce — `en` (+8.3px), `fi` and `ja` break too. Measured
+                  // per #1266; every incident attributed to this one row.
+                  //
+                  // The extra run is paid out of the donut's `Expanded` below,
+                  // which yields it (contrast §2.10a point 3, where Network
+                  // Health's fixed 120px gauge could not) — verified by
+                  // re-measuring for bottom overflows, not assumed.
+                  Wrap(
+                    alignment: WrapAlignment.spaceBetween,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    spacing: AppSpacing.lg,
+                    runSpacing: AppSpacing.xxs,
                     children: [
                       AppText.labelLarge(radio.band),
-                      const Spacer(),
                       AppText.bodySmall(
-                        'Ch ${radio.channelDisplay}  \u00b7  ${radio.channelBandwidth}',
+                        '${loc(context).channel} ${radio.channelDisplay}'
+                        '  \u00b7  ${radio.channelBandwidth}',
                         color: colorScheme.onSurfaceVariant,
                       ),
                     ],

--- a/lib/page/wifi_settings/cards/usp_wifi_performance_card.dart
+++ b/lib/page/wifi_settings/cards/usp_wifi_performance_card.dart
@@ -187,27 +187,42 @@ class _SignalTab extends StatelessWidget {
           ),
         ),
         AppGap.sm(),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
+        // Legend. Degradation shape per #1226 (the full reasoning lives in
+        // usp_traffic_analysis_card.dart), adapted as #1233 adapted it: there
+        // are no totals to keep at full size, so every child is a legend entry
+        // and the `Wrap` is centred rather than `spaceBetween`.
+        //
+        // Four entries at this card's narrowest realization (261px) is the
+        // widest legend in the epic — `ru` overflowed the old `Row` by 149px —
+        // so entries wrap to a second run here routinely rather than
+        // exceptionally. The `Expanded` above holds a `ListView`, which yields
+        // that height freely (contrast §2.10a point 3, where a fixed 120px
+        // gauge could not).
+        //
+        // Two spacing deltas, both deliberate. The old `Row` emitted a trailing
+        // `AppGap.md()` after the *last* entry, so `MainAxisAlignment.center`
+        // was centring 12px of empty space along with the content; `Wrap`'s
+        // `spacing` has no trailing run, so the legend shifts slightly right.
+        // And the gap between entries goes 12px → 16px, because `AppSpacing.lg`
+        // is what all six #1233 legends and #1226's use — conforming to the
+        // shared shape matters more here than preserving this one row's 12px,
+        // and the measurement says 16px is affordable even at 261px.
+        Wrap(
+          alignment: WrapAlignment.center,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          spacing: AppSpacing.lg,
+          runSpacing: AppSpacing.xs,
           children: [
             for (final tier in [
               SignalTier.excellent,
               SignalTier.good,
               SignalTier.fair,
               SignalTier.weak,
-            ]) ...[
-              Container(
-                width: 8,
-                height: 8,
-                decoration: BoxDecoration(
-                  color: tier.resolveColor(colorScheme),
-                  shape: BoxShape.circle,
-                ),
+            ])
+              _LegendEntry(
+                color: tier.resolveColor(colorScheme),
+                label: tier.resolveLabel(context),
               ),
-              AppGap.xs(),
-              AppText.labelSmall(tier.resolveLabel(context)),
-              AppGap.md(),
-            ],
           ],
         ),
       ],
@@ -272,31 +287,89 @@ class _SpeedTab extends StatelessWidget {
           ),
         ),
         AppGap.sm(),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
+        // Legend — the Signal tab's shape with two entries instead of four.
+        // Only the long-translation locales overflowed the old `Row` here
+        // (`es`, `fr`, `pt_PT`, `ru`, `tr`), which is what two entries versus
+        // four looks like: this one is translation-length bound where the
+        // Signal tab's is geometry bound (it overflowed in `en` too).
+        Wrap(
+          alignment: WrapAlignment.center,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          spacing: AppSpacing.lg,
+          runSpacing: AppSpacing.xs,
           children: [
-            Container(
-              width: 8,
-              height: 8,
-              decoration: BoxDecoration(
-                color: colorScheme.primary,
-                shape: BoxShape.circle,
-              ),
+            _LegendEntry(
+              color: colorScheme.primary,
+              label: loc(context).downlink,
             ),
-            AppGap.xs(),
-            AppText.labelSmall(loc(context).downlink),
-            AppGap.lg(),
-            Container(
-              width: 8,
-              height: 8,
-              decoration: BoxDecoration(
-                color: colorScheme.secondary,
-                shape: BoxShape.circle,
-              ),
+            _LegendEntry(
+              color: colorScheme.secondary,
+              label: loc(context).uplink,
             ),
-            AppGap.xs(),
-            AppText.labelSmall(loc(context).uplink),
           ],
+        ),
+      ],
+    );
+  }
+}
+
+// =============================================================================
+// Legend primitives (shared by the Signal and Speed tabs)
+// =============================================================================
+
+class _LegendDot extends StatelessWidget {
+  final Color color;
+  const _LegendDot({required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 8,
+      height: 8,
+      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+    );
+  }
+}
+
+/// One legend entry: colour dot, gap, label — the unit that must never split, so
+/// a label never separates from the colour it explains (#1226 rule 2).
+///
+/// File-private on purpose, and this is now the **fifth** copy of the shape
+/// (`usp_network_health_card`, `usp_system_status_card` as `_StatLegendEntry`,
+/// `usp_traffic_analysis_card`, `device_analytics`). Extracting one shared
+/// widget from them needs Article XIV approval, which #1245 is raised to have;
+/// #1233 deliberately chose not to block on that conversation and #1229 follows
+/// it, so the shape is replicated in place. #1245's inventory needs this file
+/// added to it.
+class _LegendEntry extends StatelessWidget {
+  final Color color;
+  final String label;
+  const _LegendEntry({required this.color, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _LegendDot(color: color),
+        AppGap.xs(),
+        // `Flexible`, because a `Row` hands non-flex children unbounded width: a
+        // bare label takes its full intrinsic width on one line and overflows no
+        // matter how the enclosing `Wrap` arranges the entries (§2.10a point 1).
+        // Loose fit, so a short label still hugs and entries share a run.
+        //
+        // One-line ellipsis, unlike system_status/network_health: every label
+        // here is a bare tier or series name keying an already-colour-coded bar
+        // or chart, so a clipped label still communicates and the colour carries
+        // the identification. Those two cards compose statistics into their
+        // labels and therefore soft-wrap instead — an ellipsis would cut a
+        // number in half (§2.10a point 2).
+        Flexible(
+          child: AppText.labelSmall(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
         ),
       ],
     );

--- a/test/fixtures/known_overflows.json
+++ b/test/fixtures/known_overflows.json
@@ -25,18 +25,6 @@
       "da", "de", "el", "en", "es", "es_AR", "fi", "fr", "fr_CA", "id",
       "it", "nb", "nl", "pl", "pt", "pt_PT", "ru", "sv", "th", "tr",
       "vi"
-    ],
-    "wifi_performance|min|0": [
-      "da", "de", "el", "en", "es", "es_AR", "fi", "fr", "fr_CA", "id",
-      "it", "nl", "pl", "pt", "pt_PT", "ru", "sv", "th", "vi"
-    ],
-    "wifi_performance|min|1": [
-      "es", "es_AR", "fr", "fr_CA", "pt_PT", "ru", "tr"
-    ],
-    "wifi_performance|preferred|0": [
-      "de", "es", "es_AR", "fi", "fr", "id", "it", "nl", "pl", "pt",
-      "pt_PT", "ru", "sv", "th"
-    ],
-    "wifi_performance|preferred|1": ["es", "fr", "fr_CA", "pt_PT", "ru"]
+    ]
   }
 }

--- a/test/page/dashboard/views/components/wifi_performance_readability_test.dart
+++ b/test/page/dashboard/views/components/wifi_performance_readability_test.dart
@@ -1,0 +1,312 @@
+@Tags(['dashboard-card'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/dashboard/models/display_mode.dart';
+import 'package:privacy_gui/page/dashboard/models/usp_widget_specs.dart';
+
+import '../../../../util/app_test_fonts.dart';
+import '../../../../util/dashboard/dashboard_card_probe.dart';
+
+/// WiFi Performance readability (#1229).
+///
+/// ## Why this file exists alongside the #1183 gate
+///
+/// #1229 clears 45 coordinates by letting two legend rows *give* — `Row` becomes
+/// `Wrap`, labels become `Flexible` with a one-line ellipsis. Both halves of that
+/// have a failure mode the gate is blind to, because the gate cannot tell a row
+/// that fits from a row that fits *because it destroyed its content*:
+///
+///   - the `Wrap` could survive by dropping entries, leaving coloured dots on the
+///     bar/chart with nothing naming them;
+///   - the ellipsis could become load-bearing and clip every tier name to a stub,
+///     which is a green gate and an unreadable legend.
+///
+/// The card's fourth acceptance criterion is the other blind spot — "per-band
+/// metrics stay distinguishable at the narrowest clean width — the card's value
+/// is the comparison between bands". That one is about the **Channels** tab,
+/// which #1229 does not modify: those coordinates were already clean. It is
+/// asserted here anyway, because "already clean" is not the same as "checked",
+/// and because nothing else in the suite would notice if a later fix to this file
+/// collapsed the per-band rows.
+///
+/// Tagged `dashboard-card` so it gates PRs: `run_tests.sh` excludes
+/// `golden||loc||ui`, so a `ui`-tagged test here would block nothing.
+///
+/// ## Mutation ledger
+///
+/// Each group was verified to fail under a mutation of the code it guards; a
+/// readability test that passes on the broken layout is worse than none. Each
+/// mutation was also run against the gate, because a mutation the gate already
+/// catches proves nothing about *this* file.
+///
+///   | mutation                                     | this file | the gate |
+///   |----------------------------------------------|-----------|----------|
+///   | drop `SignalTier.fair` from the legend list   | 5 fail    | green    |
+///   | `Row` + `Flexible` entries, no `Wrap`         | 3 fail    | green    |
+///   | drop the per-radio SNR readout               | 2 fail    | green    |
+///   | `Wrap` back to a bare `Row` (pre-#1229)      | green     | 33 fail  |
+///
+/// The last row is the instructive one, and it is why the second differs from
+/// the obvious guess. Reverting to a bare `Row` does **not** clip anything: a
+/// `Row` hands its non-flex children unbounded width, so each entry's inner
+/// `Flexible` never binds, every label paints at full intrinsic width, and the
+/// *outer* `Row` overflows — which is precisely the pre-#1229 failure the gate
+/// already measures (33 coordinates, tab 0). The gate owns that regression.
+///
+/// The regression the gate cannot see is the one that *succeeds* at fitting:
+/// wrap each entry in `Flexible` and keep the single `Row`. Now the entries are
+/// flex children, each takes a quarter of 261px, the inner `Flexible` binds, and
+/// every tier name ellipsizes to a stub — in `en` too, not just the long
+/// translations. All 157 wifi_performance gate cases stay green. That is the
+/// shape a well-meaning "just make it fit" edit lands on, and only this file
+/// fails it.
+void main() {
+  setUpAll(() async {
+    // Real fonts: under the Ahem block font every glyph is one square em, so what
+    // fits — and therefore what ellipsizes — is fiction.
+    await loadAppFonts();
+  });
+
+  const cardId = 'wifi_performance';
+  final spec = UspWidgetSpecs.all.firstWhere((s) => s.id == cardId);
+  final constraints = spec.getConstraints(DisplayMode.normal);
+
+  /// Pumps the card at the narrowest width the grid ever gives its min span —
+  /// the worst case the gate measures, and where degradation is most aggressive.
+  /// One pump, as the gate does.
+  Future<void> pumpNarrowest(
+    WidgetTester tester, {
+    required int tabIndex,
+    required Locale locale,
+  }) async {
+    final narrowest =
+        narrowestRealizationOf(constraints.minColumns, minScreen: 0)!;
+    await probeCardOverflow(
+      tester,
+      cardId: cardId,
+      widthCase: CardWidthCase(
+        screenWidth: narrowest.screenWidth,
+        cardWidth: narrowest.cardWidth,
+        columnSpan: constraints.minColumns,
+        label: 'min',
+      ),
+      cardHeightRows: constraints.minHeightRows,
+      tabIndex: tabIndex,
+      locale: locale,
+    );
+  }
+
+  /// Every `Text` in the tree that actually painted a non-empty string.
+  List<Text> renderedTexts(WidgetTester tester) => tester
+      .widgetList<Text>(find.byType(Text))
+      .where((t) => t.data != null && t.data!.isNotEmpty)
+      .toList();
+
+  /// The one rendered `Text` holding exactly [label], or a failure naming what
+  /// was rendered instead — a *missing* label is the interesting failure here, so
+  /// the message has to be diagnosable.
+  ///
+  /// Exact match rather than `contains`: a clipped `Text` still carries its full
+  /// string (the ellipsis is a paint-time effect), so equality stays correct
+  /// under degradation while `contains` would let one tier name match another's.
+  Text exactly(WidgetTester tester, String label) {
+    final matches =
+        renderedTexts(tester).where((t) => t.data == label).toList();
+    expect(matches, hasLength(1),
+        reason: 'expected exactly one rendered Text "$label". Rendered: '
+            '${renderedTexts(tester).map((t) => t.data).toList()}');
+    return matches.single;
+  }
+
+  /// Whether [text] had to drop content to fit — the question the gate cannot
+  /// answer. `didExceedMaxLines` is the renderer's own verdict, so this does not
+  /// re-derive text metrics the layout already computed.
+  bool isClipped(WidgetTester tester, Text text) => tester
+      .renderObject<RenderParagraph>(find.byWidget(text))
+      .didExceedMaxLines;
+
+  Rect rectOf(WidgetTester tester, Text text) =>
+      tester.getRect(find.byWidget(text));
+
+  group('legend entries survive degradation (#1229)', () {
+    // A legend is a colour→series mapping, and the `Wrap` may reorder it or push
+    // entries onto later runs. What it may not do is lose one: a dropped entry
+    // leaves a coloured bar with nothing naming it.
+    //
+    // Asserted on the labels rather than on the dots because both come from the
+    // same `for` over `SignalTier`, so a dropped entry drops both — the label is
+    // a faithful proxy and the dot is file-private (same choice as #1233).
+    testWidgets('the Signal tab names all four signal tiers', (tester) async {
+      final locale = _localeFor('ru');
+      await pumpNarrowest(tester, tabIndex: 0, locale: locale);
+      final l = await AppLocalizations.delegate.load(locale);
+
+      for (final label in [l.excellent, l.good, l.fair, l.weak]) {
+        exactly(tester, label);
+      }
+    });
+
+    testWidgets('the Speed tab names both series', (tester) async {
+      final locale = _localeFor('ru');
+      await pumpNarrowest(tester, tabIndex: 1, locale: locale);
+      final l = await AppLocalizations.delegate.load(locale);
+
+      exactly(tester, l.downlink);
+      exactly(tester, l.uplink);
+    });
+  });
+
+  group('legend labels are not clipped at the narrowest width (#1229)', () {
+    // The `Flexible` + one-line ellipsis is a safety net, not the mechanism: at
+    // 261px the `Wrap` absorbs all four tier names by running onto a second line,
+    // and measurement confirms none of them clips — `ru`'s longest,
+    // 'Удовлетворительный', renders at 123px inside a ~243px run.
+    //
+    // So this is a canary, and deliberately so. If a translation grows past a
+    // whole run, or spacing/entry count changes, the ellipsis starts firing and
+    // the legend degrades from "wrapped" to "truncated" with the gate still
+    // green. That is exactly the transition worth failing on.
+    for (final tag in ['en', 'ru', 'th']) {
+      testWidgets('Signal tier names render in full in $tag', (tester) async {
+        final locale = _localeFor(tag);
+        await pumpNarrowest(tester, tabIndex: 0, locale: locale);
+        final l = await AppLocalizations.delegate.load(locale);
+
+        for (final label in [l.excellent, l.good, l.fair, l.weak]) {
+          final t = exactly(tester, label);
+          expect(isClipped(tester, t), isFalse,
+              reason:
+                  'tier name "$label" is ellipsized at the narrowest width. '
+                  'The Wrap is supposed to spend a second run before any label '
+                  'gives; a clipped tier name means the legend has stopped '
+                  'keying the bar colours.');
+        }
+      });
+
+      testWidgets('Speed series names render in full in $tag', (tester) async {
+        final locale = _localeFor(tag);
+        await pumpNarrowest(tester, tabIndex: 1, locale: locale);
+        final l = await AppLocalizations.delegate.load(locale);
+
+        for (final label in [l.downlink, l.uplink]) {
+          final t = exactly(tester, label);
+          expect(isClipped(tester, t), isFalse,
+              reason: 'series name "$label" is ellipsized at the narrowest '
+                  'width, so the chart\'s two colours are no longer named.');
+        }
+      });
+    }
+
+    testWidgets('each tier label stays beside its own dot', (tester) async {
+      // Dot and label live in one `Row(mainAxisSize: min)` precisely so the
+      // `Wrap` moves them together. If an entry ever splits across runs, the
+      // colour and the word it explains end up on different lines and the
+      // mapping is gone even though every label is present.
+      final locale = _localeFor('ru');
+      await pumpNarrowest(tester, tabIndex: 0, locale: locale);
+      final l = await AppLocalizations.delegate.load(locale);
+
+      // The dots are 8px circles; find them by their decoration rather than by
+      // the private widget type.
+      final dots = tester
+          .widgetList<Container>(find.byType(Container))
+          .where((c) =>
+              c.decoration is BoxDecoration &&
+              (c.decoration as BoxDecoration).shape == BoxShape.circle)
+          .toList();
+      expect(dots, hasLength(4),
+          reason: 'the Signal legend must paint one colour dot per tier');
+
+      for (final label in [l.excellent, l.good, l.fair, l.weak]) {
+        final labelRect = rectOf(tester, exactly(tester, label));
+        final sameRun = dots
+            .map((d) => tester.getRect(find.byWidget(d)))
+            .where((r) => (r.center.dy - labelRect.center.dy).abs() < 2.0)
+            .where((r) => r.right <= labelRect.left + 1.0);
+        expect(sameRun, isNotEmpty,
+            reason: 'tier "$label" has no colour dot to its left on the same '
+                'line, so its entry was split across runs.');
+      }
+    });
+  });
+
+  group('per-band metrics stay distinguishable (#1229 AC4)', () {
+    // AC4 covers the Channels tab, which #1229 does not touch — those
+    // coordinates were already clean. Asserted anyway: the AC is gate-invisible,
+    // and this pins what "distinguishable" was verified to mean at 261px, namely
+    // that each radio keeps its own band / channel line and its own client-count
+    // / SNR line, with nothing clipped.
+    for (final tag in ['en', 'ru']) {
+      testWidgets('each radio keeps its own channel and SNR line in $tag',
+          (tester) async {
+        final locale = _localeFor(tag);
+        await pumpNarrowest(tester, tabIndex: 2, locale: locale);
+
+        final texts = renderedTexts(tester);
+        final bands =
+            texts.where((t) => _bandRe.hasMatch(t.data!.trim())).toList();
+        expect(bands.length, greaterThanOrEqualTo(2),
+            reason:
+                'the comparison between bands is this tab\'s purpose, so at '
+                'least two radios must be named. Rendered: '
+                '${texts.map((t) => t.data).toList()}');
+
+        // `Ch <n> · <bandwidth>` and the SNR readout are unique to the per-radio
+        // rows (the header badge and the donut centre also mention clients, so a
+        // client-count match alone would not be).
+        final channels = texts.where((t) => t.data!.startsWith('Ch ')).toList();
+        final snrs = texts.where((t) => t.data!.contains(_snrMarker)).toList();
+        expect(channels, hasLength(bands.length),
+            reason:
+                'every radio needs its channel and bandwidth — that is what '
+                'makes the bands comparable rather than merely listed.');
+        expect(snrs, hasLength(bands.length),
+            reason: 'every radio needs its own SNR readout.');
+
+        for (final t in [...bands, ...channels, ...snrs]) {
+          expect(isClipped(tester, t), isFalse,
+              reason: '"${t.data}" is clipped at the narrowest width, so this '
+                  'band\'s reading cannot be compared with the others\'.');
+        }
+
+        // Band label and channel share a line; each radio's rows are disjoint
+        // from the next radio's, which is what keeps two readings from reading as
+        // one.
+        final bandTops = bands.map((t) => rectOf(tester, t).top).toList()
+          ..sort();
+        for (var i = 1; i < bandTops.length; i++) {
+          expect(bandTops[i] - bandTops[i - 1], greaterThan(16.0),
+              reason: 'two band rows are within 16px of each other, so their '
+                  'readouts visually merge.');
+        }
+        for (final band in bands) {
+          final bandRect = rectOf(tester, band);
+          final onSameLine = channels.where((c) =>
+              (rectOf(tester, c).center.dy - bandRect.center.dy).abs() < 2.0);
+          expect(onSameLine, isNotEmpty,
+              reason: 'band "${band.data}" has no channel readout on its own '
+                  'line, so the channel cannot be attributed to it.');
+        }
+      });
+    }
+  });
+}
+
+/// Band labels are `WifiRadioUIModel.band` — `2.4GHz`, `5GHz`, `6GHz`.
+final _bandRe = RegExp(r'^\d+(\.\d+)?GHz$');
+
+/// The SNR readout's literal prefix. `snrValue` is `SNR: {value} dB`, and the
+/// marker is taken from the string's own shape rather than hardcoded per locale.
+const _snrMarker = 'SNR';
+
+Locale _localeFor(String tag) =>
+    AppLocalizations.supportedLocales.firstWhere((l) {
+      final t = l.countryCode == null || l.countryCode!.isEmpty
+          ? l.languageCode
+          : '${l.languageCode}_${l.countryCode}';
+      return t == tag;
+    });

--- a/test/page/dashboard/views/components/wifi_performance_readability_test.dart
+++ b/test/page/dashboard/views/components/wifi_performance_readability_test.dart
@@ -11,7 +11,7 @@ import 'package:privacy_gui/page/dashboard/models/usp_widget_specs.dart';
 import '../../../../util/app_test_fonts.dart';
 import '../../../../util/dashboard/dashboard_card_probe.dart';
 
-/// WiFi Performance readability (#1229).
+/// WiFi Performance readability (#1229, extended by #1266).
 ///
 /// ## Why this file exists alongside the #1183 gate
 ///
@@ -28,9 +28,13 @@ import '../../../../util/dashboard/dashboard_card_probe.dart';
 /// The card's fourth acceptance criterion is the other blind spot — "per-band
 /// metrics stay distinguishable at the narrowest clean width — the card's value
 /// is the comparison between bands". That one is about the **Channels** tab,
-/// which #1229 does not modify: those coordinates were already clean. It is
-/// asserted here anyway, because "already clean" is not the same as "checked",
-/// and because nothing else in the suite would notice if a later fix to this file
+/// which #1229 did not modify: those coordinates were already clean. It was
+/// asserted here anyway, because "already clean" is not the same as "checked" —
+/// and that turned out to be the point. #1266 found the tab's band/channel row
+/// was only clean because `'Ch '` was a hardcoded English abbreviation, gave it
+/// the same `Wrap` treatment, and rewrote this group's invariant accordingly
+/// (see the group's own comment). So the tab is now guarded here for the ordinary
+/// reason as well: nothing else in the suite would notice if a later fix
 /// collapsed the per-band rows.
 ///
 /// Tagged `dashboard-card` so it gates PRs: `run_tests.sh` excludes
@@ -43,14 +47,17 @@ import '../../../../util/dashboard/dashboard_card_probe.dart';
 /// mutation was also run against the gate, because a mutation the gate already
 /// catches proves nothing about *this* file.
 ///
-///   | mutation                                     | this file | the gate |
-///   |----------------------------------------------|-----------|----------|
-///   | drop `SignalTier.fair` from the legend list   | 5 fail    | green    |
-///   | `Row` + `Flexible` entries, no `Wrap`         | 3 fail    | green    |
-///   | drop the per-radio SNR readout               | 2 fail    | green    |
-///   | `Wrap` back to a bare `Row` (pre-#1229)      | green     | 33 fail  |
+///   | mutation                                          | this file | the gate |
+///   |---------------------------------------------------|-----------|----------|
+///   | drop `SignalTier.fair` from the legend list        | 5 fail    | green    |
+///   | `Row` + `Flexible` entries, no `Wrap`             | 3 fail    | green    |
+///   | drop the per-radio SNR readout                    | 2 fail    | green    |
+///   | `Wrap` back to a bare `Row` (pre-#1229, tab 0)    | green     | 33 fail  |
+///   | Channels `Column`: `stretch` → `start` (#1266)    | 1 fail    | green    |
+///   | `loc(context).channel` → `'Ch '` (#1266)         | 4 fail    | green    |
+///   | Channels `Wrap` → `Row` + `Spacer`, localized     | 1 fail    | 3 fail   |
 ///
-/// The last row is the instructive one, and it is why the second differs from
+/// The fourth row is the instructive one, and it is why the second differs from
 /// the obvious guess. Reverting to a bare `Row` does **not** clip anything: a
 /// `Row` hands its non-flex children unbounded width, so each entry's inner
 /// `Flexible` never binds, every label paints at full intrinsic width, and the
@@ -64,6 +71,20 @@ import '../../../../util/dashboard/dashboard_card_probe.dart';
 /// translations. All 157 wifi_performance gate cases stay green. That is the
 /// shape a well-meaning "just make it fit" edit lands on, and only this file
 /// fails it.
+///
+/// The three #1266 rows say the same thing about the Channels tab, and the last
+/// two are a pair worth reading together. Localizing `'Ch '` on its own costs 3
+/// gate coordinates (`th` @261, `tr` @261 and @288) — the ratchet forbids it.
+/// Hardening on its own costs nothing and gains nothing the gate can see. Only
+/// the two together are both green and honest, which is why they shipped as one
+/// change and why the middle row matters: with the abbreviation back, this file
+/// fails in every locale while the gate notices nothing at all.
+///
+/// The `stretch` → `start` row is the subtlest of the set. `spaceBetween` is a
+/// no-op under loose width constraints, so dropping the `stretch` slides the
+/// channel readout left to sit one `spacing` gap after the band label, in every
+/// locale, while overflowing nothing — a pure visual regression that all 157
+/// gate cases pass.
 void main() {
   setUpAll(() async {
     // Real fonts: under the Ahem block font every glyph is one square em, so what
@@ -93,6 +114,31 @@ void main() {
         cardWidth: narrowest.cardWidth,
         columnSpan: constraints.minColumns,
         label: 'min',
+      ),
+      cardHeightRows: constraints.minHeightRows,
+      tabIndex: tabIndex,
+      locale: locale,
+    );
+  }
+
+  /// Pumps the card at the narrowest realization of its *preferred* span — the
+  /// width the grid gives it by default, and the only place where "this fits on
+  /// one line" is a claim about the design rather than about degradation.
+  Future<void> pumpPreferred(
+    WidgetTester tester, {
+    required int tabIndex,
+    required Locale locale,
+  }) async {
+    final narrowest =
+        narrowestRealizationOf(constraints.preferredColumns, minScreen: 0)!;
+    await probeCardOverflow(
+      tester,
+      cardId: cardId,
+      widthCase: CardWidthCase(
+        screenWidth: narrowest.screenWidth,
+        cardWidth: narrowest.cardWidth,
+        columnSpan: constraints.preferredColumns,
+        label: 'preferred',
       ),
       cardHeightRows: constraints.minHeightRows,
       tabIndex: tabIndex,
@@ -234,17 +280,29 @@ void main() {
     });
   });
 
-  group('per-band metrics stay distinguishable (#1229 AC4)', () {
-    // AC4 covers the Channels tab, which #1229 does not touch — those
-    // coordinates were already clean. Asserted anyway: the AC is gate-invisible,
-    // and this pins what "distinguishable" was verified to mean at 261px, namely
-    // that each radio keeps its own band / channel line and its own client-count
-    // / SNR line, with nothing clipped.
-    for (final tag in ['en', 'ru']) {
-      testWidgets('each radio keeps its own channel and SNR line in $tag',
+  group('per-band metrics stay distinguishable (#1229 AC4, #1266)', () {
+    // AC4 covers the Channels tab. #1229 left it alone — those coordinates were
+    // already clean — and asserted it anyway, because the AC is gate-invisible.
+    //
+    // #1266 then overturned the design decision this group originally pinned.
+    // #1229 recorded "band label and channel share a line" as the meaning of
+    // distinguishable, which was true of the `Row` + `Spacer` it measured. But
+    // that row only fit because `'Ch '` was a hardcoded English abbreviation:
+    // with the real `channel` key it overflowed in `th` and `tr` on the shipped
+    // fixture, so #1266 localized it and gave the row the #1226 `Wrap`. The
+    // channel readout may now take a second run.
+    //
+    // So the invariant weakens from *same line* to *attributable*: each radio's
+    // band and channel must be adjacent and belong to the same block, separated
+    // from the next radio's. That is what actually carries AC4 — "the card's
+    // value is the comparison between bands" survives a two-line block, and does
+    // not survive a channel readout that cannot be assigned to a band.
+    for (final tag in ['en', 'ru', 'tr']) {
+      testWidgets('each radio keeps its own channel and SNR readout in $tag',
           (tester) async {
         final locale = _localeFor(tag);
         await pumpNarrowest(tester, tabIndex: 2, locale: locale);
+        final l = await AppLocalizations.delegate.load(locale);
 
         final texts = renderedTexts(tester);
         final bands =
@@ -255,15 +313,23 @@ void main() {
                 'least two radios must be named. Rendered: '
                 '${texts.map((t) => t.data).toList()}');
 
-        // `Ch <n> · <bandwidth>` and the SNR readout are unique to the per-radio
-        // rows (the header badge and the donut centre also mention clients, so a
-        // client-count match alone would not be).
-        final channels = texts.where((t) => t.data!.startsWith('Ch ')).toList();
+        // `<channel> <n> · <bandwidth>` and the SNR readout are unique to the
+        // per-radio rows (the header badge and the donut centre also mention
+        // clients, so a client-count match alone would not be).
+        //
+        // Matched on the localized `channel` string, not on `'Ch '`: that literal
+        // is exactly what #1266 removed, and a test that still recognised it
+        // would silently match nothing and pass on `hasLength(0)` if the band
+        // regex also stopped matching.
+        final channels =
+            texts.where((t) => t.data!.startsWith('${l.channel} ')).toList();
         final snrs = texts.where((t) => t.data!.contains(_snrMarker)).toList();
         expect(channels, hasLength(bands.length),
             reason:
                 'every radio needs its channel and bandwidth — that is what '
-                'makes the bands comparable rather than merely listed.');
+                'makes the bands comparable rather than merely listed. Looked '
+                'for a "${l.channel} " prefix in: '
+                '${texts.map((t) => t.data).toList()}');
         expect(snrs, hasLength(bands.length),
             reason: 'every radio needs its own SNR readout.');
 
@@ -273,9 +339,8 @@ void main() {
                   'band\'s reading cannot be compared with the others\'.');
         }
 
-        // Band label and channel share a line; each radio's rows are disjoint
-        // from the next radio's, which is what keeps two readings from reading as
-        // one.
+        // Each radio's block is disjoint from the next radio's, which is what
+        // keeps two readings from reading as one.
         final bandTops = bands.map((t) => rectOf(tester, t).top).toList()
           ..sort();
         for (var i = 1; i < bandTops.length; i++) {
@@ -283,16 +348,98 @@ void main() {
               reason: 'two band rows are within 16px of each other, so their '
                   'readouts visually merge.');
         }
+
+        // Attribution, post-#1266: the channel readout may sit on the band's
+        // line or on the run directly below it, but it must be nearer to its own
+        // band than to any other — a readout that drifts closer to the next
+        // radio's block is worse than a missing one, because it reads as that
+        // radio's channel.
         for (final band in bands) {
           final bandRect = rectOf(tester, band);
-          final onSameLine = channels.where((c) =>
-              (rectOf(tester, c).center.dy - bandRect.center.dy).abs() < 2.0);
-          expect(onSameLine, isNotEmpty,
-              reason: 'band "${band.data}" has no channel readout on its own '
-                  'line, so the channel cannot be attributed to it.');
+          final nearest = channels.reduce((a, b) =>
+              (rectOf(tester, a).center.dy - bandRect.center.dy).abs() <
+                      (rectOf(tester, b).center.dy - bandRect.center.dy).abs()
+                  ? a
+                  : b);
+          final nearestRect = rectOf(tester, nearest);
+          expect(nearestRect.top, greaterThanOrEqualTo(bandRect.top - 1.0),
+              reason: 'the channel readout nearest band "${band.data}" sits '
+                  'above it, so it belongs to the block before this one.');
+
+          final otherBandTops = bands
+              .where((b) => b != band)
+              .map((b) => rectOf(tester, b).top)
+              .where((top) => top > bandRect.top);
+          for (final nextTop in otherBandTops) {
+            expect(nearestRect.top, lessThan(nextTop),
+                reason: 'the channel readout for band "${band.data}" is below '
+                    'the next band label, so it reads as that band\'s channel.');
+          }
         }
       });
     }
+
+    testWidgets('the channel readout is right-aligned while it fits (#1266)',
+        (tester) async {
+      // `Wrap(alignment: spaceBetween)` is only a drop-in for the old `Spacer`
+      // while the row is width-bounded: a `Wrap` under loose constraints
+      // shrink-wraps to its widest run, leaving `spaceBetween` no free space to
+      // distribute, and the channel string silently slides left to sit one
+      // `spacing` gap after the band label. The `CrossAxisAlignment.stretch` on
+      // the enclosing Column is what prevents that, and nothing else would
+      // notice if it were reverted to `start` — the gate cannot see it, because
+      // a shrink-wrapped row overflows nothing.
+      //
+      // `en` at the preferred width, where every radio's block is comfortably
+      // one run: both children share a run, so the right edges must line up.
+      final locale = _localeFor('en');
+      await pumpPreferred(tester, tabIndex: 2, locale: locale);
+      final l = await AppLocalizations.delegate.load(locale);
+
+      final texts = renderedTexts(tester);
+      final bands = texts.where((t) => _bandRe.hasMatch(t.data!.trim()));
+      final channels =
+          texts.where((t) => t.data!.startsWith('${l.channel} ')).toList();
+      expect(channels, isNotEmpty);
+
+      for (final band in bands) {
+        final bandRect = rectOf(tester, band);
+        final sameRun = channels.where((c) =>
+            (rectOf(tester, c).center.dy - bandRect.center.dy).abs() < 2);
+        expect(sameRun, isNotEmpty,
+            reason: 'at the preferred width every block should still be one '
+                'run, so band "${band.data}" should share its line with its '
+                'channel readout.');
+
+        // The measurement that actually detects a lost `stretch`, and the reason
+        // it is not "the channel sits well right of the band": the channel string
+        // is ~100px wide, so it clears the band by a wide margin even when the
+        // row has shrink-wrapped. The comparison has to be against the width the
+        // row was *offered*.
+        //
+        // The block's `Column` is that reference under either alignment: the
+        // second row holds an `Expanded` loader, so it takes the full offered
+        // width regardless, and the `Column` shrink-wraps to it. So the `Wrap`
+        // matching the `Column`'s width is exactly the claim "the Wrap was handed
+        // a tight width", and it is what `spaceBetween` needs to do anything.
+        final wrapRect = tester.getRect(find.ancestor(
+            of: find.byWidget(band), matching: find.byType(Wrap)));
+        // Ancestor finders walk outward from the descendant, so `.first` is the
+        // innermost — the per-radio block's own Column, not the tab's.
+        final columnRect = tester.getRect(find
+            .ancestor(of: find.byWidget(band), matching: find.byType(Column))
+            .first);
+        expect(wrapRect.width, greaterThanOrEqualTo(columnRect.width - 1.0),
+            reason: 'the band/channel row for "${band.data}" is narrower than '
+                'its own block (${wrapRect.width} vs ${columnRect.width}), so '
+                'the Wrap shrink-wrapped and `spaceBetween` had no free space '
+                'to distribute. The enclosing Column has stopped stretching.');
+        expect(rectOf(tester, sameRun.first).right,
+            greaterThanOrEqualTo(wrapRect.right - 1.0),
+            reason: 'the channel readout does not reach the right edge of its '
+                'row, so it is no longer where the old `Spacer` put it.');
+      }
+    });
   });
 }
 


### PR DESCRIPTION
Closes #1229, closes #1266. Track A of #1183. Design of record: `doc/dashboard/dashboard_density_design.md` §2.10b and §2.10c (both added here).

Base is `gate/1183-overflow-gate` (#1248), not `dev-2.7.0`, per the ticket: the gate, its fixture, its probe and the design of record are all introduced by #1248 and are absent on `dev-2.7.0`, so "N coordinates removed from `known_overflows.json`" is not executable there.

**Two tickets, because the second was found by the first.** #1229 cleared the card's 45 coordinates from the Signal and Speed legends. It also recorded two observations about the Channels tab as deliberately unfixed — and both turned out to be wrong when measured, which is #1266. They ship together because #1266 is ratchet work with coordinates of its own (the #1249 precedent), not gate-invisible hardening (the #1258 one).

---

# Part 1 — #1229: the two legend rows

## The split was measured, not inferred

Both of this card's overflow sites are legend rows of the shape #1226 settled and #1233 replicated six times: a centred `Row` of colour dot, gap, and unconstrained label. Together they are the card's **entire** 45 coordinates.

§1.1's greedy cover credits `:190` with 33 and never names the Speed tab, so the remaining 12 had to be located by re-running §1.1's attribution method scoped to this card:

| Site | Tab | Coordinates |
|---|---|---:|
| `usp_wifi_performance_card.dart:190` | Signal | 33 |
| `usp_wifi_performance_card.dart:275` | Speed | 12 |

No coordinate needs both sites; the total is exactly 45. Inferring the second site from the ticket title would have been a guess with a 12-coordinate blast radius.

## Same shape, same fix, different cause

The locale footprint says which:

- **`:190`** — four entries at a 261px card. Overflows in `en` too (`ru` missed by 149px): **geometry**-bound.
- **`:275`** — two entries. Overflows only in `es`/`es_AR`/`fr`/`fr_CA`/`pt_PT`/`ru`/`tr`: **translation-length**-bound.

That distinction is free to read off the allowlist — `["*"]` means the card is too narrow for the content in any language, a locale list means the layout is fine and one translation is long — and it predicts which sites regress when a string changes versus when spacing changes.

Both rows sit under an `Expanded` holding a `ListView`/`AppBarChart`, so §2.10a point 3's precondition holds and the second run is affordable. **Verified rather than assumed**: re-running attribution after the fix returns 0 incidents at any site, tab or locale, so no bottom overflow was traded in — the exact failure Network Health's fixed 120px gauge produced.

Inter-entry spacing on the Signal tab goes 12px -> 16px, to `AppSpacing.lg` as all six #1233 legends and #1226's use; the measurement says 16px is affordable even at 261px.

## Choosing the mutations turned up a method finding

#1233 and #1228 recorded "verified to fail under a mutation". That is necessary but not sufficient, and this ticket found out why. Every candidate mutation was run against the gate as well:

| mutation | readability test | gate |
|---|---|---|
| drop `SignalTier.fair` from the legend list | 5 fail | green |
| `Row` + `Flexible` entries, no `Wrap` | 3 fail | green |
| drop the per-radio SNR readout | 2 fail | green |
| `Wrap` back to a bare `Row` (pre-#1229) | **green** | **33 fail** |

The last row is the instructive one. Reverting to a bare `Row` does not clip anything: a `Row` hands its non-flex children unbounded width, so each entry's inner `Flexible` never binds, every label paints at full intrinsic width, and the *outer* row overflows instead. The gate owns that regression.

The regression the gate cannot see is the one that *succeeds* at fitting: keep the single `Row` and wrap each entry in `Flexible`. Every tier name then ellipsizes to a stub — in `en`, not just the long translations — while all 157 `wifi_performance` gate cases stay green. That is the shape a well-meaning "just make it fit" edit lands on, and it is what the new test is validated against. Generalised into §2.10b as a rule for the remaining Track A tickets.

## #1229 acceptance criteria

- [x] Card renders clean at its narrowest realization across all 26 locales and all 3 tabs — `wifi_performance` gate 157/157
- [x] All 45 coordinates removed from `test/fixtures/known_overflows.json` and the gate passes — 4 keys (19 + 7 + 14 + 5), gate 1644/1644
- [x] `wifi_performance` has no remaining allowlist entries — verified programmatically; allowlist **226 -> 181** coordinates (19 -> 15 keys)
- [x] Per-band metrics stay distinguishable at the narrowest clean width — asserted, and then rewritten by #1266 (below)

---

# Part 2 — #1266: an English abbreviation was hiding a geometry problem

#1229 left the Channels tab alone on the strength of two claims: that its per-radio rows were clean "by about 48px of headroom", and that the headroom was unmeasurable because the channel string is data-dependent. The 48px was real. The reasoning from it was not — it was measured with `'Ch '`, a hardcoded English abbreviation, in the row. **The abbreviation was the bug, and it was concealing the geometry problem rather than the row not having one.**

The `channel` ARB key already exists in all 26 locales (`tr` = `Channel (Kanal)`, 15 chars, the worst of the set), so localizing is a one-line change with no ARB work. It is also **3 gate coordinates on the fixture the gate ships**:

| locale | `channel` | 261px (min) | 288px (preferred) |
|---|---|---|---|
| `tr` | `Channel (Kanal)` | +4.1px, +41.0px | +14.0px |
| `th` | `ช่องสัญญาณ` | +17.0px | clean |
| other 24 | — | clean | clean |

## Why the two halves cannot ship apart

- **Localizing alone runs the ratchet backwards.** It adds 3 coordinates to a mechanism (§2.9) whose whole contract is that the count only falls, and would have to be booked as an allowlist *addition*. Nothing in Part 4 permits that.
- **Hardening alone is gate-invisible.** With `'Ch '` in place the row is clean everywhere, so the `Wrap` changes no coordinate and the gate cannot tell whether it worked. That is the #1258 shape, and it is why #1229's bullet reached for #1258.
- **Together they are self-verifying.** The localization supplies the failure the hardening has to clear, on the shipped fixture, at both widths. Net coordinate change **0**, and the honest string ships.

## The fix, and the trap inside it

The row gets #1226's `Wrap(alignment: spaceBetween)`. Neither side yields: `band` is the block's identity and the channel string is composed data whose ellipsis would land inside `320MHz` and misinform (§2.10a point 2). So both keep their intrinsic width and the row spends a second run, paid out of the donut's `Expanded`.

`WrapAlignment.spaceBetween` is a **silent no-op under loose width constraints** — `RenderWrap` sizes to its widest run, so `freeMainAxisSpace` is 0 and there is nothing to distribute, and the channel string lands one `spacing` gap after the band instead of at the right edge. `CrossAxisAlignment.stretch` on the enclosing `Column` is what prevents that. It overflows nothing, so **all 157 gate cases pass either way** — the readability test is the only thing that can see it.

**This applies retroactively:** #1226's and #1233's `spaceBetween` legends should be checked for the same precondition, since a shrink-wrapped legend and a correct one are indistinguishable in a green gate. Recorded in §2.10c point 3.

## Attribution halved the change

#1229's bullet had assumed both per-radio rows needed the same treatment. Regexing `usp_wifi_performance_card.dart:(\d+)` over `OverflowIncident.fullLog` — §1.1's method at per-line resolution — put **every** incident, both fixtures, all locales, both widths, on the band/channel row and **none** on the clients/SNR/loader row below it, whose `Expanded` loader already binds. That row is untouched.

## What #1266 does to #1229's test

#1229's AC4 group pinned "band label and channel share a line", which the `Wrap` now permits to be false. The invariant weakens from *same line* to **attributable**: each channel readout must be nearer its own band than any other, and never below the next band label. It also had to stop matching on `'Ch '` — a test that still recognised the removed literal would silently match nothing and pass. Three new mutations, each also run against the gate:

| mutation | readability test | gate |
|---|---|---|
| Channels `Column`: `stretch` -> `start` | **1 fail** | **green** |
| `loc(context).channel` -> `'Ch '` | **4 fail** | **green** |
| Channels `Wrap` -> `Row` + `Spacer`, localized | 1 fail | 3 fail |

The first two are the pair that matters: both are real regressions that the gate's 157 cases cannot distinguish from correct code.

## Method finding: two `testWifiData` fixtures exist, and the gate reads one

The dashboard gate reads `test/golden_test/page/dashboard/cards/fixtures/cards_test_data.dart` (via `kitchenSinkOverrides()`); the Statistics page reads `test/golden_test/page/statistics/fixtures/statistics_test_data.dart`. I edited the latter first and got a confident, meaningless "all clean" from the gate. Only dumping the rendered `Text` list revealed the added radio was absent. **Rule, recorded in §2.10c point 2: when a measurement depends on fixture data, verify the render contains the data, not just that the verdict is green.**

## #1266 acceptance criteria

- [x] `'Ch '` replaced with the localized `channel` key; no ARB edit needed (all 26 locales already have it)
- [x] The band/channel row hardened to #1226's shape; the clients/SNR row left alone, per attribution
- [x] `spaceBetween` verified effective, not silently shrink-wrapped — pinned by a test the gate cannot replace
- [x] Gate net coordinate change **0**; no allowlist addition
- [x] #1229's AC4 group rewritten rather than deleted, mutations re-verified, ledger updated
- [x] 26 locales x both widths clean on the shipped fixture
- [ ] **No bottom overflow introduced** — holds on the shipped fixture; **fails on a tri-band profile the gate cannot express.** See below.

---

## Verification

- overflow gate **1644/1644**; `wifi_performance` **157/157**
- `wifi_performance` readability **13/13** (was 11; +1 locale case, +1 alignment case)
- all three readability files **62/62**
- `usp_analytics_cards_test.dart` (the only test that imports this card) **13/13**
- full functional suite `./run_tests.sh` **5360/5360** (was 5358)
- `fvm flutter analyze` clean on both changed files; `fvm dart format` clean

## Left deliberately unfixed, and one honest cost

**The tri-band bottom overflow.** The gate's data domain is a single hardcoded profile — `testRadios` is 2 radios, 2-digit channels, `160MHz` widest — and `buildDashboardCardApp()` takes no overrides, so no card can be measured against different data without editing the fixture. Measured by temporarily adding a third tri-band radio (`Channel 233 (Auto) · 320MHz`) and reverting:

| | before (`'Ch '`) | localized, old `Row` | localized + `Wrap` (this PR) |
|---|---|---|---|
| 2 radios (the gate's fixture) | clean | 3 coordinates | **clean, 26 locales x both widths** |
| 3 radios, tri-band | clean | `en` +8.3px, plus `fi`, `ja` and the two above | one **+9.0px bottom** (`tr` @261 only) |

That remaining incident is **not** the band/channel row: it is the donut's centre label at `:575`, squeezed once three two-run blocks have taken enough of the column that its `Expanded` no longer fits the label's two lines. So this PR does trade a right overflow for a bottom overflow on that unshipped profile — exactly the trade §2.10a point 3 warns about, stated rather than buried.

It is left unfixed on purpose. At that height the donut is visually useless whether or not it reports an overflow, so "shrink the donut to fit" would silence the gate without fixing anything. Deciding what the tab drops at that density — the donut, or the whole tab becoming scrollable like the Signal tab's `ListView` — is a density decision, and it is not verifiable at all until the gate can express a second data profile.

**Filed as #1267**, which pairs that decision with the gate change that makes it measurable (an `overrides` parameter on `buildDashboardCardApp()` / `kitchenSinkOverrides()`, plus a tri-band fixture). Not folded into #1235 (`network_health`'s fixed 120px gauge centre): same family, but different axis (vertical vs horizontal), different trigger (data vs translation length) and different visibility (invisible until #1267 lands vs 3 live coordinates) — and #1235's ACs are executable ratchet claims that an unverifiable one would make unclosable. Recorded in §2.10c.

**An abbreviation is the one defect this epic's instrument is structurally blind to.** A hardcoded English string makes every width measurement at that site optimistic by however much the translation is longer, and the gate reports the optimistic number in all 26 locales — a locale sweep cannot find a string that never varies. Worth a grep pass over the remaining Track A sites. §2.10c point 1.

## Follow-up

`_LegendDot`/`_LegendEntry` here is the **fifth** copy of the shape. Extracting a shared widget needs an Article XIV decision, which #1245 exists to obtain; #1233 was explicitly told not to block on that conversation and this PR follows it. #1245's inventory is written against four files and four cards (including its AC "all four cards render identically") and needs `wifi_performance` added once this merges — recorded in §1.1 and in the widget's own doc comment. Note this file lives under `lib/page/wifi_settings/cards/`, not `lib/page/dashboard/views/components/`, which is an argument against #1245's proposed location for the shared widget.


---

**Note on the last commit** (`e3d3f4bb`, docs-only): it appends a §1.1 subsection
recording the per-line attribution for the *next* batch (#1234–#1237), measured
while this branch was still the newest edit to that document. It changes nothing
in this PR's scope; it is here rather than on the follow-up branch to avoid two
branches editing the same document section concurrently.
