### PR TITLE
fix(port-forwarding/ipv6): stop protocol control clipping in narrow dialogs (#1261)

### DIFF
--- a/lib/page/dashboard/views/dialogs/port_forwarding_dialog.dart
+++ b/lib/page/dashboard/views/dialogs/port_forwarding_dialog.dart
@@ -193,6 +193,11 @@ class _PortForwardingDialogState extends State<PortForwardingDialog> {
       scrollable: true,
       content: Column(
         mainAxisSize: MainAxisSize.min,
+        // Left-align the children. The text fields already fill the content
+        // width so they look the same either way, but an intrinsically-sized
+        // child (the protocol block below) would be centred by the default
+        // CrossAxisAlignment.center and sit indented from the fields (#1261).
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           AppTextField(
             controller: _descController,

--- a/lib/page/dashboard/views/dialogs/port_forwarding_dialog.dart
+++ b/lib/page/dashboard/views/dialogs/port_forwarding_dialog.dart
@@ -237,10 +237,17 @@ class _PortForwardingDialogState extends State<PortForwardingDialog> {
             ),
           ),
           AppGap.lg(),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          // Stack the protocol label above the segmented control (Column, not a
+          // spaceBetween Row) so a long localized label (e.g. fi "Protokolla" +
+          // "Molemmat", tr "Her İkisi") can't squeeze the control and clip its
+          // last segment in a narrow AppDialog (#1261). The control gets the
+          // full content width. A Wrap can't be used here because SegmentedButton
+          // has no dry-layout support and Wrap measures its children.
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               AppText.bodyMedium(loc(context).protocol),
+              AppGap.sm(),
               SegmentedButton<String>(
                 segments: [
                   ButtonSegment(value: 'TCP', label: Text(loc(context).tcp)),

--- a/lib/page/ipv6_port_service/views/dialogs/ipv6_port_service_rule_dialog.dart
+++ b/lib/page/ipv6_port_service/views/dialogs/ipv6_port_service_rule_dialog.dart
@@ -159,10 +159,17 @@ class _Ipv6PortServiceRuleDialogState extends State<Ipv6PortServiceRuleDialog> {
             ),
           ),
           AppGap.lg(),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          // Stack the protocol label above the segmented control (Column, not a
+          // spaceBetween Row) so a long localized label (e.g. fi "Protokolla" +
+          // "Molemmat", tr "Her İkisi") can't squeeze the control and clip its
+          // last segment in a narrow AppDialog (#1261). The control gets the
+          // full content width. A Wrap can't be used here because SegmentedButton
+          // has no dry-layout support and Wrap measures its children.
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               AppText.bodyMedium(loc(context).protocol),
+              AppGap.sm(),
               SegmentedButton<String>(
                 segments: UspIpv6PortServiceService.protocolOptions
                     .map(

--- a/lib/page/ipv6_port_service/views/dialogs/ipv6_port_service_rule_dialog.dart
+++ b/lib/page/ipv6_port_service/views/dialogs/ipv6_port_service_rule_dialog.dart
@@ -135,6 +135,11 @@ class _Ipv6PortServiceRuleDialogState extends State<Ipv6PortServiceRuleDialog> {
       scrollable: true,
       content: Column(
         mainAxisSize: MainAxisSize.min,
+        // Left-align the children. The text fields already fill the content
+        // width so they look the same either way, but an intrinsically-sized
+        // child (the protocol block below) would be centred by the default
+        // CrossAxisAlignment.center and sit indented from the fields (#1261).
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           AppTextField(
             controller: _descriptionController,
@@ -171,9 +176,23 @@ class _Ipv6PortServiceRuleDialogState extends State<Ipv6PortServiceRuleDialog> {
               AppText.bodyMedium(loc(context).protocol),
               AppGap.sm(),
               SegmentedButton<String>(
+                // Drop the check icon: SegmentedButton sizes all segments
+                // equally, and the icon eats ~24px of the selected one. This
+                // dialog defaults to 'Both' — the longest label — so with the
+                // icon the fi "Molemmat" wraps to "Molemm/at". The selected
+                // segment is still distinguished by its fill colour.
+                showSelectedIcon: false,
+                // The value stays the raw option name — UspIpv6PortServiceService
+                // maps it to an IANA number ('Both' -> 255), so it must not be
+                // localized. Only the label is translated, and only for 'Both';
+                // TCP/UDP are protocol names that stay as-is in every locale
+                // (matching the other port-forwarding dialogs).
                 segments: UspIpv6PortServiceService.protocolOptions
-                    .map(
-                        (name) => ButtonSegment(value: name, label: Text(name)))
+                    .map((name) => ButtonSegment(
+                          value: name,
+                          label:
+                              Text(name == 'Both' ? loc(context).both : name),
+                        ))
                     .toList(),
                 selected: {_protocol},
                 onSelectionChanged: (v) => setState(() => _protocol = v.first),

--- a/lib/page/port_forwarding/views/dialogs/port_range_forwarding_dialog.dart
+++ b/lib/page/port_forwarding/views/dialogs/port_range_forwarding_dialog.dart
@@ -183,6 +183,11 @@ class _PortRangeForwardingDialogState extends State<PortRangeForwardingDialog> {
       scrollable: true,
       content: Column(
         mainAxisSize: MainAxisSize.min,
+        // Left-align the children. The text fields already fill the content
+        // width so they look the same either way, but an intrinsically-sized
+        // child (the protocol block below) would be centred by the default
+        // CrossAxisAlignment.center and sit indented from the fields (#1261).
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           AppTextField(
             controller: _descController,

--- a/lib/page/port_forwarding/views/dialogs/port_range_forwarding_dialog.dart
+++ b/lib/page/port_forwarding/views/dialogs/port_range_forwarding_dialog.dart
@@ -240,10 +240,17 @@ class _PortRangeForwardingDialogState extends State<PortRangeForwardingDialog> {
             onChanged: (_) => _onInputChanged(),
           ),
           AppGap.lg(),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          // Stack the protocol label above the segmented control (Column, not a
+          // spaceBetween Row) so a long localized label (e.g. fi "Protokolla" +
+          // "Molemmat") can't squeeze the control and clip its last segment in a
+          // narrow AppDialog (#1261). The control gets the full content width. A
+          // Wrap can't be used here because SegmentedButton has no dry-layout
+          // support and Wrap measures its children.
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               AppText.bodyMedium(loc(context).protocol),
+              AppGap.sm(),
               SegmentedButton<String>(
                 segments: [
                   const ButtonSegment(value: 'TCP', label: Text('TCP')),

--- a/lib/page/port_forwarding/views/dialogs/port_triggering_dialog.dart
+++ b/lib/page/port_forwarding/views/dialogs/port_triggering_dialog.dart
@@ -127,10 +127,16 @@ class _PortTriggeringDialogState extends State<PortTriggeringDialog> {
               ],
             ),
             AppGap.md(),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            // Stack the protocol label above the segmented control so a long
+            // localized label (e.g. fi "Protokolla" + "Molemmat") can't squeeze
+            // the control and clip its last segment in a narrow AppDialog
+            // (#1261). A Wrap can't be used here because SegmentedButton has no
+            // dry-layout support and Wrap measures its children.
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 AppText.bodyMedium(loc(context).protocol),
+                AppGap.sm(),
                 SegmentedButton<String>(
                   segments: [
                     const ButtonSegment(value: 'TCP', label: Text('TCP')),
@@ -169,10 +175,16 @@ class _PortTriggeringDialogState extends State<PortTriggeringDialog> {
               ],
             ),
             AppGap.md(),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            // Stack the protocol label above the segmented control so a long
+            // localized label (e.g. fi "Protokolla" + "Molemmat") can't squeeze
+            // the control and clip its last segment in a narrow AppDialog
+            // (#1261). A Wrap can't be used here because SegmentedButton has no
+            // dry-layout support and Wrap measures its children.
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 AppText.bodyMedium(loc(context).protocol),
+                AppGap.sm(),
                 SegmentedButton<String>(
                   segments: [
                     const ButtonSegment(value: 'TCP', label: Text('TCP')),


### PR DESCRIPTION
## Summary

Fixes the clipping regression reported in #1261. After the AppDialog migration (#1206), the narrower dialog content width no longer had room to place the protocol `SegmentedButton` beside a long localized label. In `fi` / desktop1280 the third segment `Molemmat` was clipped mid-word to `Molem`, and `Protokolla` butted against the control with zero gutter. The golden overflow detector independently flagged the 3 `port_forwarding-*_single_port|fi|desktop1280` screens as **new** overflows.

## Root cause

Every affected dialog laid the protocol control out as:

```dart
Row(
  mainAxisAlignment: MainAxisAlignment.spaceBetween,
  children: [ AppText.bodyMedium(loc(context).protocol), SegmentedButton<String>(...) ],
)
```

`spaceBetween` gives the `SegmentedButton` its intrinsic width; in a narrow AppDialog (content width 350px) a long label (`fi` `Protokolla` + `Molemmat`, `tr` `Her İkisi`) leaves no room and the control overflows / clips at the right edge.

## Fix

Stack the protocol label **above** the segmented control (`Column`, `crossAxisAlignment.start`) so the control always gets the full content width and can never be squeezed/clipped by a long label.

`Wrap` was tried first and rejected: `SegmentedButton` has **no dry-layout support**, and `Wrap` measures its children — this throws `StateError: A RenderObject does not have any constraints before it has been laid out` during layout. `Column` uses only a real layout pass, so it is safe.

Applied to the whole protocol-row class in the two failing areas the issue names:

- `lib/page/dashboard/views/dialogs/port_forwarding_dialog.dart` (single-port)
- `lib/page/port_forwarding/views/dialogs/port_range_forwarding_dialog.dart`
- `lib/page/port_forwarding/views/dialogs/port_triggering_dialog.dart` (both trigger + forward protocol rows)
- `lib/page/ipv6_port_service/views/dialogs/ipv6_port_service_rule_dialog.dart`

`static_route` and other pages were intentionally left untouched (out of this issue's scope).

## Scope note

This PR addresses finding **(b)** of #1261 — the genuine clipping/overflow regression. Finding **(a)**, the 312-screen design shift from the AppDialog frame change, is a design decision that needs a human eye against the spec + a manual `Generate Golden` re-baseline, per the issue's own guidance. That is **not** done here.

## Verification

- Golden regeneration for `fi` / desktop1280 on both view suites: **All 22 tests passed**, `goldens/overflow_warnings.json` is empty (zero RenderFlex overflow). Before the fix the same run reported overflow at `port_range_forwarding_dialog.dart:243` and the 3 new single-port overflows.
- Rendered goldens inspected: `Molemmat` fully visible, `Protokolla` readable with proper spacing, label stacked above control, nothing clipped at the right edge.
- Logic/provider/service tests: `test/page/port_forwarding/` + `test/page/ipv6_port_service/` → **94/94 passed**.
- `flutter analyze` on all 4 changed files → **No issues found**.
- `dart format --set-exit-if-changed` → clean.

Refs #1261
