### PR TITLE
refactor(ui): draw the "maps to" arrow as an icon, not U+2192 (#1247)

### DIFF
--- a/doc/theme/unicode_glyph_coverage_decision.md
+++ b/doc/theme/unicode_glyph_coverage_decision.md
@@ -1,0 +1,171 @@
+# Unicode Symbols in UI Strings — Glyph Coverage Decision
+
+**Last Updated: 2026-08-12** · Resolves #1247 · Follow-up to #1249 (`31d71e0f`) · Status: **decided and implemented**
+
+## Purpose
+
+The app bundles eleven fonts so that every locale renders offline, without
+network and without relying on host fonts. A UI string that uses a codepoint
+none of those eleven map is therefore a latent defect even when it looks
+correct: the browser is resolving a font the app never declared.
+
+This document records which codepoints are safe to put in UI strings, the
+measurement behind that, and the decision taken for U+2192.
+
+## The declared font set
+
+Eleven fonts, all eager-loaded and registered before the first frame:
+
+| Font | Role |
+|---|---|
+| `NeueHaasGrotTextRound-55Roman` / `-75Bold` | Primary (from `ui_kit_library`) |
+| `NotoSans-Latin` | Greek, Cyrillic, Vietnamese (`el`/`ru`/`vi`) |
+| `NotoSansCJK{sc,tc,hk,jp,kr}.subset` | CJK, per locale |
+| `NotoSansThai`, `NotoSansArabic` | `th`, `ar` |
+| `Roboto` | Engine's global fallback, declared bare so it resolves locally |
+
+Two things about the chain matter for this decision:
+
+1. **The Noto fallbacks are locale-gated.** `FallbackFontResolver`
+   (`lib/localization/fallback_font_resolver.dart`) returns `null` for
+   en/fr/de/es/pt and the other Latin locales. For those locales the chain is
+   **NeueHaas → Roboto only** — 429 and 896 codepoints respectively. A glyph
+   present only in a CJK subset does *not* rescue an English string.
+2. **The CJK subsets are generated from ARB text.** `tools/font_subset/`
+   subsets against the characters found in the `zh`/`zh_TW`/`ja`/`ko` ARB files
+   plus ASCII and the CJK punctuation blocks. Symbols that appear only in
+   hardcoded Dart literals are not in that charset even though the full source
+   fonts have them.
+
+## Measurement
+
+Measured with fontTools against the pinned `ui_kit_library` (`v2.34.5`,
+`bcee4067`) and `assets/fonts/fallback/`. `YES` = the font's `cmap` maps it.
+
+| Codepoint | NeueHaas | Roboto | NotoSans-Latin | Thai/Arabic | CJK subsets | **Union** |
+|---|---|---|---|---|---|---|
+| U+2192 `→` | no | no | no | no | no | **none** |
+| U+2190 `←` | no | no | no | no | no | **none** |
+| U+2191 `↑` | no | no | no | no | no | **none** |
+| U+2193 `↓` | no | no | no | no | no | **none** |
+| U+2013 `–` | YES | YES | YES | YES | YES | **all 11** |
+| U+2014 `—` | YES | YES | YES | YES | YES | **all 11** |
+| U+00BB `»` | YES | YES | YES | YES | no | 6 of 11 |
+| U+203A `›` | YES | YES | YES | YES | no | 6 of 11 |
+
+The arrows resolve in every browser tested, which is why this was never visible
+as a bug. That resolution comes from a system font outside the declared set —
+precisely the dependency the fallbacks exist to remove.
+
+The full Noto Sans CJK OTFs under `tools/font_subset/full_fonts/` **do** map
+U+2192. Only the generated subsets drop it. This is what makes "add arrows to
+the CJK subset" look viable when it is not: it would fix nothing for the Latin
+locales, which is where all eight sites render.
+
+## Decision
+
+**U+2192 in a rendered UI string is replaced by `AppIcon.font(Icons.arrow_forward)`.**
+Icon fonts ship with the app, so coverage is guaranteed offline. This extends
+`31d71e0f`, which did the same for U+2191/U+2193/U+23F1/U+26A0, to the
+"maps to" separator.
+
+Chosen over two cheaper alternatives:
+
+- **Re-subsetting `Roboto` to add the Arrows block** would fix all sites with no
+  code change, since Roboto is the one fallback declared for every locale. It
+  was rejected because `tools/font_subset/regenerate.sh` regenerates only the
+  five CJK subsets and treats the non-CJK fallbacks as fixed committed
+  artifacts; adding Roboto to that pipeline makes a vendored binary a
+  maintenance surface for a separator. Still the right move if arrow coverage
+  is ever wanted in bulk.
+- **An ASCII/en-dash separator** is zero-risk (U+2013 is in all eleven) but
+  loses the direction the arrow carries, and leaves the app inconsistent with
+  the icon treatment `31d71e0f` established.
+
+### Rules
+
+1. A rendered UI string **must not** depend on a codepoint outside the union
+   above. Direction markers are drawn with `AppIcon.font`; U+2013/U+2014 are
+   safe as separators.
+2. **Logger, console and LLM-prompt strings are out of scope.** They never pass
+   through Flutter's font stack. `lib/ai/prompts/` and `[USP]`-prefixed log
+   strings keep their arrows deliberately.
+3. Anything added to `lib/util/languages.dart` or the CJK ARB files needs
+   `tools/font_subset/regenerate.sh` re-run, per that script's header.
+
+## Implementation
+
+`MapsToRow` (`lib/page/_shared/components/layout_blocks/row_blocks.dart`) is the
+single definition of the arrow: it takes `source` and `target` as **Strings** and
+composes `AppText + AppIcon.font + AppText`.
+
+This keeps `PortForwardingRuleUIModel.portSummary` and
+`PortTriggeringRuleUIModel.summary` returning Strings — #1247 AC #3 — rather
+than pushing widgets into UI models. Each model gained getters for the two
+halves (`portRangeDisplay`/`internalTargetDisplay`,
+`triggerSummaryPart`/`forwardSummaryPart`); the composed `…summary` getters
+remain for diagnostics and now use ASCII `->`.
+
+`ToggleRow` gained `subtitleContent` (a `Widget?`) alongside its String
+`subtitle`, because two of the sites are `ToggleRow` subtitles. Existing String
+callers are unaffected.
+
+**One deliberate visual change.** `usp_firewall_overview_card.dart:255` read
+`'${rule.portSummary} → ${rule.internalClient}'`, rendering
+`8080 → 192.168.1.100:80 → 192.168.1.100` — the internal client twice, once
+bare and once inside `portSummary`. It is now a single
+`8080 → 192.168.1.100:80`. Preserving both arrows would have drawn two icons
+for duplicate information.
+
+### Sites converted
+
+| File | Note |
+|---|---|
+| `lib/page/_shared/models/port_forwarding_rule_ui_model.dart` | getter split; `portSummary` → ASCII |
+| `lib/page/port_forwarding/models/port_triggering_rule_ui_model.dart` | getter split; `summary` → ASCII |
+| `lib/page/statistics/views/sections/stats_port_mapping_section.dart` | `MapsToRow` |
+| `lib/page/firewall/cards/usp_firewall_overview_card.dart` | `MapsToRow`; duplicate arrow collapsed |
+| `lib/page/port_forwarding/cards/usp_port_forwarding_card.dart` | two `ToggleRow` subtitles |
+| `lib/page/port_forwarding/views/components/usp_{single_port,port_range,port_triggering}_tab.dart` | `MapsToRow` |
+| `lib/ai/registry/router_component_registry.dart` | three `AppListTile` subtitles |
+| `lib/demo/pages/pnp_demo_launcher.dart` | en dash — a three-step sequence, not a mapping |
+
+## Verification
+
+- `test/page/_shared/components/layout_blocks/maps_to_row_test.dart` asserts no
+  rendered `Text` contains U+2192, that the arrow is an `Icon`, and that long
+  operands ellipsize without overflow. Tagged `dashboard-card` (not `ui`) so
+  `run_tests.sh` includes it. Mutation-checked: reverting `MapsToRow` to a
+  character arrow fails 3 of its 5 tests.
+- `./run_tests.sh` — 5352 passing.
+- `dashboard_card_overflow_test.dart` — 1644 passing, allowlist unchanged.
+  Both `port_forwarding` and `firewall_overview` are gate-probed, and the icon
+  is narrower than the glyph box it replaced, so no coordinate moved.
+
+## Reproducing the measurement
+
+Run from the repo root. `LinksysIcons.otf` is excluded on purpose: it is the
+icon font `AppIcon.font` draws from, not part of the *text* fallback chain, so
+counting it would mask exactly the gap being measured.
+
+```bash
+python3 -m venv /tmp/fc && /tmp/fc/bin/pip install -q fonttools brotli
+/tmp/fc/bin/python - <<'PY'
+from fontTools.ttLib import TTFont
+import glob, os
+paths = glob.glob('assets/fonts/fallback/*.woff2') + [
+    p for p in glob.glob(os.path.expanduser(
+        '~/.pub-cache/git/privacyGUI-UI-kit-bcee4067*/assets/fonts/*.otf'))
+    if 'LinksysIcons' not in p]
+assert len(paths) == 11, f'expected 11 text fonts, found {len(paths)}'
+union = set()
+for p in paths:
+    f = TTFont(p, fontNumber=0, lazy=True)
+    union |= set(f.getBestCmap()); f.close()
+for cp in (0x2192, 0x2013):
+    print(hex(cp), 'covered' if cp in union else 'MISSING')
+PY
+```
+
+Expected: `0x2192 MISSING`, `0x2013 covered`. Bump the `bcee4067` glob when
+`ui_kit_library` is repinned in `pubspec.lock`.

--- a/doc/theme/unicode_glyph_coverage_decision.md
+++ b/doc/theme/unicode_glyph_coverage_decision.md
@@ -71,13 +71,19 @@ Icon fonts ship with the app, so coverage is guaranteed offline. This extends
 
 Chosen over two cheaper alternatives:
 
-- **Re-subsetting `Roboto` to add the Arrows block** would fix all sites with no
-  code change, since Roboto is the one fallback declared for every locale. It
-  was rejected because `tools/font_subset/regenerate.sh` regenerates only the
-  five CJK subsets and treats the non-CJK fallbacks as fixed committed
-  artifacts; adding Roboto to that pipeline makes a vendored binary a
-  maintenance surface for a separator. Still the right move if arrow coverage
-  is ever wanted in bulk.
+- **Adding the Arrows block to the CJK subsets** — the ticket's first choice —
+  cannot work at all, and this is the more fundamental objection than any cost
+  argument. Those subsets are only loaded for CJK locales; for en/fr/de/es/pt
+  the chain is NeueHaas → Roboto only, and all eight U+2192 sites are hardcoded
+  English strings with no U+2192 in any ARB file. Patching a CJK subset would
+  not affect a single one of them.
+- **Re-subsetting `Roboto` to add the Arrows block** is the only viable form of
+  that idea — Roboto is the one fallback declared for every locale, so it would
+  fix all sites with no code change. Rejected on cost, not validity:
+  `tools/font_subset/regenerate.sh` regenerates only the five CJK subsets and
+  treats the non-CJK fallbacks as fixed committed artifacts; adding Roboto to
+  that pipeline makes a vendored binary a maintenance surface for a separator.
+  Still the right move if arrow coverage is ever wanted in bulk.
 - **An ASCII/en-dash separator** is zero-risk (U+2013 is in all eleven) but
   loses the direction the arrow carries, and leaves the app inconsistent with
   the icon treatment `31d71e0f` established.
@@ -87,6 +93,13 @@ Chosen over two cheaper alternatives:
 1. A rendered UI string **must not** depend on a codepoint outside the union
    above. Direction markers are drawn with `AppIcon.font`; U+2013/U+2014 are
    safe as separators.
+1. **An icon standing in for a character must be given the text's colour
+   explicitly.** `AppText` resolves colour from `DefaultTextStyle`; `AppIcon`
+   falls back to `IconTheme.of(context).color ?? Colors.black`. Containers set
+   one or the other, not both — `AppListTile` wraps its subtitle in a
+   `DefaultTextStyle` at 0.7 alpha and no `IconTheme` — so an icon left to its
+   own chain diverges from the text beside it. Resolve once
+   (`color ?? DefaultTextStyle.of(context).style.color`) and pass it to both.
 2. **Logger, console and LLM-prompt strings are out of scope.** They never pass
    through Flutter's font stack. `lib/ai/prompts/` and `[USP]`-prefixed log
    strings keep their arrows deliberately.
@@ -107,8 +120,8 @@ halves (`portRangeDisplay`/`internalTargetDisplay`,
 remain for diagnostics and now use ASCII `->`.
 
 `ToggleRow` gained `subtitleContent` (a `Widget?`) alongside its String
-`subtitle`, because two of the sites are `ToggleRow` subtitles. Existing String
-callers are unaffected.
+`subtitle`, because two of the sites are `ToggleRow` subtitles. The two are
+mutually exclusive and asserted as such; existing String callers are unaffected.
 
 **One deliberate visual change.** `usp_firewall_overview_card.dart:255` read
 `'${rule.portSummary} → ${rule.internalClient}'`, rendering
@@ -137,6 +150,11 @@ for duplicate information.
   operands ellipsize without overflow. Tagged `dashboard-card` (not `ui`) so
   `run_tests.sh` includes it. Mutation-checked: reverting `MapsToRow` to a
   character arrow fails 3 of its 5 tests.
+- `test/page/_shared/components/layout_blocks/toggle_row_test.dart` covers the
+  two `ToggleRow` subtitle channels, that passing both asserts, and that the
+  arrow icon matches the colour of the text beside it. Mutation-checked:
+  dropping the `DefaultTextStyle` fallback makes the icon render at alpha 1.0
+  against text at 0.7, and the colour test fails.
 - `./run_tests.sh` — 5352 passing.
 - `dashboard_card_overflow_test.dart` — 1644 passing, allowlist unchanged.
   Both `port_forwarding` and `firewall_overview` are gate-probed, and the icon

--- a/lib/ai/registry/router_component_registry.dart
+++ b/lib/ai/registry/router_component_registry.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:generative_ui/generative_ui.dart';
+import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
 import '../components/_components.dart';
@@ -852,8 +853,9 @@ class _DhcpCard extends StatelessWidget {
   Widget _buildReservationTile(Map<String, dynamic> reservation) {
     return AppListTile(
       title: AppText.body(reservation['hostname'] as String? ?? 'Unknown'),
-      subtitle: AppText.caption(
-        '${reservation['mac'] ?? ''} → ${reservation['ip'] ?? ''}',
+      subtitle: MapsToRow(
+        source: reservation['mac'] as String? ?? '',
+        target: reservation['ip'] as String? ?? '',
       ),
       leading: const Icon(Icons.bookmark, size: 20),
     );
@@ -862,8 +864,9 @@ class _DhcpCard extends StatelessWidget {
   Widget _buildClientTile(Map<String, dynamic> client) {
     return AppListTile(
       title: AppText.body(client['hostname'] as String? ?? 'Unknown'),
-      subtitle: AppText.caption(
-        '${client['mac'] ?? ''} → ${client['ip'] ?? ''}',
+      subtitle: MapsToRow(
+        source: client['mac'] as String? ?? '',
+        target: client['ip'] as String? ?? '',
       ),
       leading: const Icon(Icons.devices, size: 20),
     );
@@ -1002,8 +1005,9 @@ class _PortForwardingCard extends StatelessWidget {
 
     return AppListTile(
       title: AppText.body(description),
-      subtitle: AppText.caption(
-        'Port $port ($protocol) → $internalIp',
+      subtitle: MapsToRow(
+        source: 'Port $port ($protocol)',
+        target: internalIp,
       ),
       leading: Icon(
         enabled ? Icons.check_circle : Icons.cancel,

--- a/lib/demo/pages/pnp_demo_launcher.dart
+++ b/lib/demo/pages/pnp_demo_launcher.dart
@@ -134,7 +134,9 @@ class PnpDemoLauncher extends ConsumerWidget {
       _DemoEntry(
         icon: Icons.power_off,
         title: 'Modem Restart',
-        subtitle: 'Unplug → Lights off → Wait',
+        // Three-step sequence, not a two-part mapping, so MapsToRow does not
+        // fit; U+2013 is covered by every font in the declared set.
+        subtitle: 'Unplug – Lights off – Wait',
         onTap: () {
           ref.invalidate(pnpProvider);
           ref.read(pnpProvider.notifier).setDemoPhase(

--- a/lib/page/_shared/components/layout_blocks/row_blocks.dart
+++ b/lib/page/_shared/components/layout_blocks/row_blocks.dart
@@ -127,6 +127,66 @@ class NetworkBadgeWidget extends StatelessWidget {
 }
 
 // =============================================================================
+// MapsToRow - "source maps to target" pair
+// =============================================================================
+
+/// A "maps to" pair — `8080 -> 192.168.1.100:80` — drawn with an arrow icon
+/// instead of a U+2192 character.
+///
+/// U+2192 has no glyph in the primary font, in any of the nine fallbacks under
+/// `assets/fonts/fallback/`, or in the union of all eleven; the app's declared
+/// font set cannot render it, and browsers only do so by resolving a host font
+/// outside that set — the exact dependency those fallbacks exist to remove.
+/// [AppIcon.font] draws from the icon font, so coverage is guaranteed offline.
+///
+/// [source] and [target] stay Strings: the arrow is composed here in the widget
+/// layer, so UI models keep returning Strings rather than widgets.
+///
+/// Sized to match the surrounding [AppText.bodySmall]. [target] is the part
+/// that ellipsizes, since the source (a port or port range) is short and
+/// bounded while the target (an IP, optionally with a port) is not.
+class MapsToRow extends StatelessWidget {
+  final String source;
+  final String target;
+  final Color? color;
+
+  const MapsToRow({
+    super.key,
+    required this.source,
+    required this.target,
+    this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Flexible(
+          child: AppText.bodySmall(
+            source,
+            color: color,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        AppGap.xs(),
+        AppIcon.font(Icons.arrow_forward, size: 12, color: color),
+        AppGap.xs(),
+        Flexible(
+          child: AppText.bodySmall(
+            target,
+            color: color,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// =============================================================================
 // ToggleRow - Row with leading switch toggle
 // =============================================================================
 
@@ -141,6 +201,10 @@ class ToggleRow extends StatelessWidget {
   final ValueChanged<bool>? onChanged;
   final String title;
   final String? subtitle;
+
+  /// Widget subtitle, for rows whose subtitle is not plain text (e.g. a
+  /// [MapsToRow] with an arrow icon). Takes precedence over [subtitle].
+  final Widget? subtitleContent;
   final Widget? trailing;
   final VoidCallback? onTap;
   final bool isLoading;
@@ -151,6 +215,7 @@ class ToggleRow extends StatelessWidget {
     this.onChanged,
     required this.title,
     this.subtitle,
+    this.subtitleContent,
     this.trailing,
     this.onTap,
     this.isLoading = false,
@@ -183,14 +248,15 @@ class ToggleRow extends StatelessWidget {
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),
-      subtitle: subtitle != null
-          ? AppText.bodySmall(
-              subtitle!,
-              color: colorScheme.onSurfaceVariant,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            )
-          : null,
+      subtitle: subtitleContent ??
+          (subtitle != null
+              ? AppText.bodySmall(
+                  subtitle!,
+                  color: colorScheme.onSurfaceVariant,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                )
+              : null),
       trailing: trailing,
       onTap: onTap,
     );

--- a/lib/page/_shared/components/layout_blocks/row_blocks.dart
+++ b/lib/page/_shared/components/layout_blocks/row_blocks.dart
@@ -159,24 +159,34 @@ class MapsToRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // The arrow must track the text, and text and icons resolve colour from
+    // different inherited widgets: [AppText] reads [DefaultTextStyle] while
+    // [AppIcon] falls back to `IconTheme.of(context).color ?? Colors.black`.
+    // Containers commonly set only one of the two — `AppListTile` wraps its
+    // subtitle in a `DefaultTextStyle` and no `IconTheme` — so leaving the icon
+    // to its own chain lets it pick up an ambient icon colour, or black, while
+    // the text beside it renders in the container's content colour. Resolving
+    // one colour here and passing it to both keeps the pair consistent.
+    final effectiveColor = color ?? DefaultTextStyle.of(context).style.color;
+
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         Flexible(
           child: AppText.bodySmall(
             source,
-            color: color,
+            color: effectiveColor,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
           ),
         ),
         AppGap.xs(),
-        AppIcon.font(Icons.arrow_forward, size: 12, color: color),
+        AppIcon.font(Icons.arrow_forward, size: 12, color: effectiveColor),
         AppGap.xs(),
         Flexible(
           child: AppText.bodySmall(
             target,
-            color: color,
+            color: effectiveColor,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
           ),
@@ -203,7 +213,8 @@ class ToggleRow extends StatelessWidget {
   final String? subtitle;
 
   /// Widget subtitle, for rows whose subtitle is not plain text (e.g. a
-  /// [MapsToRow] with an arrow icon). Takes precedence over [subtitle].
+  /// [MapsToRow] with an arrow icon). Mutually exclusive with [subtitle] —
+  /// passing both is asserted against, and in release builds this one wins.
   final Widget? subtitleContent;
   final Widget? trailing;
   final VoidCallback? onTap;
@@ -219,7 +230,8 @@ class ToggleRow extends StatelessWidget {
     this.trailing,
     this.onTap,
     this.isLoading = false,
-  });
+  }) : assert(subtitle == null || subtitleContent == null,
+            'ToggleRow: pass subtitle or subtitleContent, not both');
 
   @override
   Widget build(BuildContext context) {

--- a/lib/page/_shared/models/port_forwarding_rule_ui_model.dart
+++ b/lib/page/_shared/models/port_forwarding_rule_ui_model.dart
@@ -93,9 +93,15 @@ class PortForwardingRuleUIModel extends Equatable with DiagnosticLoggable {
   String get portRangeDisplay =>
       isSinglePort ? '$externalPort' : '$externalPort-$externalPortEndRange';
 
-  /// Summary: "8080 → 192.168.1.100:80" or "3074-3080 → 192.168.1.50:3074".
-  String get portSummary =>
-      '$portRangeDisplay \u2192 $internalClient:$internalPort';
+  /// Summary: "8080 -> 192.168.1.100:80" or "3074-3080 -> 192.168.1.50:3074".
+  ///
+  /// Diagnostics and other non-UI callers only. UI draws the arrow as an icon
+  /// via `MapsToRow(source: portRangeDisplay, target: internalTargetDisplay)`,
+  /// because U+2192 has no glyph in the app's declared font set.
+  String get portSummary => '$portRangeDisplay -> $internalTargetDisplay';
+
+  /// Internal target display: "192.168.1.100:80".
+  String get internalTargetDisplay => '$internalClient:$internalPort';
 
   @override
   String get diagnosticName => 'PortForwardingRuleUIModel';

--- a/lib/page/firewall/cards/usp_firewall_overview_card.dart
+++ b/lib/page/firewall/cards/usp_firewall_overview_card.dart
@@ -251,8 +251,9 @@ class _PortsTab extends StatelessWidget {
                     _ProtocolBadge(protocol: rule.protocol),
                     AppGap.sm(),
                     Expanded(
-                      child: AppText.bodySmall(
-                        '${rule.portSummary} → ${rule.internalClient}',
+                      child: MapsToRow(
+                        source: rule.portRangeDisplay,
+                        target: rule.internalTargetDisplay,
                       ),
                     ),
                   ],

--- a/lib/page/port_forwarding/cards/usp_port_forwarding_card.dart
+++ b/lib/page/port_forwarding/cards/usp_port_forwarding_card.dart
@@ -87,7 +87,11 @@ class UspPortForwardingCard extends ConsumerWidget {
                     .immediateToggleForwarding(rule.instancePath!, value),
               ),
       title: rule.displayName,
-      subtitle: rule.portSummary,
+      subtitleContent: MapsToRow(
+        source: rule.portRangeDisplay,
+        target: rule.internalTargetDisplay,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
       trailing: ProtocolBadge(protocol: rule.protocol),
     );
   }
@@ -108,7 +112,11 @@ class UspPortForwardingCard extends ConsumerWidget {
                     .immediateToggleTriggering(trigger.instancePath!, value),
               ),
       title: trigger.displayName,
-      subtitle: '${trigger.triggerPortDisplay} → ${trigger.forwardPortDisplay}',
+      subtitleContent: MapsToRow(
+        source: trigger.triggerPortDisplay,
+        target: trigger.forwardPortDisplay,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
       trailing: ProtocolBadge(protocol: trigger.triggerProtocol),
     );
   }

--- a/lib/page/port_forwarding/models/port_triggering_rule_ui_model.dart
+++ b/lib/page/port_forwarding/models/port_triggering_rule_ui_model.dart
@@ -106,9 +106,20 @@ class PortTriggeringRuleUIModel extends Equatable with DiagnosticLoggable {
   String get forwardProtocolDisplay =>
       forwardRules.isNotEmpty ? forwardRules.first.forwardProtocol : '—';
 
-  /// Summary: "Trigger: 21 TCP → Forward: 1024-1030 TCP".
-  String get summary => 'Trigger: $triggerPortDisplay $triggerProtocol '
-      '→ Forward: $forwardPortDisplay $forwardProtocolDisplay';
+  /// Trigger half of the summary: "Trigger: 21 TCP".
+  String get triggerSummaryPart =>
+      'Trigger: $triggerPortDisplay $triggerProtocol';
+
+  /// Forward half of the summary: "Forward: 1024-1030 TCP".
+  String get forwardSummaryPart =>
+      'Forward: $forwardPortDisplay $forwardProtocolDisplay';
+
+  /// Summary: "Trigger: 21 TCP -> Forward: 1024-1030 TCP".
+  ///
+  /// Diagnostics and other non-UI callers only. UI draws the arrow as an icon
+  /// via `MapsToRow(source: triggerSummaryPart, target: forwardSummaryPart)`,
+  /// because U+2192 has no glyph in the app's declared font set.
+  String get summary => '$triggerSummaryPart -> $forwardSummaryPart';
 
   @override
   String get diagnosticName => 'PortTriggeringRuleUIModel';

--- a/lib/page/port_forwarding/views/components/usp_port_range_tab.dart
+++ b/lib/page/port_forwarding/views/components/usp_port_range_tab.dart
@@ -74,8 +74,9 @@ class UspPortRangeTab extends ConsumerWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   AppText.bodyMedium(rule.displayName),
-                  AppText.bodySmall(
-                    rule.portSummary,
+                  MapsToRow(
+                    source: rule.portRangeDisplay,
+                    target: rule.internalTargetDisplay,
                     color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),
                 ],

--- a/lib/page/port_forwarding/views/components/usp_port_triggering_tab.dart
+++ b/lib/page/port_forwarding/views/components/usp_port_triggering_tab.dart
@@ -74,8 +74,9 @@ class UspPortTriggeringTab extends ConsumerWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   AppText.bodyMedium(rule.displayName),
-                  AppText.bodySmall(
-                    rule.summary,
+                  MapsToRow(
+                    source: rule.triggerSummaryPart,
+                    target: rule.forwardSummaryPart,
                     color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),
                 ],

--- a/lib/page/port_forwarding/views/components/usp_single_port_tab.dart
+++ b/lib/page/port_forwarding/views/components/usp_single_port_tab.dart
@@ -75,8 +75,9 @@ class UspSinglePortTab extends ConsumerWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   AppText.bodyMedium(rule.displayName),
-                  AppText.bodySmall(
-                    rule.portSummary,
+                  MapsToRow(
+                    source: rule.portRangeDisplay,
+                    target: rule.internalTargetDisplay,
                     color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),
                 ],

--- a/lib/page/statistics/views/sections/stats_port_mapping_section.dart
+++ b/lib/page/statistics/views/sections/stats_port_mapping_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
+import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
 import 'package:privacy_gui/page/_shared/components/usp_status_dot.dart';
 import 'package:privacy_gui/page/firewall/providers/firewall_data_provider.dart';
 import 'package:privacy_gui/page/port_forwarding/providers/port_forwarding_data_provider.dart';
@@ -72,8 +73,9 @@ class StatsPortMappingSection extends ConsumerWidget {
                     _ProtocolBadge(protocol: rule.protocol),
                     AppGap.sm(),
                     Expanded(
-                      child: AppText.bodySmall(
-                        rule.portSummary,
+                      child: MapsToRow(
+                        source: rule.portRangeDisplay,
+                        target: rule.internalTargetDisplay,
                       ),
                     ),
                   ],

--- a/test/page/_shared/components/layout_blocks/maps_to_row_test.dart
+++ b/test/page/_shared/components/layout_blocks/maps_to_row_test.dart
@@ -1,0 +1,129 @@
+@Tags(['dashboard-card'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import '../../../../util/app_test_fonts.dart';
+
+/// Behavioural tests for [MapsToRow] (#1247).
+///
+/// The point of this widget is that the "maps to" arrow is drawn from the ICON
+/// font rather than as U+2192. U+2192 has no glyph in the primary font, in any
+/// of the nine fallbacks under `assets/fonts/fallback/`, or in the union of all
+/// eleven — measured with fontTools. It renders in a browser only because the
+/// host resolves a font outside the declared set, which is the dependency those
+/// fallbacks exist to remove. So the assertion that matters is not "an arrow is
+/// visible" but "no text in this row carries the unmappable codepoint".
+///
+/// Tagged `dashboard-card`, not `ui`: `run_tests.sh` excludes `ui`, and this
+/// guards two gate-probed cards (port_forwarding, firewall_overview).
+void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await loadAppFonts();
+  });
+
+  Future<void> pumpMapsTo(
+    WidgetTester tester, {
+    required String source,
+    required String target,
+    double width = 400,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.create(
+          brightness: Brightness.light,
+          seedColor: Colors.blue,
+          designThemeBuilder: (c) =>
+              CustomDesignTheme.fromJson({'style': 'flat'}),
+        ),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: width,
+              child: MapsToRow(source: source, target: target),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('the arrow does not depend on a font glyph the app does not ship', () {
+    testWidgets('no rendered text contains U+2192', (tester) async {
+      await pumpMapsTo(
+        tester,
+        source: '8080',
+        target: '192.168.1.100:80',
+      );
+
+      final texts = tester
+          .widgetList<Text>(find.byType(Text))
+          .map((t) => t.data ?? '')
+          .toList();
+
+      expect(texts, isNotEmpty, reason: 'the row must render some text');
+      for (final t in texts) {
+        expect(t.contains('→'), isFalse,
+            reason: 'U+2192 has no glyph in the declared font set: "$t"');
+      }
+    });
+
+    testWidgets('the arrow is drawn as an icon', (tester) async {
+      await pumpMapsTo(tester, source: '8080', target: '192.168.1.100:80');
+
+      expect(find.byIcon(Icons.arrow_forward), findsOneWidget);
+    });
+
+    testWidgets('both operands are still rendered', (tester) async {
+      await pumpMapsTo(tester,
+          source: '3074-3080', target: '192.168.1.50:3074');
+
+      expect(find.text('3074-3080'), findsOneWidget);
+      expect(find.text('192.168.1.50:3074'), findsOneWidget);
+    });
+  });
+
+  group('the row survives narrow cards without overflowing', () {
+    testWidgets('a long target ellipsizes instead of overflowing',
+        (tester) async {
+      // A dashboard card at its minimum width is far narrower than this text.
+      await pumpMapsTo(
+        tester,
+        source: '3074-3080',
+        target: '192.168.100.100:65535',
+        width: 120,
+      );
+
+      // Any RenderFlex overflow would have been recorded as an exception.
+      expect(tester.takeException(), isNull);
+
+      final target = tester.renderObject<RenderParagraph>(
+        find.text('192.168.100.100:65535'),
+      );
+      expect(target.size.width, lessThanOrEqualTo(120));
+    });
+
+    testWidgets('the icon is never squeezed out by long operands',
+        (tester) async {
+      await pumpMapsTo(
+        tester,
+        source: 'Trigger: 3074-3080 TCP',
+        target: 'Forward: 1024-1030 TCP',
+        width: 140,
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byIcon(Icons.arrow_forward), findsOneWidget);
+    });
+  });
+}

--- a/test/page/_shared/components/layout_blocks/toggle_row_test.dart
+++ b/test/page/_shared/components/layout_blocks/toggle_row_test.dart
@@ -1,0 +1,137 @@
+@Tags(['dashboard-card'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import '../../../../util/app_test_fonts.dart';
+
+/// Tests for [ToggleRow]'s two subtitle channels (#1247).
+///
+/// [ToggleRow] grew a `subtitleContent` [Widget] alongside its String
+/// `subtitle` so that port-forwarding rows could render a [MapsToRow]. The two
+/// are mutually exclusive, and nothing else in the suite exercised either
+/// channel — so a reversal of the selection logic would have gone unnoticed.
+void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await loadAppFonts();
+  });
+
+  Future<void> pumpToggleRow(WidgetTester tester, ToggleRow row) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.create(
+          brightness: Brightness.light,
+          seedColor: Colors.blue,
+          designThemeBuilder: (c) =>
+              CustomDesignTheme.fromJson({'style': 'flat'}),
+        ),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: row),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('subtitle channels are mutually exclusive', () {
+    testWidgets('a String subtitle renders as text', (tester) async {
+      await pumpToggleRow(
+        tester,
+        ToggleRow(
+          value: true,
+          title: 'HTTP',
+          subtitle: 'TCP 8080',
+        ),
+      );
+
+      expect(find.text('TCP 8080'), findsOneWidget);
+      expect(find.byType(MapsToRow), findsNothing);
+    });
+
+    testWidgets('subtitleContent renders the widget instead', (tester) async {
+      await pumpToggleRow(
+        tester,
+        ToggleRow(
+          value: true,
+          title: 'HTTP',
+          subtitleContent: MapsToRow(
+            source: '8080',
+            target: '192.168.1.100:80',
+          ),
+        ),
+      );
+
+      expect(find.byType(MapsToRow), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_forward), findsOneWidget);
+      expect(find.text('8080'), findsOneWidget);
+      expect(find.text('192.168.1.100:80'), findsOneWidget);
+    });
+
+    testWidgets('passing both is a programming error', (tester) async {
+      expect(
+        () => ToggleRow(
+          value: true,
+          title: 'HTTP',
+          subtitle: 'TCP 8080',
+          subtitleContent: MapsToRow(source: '8080', target: '10.0.0.1'),
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    testWidgets('neither channel renders no subtitle', (tester) async {
+      await pumpToggleRow(
+        tester,
+        ToggleRow(value: false, title: 'HTTP'),
+      );
+
+      expect(find.text('HTTP'), findsOneWidget);
+      expect(find.byType(MapsToRow), findsNothing);
+    });
+  });
+
+  group('the arrow in a subtitle tracks the surrounding text colour', () {
+    testWidgets('an unstyled MapsToRow does not fall back to black',
+        (tester) async {
+      // AppListTile wraps its subtitle in a DefaultTextStyle but no IconTheme.
+      // Without resolving one colour for both, AppIcon would land on its own
+      // fallback chain and could render black against the tile's content
+      // colour. Asserting they match is what pins that behaviour down.
+      await pumpToggleRow(
+        tester,
+        ToggleRow(
+          value: true,
+          title: 'HTTP',
+          subtitleContent: MapsToRow(
+            source: '8080',
+            target: '192.168.1.100:80',
+          ),
+        ),
+      );
+
+      final icon = tester.widget<Icon>(
+        find.descendant(
+          of: find.byType(MapsToRow),
+          matching: find.byIcon(Icons.arrow_forward),
+        ),
+      );
+      final text = tester.widget<Text>(
+        find.descendant(
+          of: find.byType(MapsToRow),
+          matching: find.text('8080'),
+        ),
+      );
+
+      final textColor = text.style?.color ??
+          DefaultTextStyle.of(tester.element(find.text('8080'))).style.color;
+
+      expect(icon.color, isNotNull);
+      expect(icon.color, equals(textColor));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

U+2192 (`→`) has **no glyph in any of the eleven fonts the app declares**. Browsers render it anyway by resolving a host font outside that set — which is exactly the dependency the bundled fallbacks exist to remove. This replaces the eight rendered occurrences with `AppIcon.font(Icons.arrow_forward)`, extending what `31d71e0f` already did for U+2191/U+2193/U+23F1/U+26A0.

Closes #1247.

## Why not the cheaper options the ticket proposed

The ticket recommended option 1 (bundle a covering fallback) then option 2 (ASCII/en-dash). Measuring first showed **option 1 as written cannot work**:

- The Noto fallbacks are **locale-gated**. `FallbackFontResolver.bareFamilyForLocale` returns `null` for en/fr/de/es/pt, so for those locales the chain is **NeueHaas → Roboto only** (429 and 896 codepoints). All eight sites are hardcoded English strings — no ARB carries U+2192 — so adding arrows to a CJK subset would fix nothing at any of them.
- The full Noto CJK OTFs under `tools/font_subset/full_fonts/` **do** map U+2192; only the generated subsets drop it. That is what makes option 1 look viable when it isn't.
- The one viable form of option 1 is re-subsetting **Roboto** (the sole fallback declared for every locale). Rejected: `regenerate.sh` regenerates only the five CJK subsets and treats the non-CJK fallbacks as fixed committed artifacts. Still the right move if arrow coverage is ever wanted in bulk.

Measured with fontTools against the pinned `ui_kit_library` (`v2.34.5`, `bcee4067`):

| Codepoint | Union of the 11 text fonts |
|---|---|
| U+2192 `→`, U+2190, U+2191, U+2193 | **none** |
| U+2013 `–`, U+2014 `—` | all 11 |
| U+00BB `»`, U+203A `›` | 6 of 11 |

Full rationale, rules and a runnable re-measurement snippet: `doc/theme/unicode_glyph_coverage_decision.md`.

## Approach — AC #3 is preserved, not overridden

The ticket assumed option 3 forces `portSummary`/`summary` from `String` to `Widget`. It doesn't. `MapsToRow` takes `source` and `target` as **Strings** and composes `AppText + AppIcon.font + AppText` in the widget layer, so **the UI models keep returning Strings** — AC #3 holds, and no widgets leak into models.

- `MapsToRow` (`row_blocks.dart`) is the single definition of the arrow.
- Each model gained getters for the two halves; the composed `…summary` getters remain for diagnostics and now use ASCII `->`.
- `ToggleRow` gained `subtitleContent` (`Widget?`) alongside its String `subtitle`, since two sites are `ToggleRow` subtitles. Existing String callers unaffected.
- Per Article XIV: UI Kit has **no** inline-icon primitive (no `WidgetSpan` anywhere in it), so this composes existing atoms rather than adding a component.

Out of scope by design: logger, console and LLM-prompt strings never pass through Flutter's font stack. `lib/ai/prompts/` and `[USP]`-prefixed logs keep their arrows.

## ⚠️ One deliberate visual change — please eyeball this

`usp_firewall_overview_card.dart` read `'${rule.portSummary} → ${rule.internalClient}'`, which rendered:

```
8080 → 192.168.1.100:80 → 192.168.1.100
```

— the internal client twice, once bare and once already inside `portSummary`. It is now a single `8080 → 192.168.1.100:80`. Preserving both arrows would have drawn two icons for duplicate information. This is the only site whose output changes beyond glyph→icon.

`pnp_demo_launcher.dart` uses an en dash instead: it's a three-step sequence, not a mapping.

## Verification

- **New guard test** `test/page/_shared/components/layout_blocks/maps_to_row_test.dart` — asserts no rendered `Text` carries U+2192, that the arrow is an `Icon`, and that long operands ellipsize without overflow at 120/140px. Tagged `dashboard-card` (not `ui`) so `run_tests.sh` includes it. **Mutation-checked**: reverting `MapsToRow` to a character arrow fails 3 of its 5 tests.
- `./run_tests.sh` — **5352 passing**.
- `dashboard_card_overflow_test.dart` — **1644 passing, `known_overflows.json` untouched**. Both `port_forwarding` and `firewall_overview` are gate-probed, and the icon is narrower than the glyph box it replaced.
- Affected golden tests (port_forwarding, dashboard cards, statistics, firewall) regenerated and re-run green.
- `dart format` clean; `flutter analyze` reports no error/warning on any changed file.

## Base branch

Targets **`gate/1183-overflow-gate`** (#1248), not `dev-2.7.0` — the overflow gate, its fixture and its probe only exist there, and the arrow sites sit inside two gate-probed cards. Rebased onto the current base tip, including the stricter probe from `30c2b8f7`.
