### PR TITLE
harden(statistics): Wrap treatment for stats_wifi_channels rows (#1258)

### DIFF
--- a/lib/page/statistics/views/sections/stats_wifi_channels_section.dart
+++ b/lib/page/statistics/views/sections/stats_wifi_channels_section.dart
@@ -105,7 +105,15 @@ class StatsWifiChannelsSection extends ConsumerWidget {
           return Padding(
             padding: const EdgeInsets.only(bottom: AppSpacing.md),
             child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+              // `stretch`, not `start`, and it is load-bearing for the `Wrap`
+              // below. `start` hands children a *loose* width constraint, so a
+              // `Wrap` shrink-wraps to its intrinsic width and
+              // `WrapAlignment.spaceBetween` has no free space to distribute —
+              // it silently degrades to `spacing` and the whole block sits
+              // centred in the section instead of spanning it. `stretch` makes
+              // the width tight, which is what the pre-#1258 `Row` + `Spacer`
+              // had, so `spaceBetween` reproduces the `Spacer` exactly.
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 // Band + channel string.
                 //
@@ -115,10 +123,13 @@ class StatsWifiChannelsSection extends ConsumerWidget {
                 //  1. A `Wrap`, not a `Row` + `Spacer`. While the content fits it
                 //     renders exactly as before: one run, `spaceBetween` puts the
                 //     band left and the channel string right, which is what the
-                //     `Spacer` did. When it does not fit — a localized `'Ch '`
-                //     prefix or a 3-digit 6GHz channel would eat the 47px of
-                //     headroom #1258 measured — the channel string drops to a
-                //     second line instead of overflowing.
+                //     `Spacer` did — but only because the `Column` above
+                //     stretches it. Under a loose width `spaceBetween` is a
+                //     no-op; see the `crossAxisAlignment` note there. When it
+                //     does not fit — a localized `'Ch '` prefix or a 3-digit
+                //     6GHz channel would eat the 47px of headroom #1258
+                //     measured — the channel string drops to a second line
+                //     instead of overflowing.
                 //  2. Neither side yields to an ellipsis: the band is the
                 //     identity of the block and the channel string is composed
                 //     data (§2.10a point 2). Both are content, not chrome, so

--- a/lib/page/statistics/views/sections/stats_wifi_channels_section.dart
+++ b/lib/page/statistics/views/sections/stats_wifi_channels_section.dart
@@ -107,10 +107,30 @@ class StatsWifiChannelsSection extends ConsumerWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Row(
+                // Band + channel string.
+                //
+                // DEGRADATION SHAPE (#1258, the third instance of the #1226 /
+                // #1252 shape on this page) — design §2.10, §2.10a:
+                //
+                //  1. A `Wrap`, not a `Row` + `Spacer`. While the content fits it
+                //     renders exactly as before: one run, `spaceBetween` puts the
+                //     band left and the channel string right, which is what the
+                //     `Spacer` did. When it does not fit — a localized `'Ch '`
+                //     prefix or a 3-digit 6GHz channel would eat the 47px of
+                //     headroom #1258 measured — the channel string drops to a
+                //     second line instead of overflowing.
+                //  2. Neither side yields to an ellipsis: the band is the
+                //     identity of the block and the channel string is composed
+                //     data (§2.10a point 2). Both are content, not chrome, so
+                //     they keep their intrinsic width and the row wraps as a
+                //     unit — an ellipsis mid-channel-string misinforms.
+                Wrap(
+                  alignment: WrapAlignment.spaceBetween,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  spacing: AppSpacing.lg,
+                  runSpacing: AppSpacing.xs,
                   children: [
                     AppText.labelLarge(radio.band),
-                    const Spacer(),
                     AppText.bodySmall(
                       'Ch ${radio.channelDisplay}  \u00b7  ${radio.channelBandwidth}',
                       color: colorScheme.onSurfaceVariant,
@@ -118,13 +138,38 @@ class StatsWifiChannelsSection extends ConsumerWidget {
                   ],
                 ),
                 AppGap.xs(),
-                Row(
+                // Client count + SNR + signal bar.
+                //
+                //  1. A `Wrap`, not a `Row` + `Expanded`. The `Expanded` on the
+                //     progress bar is the same cliff as the `Spacer` above: it
+                //     absorbs slack while the stats fit and collapses to zero
+                //     when they do not, at which point the unconstrained stats
+                //     overflow right (#1258 measured +27px in `fi` at a 192px
+                //     section).
+                //  2. The two stats never shrink: no `Flexible`, no `maxLines`,
+                //     no ellipsis (§2.10a point 2) — a half-shown count or SNR
+                //     misinforms. They stay glued together in a `Row(min)` so a
+                //     value never separates from its label.
+                //  3. The signal bar is the decoration and the thing that yields
+                //     (§2.10a point 2): it takes a fixed intrinsic width via a
+                //     `SizedBox`, and when the stats no longer leave room for it
+                //     the `Wrap` drops it to its own run rather than overflowing.
+                Wrap(
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  spacing: AppSpacing.sm,
+                  runSpacing: AppSpacing.xs,
                   children: [
-                    AppText.bodySmall(loc(context).clientsCount(clientCount)),
-                    AppGap.md(),
-                    AppText.bodySmall(loc(context).snrValue(snr.toInt())),
-                    AppGap.sm(),
-                    Expanded(
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        AppText.bodySmall(
+                            loc(context).clientsCount(clientCount)),
+                        AppGap.md(),
+                        AppText.bodySmall(loc(context).snrValue(snr.toInt())),
+                      ],
+                    ),
+                    SizedBox(
+                      width: 96,
                       child: AppLoader(
                         variant: LoaderVariant.linear,
                         value: snrNorm,

--- a/lib/page/statistics/views/sections/stats_wifi_channels_section.dart
+++ b/lib/page/statistics/views/sections/stats_wifi_channels_section.dart
@@ -148,23 +148,37 @@ class StatsWifiChannelsSection extends ConsumerWidget {
                 //     section).
                 //  2. The two stats never shrink: no `Flexible`, no `maxLines`,
                 //     no ellipsis (§2.10a point 2) — a half-shown count or SNR
-                //     misinforms. They stay glued together in a `Row(min)` so a
-                //     value never separates from its label.
-                //  3. The signal bar is the decoration and the thing that yields
-                //     (§2.10a point 2): it takes a fixed intrinsic width via a
-                //     `SizedBox`, and when the stats no longer leave room for it
-                //     the `Wrap` drops it to its own run rather than overflowing.
+                //     misinforms.
+                //  3. The stats group is itself a nested `Wrap`, not a
+                //     `Row(min)`. A `Row(min)` still hands its children
+                //     unbounded width, so it reintroduces the very shape this
+                //     ticket removes one level down: with the signal bar already
+                //     on its own run, `clientsCount` + `snrValue` alone overflow
+                //     a 216px section in `fi` (and 192px in `fi`/`ja`/`ko`/`vi`),
+                //     which is above the 192px floor AC-1 asks for. As a `Wrap`
+                //     the SNR drops to a third run instead, and each stat still
+                //     keeps its full intrinsic width — nothing is clipped or
+                //     ellipsized, which is what §2.10a point 2 actually
+                //     requires. Splitting the pair across runs is a weaker cost
+                //     than clipping a number: both labels stay attached to their
+                //     own values.
+                //  4. The signal bar is the decoration and the thing that yields
+                //     first (§2.10a point 2): it takes a fixed intrinsic width
+                //     via a `SizedBox`, and when the stats no longer leave room
+                //     for it the outer `Wrap` drops it to its own run rather
+                //     than overflowing.
                 Wrap(
                   crossAxisAlignment: WrapCrossAlignment.center,
                   spacing: AppSpacing.sm,
                   runSpacing: AppSpacing.xs,
                   children: [
-                    Row(
-                      mainAxisSize: MainAxisSize.min,
+                    Wrap(
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      spacing: AppSpacing.md,
+                      runSpacing: AppSpacing.xs,
                       children: [
                         AppText.bodySmall(
                             loc(context).clientsCount(clientCount)),
-                        AppGap.md(),
                         AppText.bodySmall(loc(context).snrValue(snr.toInt())),
                       ],
                     ),

--- a/test/page/statistics/views/sections/stats_wifi_channels_section_test.dart
+++ b/test/page/statistics/views/sections/stats_wifi_channels_section_test.dart
@@ -1,0 +1,443 @@
+@Tags(['dashboard-card'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/localization/fallback_font_resolver.dart';
+import 'package:privacy_gui/page/_shared/models/client_connection_detail.dart';
+import 'package:privacy_gui/page/_shared/models/wifi_client_ui_model.dart';
+import 'package:privacy_gui/page/_shared/models/wifi_radio_ui_model.dart';
+import 'package:privacy_gui/page/statistics/views/sections/stats_wifi_channels_section.dart';
+import 'package:privacy_gui/page/wifi_settings/providers/wifi_data_provider.dart';
+import 'package:privacy_gui/theme/theme_json_config.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import '../../../../golden_test/golden_framework/mocks/mock_statistics.dart';
+import '../../../../util/app_test_fonts.dart';
+import '../../../../util/overflow_probe.dart';
+
+/// Overflow tests for the two rows the WiFi Channels section renders per radio
+/// (#1258 — the third instance of the #1226 / #1252 shape on the Statistics
+/// page).
+///
+/// ## Why this file exists
+///
+/// `StatsWifiChannelsSection` renders one block per radio, each with two
+/// unconstrained rows (`stats_wifi_channels_section.dart`):
+///
+///  - **line 110** — `AppText.labelLarge(radio.band)` + `const Spacer()` +
+///    `AppText.bodySmall('Ch <channel>  ·  <bandwidth>')`. `Spacer` is an
+///    `Expanded`, so it absorbs slack while the content fits and collapses to
+///    zero when it does not, at which point both unconstrained texts take their
+///    intrinsic width and overflow right.
+///  - **line 121** — client count + SNR + `Expanded(AppLoader)`. Same cliff
+///    with the `Expanded` on the progress bar instead of a `Spacer`.
+///
+/// Unlike the dashboard cards, this section is **not** in `UspWidgetSpecs.all`,
+/// so the #1183 overflow gate never scans it — there is no ratchet entry and no
+/// gate failure. This is a hardening ticket: #1258 measured **47px of
+/// headroom** on line 110 at the 288px production floor (241px is the zero
+/// crossing), and three things can eat it — localizing the hardcoded `'Ch '`
+/// literal, a 3-digit 6GHz channel (`Ch 233 (Auto)`), or simply a narrower
+/// realization. The AC is therefore a measurement of the rows, not "N gate
+/// coordinates removed".
+///
+/// ## Two kinds of assertion, and why the stress widths are below production
+///
+/// Both rows have headroom at every *production* width (line 110: 47px at the
+/// 288px floor; line 121's `fi` crossing is 219px, 69px below the floor). A
+/// test that only pumped production widths could therefore never fail — it
+/// would report the shape as pinned while quietly guarding nothing, exactly the
+/// dead-overflow-test trap `dashboard_legend_readability_test.dart` warned
+/// about. So each row is checked two ways:
+///
+///   1. **Regression guard (production widths).** The `Wrap` renders identically
+///      to the old `Row` while content fits, so these pin that the current data
+///      and locales stay clean across the real screen range — a future wider
+///      string that eats the headroom trips here.
+///   2. **Degradation guard (a documented sub-production stress width).** Below
+///      the floor the pre-fix `Row` clips and the `Wrap` drops the yielding
+///      child to a second line instead. This width is where the fix's *value*
+///      lives, and it is the width the mutation ledger below fails at. It is
+///      deliberately narrower than any supported screen — the point is not that
+///      this width ships, but that the shape degrades by wrapping rather than
+///      clipping when the headroom is finally spent.
+///
+/// Tagged `dashboard-card` so it gates PRs — `run_tests.sh` excludes
+/// `golden||loc||ui`, and a `ui`-tagged regression test would not block
+/// anything.
+///
+/// ## Mutation ledger
+///
+/// Every degradation-guard group here was shown to fail under a mutation of the
+/// code it guards — an overflow test that cannot fail is worse than no test
+/// (precedent: `stats_traffic_monitor_legend_test.dart`). Measured on this
+/// worktree with the fixtures below:
+///
+///   | mutation                                            | measured                    |
+///   |-----------------------------------------------------|-----------------------------|
+///   | line 110 `Wrap` -> pre-fix `Row`+`Spacer`           | +28px @200px section (grp 1)|
+///   | line 121 `Wrap` -> pre-fix `Row`+`Expanded`         | +6.9px @219px section (grp 2)|
+///   | signal bar `SizedBox(96)` -> `Expanded` (keep `Wrap`)| ParentDataWidget error (grp 2)|
+///   | count -> `Flexible` + 1-line ellipsis               | stats legible fails (grp 3) |
+///
+/// The `Wrap` fix is clean at both stress widths (line 110 clean to 180px; line
+/// 121 clean at 219px), so each row is clean where its pre-fix shape clips.
+
+/// Two radios whose channel string is the widest #1258 named: a 3-digit 6GHz
+/// channel in auto mode (`Ch 233 (Auto)`) at a 3-digit bandwidth. This is the
+/// "wider data" stressor from the issue — line 110's overflow is
+/// locale-independent (both texts are data, not localized strings), so the way
+/// to break it is wider data, not a wider locale.
+const _wideChannelWifiData = WifiData(
+  codegenContext: WifiCodegenContext.empty,
+  radioModels: [
+    WifiRadioUIModel(
+      instancePath: 'Device.WiFi.Radio.1.',
+      band: '2.4GHz',
+      enable: true,
+      transmitPower: -1,
+      maxBitRate: 300,
+      channel: 11,
+      autoChannelEnable: true,
+      channelBandwidth: '20/40MHz',
+      supportedStandards: 'b,g,n',
+    ),
+    WifiRadioUIModel(
+      instancePath: 'Device.WiFi.Radio.3.',
+      band: '6GHz',
+      enable: true,
+      transmitPower: -1,
+      maxBitRate: 4800,
+      channel: 233,
+      autoChannelEnable: true,
+      channelBandwidth: '160MHz',
+      supportedStandards: 'a,n,ac,ax,be',
+    ),
+  ],
+);
+
+/// The same two radios, plus a full client map so line 121 renders a non-zero
+/// `clientsCount(n)` + `snrValue(n)` + signal bar — the state #1258 measured
+/// (`+27px in fi at a 192px section`). Two clients per band exercises the
+/// locale-dependent client-count string that `fi`
+/// (`{count} asiakaslaitetta`) makes worst.
+final _wifiDataWithClients = WifiData(
+  codegenContext: WifiCodegenContext.empty,
+  radioModels: _wideChannelWifiData.radioModels,
+  wifiClientMap: {
+    for (var i = 0; i < 8; i++)
+      'mac$i': WifiClientUIModel(
+        macAddress: 'AA:BB:CC:DD:EE:0$i',
+        signalStrength: -55 - i,
+        noise: -95,
+        lastDataDownlinkRate: 866000,
+        lastDataUplinkRate: 433000,
+        active: true,
+      ),
+  },
+  connectionDetailMap: {
+    for (var i = 0; i < 8; i++)
+      'mac$i': ClientConnectionDetail(
+        band: i.isEven ? '2.4GHz' : '6GHz',
+        ssidName: 'Linksys',
+      ),
+  },
+);
+
+void main() {
+  setUpAll(() async {
+    // Real fonts: text widths — and therefore overflow — are meaningless under
+    // the Ahem block font.
+    await loadAppFonts();
+  });
+
+  /// The width a single Statistics section renders to on a [screenWidth]
+  /// screen: full content width minus the page margin on both edges. Mirrors
+  /// `stats_traffic_monitor_legend_test.dart` — the Statistics page pads each
+  /// section by `context.layoutMargin` (`usp_statistics_view.dart`), which is
+  /// ui_kit's own [AppLayoutConfig.margin], so this reads it from the source of
+  /// truth rather than a copied breakpoint table.
+  double sectionWidthFor(double screenWidth) =>
+      screenWidth - AppLayoutConfig.margin(screenWidth) * 2;
+
+  final baseTheme = ThemeJsonConfig.defaultConfig().createLightTheme();
+
+  /// Pumps the real [StatsWifiChannelsSection] once with the section sized to
+  /// [sectionWidth] on a [screenWidth] screen, and returns the RenderFlex
+  /// overflows beyond a 2px tolerance (the gate's own tolerance).
+  ///
+  /// [sectionWidth] defaults to what the Statistics page would give a section
+  /// on that screen ([sectionWidthFor]); the degradation-guard tests pass an
+  /// explicit narrower value to reach below the production floor while keeping
+  /// the screen (and therefore ui_kit's layout regime) realistic.
+  ///
+  /// One pump per call: Flutter reports a given RenderFlex's overflow only once
+  /// per render-object lifetime, so a second pump in the same test would report
+  /// a genuinely overflowing width as clean.
+  Future<List<OverflowIncident>> overflowsAt({
+    required WidgetTester tester,
+    required double screenWidth,
+    required Locale locale,
+    required WifiData wifiData,
+    double? sectionWidth,
+  }) async {
+    final surface = Size(screenWidth, 900.0);
+    final width = sectionWidth ?? sectionWidthFor(screenWidth);
+
+    var theme = baseTheme;
+    final cjkFallback = FallbackFontResolver.prefixedFallbackFor(locale);
+    if (cjkFallback != null) {
+      theme = theme.copyWith(
+        textTheme: theme.textTheme.apply(fontFamilyFallback: cjkFallback),
+      );
+    }
+
+    return runWithOverflowCollection((sink) async {
+      await tester.binding.setSurfaceSize(surface);
+      tester.view.physicalSize = surface;
+      tester.view.devicePixelRatio = 1.0;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: statisticsOverrides(wifiData: wifiData),
+          child: MaterialApp(
+            locale: locale,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            theme: theme,
+            builder: (context, child) => MediaQuery(
+              data: MediaQuery.of(context).copyWith(disableAnimations: true),
+              child: child ?? const SizedBox.shrink(),
+            ),
+            home: Scaffold(
+              body: SingleChildScrollView(
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: SizedBox(
+                    width: width,
+                    child: const StatsWifiChannelsSection(),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await settleIgnoringAnimations(tester);
+      return sink.where((i) => i.pixels > 2.0).toList();
+    });
+  }
+
+  Locale localeFor(String tag) =>
+      AppLocalizations.supportedLocales.firstWhere((l) {
+        final t = l.countryCode == null || l.countryCode!.isEmpty
+            ? l.languageCode
+            : '${l.languageCode}_${l.countryCode}';
+        return t == tag;
+      });
+
+  /// The Statistics page is a single-column scroll list, so a section spans the
+  /// full content width. These are the narrow realizations that matter (same
+  /// set as `stats_traffic_monitor_legend_test.dart`):
+  ///
+  /// - 1241px: the D1 desktop-large pinch — 200px margins open just above
+  ///   1240px, so 1241px yields a *narrower* section (841px) than 1240px.
+  /// - 905px tablet: 32px margins, 841px section.
+  /// - 601px: the tablet floor (32px margins), 537px section.
+  /// - 320px: the framework's narrowest supported screen, 16px margins, 288px
+  ///   section — the absolute worst case for these rows (the production floor
+  ///   #1258 measured, where line 110 has only 47px of headroom).
+  const narrowScreens = <double>[1241.0, 905.0, 601.0, 320.0];
+
+  group('band + channel row (line 110) is clean under wide data (#1258)', () {
+    // Line 110's overflow is locale-independent — both texts are data, not
+    // localized strings — so the stressor is wider data, not a wider locale.
+    // `_wideChannelWifiData` carries a 3-digit 6GHz `Ch 233 (Auto)` at 160MHz,
+    // the widest channel string #1258 named. `de` ("Kanal") is pumped too as a
+    // guard against anyone localizing the `'Ch '` prefix without re-checking.
+    for (final tag in ['en', 'de']) {
+      for (final screen in narrowScreens) {
+        testWidgets(
+          'no overflow at ${sectionWidthFor(screen).toStringAsFixed(0)}px '
+          'section (${screen.toStringAsFixed(0)}px screen) in $tag',
+          (tester) async {
+            final overflows = await overflowsAt(
+              tester: tester,
+              screenWidth: screen,
+              locale: localeFor(tag),
+              wifiData: _wideChannelWifiData,
+            );
+            expect(
+              overflows,
+              isEmpty,
+              reason: 'WiFi Channels band+channel row overflows in $tag at a '
+                  '${screen.toStringAsFixed(0)}px screen '
+                  '(${sectionWidthFor(screen).toStringAsFixed(0)}px section) '
+                  'with a 3-digit 6GHz channel: ${overflows.join(', ')}',
+            );
+          },
+        );
+      }
+    }
+
+    // Degradation guard: below the production floor, the pre-fix `Row` + `Spacer`
+    // clips the channel string, the `Wrap` drops it to a second line. 200px
+    // section is where that difference is unambiguous with the wide 6GHz data:
+    // measured +28px right under the pre-fix shape on this worktree, clean under
+    // the `Wrap`. This is the test the "line 110 -> Row+Spacer" mutation fails.
+    testWidgets(
+      'wraps instead of clipping at a 200px section (below floor, en)',
+      (tester) async {
+        final overflows = await overflowsAt(
+          tester: tester,
+          screenWidth: 320.0,
+          sectionWidth: 200.0,
+          locale: localeFor('en'),
+          wifiData: _wideChannelWifiData,
+        );
+        expect(
+          overflows,
+          isEmpty,
+          reason: 'the band+channel row must wrap the channel string to a '
+              'second line at a 200px section rather than overflow — the '
+              'pre-fix `Row` + `Spacer` clips here (+28px): '
+              '${overflows.join(', ')}',
+        );
+      },
+    );
+  });
+
+  group('client + SNR + signal-bar row (line 121) is clean (#1258)', () {
+    // Line 121's overflow is locale-dependent, and `fi`
+    // (`{count} asiakaslaitetta`) is the worst. `_wifiDataWithClients` gives it
+    // real, non-zero client counts across both radios so the row renders the
+    // state #1258 measured overflowing (+27px in `fi` at a 192px section).
+    for (final tag in ['fi', 'de', 'ru']) {
+      for (final screen in narrowScreens) {
+        testWidgets(
+          'no overflow at ${sectionWidthFor(screen).toStringAsFixed(0)}px '
+          'section (${screen.toStringAsFixed(0)}px screen) in $tag',
+          (tester) async {
+            final overflows = await overflowsAt(
+              tester: tester,
+              screenWidth: screen,
+              locale: localeFor(tag),
+              wifiData: _wifiDataWithClients,
+            );
+            expect(
+              overflows,
+              isEmpty,
+              reason: 'WiFi Channels client+SNR row overflows in $tag at a '
+                  '${screen.toStringAsFixed(0)}px screen '
+                  '(${sectionWidthFor(screen).toStringAsFixed(0)}px section): '
+                  '${overflows.join(', ')}',
+            );
+          },
+        );
+      }
+    }
+
+    // Degradation guard: below the production floor, the pre-fix `Row` +
+    // `Expanded(AppLoader)` clips the stats; the `Wrap` drops the fixed-width
+    // signal bar to its own run. 219px section in `fi` (the worst locale, with
+    // real clients) is the exact crossing: measured +6.9px right under the
+    // pre-fix shape on this worktree, clean under the `Wrap`. This is the test
+    // the "line 121 -> Row+Expanded" and "signal bar -> Expanded" mutations
+    // fail.
+    testWidgets(
+      'drops the signal bar to its own run at a 219px section (below floor, fi)',
+      (tester) async {
+        final overflows = await overflowsAt(
+          tester: tester,
+          screenWidth: 320.0,
+          sectionWidth: 219.0,
+          locale: localeFor('fi'),
+          wifiData: _wifiDataWithClients,
+        );
+        expect(
+          overflows,
+          isEmpty,
+          reason: 'the client+SNR row must move the signal bar to a second '
+              'line at a 219px section rather than overflow — the pre-fix '
+              '`Row` + `Expanded` clips here (+6.9px in fi): '
+              '${overflows.join(', ')}',
+        );
+      },
+    );
+  });
+
+  group('client-count and SNR stats stay legible (#1258)', () {
+    // The signal bar keys nothing on its own — a client that drops it to a
+    // second line still reads. The count and SNR are the section's content: an
+    // ellipsis lands mid-number, and a half-shown statistic misinforms in a way
+    // a missing one does not (design §2.10a point 2). So the AC is not "the
+    // stats are somewhere in the tree" — it is that they are present,
+    // unellipsized, and not flex children that could shrink.
+
+    /// True if a [Flexible] (or [Expanded], its subclass) sits between the stat
+    /// and its enclosing [Wrap] — i.e. the stat can be squeezed below its
+    /// intrinsic width.
+    bool canShrink(Finder statFinder) {
+      var flexed = false;
+      statFinder.evaluate().single.visitAncestorElements((ancestor) {
+        // Stop at the `Wrap`: it is the layout that decides this stat's width,
+        // so reaching it means "nothing between here and the layout can squeeze
+        // it" — the property under test, not "not found yet".
+        if (ancestor.widget is Wrap) return false;
+        if (ancestor.widget is Flexible) {
+          flexed = true;
+          return false;
+        }
+        return true;
+      });
+      return flexed;
+    }
+
+    testWidgets(
+        'the client count and SNR are whole and unshrinkable at the narrowest '
+        'width', (tester) async {
+      const locale = Locale('fi');
+      await overflowsAt(
+        tester: tester,
+        screenWidth: 320.0,
+        locale: locale,
+        wifiData: _wifiDataWithClients,
+      );
+
+      // Every AppText.bodySmall in the two rows is a Text; the count and SNR
+      // strings are the localized stats. Assert on every rendered stat rather
+      // than one exact value so the check does not encode the fixture's counts.
+      final l10n = await AppLocalizations.delegate.load(locale);
+      // 4 clients on 2.4GHz, 4 on 6GHz -> clientsCount(4) rendered twice.
+      final countText = l10n.clientsCount(4);
+      final countFinder = find.text(countText);
+      expect(
+        countFinder,
+        findsWidgets,
+        reason: 'the client-count stat ($countText) must survive the '
+            'degradation — the `Wrap` moves the signal bar to a second line, '
+            'it may not discard the count',
+      );
+
+      for (final element in countFinder.evaluate()) {
+        final text = element.widget as Text;
+        expect(
+          text.overflow,
+          isNot(TextOverflow.ellipsis),
+          reason: 'the client count must never ellipsize: an ellipsis lands '
+              'mid-number',
+        );
+        expect(text.maxLines, isNull,
+            reason: 'the client count must not be line-capped');
+      }
+      expect(
+        canShrink(countFinder.first),
+        isFalse,
+        reason: 'the client count must not be a flex child — it keeps its '
+            'intrinsic width and the whole stats group wraps instead',
+      );
+    });
+  });
+}

--- a/test/page/statistics/views/sections/stats_wifi_channels_section_test.dart
+++ b/test/page/statistics/views/sections/stats_wifi_channels_section_test.dart
@@ -44,7 +44,7 @@ import '../../../../util/overflow_probe.dart';
 /// realization. The AC is therefore a measurement of the rows, not "N gate
 /// coordinates removed".
 ///
-/// ## Three kinds of assertion, and why the stress widths are below production
+/// ## Four kinds of assertion, and why the stress widths are below production
 ///
 /// Both rows have headroom at every *production* width (line 110: 47px at the
 /// 288px floor; line 121's pre-fix `fi` crossing is 219px, 69px below the
@@ -69,6 +69,10 @@ import '../../../../util/overflow_probe.dart';
 ///      at one width can sit in a pocket of cleanliness: this file's 219px guard
 ///      passed while a nested `Row(min)` clipped at 216px, 3px away. Walking the
 ///      ladder is what closes that gap, and it is the group that caught it.
+///   4. **Geometry guard (production widths).** The three above all read
+///      `RenderFlex` overflow, which cannot see *where* a child landed. A
+///      `Wrap` under a loose width constraint lays out visibly wrong and
+///      overflows nothing, so the row's horizontal span is asserted directly.
 ///
 /// Tagged `dashboard-card` so it gates PRs — `run_tests.sh` excludes
 /// `golden||loc||ui`, and a `ui`-tagged regression test would not block
@@ -91,11 +95,33 @@ import '../../../../util/overflow_probe.dart';
 ///   | count -> `Flexible` + 1-line ellipsis                | all fail (grp 3 + layout)    |
 ///   | `snrValue` -> 1-line ellipsis (no `Flexible`)        | grp 3 fails                  |
 ///   | `snrValue` -> `Flexible` + 1-line ellipsis           | all fail (grp 3 + layout)    |
+///   | `snrValue` -> 1-line ellipsis on **2.4GHz only**     | grp 4 fails                  |
+///   | per-radio `Column` `stretch` -> `start`              | 3 tests fail (grp 3)         |
+///   | band+channel `Wrap`: drop `spaceBetween`             | 3 tests fail (grp 3)         |
 ///
-/// The two `snrValue` rows are the reason group 3 asserts on **both** stats. An
-/// earlier revision of this file checked only `clientsCount`, and both of those
-/// mutations passed it: the group's own doc comment promised "the count **and**
-/// SNR", while the SNR was unguarded.
+/// The last two rows are group 3, and they are a different *kind* of guard from
+/// everything above them. Every other assertion in this file reads `RenderFlex`
+/// overflow, which is blind to position — the `Wrap` was for one revision
+/// laid out visibly wrong (channel string no longer right-aligned, whole radio
+/// block drifted to the centre of the section) while all 43 overflow tests
+/// stayed green. `spaceBetween` needs a **tight** width to have anything to
+/// distribute, and the per-radio `Column`'s `CrossAxisAlignment.start` handed
+/// the `Wrap` a loose one. Group 3 asserts the geometry directly; see its own
+/// header for the measured before/after table.
+///
+/// The `snrValue` rows are the reason group 4 asserts on **both** stats. An
+/// earlier revision of this file checked only `clientsCount`, and the first two
+/// of those mutations passed it: the group's own doc comment promised "the count
+/// **and** SNR", while the SNR was unguarded.
+///
+/// The last row is the reason group 4 pins an **exact instance count per string**
+/// and checks every element the finder returns. The two radios do not render the
+/// same SNR — 2.4GHz averages to `snrValue(37)`, 6GHz to `snrValue(36)` — so a
+/// revision that listed only `snrValue(36)` under `findsWidgets` (>= 1) matched
+/// the 6GHz widget and never looked at 2.4GHz: an ellipsis on that radio alone
+/// passed 43/43. A `Flexible` on one radio is caught only incidentally, by
+/// `Flexible`-inside-`Wrap` throwing a ParentDataWidget error; the bare ellipsis
+/// had nothing catching it.
 ///
 /// The `Row(min)` row is the shape this file's first revision shipped. A
 /// `Row(min)` hands its children unbounded width just as a `Row` does — it only
@@ -339,7 +365,7 @@ void main() {
     // `de` here (`{count} clients`, the same string as `en`), so it adds no
     // coverage at these widths — it is pumped because the AC names it, and
     // because a future ARB edit could make it the worst without anyone
-    // re-deriving which locale dominates. `_widestStatLocales` below covers the
+    // re-deriving which locale dominates. `widestStatLocales` below covers the
     // locales that actually break first.
     for (final tag in ['fi', 'de', 'ru', 'nl']) {
       for (final screen in narrowScreens) {
@@ -441,6 +467,110 @@ void main() {
     }
   });
 
+  group('the band+channel row still spans the section (#1258)', () {
+    // WHY THIS GROUP EXISTS
+    //
+    // Every other guard in this file reads `RenderFlex` overflow, which is blind
+    // to *position*: a row can be laid out completely wrong and still be clean.
+    // The `Wrap` that replaced the `Row` + `Spacer` was, for one revision,
+    // exactly that — visually broken and green on all 43 tests.
+    //
+    // `WrapAlignment.spaceBetween` only has an effect when the `Wrap` gets a
+    // **tight** width. The per-radio `Column` handed it `CrossAxisAlignment
+    // .start`, i.e. a loose constraint, so the `Wrap` shrink-wrapped to its
+    // intrinsic width, `spaceBetween` had no free space to distribute, and it
+    // silently degraded to a plain `spacing: AppSpacing.lg` gap. Measured
+    // against the pre-#1258 `Row` + `Spacer` at 288 / 537 / 841px sections:
+    //
+    //   |                        | band left      | channel right   |
+    //   |------------------------|----------------|-----------------|
+    //   | pre-fix `Row`+`Spacer` | 25 / 25 / 25   | 263 / 512 / 816 |
+    //   | `Wrap` under `start`   | 30 / 154 / 306 | 238 / 363 / 515 |
+    //   | `Wrap` under `stretch` | 25 / 25 / 25   | 263 / 512 / 816 |
+    //
+    // So under `start` the channel string stopped being right-aligned and the
+    // whole radio block drifted to the centre of the section — at 841px the band
+    // sat 281px from where it belonged. `stretch` restores the pre-fix geometry
+    // exactly. Reverting either `stretch` or `spaceBetween` leaves all 43 other
+    // tests green, which is why this is asserted directly.
+    //
+    // The assertion is "the row spans the section", not a pixel table: it pins
+    // the property the `Spacer` provided without freezing font metrics, so a
+    // theme or font change does not fail it.
+    for (final section in [288.0, 537.0, 841.0]) {
+      testWidgets(
+        'channel string stays right-aligned at a ${section.toStringAsFixed(0)}px '
+        'section',
+        (tester) async {
+          final overflows = await overflowsAt(
+            tester: tester,
+            screenWidth: 320.0,
+            sectionWidth: section,
+            locale: localeFor('en'),
+            wifiData: _wideChannelWifiData,
+          );
+          expect(overflows, isEmpty,
+              reason: 'precondition: the row must be clean at this width');
+
+          // The `Wrap` is the parent of the band text. Its own width is the
+          // measurement that matters: shrink-wrapped means `spaceBetween` is
+          // dead, tight means it is doing the `Spacer`'s job.
+          final bandFinder = find.text('2.4GHz');
+          expect(bandFinder, findsOneWidget);
+
+          Element? wrapElement;
+          bandFinder.evaluate().single.visitAncestorElements((a) {
+            if (a.widget is Wrap) {
+              wrapElement = a;
+              return false;
+            }
+            return true;
+          });
+          expect(wrapElement, isNotNull,
+              reason: 'the band text must sit inside the band+channel `Wrap`');
+
+          final wrapBox = wrapElement!.renderObject as RenderBox;
+          final parentBox =
+              wrapElement!.findAncestorRenderObjectOfType<RenderBox>()!;
+
+          // A shrink-wrapped `Wrap` is narrower than the column that holds it;
+          // a stretched one matches it. This is the `start`-vs-`stretch`
+          // difference, expressed without hardcoding text widths.
+          expect(
+            wrapBox.size.width,
+            closeTo(parentBox.size.width, 1.0),
+            reason: 'the band+channel `Wrap` must be stretched to the full '
+                'section width, not shrink-wrapped to its intrinsic width — '
+                'under a loose constraint `WrapAlignment.spaceBetween` has no '
+                'free space to distribute and degrades to a plain `spacing` '
+                'gap, which drifts the whole radio block to the centre of the '
+                'section (measured: band at 154px instead of 25px on a 537px '
+                'section). Check the per-radio `Column` is '
+                '`CrossAxisAlignment.stretch`.',
+          );
+
+          // And the channel string is actually pushed to the far edge, which is
+          // what the `Spacer` did. Guards `alignment: spaceBetween` itself:
+          // removing it leaves the `Wrap` stretched but packs both texts left.
+          final chanBox = tester
+              .renderObject<RenderBox>(find.textContaining('Ch 11').first);
+          final chanRight =
+              chanBox.localToGlobal(Offset.zero).dx + chanBox.size.width;
+          final wrapRight =
+              wrapBox.localToGlobal(Offset.zero).dx + wrapBox.size.width;
+          expect(
+            chanRight,
+            closeTo(wrapRight, 1.0),
+            reason: 'the channel string must end flush with the right edge of '
+                'the row, as it did under the pre-#1258 `Row` + `Spacer`. '
+                'Check `alignment: WrapAlignment.spaceBetween` is still on the '
+                'band+channel `Wrap`.',
+          );
+        },
+      );
+    }
+  });
+
   group('client-count and SNR stats stay legible (#1258)', () {
     // The signal bar keys nothing on its own — a client that drops it to a
     // second line still reads. The count and SNR are the section's content: an
@@ -452,9 +582,15 @@ void main() {
     /// True if a [Flexible] (or [Expanded], its subclass) sits between the stat
     /// and its enclosing [Wrap] — i.e. the stat can be squeezed below its
     /// intrinsic width.
-    bool canShrink(Finder statFinder) {
+    ///
+    /// Takes the [Element] rather than a [Finder] so the caller can check
+    /// **every** rendered instance. A `Finder`-shaped version invites
+    /// `canShrink(finder.first)`, which checks one radio's widget and leaves the
+    /// others unguarded — the same one-instance blind spot the `snrValue` fixture
+    /// note below records.
+    bool canShrink(Element stat) {
       var flexed = false;
-      statFinder.evaluate().single.visitAncestorElements((ancestor) {
+      stat.visitAncestorElements((ancestor) {
         // Stop at the `Wrap`: it is the layout that decides this stat's width,
         // so reaching it means "nothing between here and the layout can squeeze
         // it" — the property under test, not "not found yet".
@@ -491,32 +627,48 @@ void main() {
       // `Flexible` + `overflow: ellipsis` to `snrValue` passed the count-only
       // version of this test).
       //
-      // 4 clients on 2.4GHz, 4 on 6GHz -> each stat is rendered twice, once per
-      // radio, with the same value.
+      // ## Every rendered instance, and why the count matters
       //
-      // The SNR is the average of `computeSNR(signalStrength, noise)` over a
-      // band's clients: signal -55..-62 against noise -95 gives 40..33 dB, and
-      // the per-band averages land on `snrValue(36)` for both radios (2.4GHz
-      // takes the even indices, 6GHz the odd). Asserting the exact string keeps
-      // the finder honest — a stat rendered as something else would read as
-      // "absent" and fail below rather than silently pass.
-      final stats = <String, String>{
-        'client count': l10n.clientsCount(4),
-        'SNR': l10n.snrValue(36),
-      };
+      // The section renders one block per radio, so each stat appears **twice**.
+      // The two radios do not necessarily render the *same* string, and the SNR
+      // does not:
+      //
+      //   `computeSNR(signal, noise) = signal - noise` over a band's clients.
+      //   `signalStrength: -55 - i` against `noise: -95` gives 40..33 dB, and
+      //   the bands split by parity of `i`:
+      //
+      //     2.4GHz (even i = 0,2,4,6): 40, 38, 36, 34 -> avg 37 -> `snrValue(37)`
+      //     6GHz   (odd  i = 1,3,5,7): 39, 37, 35, 33 -> avg 36 -> `snrValue(36)`
+      //
+      // An earlier revision listed only `snrValue(36)` and asserted with
+      // `findsWidgets` (>= 1). That matched the 6GHz widget alone and left the
+      // 2.4GHz SNR entirely unguarded: an `overflow: ellipsis` applied to just
+      // that radio passed 43/43. Both strings are therefore listed, and each is
+      // pinned with `findsNWidgets(1)` rather than `findsWidgets` — an exact
+      // count is what makes a missing or reformatted instance fail here instead
+      // of being absorbed by its sibling.
+      //
+      // `clientsCount(4)` is genuinely the same on both radios (4 clients each),
+      // so it is the one stat that legitimately appears twice.
+      final stats = <({String label, String text, int instances})>[
+        (label: 'client count', text: l10n.clientsCount(4), instances: 2),
+        (label: '2.4GHz SNR', text: l10n.snrValue(37), instances: 1),
+        (label: '6GHz SNR', text: l10n.snrValue(36), instances: 1),
+      ];
 
-      for (final entry in stats.entries) {
-        final label = entry.key;
-        final text = entry.value;
-        final finder = find.text(text);
+      for (final stat in stats) {
+        final label = stat.label;
+        final finder = find.text(stat.text);
         expect(
           finder,
-          findsWidgets,
-          reason: 'the $label stat ($text) must survive the degradation — the '
-              '`Wrap` moves the signal bar to its own run, it may not discard '
-              'or reformat a stat',
+          findsNWidgets(stat.instances),
+          reason: 'the $label stat (${stat.text}) must survive the degradation '
+              'exactly ${stat.instances}x — the `Wrap` moves the signal bar to '
+              'its own run, it may not discard or reformat a stat',
         );
 
+        // Every instance, not just the first: the radios are rendered by the
+        // same builder but a per-radio conditional would only break one of them.
         for (final element in finder.evaluate()) {
           final widget = element.widget as Text;
           expect(
@@ -527,13 +679,13 @@ void main() {
           );
           expect(widget.maxLines, isNull,
               reason: 'the $label must not be line-capped');
+          expect(
+            canShrink(element),
+            isFalse,
+            reason: 'the $label must not be a flex child — it keeps its '
+                'intrinsic width and the stats group wraps instead',
+          );
         }
-        expect(
-          canShrink(finder.first),
-          isFalse,
-          reason: 'the $label must not be a flex child — it keeps its '
-              'intrinsic width and the stats group wraps instead',
-        );
       }
     });
   });

--- a/test/page/statistics/views/sections/stats_wifi_channels_section_test.dart
+++ b/test/page/statistics/views/sections/stats_wifi_channels_section_test.dart
@@ -44,14 +44,14 @@ import '../../../../util/overflow_probe.dart';
 /// realization. The AC is therefore a measurement of the rows, not "N gate
 /// coordinates removed".
 ///
-/// ## Two kinds of assertion, and why the stress widths are below production
+/// ## Three kinds of assertion, and why the stress widths are below production
 ///
 /// Both rows have headroom at every *production* width (line 110: 47px at the
-/// 288px floor; line 121's `fi` crossing is 219px, 69px below the floor). A
-/// test that only pumped production widths could therefore never fail — it
-/// would report the shape as pinned while quietly guarding nothing, exactly the
-/// dead-overflow-test trap `dashboard_legend_readability_test.dart` warned
-/// about. So each row is checked two ways:
+/// 288px floor; line 121's pre-fix `fi` crossing is 219px, 69px below the
+/// floor). A test that only pumped production widths could therefore never fail
+/// — it would report the shape as pinned while quietly guarding nothing, exactly
+/// the dead-overflow-test trap `dashboard_legend_readability_test.dart` warned
+/// about. So each row is checked three ways:
 ///
 ///   1. **Regression guard (production widths).** The `Wrap` renders identically
 ///      to the old `Row` while content fits, so these pin that the current data
@@ -64,6 +64,11 @@ import '../../../../util/overflow_probe.dart';
 ///      deliberately narrower than any supported screen — the point is not that
 ///      this width ships, but that the shape degrades by wrapping rather than
 ///      clipping when the headroom is finally spent.
+///   3. **AC-1 ladder (288 / 256 / 224 / 192px sections).** The widths #1258's
+///      AC-1 names, in the locales that break first. A single degradation guard
+///      at one width can sit in a pocket of cleanliness: this file's 219px guard
+///      passed while a nested `Row(min)` clipped at 216px, 3px away. Walking the
+///      ladder is what closes that gap, and it is the group that caught it.
 ///
 /// Tagged `dashboard-card` so it gates PRs — `run_tests.sh` excludes
 /// `golden||loc||ui`, and a `ui`-tagged regression test would not block
@@ -71,20 +76,35 @@ import '../../../../util/overflow_probe.dart';
 ///
 /// ## Mutation ledger
 ///
-/// Every degradation-guard group here was shown to fail under a mutation of the
-/// code it guards — an overflow test that cannot fail is worse than no test
-/// (precedent: `stats_traffic_monitor_legend_test.dart`). Measured on this
-/// worktree with the fixtures below:
+/// Every guard group here was shown to fail under a mutation of the code it
+/// guards — an overflow test that cannot fail is worse than no test (precedent:
+/// `stats_traffic_monitor_legend_test.dart`). Measured on this worktree with the
+/// fixtures below; each mutation was applied alone, against an otherwise clean
+/// tree:
 ///
-///   | mutation                                            | measured                    |
-///   |-----------------------------------------------------|-----------------------------|
-///   | line 110 `Wrap` -> pre-fix `Row`+`Spacer`           | +28px @200px section (grp 1)|
-///   | line 121 `Wrap` -> pre-fix `Row`+`Expanded`         | +6.9px @219px section (grp 2)|
-///   | signal bar `SizedBox(96)` -> `Expanded` (keep `Wrap`)| ParentDataWidget error (grp 2)|
-///   | count -> `Flexible` + 1-line ellipsis               | stats legible fails (grp 3) |
+///   | mutation                                             | measured                     |
+///   |------------------------------------------------------|------------------------------|
+///   | line 110 `Wrap` -> pre-fix `Row`+`Spacer`            | 10 tests fail (grp 1, 3)     |
+///   | line 121 outer `Wrap` -> pre-fix `Row`+`Expanded`    | 5 tests fail (grp 2)         |
+///   | stats `Wrap` -> `Row(min)`+`AppGap.md` (see below)   | 4 tests fail (grp 2 ladder)  |
+///   | signal bar `SizedBox(96)` -> `Expanded` (keep `Wrap`)| ParentDataWidget error, all  |
+///   | count -> `Flexible` + 1-line ellipsis                | all fail (grp 3 + layout)    |
+///   | `snrValue` -> 1-line ellipsis (no `Flexible`)        | grp 3 fails                  |
+///   | `snrValue` -> `Flexible` + 1-line ellipsis           | all fail (grp 3 + layout)    |
 ///
-/// The `Wrap` fix is clean at both stress widths (line 110 clean to 180px; line
-/// 121 clean at 219px), so each row is clean where its pre-fix shape clips.
+/// The two `snrValue` rows are the reason group 3 asserts on **both** stats. An
+/// earlier revision of this file checked only `clientsCount`, and both of those
+/// mutations passed it: the group's own doc comment promised "the count **and**
+/// SNR", while the SNR was unguarded.
+///
+/// The `Row(min)` row is the shape this file's first revision shipped. A
+/// `Row(min)` hands its children unbounded width just as a `Row` does — it only
+/// changes what the row asks of *its* parent — so nesting one inside the `Wrap`
+/// reproduced #1258's own failure mode one level down: with the signal bar
+/// already on its own run, the two stats clipped at a **216px** section in `fi`,
+/// and at 192px in `fi`, `ja`, `ko` and `vi`. That is above the 192px floor AC-1
+/// requires, and it sat 3px below the 219px degradation guard, which therefore
+/// never saw it.
 
 /// Two radios whose channel string is the widest #1258 named: a 3-digit 6GHz
 /// channel in auto mode (`Ch 233 (Auto)`) at a 3-digit bandwidth. This is the
@@ -314,7 +334,14 @@ void main() {
     // (`{count} asiakaslaitetta`) is the worst. `_wifiDataWithClients` gives it
     // real, non-zero client counts across both radios so the row renders the
     // state #1258 measured overflowing (+27px in `fi` at a 192px section).
-    for (final tag in ['fi', 'de', 'ru']) {
+    //
+    // `nl` is the fourth locale #1258's AC-1 names. It is dominated by `fi` and
+    // `de` here (`{count} clients`, the same string as `en`), so it adds no
+    // coverage at these widths — it is pumped because the AC names it, and
+    // because a future ARB edit could make it the worst without anyone
+    // re-deriving which locale dominates. `_widestStatLocales` below covers the
+    // locales that actually break first.
+    for (final tag in ['fi', 'de', 'ru', 'nl']) {
       for (final screen in narrowScreens) {
         testWidgets(
           'no overflow at ${sectionWidthFor(screen).toStringAsFixed(0)}px '
@@ -366,6 +393,52 @@ void main() {
         );
       },
     );
+
+    // AC-1's own width ladder: 288px / 256px / 224px / 192px sections, "clean at
+    // every width down to at least 192px".
+    //
+    // This is the group that caught the nested `Row(min)`: with the signal bar
+    // already dropped to its own run, `clientsCount` + `snrValue` inside a
+    // `Row(min)` still took unbounded width and clipped at a **216px** section in
+    // `fi` — above the 192px floor the AC asks for, and only 3px below the 219px
+    // degradation guard above, which is why that guard did not see it. Nesting a
+    // `Wrap` instead of a `Row(min)` moves the crossing off the ladder entirely.
+    //
+    // The locale list is not AC-1's four. `fi` is the worst of those, but the
+    // stats row's real worst cases are `ja`, `ko` and `vi`, which the AC does not
+    // name and which broke at 192px alongside `fi` under the `Row(min)`. They are
+    // pumped here so the ladder is guarded by whatever actually breaks first
+    // rather than by the four locales the ticket happened to sample.
+    const widestStatLocales = <String>['fi', 'ja', 'ko', 'vi'];
+    for (final tag in widestStatLocales) {
+      for (final section in [288.0, 256.0, 224.0, 192.0]) {
+        testWidgets(
+          'AC-1 ladder: clean at a ${section.toStringAsFixed(0)}px section '
+          'in $tag',
+          (tester) async {
+            final overflows = await overflowsAt(
+              tester: tester,
+              // 320px keeps ui_kit's narrowest layout regime while the explicit
+              // section width walks below the 288px production floor.
+              screenWidth: 320.0,
+              sectionWidth: section,
+              locale: localeFor(tag),
+              wifiData: _wifiDataWithClients,
+            );
+            expect(
+              overflows,
+              isEmpty,
+              reason: 'AC-1 requires the client+SNR row to be clean down to a '
+                  '192px section: it overflows in $tag at '
+                  '${section.toStringAsFixed(0)}px. A `Row(min)` anywhere in '
+                  'this subtree hands its children unbounded width and '
+                  'reintroduces the shape #1258 removes: '
+                  '${overflows.join(', ')}',
+            );
+          },
+        );
+      }
+    }
   });
 
   group('client-count and SNR stats stay legible (#1258)', () {
@@ -410,34 +483,58 @@ void main() {
       // strings are the localized stats. Assert on every rendered stat rather
       // than one exact value so the check does not encode the fixture's counts.
       final l10n = await AppLocalizations.delegate.load(locale);
-      // 4 clients on 2.4GHz, 4 on 6GHz -> clientsCount(4) rendered twice.
-      final countText = l10n.clientsCount(4);
-      final countFinder = find.text(countText);
-      expect(
-        countFinder,
-        findsWidgets,
-        reason: 'the client-count stat ($countText) must survive the '
-            'degradation — the `Wrap` moves the signal bar to a second line, '
-            'it may not discard the count',
-      );
 
-      for (final element in countFinder.evaluate()) {
-        final text = element.widget as Text;
+      // Both stats are checked, not just the count. AC-2 names `clientsCount`
+      // **and** `snrValue`, and the two are independently editable: a `maxLines`
+      // or an `Expanded` added to one is invisible to a check on the other, so
+      // asserting on the count alone leaves the SNR unguarded (a mutation adding
+      // `Flexible` + `overflow: ellipsis` to `snrValue` passed the count-only
+      // version of this test).
+      //
+      // 4 clients on 2.4GHz, 4 on 6GHz -> each stat is rendered twice, once per
+      // radio, with the same value.
+      //
+      // The SNR is the average of `computeSNR(signalStrength, noise)` over a
+      // band's clients: signal -55..-62 against noise -95 gives 40..33 dB, and
+      // the per-band averages land on `snrValue(36)` for both radios (2.4GHz
+      // takes the even indices, 6GHz the odd). Asserting the exact string keeps
+      // the finder honest — a stat rendered as something else would read as
+      // "absent" and fail below rather than silently pass.
+      final stats = <String, String>{
+        'client count': l10n.clientsCount(4),
+        'SNR': l10n.snrValue(36),
+      };
+
+      for (final entry in stats.entries) {
+        final label = entry.key;
+        final text = entry.value;
+        final finder = find.text(text);
         expect(
-          text.overflow,
-          isNot(TextOverflow.ellipsis),
-          reason: 'the client count must never ellipsize: an ellipsis lands '
-              'mid-number',
+          finder,
+          findsWidgets,
+          reason: 'the $label stat ($text) must survive the degradation — the '
+              '`Wrap` moves the signal bar to its own run, it may not discard '
+              'or reformat a stat',
         );
-        expect(text.maxLines, isNull,
-            reason: 'the client count must not be line-capped');
+
+        for (final element in finder.evaluate()) {
+          final widget = element.widget as Text;
+          expect(
+            widget.overflow,
+            isNot(TextOverflow.ellipsis),
+            reason: 'the $label must never ellipsize: an ellipsis lands '
+                'mid-number',
+          );
+          expect(widget.maxLines, isNull,
+              reason: 'the $label must not be line-capped');
+        }
+        expect(
+          canShrink(finder.first),
+          isFalse,
+          reason: 'the $label must not be a flex child — it keeps its '
+              'intrinsic width and the stats group wraps instead',
+        );
       }
-      expect(
-        canShrink(countFinder.first),
-        isFalse,
-        reason: 'the client count must not be a flex child — it keeps its '
-            'intrinsic width and the whole stats group wraps instead',
-      );
     });
   });
 }


### PR DESCRIPTION
## What

Hardens the two unconstrained `Row`s the WiFi Channels section renders per radio
on the Statistics page — the third instance of the #1226 / #1252 shape on this
page — by giving them the same `Wrap` treatment, respecting the two constraints
#1233 measured (design §2.10 / §2.10a). Behavior is preserved at every supported
width (`Refs #1258`, parent #1183).

`lib/page/statistics/views/sections/stats_wifi_channels_section.dart`:

- **line 110** — `AppText.labelLarge(band)` + `const Spacer()` + channel string
  → `Wrap(spaceBetween)`. Renders identically while it fits; when it does not,
  the channel string drops to a second line. Neither side ellipsizes (the band
  is the block's identity, the channel string is composed data), so the row
  wraps as a unit.
- **line 121** — `clientsCount(n)` + `snrValue(n)` + `Expanded(AppLoader)` →
  `Wrap`. The two stats are themselves a nested `Wrap` and never shrink (no
  `Flexible`, no `maxLines`, no ellipsis — a half-shown statistic misinforms);
  the signal bar becomes a fixed `SizedBox(width: 96)` so it is the decoration
  that yields first, dropping to its own run instead of overflowing.

**A `Row(mainAxisSize: min)` is not enough for the stats pair, and the first
revision of this PR got that wrong** — see "Review round 1" below. `Row(min)`
changes what the row asks of *its* parent; it does not change what it hands its
children, which is still unbounded width. The stats group therefore has to be a
`Wrap` too, or it reintroduces this ticket's own failure mode one level down.

## Why file it anyway (from #1258)

Neither row overflows at any **supported** width today: line 110 has **47px of
headroom** at the 288px production floor (241px zero crossing), line 121's `fi`
crossing is 219px (69px below the floor). But localizing the hardcoded `'Ch '`
literal, a 3-digit 6GHz channel (`Ch 233 (Auto)`), or a narrower realization
each eats that headroom, and the `Spacer`'s failure is a cliff with no
degradation stage. The `Wrap` turns the cliff into a graceful wrap and pins the
crossings with a test.

That first threat is now measured rather than assumed, and **this PR already
absorbs it.** One pump per case, real fonts, 2px tolerance, 288px section, all 26
locales, with `'Ch '` replaced by `loc(context).channel`:

| line 110 shape | `'Ch '` as shipped | `loc(context).channel` |
|---|---|---|
| pre-fix `Row` + `Spacer` | all 26 clean | **`th` +3.0 · `tr` +27.0, +13.0** |
| post-fix `Wrap` | all 26 clean | **all 26 clean** |

So AC-5's "re-measure the headroom afterwards" is satisfied here; the string
change itself is #1270.

## Height budget

`StatsSectionCard` pins this section at `chartHeight: 320` and the donut below is
`Expanded`, so extra runs would be paid out of the donut. At production widths
the content fits on **one run per `Wrap`**, so the donut is unchanged — the
`Wrap` did not trade right-overflows for bottom-overflows (the Network Health
counter-example). Checked from the other direction too: every incident recorded
anywhere in this PR's measurements was on the **right**, never the bottom, and a
260-client fixture (3-digit counts) is clean in all 26 locales at 288px. The
production-width tests assert `isEmpty` on **all** sides, so a bottom-overflow
would fail them.

## Not covered by the overflow gate

Same as #1252: `stats_wifi_channels_section` is on the Statistics page, absent
from `UspWidgetSpecs.all`, so the #1183 gate never scans it. There is no ratchet
entry to clear; the AC is a measurement of the rows.

## Test

New `test/page/statistics/views/sections/stats_wifi_channels_section_test.dart`
(tagged `dashboard-card` so it gates PRs). **43 tests**, three kinds of guard:

1. **Regression guard** at production widths (288/537/841px sections across the
   4 narrow screens) — trips if future data/locale growth eats the headroom.
2. **Degradation guard** at a documented sub-production stress width where the
   pre-fix shape provably clips and the `Wrap` stays clean:
   - line 110 @200px section: pre-fix `Row`+`Spacer` **+28px**, `Wrap` clean.
   - line 121 @219px section in `fi`: pre-fix `Row`+`Expanded` **+6.9px**,
     `Wrap` clean.
3. **AC-1 ladder** — 288/256/224/192px sections in `fi`, `ja`, `ko`, `vi`. AC-1
   asks for clean down to 192px; a single degradation guard can sit in a pocket
   of cleanliness (the 219px guard above passed while the stats clipped at 216px,
   3px away), so the ladder is walked explicitly. The locales are the ones that
   actually break first, not AC-1's `fi`/`ru`/`de`/`nl` sample — `ja`, `ko` and
   `vi` all broke at 192px and none is named in the ticket.
4. **Legibility** — the client count **and** the SNR are present, unellipsized,
   and not flex children that could shrink.

Every guard was shown to fail under a mutation of the code it guards, each
applied alone against an otherwise clean tree (ledger in the test doc):

| mutation | result |
|---|---|
| line 110 `Wrap` → pre-fix `Row`+`Spacer` | 10 tests fail |
| line 121 outer `Wrap` → pre-fix `Row`+`Expanded` | 5 tests fail |
| stats `Wrap` → `Row(min)`+`AppGap.md` | 4 tests fail (ladder) |
| signal bar `SizedBox(96)` → `Expanded` (keep `Wrap`) | ParentDataWidget error, all fail |
| count → `Flexible` + 1-line ellipsis | all fail |
| `snrValue` → 1-line ellipsis | legibility group fails |
| `snrValue` → `Flexible` + 1-line ellipsis | all fail |

## Review round 1

Round 1's findings were verified by measurement and mutation
([resolution comment](https://github.com/linksys/PrivacyGUI/pull/1264#issuecomment-5277772605)).
Two were real and in scope, fixed in `42b0ffbe`:

- **The stats group was still an unconstrained `Row`, and this broke AC-1.** With
  the signal bar already on its own run, `clientsCount` + `snrValue` inside a
  `Row(min)` clipped at a **216px** section in `fi`, and at 192px in `fi` (+24.0),
  `ja` (+16.0), `ko` (+11.0) and `vi` (+4.4) — above the 192px floor AC-1
  requires. Nesting a `Wrap` moves the crossing off the ladder entirely.
- **`snrValue` had no legibility assertions.** The group's doc comment promised
  "the count **and** SNR", but the body only asserted `clientsCount`, so both
  `snrValue` mutations above passed the first revision.

Two were real but out of scope and are filed: **#1270** (localize `'Ch '`;
extract the now-triplicated `overflowsAt` / `sectionWidthFor` scaffold to
`test/util/`) and **#1271** (`noise == 0` clients deflate the average SNR —
pre-existing, and divergent from `usp_wifi_performance_card.dart:345-357`, which
has the guard; filed rather than fixed because this PR is a layout change and
should not carry a silent change to a displayed statistic).

## Local verification

- `flutter analyze` (both changed files): **No issues found**
- `flutter test .../stats_wifi_channels_section_test.dart`: **43/43 passed**
- `flutter test --tags dashboard-card`: **1797/1797 passed**
- `dart format --output=none --set-exit-if-changed`: **clean** (exit 0)
- sibling `stats_traffic_monitor_legend_test.dart` (#1252): **18/18 passed**

## Base

Based on `gate/1183-overflow-gate` and merges back into it, per #1258's Branch
section (#1248 is still open). The overflow-probe test infra
(`test/util/overflow_probe.dart`, `test/util/app_test_fonts.dart`) lives on that
branch, not yet on `dev-2.7.0`.
