### PR TITLE
fix(dashboard): close Track A's four card-own overflow tickets, by shape (#1234, #1235, #1236, #1237)

### DIFF
--- a/doc/dashboard/dashboard_density_design.md
+++ b/doc/dashboard/dashboard_density_design.md
@@ -878,8 +878,10 @@ explicit decision in that ticket rather than an implementation detail.
 ### 2.10d What closing the four card-own tickets taught us (#1234–#1237 — implemented)
 
 87 coordinates → **0**, on one branch, one commit per shape. §1.1's decomposition
-held to the coordinate, including its uncomfortable prediction that two of the
-four commits would move nothing on their own:
+held to the coordinate, including its uncomfortable prediction that the two
+`system_status` sites sharing `min|0`'s 26 coordinates would each clear **none**
+of them alone — the legend row moved only the 2 outside that key, and the 26 fell
+in one step when the gauge row followed:
 
 | Commit (shape) | Sites | Coordinates |
 |---|---|---:|
@@ -917,7 +919,8 @@ cannot tell you when it doesn't**, so the precondition is measured *before* the
 conversion or not at all. #1233's and #1266's conversions were safe for a reason
 that has to be checked, not inherited.
 
-**3. Every fix is one of three things to the gate, and two of them owe a test.**
+**3. Every fix is one of three things to the gate — and a green gate is not a
+green criterion.**
 
 | Fix class | Example | The gate afterwards |
 |---|---|---|
@@ -931,6 +934,28 @@ ever produce a coordinate. The mutation ledger makes that concrete — shrinking
 score's font unconditionally clears **all 209** gate cases. So a self-relaxing fix
 has to ship its own floor: `usp_gauge_center_readability_test.dart` asserts a 12px
 painted minimum, which is the replacement for what `scaleDown` took away.
+
+That table is the *revert* axis, and it is not the only one. A constraining fix
+keeps the signal, so the gate does own its revert — but it never owned the
+**choice**: `maxLines: 1` and a soft-wrap clear the same coordinates, and at three
+of these sites one of them destroys the string. Measured on this branch:
+ellipsizing `lan_info`'s router IP, its DHCP status, or the shared InfoGrid value
+renderer leaves **all 1644** gate cases green. #1236 AC 4 and #1237 AC 5 name those
+readings ("truncating an IP in the middle makes it useless"; "timezone names stay
+identifiable"), so `usp_hero_row_readability_test.dart` asserts them across four
+locales each — and each mutation kills exactly its own group, so a failure says
+which criterion broke. The rule that falls out is narrower than "constraining
+fixes need tests", which would be licence to test every `Flexible` on the branch:
+**a fix owes a test when the gate stays green through both the right and the wrong
+version of it** — whether because the fix removed the signal (#1234, #1235) or
+because the signal never told the two apart (#1236, #1237). Where the gate does
+discriminate, the allowlist entry it deletes *is* the assertion.
+
+The same test covers the one place this branch made a reading *worse*: #1237's
+badge now ellipsizes (`de` paints 45.4px of an 85.1px label), which §2.10a point 2
+requires of a capsule but which no coordinate can report, since a narrower badge
+overflows *less*. That gets a floor too, not a fidelity claim — enough glyphs to
+key the state, with the colour carrying the rest.
 
 **4. A ticket's diagnosis is a report, not a measurement.** #1235 states the tier
 label is wider than the space inside the circle. The three coordinates are
@@ -990,7 +1015,8 @@ is the only card in the baseline where §1.3's arithmetic permits the other fix
 (fit width 288px, so `minColumns` 3 → 5 would have worked). It stays 3, with the
 reasoning recorded at the declaration site: the floor is the user's, it costs 5 of
 12 columns in every layout to buy headroom in a handful of locales, and the
-card-own fix cleared all 21 coordinates for one `Flexible` and a soft-wrap.
+card-own fix cleared all 21 coordinates by deleting a single-child `Row` that
+had no other effect — the cheapest fix on the branch.
 
 ### 2.11 fl_chart's 19 coordinates get a primary plan and a documented fallback
 
@@ -1122,9 +1148,11 @@ addition — it changes no card's rendering until a threshold is declared.
 Ceiling **515 / 560**. The other 45 are the dependency-blocked ones (§1.1).
 
 After #1234–#1237 the allowlist holds **94** coordinates: 67 `firewall_overview`
-(#1230) and 27 `connected_devices` (#1238). Both remaining entries are the
-dependency-blocked kind — fl_chart's internals and a ui_kit `AppListTile` change —
-so Track A's card-own work is complete.
+(#1230) and 27 `connected_devices` (#1238). Both are the dependency-blocked kind —
+fl_chart's internals and a ui_kit `AppListTile` change — so Track A's card-own
+work is complete. Their `tracking` notes are left as the epic requires: a ticket
+touches only the notes of cards it closes, so both cards keep the `baseline #1183`
+default until their own ticket names an owner.
 
 #1266 is in this track despite clearing nothing: it is the only entry that *adds*
 coordinates (3, by localizing a hardcoded string) and removes them again in the
@@ -1163,6 +1191,7 @@ the likeliest way to get this wrong.
 | Work | Method | Why |
 |---|---|---|
 | All of Track A except #1225 | **Ratchet, not TDD** | The failing assertions are *already committed* — the 560 entries in `known_overflows.json`. The red→green move is: fix the layout, delete the allowlist entry, gate passes. Deleting an entry that still overflows fails that test, so it cannot be faked. |
+| …plus two readability tests, added by #1234–#1237 | **Ratchet + a floor test** | The ratchet verifies that the overflow is gone. It cannot verify what the fix *chose*, in two situations, and both occurred on that branch (§2.10d point 3). (a) The fix makes a subtree self-relaxing, so the signal is gone for good: measured, shrinking the health score's font unconditionally clears all 209 of its gate cases. (b) Two fixes clear the same coordinates and only one preserves the reading: measured, `maxLines: 1` on the router IP, the DHCP status, or the InfoGrid value renderer leaves all 1644 cases green while cutting a string #1236 AC 4 / #1237 AC 5 require whole. The test is owed when **the gate stays green through both the right and the wrong fix** — not whenever a fix constrains. A plain `Flexible` is fully verified by the entry it deletes. |
 | #1232 | **TDD** | The gate asserts only "no overflow"; it cannot detect *wrong density*. Threshold selection, popup cut-off, and absent-`normalAbove` behaviour can all break while the gate stays green. Tests go red first. |
 | #1231 | **Neither** | Not an assertion — it fixes a failure the gate is structurally blind to (§2.8), so it is verified by eye or golden. |
 | #1225 | **Property tests + no-op diff** | Planned as "neither", since converting a sampled invariant into a guaranteed one changes no assertion. In the event it had a testable seam after all: the search is pinned by a property (no supported width is narrower than the one pumped, which fails on a coarser step) and the no-op claim by diffing the full sweep's 560 allowlisted hits before and after — they matched exactly. |

--- a/doc/dashboard/dashboard_density_design.md
+++ b/doc/dashboard/dashboard_density_design.md
@@ -1001,14 +1001,27 @@ locale sweep, *and* the branch never renders at all — it is the `else` of
 four tickets. This is §2.10c finding 2 in its purest form: the data decides what
 the instrument can see.
 
-**7. Two entries for #1245's de-duplication inventory.** The two hand-rolled
-"View details" footers exist for one reason: `detailRoute` cannot carry query
-parameters (`?tab=`, `?deviceId=`), so neither card can use
+**7. Two entries for #1245's de-duplication inventory.** There are **three**
+hand-rolled "View details" footers, not two — `usp_system_status_card.dart:118`,
+`usp_device_info_card.dart:134` and `usp_traffic_analysis_card.dart:141` — plus
+the template's own at `dashboard_card_template.dart:393`, so four copies of one
+shape. They exist for one reason: `detailRoute` cannot carry query parameters
+(`?tab=`, `?deviceId=`), so none of the three can use
 `DashboardCardTemplate._buildDetailFooter`. #1227 fixed the template's copy and
-could not fix theirs. The fix here was replicated *verbatim* rather than extracted,
-because extracting it would make a third copy of the widget while leaving the
-cause in place. The cause — `detailRoute`'s signature — is the inventory entry.
-The second entry is the footer shape itself, now identical in three places.
+could not fix theirs. The fix here was replicated *verbatim* rather than
+extracted, because extracting it would make a fifth copy of the widget while
+leaving the cause in place. The cause — `detailRoute`'s signature — is the
+inventory entry. The second entry is the footer shape itself.
+
+These four tickets hardened two of the three. `traffic_analysis`'s is left
+unflexed on purpose: its `minColumns` is **4**, not 3, so the width enumeration
+never realizes it at the 157.4px where this shape bites, and it carries no
+allowlist entry in any of its 26 locales. That is the ratchet doing its job in
+the other direction — it says which copies actually need the change, and this one
+does not yet. It is also why the copy is worth recording rather than patched
+prophylactically: if the floor ever drops to 3, the gate raises coordinates for
+it and the fix is the same three-line `Flexible` used twice above. Hardening it
+blind today would spend the signal that tells us it is needed.
 
 **8. Widening was genuinely available once, and was declined.** `time_settings`
 is the only card in the baseline where §1.3's arithmetic permits the other fix

--- a/doc/dashboard/dashboard_density_design.md
+++ b/doc/dashboard/dashboard_density_design.md
@@ -875,6 +875,123 @@ all 18 cards doubles 1644 cases and will surface coordinates nobody has looked a
 shape (opt-in per card / second allowlist keyed by profile / one allowlist) is an
 explicit decision in that ticket rather than an implementation detail.
 
+### 2.10d What closing the four card-own tickets taught us (#1234–#1237 — implemented)
+
+87 coordinates → **0**, on one branch, one commit per shape. §1.1's decomposition
+held to the coordinate, including its uncomfortable prediction that two of the
+four commits would move nothing on their own:
+
+| Commit (shape) | Sites | Coordinates |
+|---|---|---:|
+| "View details" footer | `system_status:118`, `device_info:140` | 34→28, 2→0 |
+| Hero inner row | `lan_info:56`, `time_settings:108` | 27→0, 21→0 |
+| Legend row | `system_status:218` | 28→26 |
+| Twin gauge row | `system_status:196` | 26→**0** |
+| Gauge centre | `network_health:150` | 3→0 |
+
+The ratchet now stands at **94 coordinates**, all owned by #1230 (67,
+`firewall_overview`) and #1238 (27, `connected_devices`).
+
+**1. One shape, two techniques — and sometimes the technique is deletion.** The
+hero inner row is the same idiom in two files and **48 of the 84 coordinates**,
+the largest single shape in the baseline, with the same measured cause in both: a
+fixed 56px avatar plus `AppGap.lg` leaves the `Expanded` column **61.4px**, and a
+`Row` hands its non-flex children *unbounded* width. `lan_info` overflowed in all
+26 locales including `en` (+47.7px), so this was never a translation-length
+defect. But the two fixes diverge, per §2.10a point 2: a composed status
+soft-wraps (`DHCP Enabled` ellipsized to `DHCP…` drops the only word the row
+exists to show), while `time_settings`' child is an `AppBadge` and **a capsule
+cannot take a second line**. That badge already ellipsized correctly and only ever
+failed because a single-child `Row` handed it infinity — so the `Row` was
+*deleted*, not flexed. Removing a `RenderFlex` beats constraining one when it had
+no other effect; the enclosing `Column` was already `start`-aligned.
+
+**2. A `Wrap` under an `Expanded` is clipped in silence.** #1234's design
+alternative (stack the two gauges instead of shrinking them) was expected to fail
+loudly: two 100px runs need ~208px against the 201px (`en`) / 181px (`de`) the
+`Expanded` offers. It fails *silently* — `RenderWrap` has no overflow indicator of
+its own and the `Expanded` pins its height, so the second circle is simply cut
+(108px between gauge centres in a 181px box, all 209 gate cases green). §2.10a
+point 3 says a `Wrap` must have height to spend; the sharper form is: **the gate
+cannot tell you when it doesn't**, so the precondition is measured *before* the
+conversion or not at all. #1233's and #1266's conversions were safe for a reason
+that has to be checked, not inherited.
+
+**3. Every fix is one of three things to the gate, and two of them owe a test.**
+
+| Fix class | Example | The gate afterwards |
+|---|---|---|
+| Constrain (`Flexible`, `maxLines`, bound a size) | all of #1236, #1237 | still sees a revert |
+| Convert to a `Wrap`/`Column` inside a pinned box | rejected stacking | blind to the *new* failure |
+| Scale (`FittedBox`) | #1235's centre | blind to it **for good** |
+
+`FittedBox(fit: BoxFit.scaleDown)` is the right fix for #1235's centre and it
+permanently removes the signal: once a subtree may shrink, no future squeeze can
+ever produce a coordinate. The mutation ledger makes that concrete — shrinking the
+score's font unconditionally clears **all 209** gate cases. So a self-relaxing fix
+has to ship its own floor: `usp_gauge_center_readability_test.dart` asserts a 12px
+painted minimum, which is the replacement for what `scaleDown` took away.
+
+**4. A ticket's diagnosis is a report, not a measurement.** #1235 states the tier
+label is wider than the space inside the circle. The three coordinates are
+**bottom** overflows (+21.0 `de`, +11.0 `ru`, +9.0 `th`): `AppGauge` respects its
+incoming constraints, so the gauge lays out 120×67 (`en`) and 120×**23** (`de`)
+against a 44px centre column. Worse, the cause is two levels up — `_MetricChip`'s
+three ~23.1px label columns soft-wrap (`Discards` over 3 lines, `Verworfene
+Pakete` over **6**), so the height left for the gauge is a function of translation
+length. Acting on the ticket's text would have produced a fix that is both lossy
+and incomplete: ellipsizing the tier truncates it *and* leaves 2 of 3 coordinates
+standing (ledger row 2). §1.1's per-line attribution is what turned this up, and
+it belongs on the *cause*, not on the symptom's line number.
+
+**5. A cleared allowlist is not a readability claim — and #1240 must not read it
+as one.** Track A's target is "nothing is clipped or overflowing". Both cards
+closed here are green at 191px and unusable there:
+
+- `time_settings`: the hero clock is a 222.5px string in a 61.4px column, so it
+  paints **5 lines / 140px** — in every locale, `en` included — while the sync
+  badge shows ~6 glyphs plus an ellipsis. Nothing overflows; everything that could
+  give, gave. §1.2 puts this card's fit width at 288px.
+- `network_health`: the centre scales to **0.52** in `de` (14.6px score, 8.4px
+  tier) because the metric labels below take 48px (`en`) to 96px (`de`) of the
+  height. §1.2 puts its fit width at 420px; it is being asked to render at 191px.
+
+Those two numbers are direct #1240 input, not defects to paper over. Related
+caveat on §1.2 itself: that table measures the narrowest width at which a card is
+*clean*, and Track A has now moved that number for five cards while leaving the
+width at which they are *readable* exactly where it was. #1240 must re-measure,
+not read §1.2's column.
+
+**6. §2.10c finding 1's grep pass, executed over these five cards.** Six
+hardcoded English strings; five are protocol acronyms that do not vary by locale
+(`CPU`, `DNS`, `IPv6`, `MAC`, and `DST`, which is arguable and left alone). One is
+a real bug: `usp_lan_info_card.dart:144` renders `value: 'Enabled'` while line 85
+of the same file uses `loc(context).enabled`, a key that exists in all 26 locales
+(`Ενεργοποιήθηκε`, `Ingeschakeld`, …). It is **not** the one-line fix #1266 was,
+because it is gate-invisible twice over: a hardcoded string cannot vary in a
+locale sweep, *and* the branch never renders at all — it is the `else` of
+`if (info.ipv6Addresses.isNotEmpty)`, and the gate's fixture supplies
+`ipv6Addresses: ['fd00::1']`. Verifying a localization there needs #1267's
+`overrides` parameter first, so it is recorded here rather than folded into these
+four tickets. This is §2.10c finding 2 in its purest form: the data decides what
+the instrument can see.
+
+**7. Two entries for #1245's de-duplication inventory.** The two hand-rolled
+"View details" footers exist for one reason: `detailRoute` cannot carry query
+parameters (`?tab=`, `?deviceId=`), so neither card can use
+`DashboardCardTemplate._buildDetailFooter`. #1227 fixed the template's copy and
+could not fix theirs. The fix here was replicated *verbatim* rather than extracted,
+because extracting it would make a third copy of the widget while leaving the
+cause in place. The cause — `detailRoute`'s signature — is the inventory entry.
+The second entry is the footer shape itself, now identical in three places.
+
+**8. Widening was genuinely available once, and was declined.** `time_settings`
+is the only card in the baseline where §1.3's arithmetic permits the other fix
+(fit width 288px, so `minColumns` 3 → 5 would have worked). It stays 3, with the
+reasoning recorded at the declaration site: the floor is the user's, it costs 5 of
+12 columns in every layout to buy headroom in a handful of locales, and the
+card-own fix cleared all 21 coordinates for one `Flexible` and a soft-wrap.
+
 ### 2.11 fl_chart's 19 coordinates get a primary plan and a documented fallback
 
 `firewall_overview`'s 19 coordinates originate inside fl_chart
@@ -995,14 +1112,19 @@ addition — it changes no card's rendering until a threshold is declared.
 | #1228 | `ethernet_ports` ×2 sites (§2.12) — **implemented** | 52 |
 | #1229 | `wifi_performance` ×2 sites (§2.10b) — **implemented** | 45 |
 | #1266 | `wifi_performance` Channels tab: localize `'Ch '` + harden (§2.10c) — **implemented** | 0 (net) |
+| #1234 | `system_status` remaining ×3 sites (§2.10d) — **implemented** | 34 |
+| #1236 | `lan_info` + `device_info` card-own (§2.10d) — **implemented** | 29 |
+| #1237 | `time_settings` card-own (§2.10d) — **implemented** | 21 |
+| #1235 | `network_health` gauge centre (§2.10d) — **implemented** | 3 |
 | #1230 | `firewall_overview` own sites (§2.11) | 48 |
-| #1234 | `system_status` remaining ×3 sites | 34 |
-| #1236 | `lan_info` + `device_info` card-own | 29 |
-| #1237 | `time_settings` card-own | 21 |
-| #1235 | `network_health` gauge centre | 3 |
 | #1238 | `connected_devices` card-own (§2.6) | 1 |
 
 Ceiling **515 / 560**. The other 45 are the dependency-blocked ones (§1.1).
+
+After #1234–#1237 the allowlist holds **94** coordinates: 67 `firewall_overview`
+(#1230) and 27 `connected_devices` (#1238). Both remaining entries are the
+dependency-blocked kind — fl_chart's internals and a ui_kit `AppListTile` change —
+so Track A's card-own work is complete.
 
 #1266 is in this track despite clearing nothing: it is the only entry that *adds*
 coordinates (3, by localizing a hardcoded string) and removes them again in the

--- a/doc/dashboard/dashboard_density_design.md
+++ b/doc/dashboard/dashboard_density_design.md
@@ -1148,11 +1148,18 @@ addition — it changes no card's rendering until a threshold is declared.
 Ceiling **515 / 560**. The other 45 are the dependency-blocked ones (§1.1).
 
 After #1234–#1237 the allowlist holds **94** coordinates: 67 `firewall_overview`
-(#1230) and 27 `connected_devices` (#1238). Both are the dependency-blocked kind —
-fl_chart's internals and a ui_kit `AppListTile` change — so Track A's card-own
-work is complete. Their `tracking` notes are left as the epic requires: a ticket
-touches only the notes of cards it closes, so both cards keep the `baseline #1183`
-default until their own ticket names an owner.
+(#1230) and 27 `connected_devices` (#1238). **49 of those are still card-own and
+clearable in this repo** — #1230's three own sites carry 48 (a rules/DMZ list
+column, an info-grid summary row, a pie-chart centre label) and #1238's
+device-count row carries 1. Only the other **45** are dependency-blocked, exactly
+as §1.1 classified them: fl_chart's 19 axis-title coordinates and the 26 that need
+a ui_kit `AppListTile` change. What these four tickets complete is the *four-shape*
+group, not Track A's card-own work — #1230 is the largest single block of
+clearable coordinates left in the epic.
+
+Their `tracking` notes are left as the epic requires: a ticket touches only the
+notes of cards it closes, so both cards keep the `baseline #1183` default until
+their own ticket names an owner.
 
 #1266 is in this track despite clearing nothing: it is the only entry that *adds*
 coordinates (3, by localizing a hardcoded string) and removes them again in the

--- a/lib/page/admin/cards/usp_device_info_card.dart
+++ b/lib/page/admin/cards/usp_device_info_card.dart
@@ -140,29 +140,42 @@ class UspDeviceInfoCard extends ConsumerWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
-            Semantics(
-              button: true,
-              label: label,
-              child: InkWell(
-                onTap: () => context.pushNamed(
-                  RouteNamed.uspNodeDetail,
-                  queryParameters: {'deviceId': deviceId},
-                ),
-                borderRadius: BorderRadius.circular(4),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    AppText.labelMedium(
-                      label,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    AppGap.xs(),
-                    Icon(
-                      Icons.arrow_forward,
-                      size: 14,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                  ],
+            // Both `Flexible`s are #1227's detail-footer shape, replicated
+            // verbatim from `DashboardCardTemplate._buildDetailFooter`. Safe to
+            // flex the link here for the reason given there: the row is
+            // end-aligned, so a short link's unused share is stranded at the
+            // *start* where it is invisible, and a row that already fits lays
+            // out exactly as before.
+            Flexible(
+              child: Semantics(
+                button: true,
+                label: label,
+                child: InkWell(
+                  onTap: () => context.pushNamed(
+                    RouteNamed.uspNodeDetail,
+                    queryParameters: {'deviceId': deviceId},
+                  ),
+                  borderRadius: BorderRadius.circular(4),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      // The arrow keeps its 14px; the label is what shortens.
+                      Flexible(
+                        child: AppText.labelMedium(
+                          label,
+                          color: Theme.of(context).colorScheme.primary,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      AppGap.xs(),
+                      Icon(
+                        Icons.arrow_forward,
+                        size: 14,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/page/admin/cards/usp_time_settings_card.dart
+++ b/lib/page/admin/cards/usp_time_settings_card.dart
@@ -105,17 +105,25 @@ class _UspTimeSettingsCardState extends ConsumerState<UspTimeSettingsCard>
                     children: [
                       AppText.titleLarge(timeDisplay),
                       AppGap.xxs(),
-                      Row(
-                        children: [
-                          AppBadge(
-                            label: time.isSynchronized
-                                ? loc(context).synchronized
-                                : time.status,
-                            color: time.isSynchronized
-                                ? appColors?.semanticSuccess
-                                : appColors?.semanticWarning,
-                          ),
-                        ],
+                      // Same shape as `usp_lan_info_card`'s hero row and the
+                      // same 61.4px column, but the fix is the opposite one,
+                      // because a capsule cannot take a second line: `AppBadge`
+                      // already ellipsizes its own label (`Flexible` +
+                      // `maxLines: 1` inside it) and only ever failed to,
+                      // because this single-child `Row` handed it *unbounded*
+                      // width and its inner `Flexible` had nothing to bind
+                      // against. The `Row` did nothing else — the enclosing
+                      // `Column` is already `CrossAxisAlignment.start`, so the
+                      // badge shrink-wraps identically without it — so it is
+                      // removed rather than given a `Flexible`. §2.10a point 2's
+                      // ellipsis-vs-wrap choice, decided by what the child *is*.
+                      AppBadge(
+                        label: time.isSynchronized
+                            ? loc(context).synchronized
+                            : time.status,
+                        color: time.isSynchronized
+                            ? appColors?.semanticSuccess
+                            : appColors?.semanticWarning,
                       ),
                     ],
                   ),

--- a/lib/page/admin/cards/usp_time_settings_card.dart
+++ b/lib/page/admin/cards/usp_time_settings_card.dart
@@ -141,6 +141,13 @@ class _UspTimeSettingsCardState extends ConsumerState<UspTimeSettingsCard>
                     label: loc(context).utcOffset, value: offsetDisplay),
               if (tzInfo != null && tzInfo.observesDST)
                 InfoGridItem(
+                  // Deliberately unlocalized, and recorded as arguable in
+                  // §2.10d point 6 rather than fixed here: unlike the `Enabled`
+                  // value on `lan_info`, `DST` has no ARB key, so localizing it
+                  // means adding one plus 26 translations — and several locales
+                  // spell it as a word rather than an initialism
+                  // (`Sommerzeit`), which is a width change in a cell this
+                  // branch has not measured. The value beside it is localized.
                   label: 'DST',
                   value: inferDstEnabled(time.localTimeZone)
                       ? loc(context).on

--- a/lib/page/dashboard/models/usp_widget_specs.dart
+++ b/lib/page/dashboard/models/usp_widget_specs.dart
@@ -174,6 +174,18 @@ abstract class UspWidgetSpecs {
     displayName: 'Time Settings',
     constraints: {
       DisplayMode.normal: WidgetGridConstraints(
+        // `minColumns` stays 3 deliberately. This is the one card in the whole
+        // baseline where raising it would have worked: its fit width is 288px
+        // (§1.2), so 3 → 5 columns would have covered every locale, while the
+        // other 12 cards need more than the 12 columns that exist (§1.3).
+        //
+        // Declined anyway, and #1237 exists partly to record why. The floor is
+        // the user's, not ours — it decides how narrow they may make this card on
+        // their own dashboard — and 5 of 12 columns is a permanent charge against
+        // every layout to buy headroom in a handful of long-timezone locales. The
+        // card-own fix (`usp_time_settings_card.dart:108`) cleared all 21
+        // coordinates for the price of one `Flexible` and a soft-wrap, so the
+        // widening bought nothing that constraining the content did not.
         minColumns: 3,
         maxColumns: 8,
         preferredColumns: 6,

--- a/lib/page/dashboard/models/usp_widget_specs.dart
+++ b/lib/page/dashboard/models/usp_widget_specs.dart
@@ -184,8 +184,9 @@ abstract class UspWidgetSpecs {
         // their own dashboard — and 5 of 12 columns is a permanent charge against
         // every layout to buy headroom in a handful of long-timezone locales. The
         // card-own fix (`usp_time_settings_card.dart:108`) cleared all 21
-        // coordinates for the price of one `Flexible` and a soft-wrap, so the
-        // widening bought nothing that constraining the content did not.
+        // coordinates by deleting a single-child `Row` that had no other effect
+        // than handing the badge unbounded width, so the widening bought nothing
+        // that constraining the content did not.
         minColumns: 3,
         maxColumns: 8,
         preferredColumns: 6,

--- a/lib/page/dashboard/views/components/usp_network_health_card.dart
+++ b/lib/page/dashboard/views/components/usp_network_health_card.dart
@@ -154,22 +154,62 @@ class _HealthOverview extends StatelessWidget {
             child: AppGauge(
               value: overallScore.toDouble(),
               size: 120,
-              centerBuilder: (ctx, v) => Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  // When the WAN is down the score gauge shows the neutral
-                  // placeholder + "Disconnected" so it speaks the same
-                  // vocabulary as the traffic-light row and the banner, rather
-                  // than "0 / Critical". See #1143.
-                  AppText.titleLarge(
-                      wanIsUp ? '$overallScore' : _kNoTrafficPlaceholder),
-                  AppText.labelSmall(
-                    wanIsUp
-                        ? tier.resolveLabel(ctx)
-                        : loc(parentContext).disconnected,
-                    color: tierClr,
-                  ),
-                ],
+              // The centre is a non-positioned `Stack` child inside `AppGauge`,
+              // so it is handed the gauge's *laid* box loose — and that box is
+              // not 120×120 here. `AppGauge` respects its incoming constraints,
+              // and this `Expanded` is squeezed hard enough that the gauge lays
+              // out at 120×67 in `en` and 120×**23** in `de`. The centre column
+              // needs 44px (28 for the score, 16 for the tier), so it reported
+              // +21.0px (`de`), +11.0px (`ru`) and +9.0px (`th`) — #1235's three
+              // coordinates. Bottom overflow, not the too-wide tier label the
+              // ticket assumed; measuring first is what turned that up.
+              //
+              // The squeeze comes from `_MetricChip`, three columns of ~23.1px
+              // of text at this width, whose labels soft-wrap: `Discards` takes
+              // 3 lines (48px) and `Verworfene Pakete` takes **6** (96px). So
+              // the height left for the gauge is a function of translation
+              // length, and the three failing locales are exactly the three with
+              // the longest metric labels — #1183's premise ("translation length
+              // must not decide whether the layout is valid") violated one level
+              // up from where it showed.
+              //
+              // `BoxFit.scaleDown` is the fix that fits AC 4 as written: "a tier
+              // abbreviated past recognition is worse than a smaller font". It
+              // never drops or truncates the tier — in `ru` it stops the label
+              // wrapping to two lines and shrinks it 3% instead — and it scales
+              // nothing at any width where the centre already fitted, so the
+              // wide layouts are byte-identical. It is also self-relaxing: the
+              // moment the metric row stops eating the height (Track B), the
+              // scale returns to 1.0 with no code change, which a hardcoded
+              // abbreviation or a dropped label would not.
+              //
+              // What it does NOT fix, deliberately: at 191px those metric labels
+              // are illegible in every locale, `en` included — `Discards` breaks
+              // mid-word across 3 lines today. That is this card being rendered
+              // at 191px when §1.2 measures its fit width at 420px, so it is a
+              // threshold question for #1240 and not something to paper over
+              // here by ellipsizing a label to `V…`. The worst scale this leaves
+              // is 0.52 in `de`, and that number is the density defect's
+              // measurement, not a design choice.
+              centerBuilder: (ctx, v) => FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    // When the WAN is down the score gauge shows the neutral
+                    // placeholder + "Disconnected" so it speaks the same
+                    // vocabulary as the traffic-light row and the banner, rather
+                    // than "0 / Critical". See #1143.
+                    AppText.titleLarge(
+                        wanIsUp ? '$overallScore' : _kNoTrafficPlaceholder),
+                    AppText.labelSmall(
+                      wanIsUp
+                          ? tier.resolveLabel(ctx)
+                          : loc(parentContext).disconnected,
+                      color: tierClr,
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/page/dashboard/views/components/usp_system_status_card.dart
+++ b/lib/page/dashboard/views/components/usp_system_status_card.dart
@@ -243,20 +243,31 @@ class _MonitorView extends StatelessWidget {
         Expanded(
           child: LayoutBuilder(
             builder: (context, constraints) {
-              final gaugeSize = math.min(
-                _kMonitorGaugeSize,
+              // `math.max` floors the result at zero. The width term goes
+              // negative below `AppSpacing.md` of available width, and while no
+              // realization the grid produces comes near that (the narrowest is
+              // 157.4px), a `LayoutBuilder` can be given a zero-width box
+              // transiently — mid-drag, or during a collapse animation — and a
+              // negative `size` would assert inside `AppGauge` rather than
+              // degrade. A zero-diameter gauge is invisible for one frame; a
+              // failed assertion is a red screen.
+              final gaugeSize = math.max(
+                0.0,
                 math.min(
-                  // `AppSpacing.md` of slack, so two circles can never touch.
-                  // `spaceEvenly` then splits that reserve into three equal
-                  // gaps, so what is actually drawn between the circles is
-                  // md/3 = 4px (measured: 72.7px circles at x=21.0 and x=97.7
-                  // in a 157.4px box). Tight on purpose — reserving a full
-                  // 12px *between* them costs 12px of diameter, and #1234's
-                  // AC 4 is about the reading inside the circle staying
-                  // legible. Air between two rings is the cheaper thing to
-                  // give up.
-                  (constraints.maxWidth - AppSpacing.md) / 2,
-                  constraints.maxHeight,
+                  _kMonitorGaugeSize,
+                  math.min(
+                    // `AppSpacing.md` of slack, so two circles can never touch.
+                    // `spaceEvenly` then splits that reserve into three equal
+                    // gaps, so what is actually drawn between the circles is
+                    // md/3 = 4px (measured: 72.7px circles at x=21.0 and x=97.7
+                    // in a 157.4px box). Tight on purpose — reserving a full
+                    // 12px *between* them costs 12px of diameter, and #1234's
+                    // AC 4 is about the reading inside the circle staying
+                    // legible. Air between two rings is the cheaper thing to
+                    // give up.
+                    (constraints.maxWidth - AppSpacing.md) / 2,
+                    constraints.maxHeight,
+                  ),
                 ),
               );
               return Row(
@@ -372,9 +383,12 @@ class _MonitorView extends StatelessWidget {
       // because a `Column` reports overflow only in its own axis and this one
       // has 72.7px of height for ~40px of text. Ellipsis, not wrap, per §2.10a
       // point 2: the label is a bare series *name*, and the reading it names is
-      // `display` right above it, which keeps its full size and full text. The
-      // full label is still on screen unabbreviated — the legend row below
-      // spells out `Arbeitsspeicher: 73%` and soft-wraps to do it.
+      // `display` right above it, which keeps its own style unshrunk and its
+      // text uncut. (`titleMedium` here against `network_health`'s `titleLarge`
+      // predates this work and is not part of the fix — the point is only that
+      // #1234 takes nothing away from the reading.) The full label is still on
+      // screen unabbreviated too — the legend row below spells out
+      // `Arbeitsspeicher: 73%` and soft-wraps to do it.
       centerBuilder: (ctx, v) => Column(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/lib/page/dashboard/views/components/usp_system_status_card.dart
+++ b/lib/page/dashboard/views/components/usp_system_status_card.dart
@@ -246,8 +246,15 @@ class _MonitorView extends StatelessWidget {
               final gaugeSize = math.min(
                 _kMonitorGaugeSize,
                 math.min(
-                  // `AppSpacing.md` is the narrowest gap that still reads as
-                  // two separate gauges rather than a figure of eight.
+                  // `AppSpacing.md` of slack, so two circles can never touch.
+                  // `spaceEvenly` then splits that reserve into three equal
+                  // gaps, so what is actually drawn between the circles is
+                  // md/3 = 4px (measured: 72.7px circles at x=21.0 and x=97.7
+                  // in a 157.4px box). Tight on purpose — reserving a full
+                  // 12px *between* them costs 12px of diameter, and #1234's
+                  // AC 4 is about the reading inside the circle staying
+                  // legible. Air between two rings is the cheaper thing to
+                  // give up.
                   (constraints.maxWidth - AppSpacing.md) / 2,
                   constraints.maxHeight,
                 ),
@@ -360,10 +367,10 @@ class _MonitorView extends StatelessWidget {
       //
       // Since the circle now shrinks with the card, the label has to be told
       // what to do when it no longer fits: `Arbeitsspeicher` is 88.1px of
-      // `bodySmall` and the narrowest circle is 70.7px across. Left alone it
+      // `bodySmall` and the narrowest circle is 72.7px across. Left alone it
       // soft-wraps mid-word inside the arc — a degradation the gate cannot see,
       // because a `Column` reports overflow only in its own axis and this one
-      // has 70.7px of height for ~40px of text. Ellipsis, not wrap, per §2.10a
+      // has 72.7px of height for ~40px of text. Ellipsis, not wrap, per §2.10a
       // point 2: the label is a bare series *name*, and the reading it names is
       // `display` right above it, which keeps its full size and full text. The
       // full label is still on screen unabbreviated — the legend row below

--- a/lib/page/dashboard/views/components/usp_system_status_card.dart
+++ b/lib/page/dashboard/views/components/usp_system_status_card.dart
@@ -118,29 +118,42 @@ class _UspSystemStatusCardState extends ConsumerState<UspSystemStatusCard> {
         Row(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
-            Semantics(
-              button: true,
-              label: label,
-              child: InkWell(
-                onTap: () => context.pushNamed(
-                  RouteNamed.uspStatistics,
-                  queryParameters: {'tab': tabIndex.toString()},
-                ),
-                borderRadius: BorderRadius.circular(4),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    AppText.labelMedium(
-                      label,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    AppGap.xs(),
-                    Icon(
-                      Icons.arrow_forward,
-                      size: 14,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                  ],
+            // Both `Flexible`s are #1227's detail-footer shape, replicated
+            // verbatim from `DashboardCardTemplate._buildDetailFooter`. Safe to
+            // flex the link here for the reason given there: the row is
+            // end-aligned, so a short link's unused share is stranded at the
+            // *start* where it is invisible, and a row that already fits lays
+            // out exactly as before.
+            Flexible(
+              child: Semantics(
+                button: true,
+                label: label,
+                child: InkWell(
+                  onTap: () => context.pushNamed(
+                    RouteNamed.uspStatistics,
+                    queryParameters: {'tab': tabIndex.toString()},
+                  ),
+                  borderRadius: BorderRadius.circular(4),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      // The arrow keeps its 14px; the label is what shortens.
+                      Flexible(
+                        child: AppText.labelMedium(
+                          label,
+                          color: Theme.of(context).colorScheme.primary,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      AppGap.xs(),
+                      Icon(
+                        Icons.arrow_forward,
+                        size: 14,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/page/dashboard/views/components/usp_system_status_card.dart
+++ b/lib/page/dashboard/views/components/usp_system_status_card.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -15,6 +17,11 @@ import 'package:privacy_gui/page/_shared/components/dashboard_card_template.dart
 import 'package:privacy_gui/page/_shared/components/usp_info_row.dart';
 import 'package:privacy_gui/route/constants.dart';
 import 'package:ui_kit_library/ui_kit.dart';
+
+/// The diameter the Monitor tab's CPU/memory gauges are drawn at whenever the
+/// card is wide enough to hold two of them side by side. Narrower realizations
+/// scale down from here; see `_MonitorView.build`.
+const double _kMonitorGaugeSize = 100;
 
 /// System Performance Dashboard — 4-tab card (F-021).
 ///
@@ -205,19 +212,62 @@ class _MonitorView extends StatelessWidget {
           value: latest?.formattedUptime ?? info.formattedUptime,
         ),
         AppGap.md(),
+        // Two `AppGauge(size: 100)` in a `spaceEvenly` row is the one overflow
+        // on this branch that no amount of `Flexible` can fix: the children are
+        // not text that can give, they are two circles asking for 200px inside
+        // a box measured at **157.4px** at the card's narrowest realization.
+        // Hence the constant +43.0px in all 26 locales — this shape is
+        // geometry-bound, not translation-bound, and `en` overflows exactly as
+        // much as `el`.
+        //
+        // Stacking them (a `Wrap`) was measured and rejected, and the
+        // measurement is worth keeping: two 100px runs plus spacing need ~208px
+        // against the 201px (`en`) / 181px (`de`) this `Expanded` offers, and
+        // **nothing reports the difference**. `RenderWrap` has no overflow
+        // indicator of its own, and the `Expanded` pins its height, so the
+        // second circle is simply clipped — 108px between centres inside a
+        // 181px box, with all 209 gate cases green. So the circles shrink
+        // instead, which is the only option that keeps both readings side by
+        // side at every width, and the guard for that lives in
+        // `usp_gauge_center_readability_test.dart` rather than in the gate.
+        //
+        // `math.min` against the natural size makes this an upper bound rather
+        // than an allotment (§2.6a point 1's idiom): every width that already
+        // fitted two 100px gauges still renders them at exactly 100px, so the
+        // wide layouts are untouched and only the narrow one changes. The
+        // height term is what protects the fix from #1266's failure mode — the
+        // row enumeration can hand this `Expanded` less height than the gauge's
+        // own diameter, and a circle taller than its box would overflow the
+        // bottom instead. Both `Infinity` cases (unbounded width, unbounded
+        // height) degrade to the natural size.
         Expanded(
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: [
-              _buildGauge(context,
-                  value: cpuPercent.toDouble(),
-                  label: loc(context).cpu,
-                  display: '$cpuPercent%'),
-              _buildGauge(context,
-                  value: memPercent.toDouble(),
-                  label: loc(context).memory,
-                  display: '$memPercent%'),
-            ],
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final gaugeSize = math.min(
+                _kMonitorGaugeSize,
+                math.min(
+                  // `AppSpacing.md` is the narrowest gap that still reads as
+                  // two separate gauges rather than a figure of eight.
+                  (constraints.maxWidth - AppSpacing.md) / 2,
+                  constraints.maxHeight,
+                ),
+              );
+              return Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  _buildGauge(context,
+                      value: cpuPercent.toDouble(),
+                      label: loc(context).cpu,
+                      display: '$cpuPercent%',
+                      size: gaugeSize),
+                  _buildGauge(context,
+                      value: memPercent.toDouble(),
+                      label: loc(context).memory,
+                      display: '$memPercent%',
+                      size: gaugeSize),
+                ],
+              );
+            },
           ),
         ),
         AppGap.sm(),
@@ -298,15 +348,35 @@ class _MonitorView extends StatelessWidget {
     required double value,
     required String label,
     required String display,
+    required double size,
   }) {
     return AppGauge(
       value: value,
-      size: 100,
+      size: size,
+      // `centerBuilder`'s widget becomes a non-positioned `Stack` child inside
+      // `AppGauge`, so it is handed loose `size × size` constraints — this
+      // `Column` is the app's own closure and the whole fix lives at this call
+      // site, with no ui_kit change to ask for.
+      //
+      // Since the circle now shrinks with the card, the label has to be told
+      // what to do when it no longer fits: `Arbeitsspeicher` is 88.1px of
+      // `bodySmall` and the narrowest circle is 70.7px across. Left alone it
+      // soft-wraps mid-word inside the arc — a degradation the gate cannot see,
+      // because a `Column` reports overflow only in its own axis and this one
+      // has 70.7px of height for ~40px of text. Ellipsis, not wrap, per §2.10a
+      // point 2: the label is a bare series *name*, and the reading it names is
+      // `display` right above it, which keeps its full size and full text. The
+      // full label is still on screen unabbreviated — the legend row below
+      // spells out `Arbeitsspeicher: 73%` and soft-wraps to do it.
       centerBuilder: (ctx, v) => Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           AppText.titleMedium(display),
-          AppText.bodySmall(label),
+          AppText.bodySmall(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
         ],
       ),
     );

--- a/lib/page/dashboard/views/components/usp_system_status_card.dart
+++ b/lib/page/dashboard/views/components/usp_system_status_card.dart
@@ -228,25 +228,66 @@ class _MonitorView extends StatelessWidget {
           ),
         ),
         AppGap.md(),
-        Row(
-          children: [
-            _LegendDot(color: colorScheme.primary),
-            AppGap.xs(),
-            AppText.labelSmall(
-                loc(context).cpuPercent('${latest?.cpuPercent ?? '--'}')),
-            AppGap.lg(),
-            _LegendDot(color: colorScheme.secondary),
-            AppGap.xs(),
-            AppText.labelSmall(
-                loc(context).memoryPercent('${latest?.memoryPercent ?? '--'}')),
-            const Spacer(),
-            if (monitorState.refreshInterval != null) ...[
-              AppIcon.font(Icons.autorenew,
-                  size: 12, color: colorScheme.onSurfaceVariant),
-              AppText.labelSmall(intervalLabel,
-                  color: colorScheme.onSurfaceVariant),
+        // The fourth legend row on this card, and the last to get #1226's shape
+        // — #1233 converted the other three (Trends / Distribution /
+        // Correlation) and left this one because it also carries the refresh
+        // chrome. Labels are composed statistics (`CPU: 47%`), so they
+        // soft-wrap rather than ellipsize (§2.10a point 2), which is what
+        // `_StatLegendEntry` does by default.
+        //
+        // §2.10a point 3's precondition holds here, and was measured rather
+        // than assumed: the `Expanded` above hands the gauge row **221px**
+        // (202px in `ru`) for 100px of gauge, so it can pay for a second and
+        // third run out of slack without squeezing the gauges — the opposite of
+        // `network_health`, whose `Expanded` holds a gauge of exactly its own
+        // fixed height and yields nothing.
+        //
+        // `SizedBox(width: double.infinity)` is load-bearing, per §2.10c
+        // finding 3: a `Wrap` sizes itself to its widest run, and this `Column`
+        // is `CrossAxisAlignment.center`, so without a tight width the legend
+        // would shrink-wrap and drift to the centre of the card at every width
+        // — a pure visual regression that overflows nothing and that the gate
+        // would pass either way.
+        //
+        // What this row does give up: the interval chip's flush-right position.
+        // A `Wrap` cannot hold a `Spacer`, and `WrapAlignment.spaceBetween`
+        // would distribute space between *all three* children, pulling the two
+        // legend entries apart instead — a bigger change to the wide layout
+        // than moving a 20px chip. So the chip joins the flow as the last
+        // entry, and every width down to the narrowest keeps the same reading
+        // order.
+        SizedBox(
+          width: double.infinity,
+          child: Wrap(
+            crossAxisAlignment: WrapCrossAlignment.center,
+            spacing: AppSpacing.lg,
+            runSpacing: AppSpacing.xs,
+            children: [
+              _StatLegendEntry(
+                color: colorScheme.primary,
+                label: loc(context).cpuPercent('${latest?.cpuPercent ?? '--'}'),
+              ),
+              _StatLegendEntry(
+                color: colorScheme.secondary,
+                label: loc(context)
+                    .memoryPercent('${latest?.memoryPercent ?? '--'}'),
+              ),
+              // Grouped in a `mainAxisSize: min` `Row` for the same reason a
+              // legend entry is: as two bare `Wrap` children the icon and its
+              // interval would be separated by `spacing` and could land on
+              // different runs.
+              if (monitorState.refreshInterval != null)
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    AppIcon.font(Icons.autorenew,
+                        size: 12, color: colorScheme.onSurfaceVariant),
+                    AppText.labelSmall(intervalLabel,
+                        color: colorScheme.onSurfaceVariant),
+                  ],
+                ),
             ],
-          ],
+          ),
         ),
       ],
     );

--- a/lib/page/local_network/cards/usp_lan_info_card.dart
+++ b/lib/page/local_network/cards/usp_lan_info_card.dart
@@ -53,13 +53,38 @@ class UspLanInfoCard extends ConsumerWidget {
                     children: [
                       AppText.titleLarge(info.ipAddress),
                       AppGap.xxs(),
+                      // The hero's 56px avatar + `AppGap.lg` leave this
+                      // `Expanded` column just **61.4px** at the card's
+                      // narrowest realization (measured), and a `Row` hands a
+                      // non-flex child unbounded width — so the status label
+                      // painted at its full intrinsic width and the row
+                      // overflowed in every locale, `en` included (+47.7px), up
+                      // to +101.8px in `el`.
+                      //
+                      // Soft-wrap, not ellipsis: `DHCP Enabled` is a composed
+                      // *status*, and ~49px of text column would ellipsize it to
+                      // `DHCP…` — dropping the one word the row exists to show.
+                      // §2.10a point 2's rule, applied to a status instead of a
+                      // statistic. The height a second run costs is free here:
+                      // this card's content sits in the card template's
+                      // `SingleChildScrollView`, so it yields, unlike the fixed
+                      // gauge of §2.10a point 3. `start` keeps the dot on the
+                      // label's first line rather than floating it to the
+                      // vertical middle of a wrapped block.
                       Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          UspStatusDot(isActive: info.dhcpEnabled, size: 8),
+                          Padding(
+                            padding: const EdgeInsets.only(top: AppSpacing.xs),
+                            child: UspStatusDot(
+                                isActive: info.dhcpEnabled, size: 8),
+                          ),
                           AppGap.xs(),
-                          AppText.bodyMedium(
-                            '${loc(context).dhcp} ${info.dhcpEnabled ? loc(context).enabled : loc(context).disabled}',
-                            color: colorScheme.onSurfaceVariant,
+                          Flexible(
+                            child: AppText.bodyMedium(
+                              '${loc(context).dhcp} ${info.dhcpEnabled ? loc(context).enabled : loc(context).disabled}',
+                              color: colorScheme.onSurfaceVariant,
+                            ),
                           ),
                         ],
                       ),

--- a/lib/page/local_network/cards/usp_lan_info_card.dart
+++ b/lib/page/local_network/cards/usp_lan_info_card.dart
@@ -141,7 +141,16 @@ class UspLanInfoCard extends ConsumerWidget {
                         : null,
                   )
                 else if (info.ipv6Enabled)
-                  InfoGridItem(label: 'IPv6', value: 'Enabled'),
+                  // `IPv6` is a protocol name and stays as it is, like `DHCP`
+                  // above; the *value* is prose and was not. Localizing it is
+                  // safe here without new measurement, which is not usually
+                  // true of a hardcoded string (#1266): this branch never
+                  // renders under the gate's fixture, but the cell it renders
+                  // into is the shared `InfoGrid` value, which soft-wraps since
+                  // #1236 and is measured in all 26 locales via the sibling
+                  // branch — and that sibling paints a full IPv6 address, far
+                  // longer than the longest `enabled` translation.
+                  InfoGridItem(label: 'IPv6', value: loc(context).enabled),
               ],
             ),
           ],

--- a/test/fixtures/known_overflows.json
+++ b/test/fixtures/known_overflows.json
@@ -1,8 +1,5 @@
 {
-  "tracking": {
-    "connected_devices": "#1238 (blocked on a ui_kit AppListTile change)",
-    "firewall_overview": "#1230 (card-own sites + the fl_chart fallback)"
-  },
+  "tracking": {},
   "allowlist": {
     "connected_devices|min|0": ["*"],
     "connected_devices|preferred|0": ["el"],

--- a/test/fixtures/known_overflows.json
+++ b/test/fixtures/known_overflows.json
@@ -1,30 +1,16 @@
 {
   "tracking": {
-    "network_health": "gauge centre #1235 (legend rows cleared by #1233)",
-    "system_status": "gauge row + action row + tab-0 legend-adjacent row #1234 (legend rows cleared by #1233)"
+    "connected_devices": "#1238 (blocked on a ui_kit AppListTile change)",
+    "firewall_overview": "#1230 (card-own sites + the fl_chart fallback)"
   },
   "allowlist": {
     "connected_devices|min|0": ["*"],
     "connected_devices|preferred|0": ["el"],
-    "device_info|min|0": ["el", "ru"],
     "firewall_overview|min|0": [
       "ar", "el", "es", "es_AR", "fi", "fr", "fr_CA", "id", "nb", "pl",
       "pt", "pt_PT", "ru", "tr", "vi"
     ],
     "firewall_overview|min|1": ["*"],
-    "firewall_overview|preferred|1": ["*"],
-    "lan_info|min|0": ["*"],
-    "lan_info|preferred|0": ["el"],
-    "network_health|min|0": ["de", "ru", "th"],
-    "system_status|min|0": ["*"],
-    "system_status|min|1": ["el", "ru"],
-    "system_status|min|2": ["el", "ru"],
-    "system_status|min|3": ["el", "ru"],
-    "system_status|preferred|0": ["fr", "fr_CA"],
-    "time_settings|min|0": [
-      "da", "de", "el", "en", "es", "es_AR", "fi", "fr", "fr_CA", "id",
-      "it", "nb", "nl", "pl", "pt", "pt_PT", "ru", "sv", "th", "tr",
-      "vi"
-    ]
+    "firewall_overview|preferred|1": ["*"]
   }
 }

--- a/test/page/dashboard/views/components/usp_gauge_center_readability_test.dart
+++ b/test/page/dashboard/views/components/usp_gauge_center_readability_test.dart
@@ -1,0 +1,297 @@
+@Tags(['dashboard-card'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/dashboard/models/display_mode.dart';
+import 'package:privacy_gui/page/dashboard/models/usp_widget_specs.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import '../../../../util/app_test_fonts.dart';
+import '../../../../util/dashboard/dashboard_card_probe.dart';
+
+/// Gauge-centre readability (#1234).
+///
+/// ## Why this file exists alongside the #1183 gate
+///
+/// `system_status`'s Monitor tab drew two `AppGauge(size: 100)` in a
+/// `spaceEvenly` row inside a box measured at 161.4px, so it overflowed by a
+/// constant +43.0px in all 26 locales. #1234 fixes it by bounding the diameter
+/// with a `LayoutBuilder` — at the narrowest realization the circles come out at
+/// 72.7px each.
+///
+/// The gate owns the overflow half of that: revert the bound and 26 coordinates
+/// come back. What the gate cannot see is what shrinking the circle does to its
+/// *contents*. `centerBuilder`'s widget is a non-positioned `Stack` child, so it
+/// is handed loose `size × size` constraints, and a `Column` under loose
+/// constraints reports overflow only in its own axis — there is 72.7px of height
+/// for ~40px of text, so anything that happens to the width is silent. Two
+/// distinct silent failures live there:
+///
+///   - the label soft-wrapping mid-word inside the arc (`Arbeitsspeicher` is
+///     88.1px of `bodySmall` in a 72.7px circle);
+///   - the *reading* clipping to a stub, which is the one thing the card exists
+///     to show, if the circle ever shrinks below it.
+///
+/// #1234's fourth acceptance criterion — "gauge readings stay legible at the
+/// narrowest clean width" — is exactly this blind spot, which is why it gets a
+/// file rather than a gate entry.
+///
+/// Tagged `dashboard-card` so it gates PRs: `run_tests.sh` excludes
+/// `golden||loc||ui`, so a `ui`-tagged test here would block nothing.
+///
+/// ## Mutation ledger
+///
+/// Each mutation was run against this file *and* the gate, because a mutation
+/// the gate already catches proves nothing about this file (§2.10b point 4).
+///
+/// The gate column is measured with `system_status`'s allowlist entries already
+/// deleted, i.e. against the ratchet as this branch leaves it — with them still
+/// in place every mutation below is trivially green and the table would say
+/// nothing.
+///
+///   | mutation                                            | this file | the gate |
+///   |-----------------------------------------------------|-----------|----------|
+///   | drop `maxLines: 1` from the centre label            | 1 fail    | green    |
+///   | `LayoutBuilder` bound removed (`size: 100`)         | green     | 26 fail  |
+///   | gauges stacked in a `Wrap` instead of shrunk        | 1 fail    | green    |
+///   | bound by width only, dropping the height term       | green     | green    |
+///
+/// The first row is the reason the file exists: dropping `maxLines` leaves every
+/// gate case green while `de` renders `Arbeits`/`speicher` broken across two
+/// lines inside a 72.7px circle.
+///
+/// The second row is the boundary between the two mechanisms — the gate owns the
+/// overflow, so this file does not restate it.
+///
+/// The third row is the design alternative #1234 rejected, and it came out worse
+/// than expected. Two 100px runs need ~208px against the 201px (`en`) / 181px
+/// (`de`) the `Expanded` offers, so the guess was "overflows the bottom in the
+/// long translations". It does not overflow anywhere: `RenderWrap` has no
+/// overflow indicator of its own, and the `Expanded` pins its height, so the
+/// second circle is *clipped in silence* — measured 108px between gauge centres
+/// inside a 181px box, all 209 gate cases green. The general lesson, which
+/// §2.10a point 3 states in terms of bottom overflow, is sharper than that: a
+/// `Wrap` under an `Expanded` cannot report the height it needed, so "the gate
+/// would tell me if the extra run did not fit" is false. That is why the
+/// precondition has to be measured before the conversion, not observed after.
+///
+/// The fourth row is honest rather than useful: at every width the row
+/// enumeration actually produces, the height term in the `math.min` is not the
+/// binding one (181–201px of height for a 72.7px circle). It is a guard against
+/// a future row span, not a live constraint, and nothing here can pin it without
+/// inventing a card height the grid never asks for.
+void main() {
+  setUpAll(() async {
+    // Real fonts: under the Ahem block font every glyph is one square em, so
+    // what fits — and therefore what ellipsizes — is fiction.
+    await loadAppFonts();
+  });
+
+  const cardId = 'system_status';
+  final spec = UspWidgetSpecs.all.firstWhere((s) => s.id == cardId);
+  final constraints = spec.getConstraints(DisplayMode.normal);
+
+  /// Pumps the Monitor tab at the narrowest width the grid ever gives the card's
+  /// min span — the worst case the gate measures, and the only width where the
+  /// diameter bound actually bites. One pump, as the gate does.
+  Future<void> pumpAt(
+    WidgetTester tester, {
+    required int columns,
+    required String label,
+    required Locale locale,
+  }) async {
+    final narrowest = narrowestRealizationOf(columns, minScreen: 0)!;
+    await probeCardOverflow(
+      tester,
+      cardId: cardId,
+      widthCase: CardWidthCase(
+        screenWidth: narrowest.screenWidth,
+        cardWidth: narrowest.cardWidth,
+        columnSpan: columns,
+        label: label,
+      ),
+      cardHeightRows: constraints.minHeightRows,
+      tabIndex: 0,
+      locale: locale,
+    );
+  }
+
+  Future<void> pumpNarrowest(WidgetTester tester, Locale locale) =>
+      pumpAt(tester,
+          columns: constraints.minColumns, label: 'min', locale: locale);
+
+  Future<void> pumpPreferred(WidgetTester tester, Locale locale) =>
+      pumpAt(tester,
+          columns: constraints.preferredColumns,
+          label: 'preferred',
+          locale: locale);
+
+  /// The `Text`s painted inside gauge [i]'s centre, in tree order: the reading
+  /// first, its label second.
+  ///
+  /// Read through the gauge rather than off the card, because the same numbers
+  /// appear again in the legend row below — a card-wide `find.text('47%')` would
+  /// match whichever came first and pass while the centre was empty.
+  List<Text> centreTexts(WidgetTester tester, int i) => tester
+      .widgetList<Text>(find.descendant(
+        of: find.byType(AppGauge).at(i),
+        matching: find.byType(Text),
+      ))
+      .where((t) => t.data != null && t.data!.isNotEmpty)
+      .toList();
+
+  RenderParagraph paragraphOf(WidgetTester tester, Text text) =>
+      tester.renderObject<RenderParagraph>(find.byWidget(text));
+
+  /// Whether [text] had to drop content to fit. `didExceedMaxLines` is the
+  /// renderer's own verdict, so this does not re-derive metrics the layout
+  /// already computed.
+  bool isClipped(WidgetTester tester, Text text) =>
+      paragraphOf(tester, text).didExceedMaxLines;
+
+  /// How many lines [text] actually painted, counted off the renderer's own
+  /// glyph boxes. This is the only measurement that distinguishes "ellipsized
+  /// onto one line" — by design, for a label longer than the circle — from
+  /// "wrapped mid-word", since both leave the widget's `data` intact and both
+  /// fit inside the box the gate measures.
+  int lineCount(WidgetTester tester, Text text) {
+    final boxes = paragraphOf(tester, text).getBoxesForSelection(
+      TextSelection(baseOffset: 0, extentOffset: text.data!.length),
+    );
+    expect(boxes, isNotEmpty,
+        reason: '"${text.data}" painted no glyphs at all');
+    return boxes.map((b) => b.top.round()).toSet().length;
+  }
+
+  group('the reading survives the shrunken circle (#1234 AC4)', () {
+    // The gauges are the tab's headline: the label names a series, the reading
+    // *is* the datum. So the two are held to different standards below — the
+    // reading may never give, the label may ellipsize but may never wrap.
+    for (final tag in ['en', 'de', 'ru', 'th']) {
+      testWidgets('both gauges show their full percentage in $tag',
+          (tester) async {
+        await pumpNarrowest(tester, _localeFor(tag));
+
+        expect(find.byType(AppGauge), findsNWidgets(2),
+            reason: 'the Monitor tab compares CPU against memory, so both '
+                'gauges must be drawn — a fix that fits by dropping one is not '
+                'a fix.');
+
+        for (var i = 0; i < 2; i++) {
+          final texts = centreTexts(tester, i);
+          expect(texts, hasLength(2),
+              reason: 'gauge $i should paint a reading and its label; got '
+                  '${texts.map((t) => t.data).toList()}');
+
+          final reading = texts.first;
+          expect(reading.data, matches(RegExp(r'^\d+%$')),
+              reason: 'gauge $i\'s first centre line should be the percentage, '
+                  'not "${reading.data}"');
+          expect(isClipped(tester, reading), isFalse,
+              reason: 'gauge $i\'s reading "${reading.data}" is clipped at the '
+                  'narrowest width. The circle has been bounded below the size '
+                  'of the number it exists to show.');
+          expect(lineCount(tester, reading), 1,
+              reason: 'gauge $i\'s reading "${reading.data}" wrapped onto a '
+                  'second line inside the arc.');
+        }
+      });
+
+      testWidgets('neither gauge label wraps inside the arc in $tag',
+          (tester) async {
+        await pumpNarrowest(tester, _localeFor(tag));
+        final l = await AppLocalizations.delegate.load(_localeFor(tag));
+
+        final labels = [
+          for (var i = 0; i < 2; i++) centreTexts(tester, i).last,
+        ];
+        expect(labels.map((t) => t.data), containsAll([l.cpu, l.memory]),
+            reason: 'each gauge must name its own series; got '
+                '${labels.map((t) => t.data).toList()}');
+
+        for (final label in labels) {
+          // One line, clipped or not. `de`'s `Arbeitsspeicher` is 88.1px of
+          // `bodySmall` inside a 72.7px circle, so the ellipsis is *expected*
+          // there and asserting `isClipped == false` would be a lie. What must
+          // not happen is the soft wrap: a mid-word break inside a 72.7px arc
+          // costs the label its readability and the centre its shape, and every
+          // gate case stays green through it.
+          expect(lineCount(tester, label), 1,
+              reason: 'gauge label "${label.data}" painted '
+                  '${lineCount(tester, label)} lines inside the arc. The label '
+                  'is a series name: it ellipsizes to one line, and the full '
+                  'string stays available in the legend row below.');
+
+          // The centre is a `Stack` child with loose `size × size` constraints,
+          // and `Stack` clips by default — so a centre that outgrew its circle
+          // would vanish at the edges rather than report anything.
+          final gauge = tester.getRect(find.ancestor(
+              of: find.byWidget(label), matching: find.byType(AppGauge)));
+          final rect = tester.getRect(find.byWidget(label));
+          expect(rect.left, greaterThanOrEqualTo(gauge.left - 1.0));
+          expect(rect.right, lessThanOrEqualTo(gauge.right + 1.0),
+              reason:
+                  'gauge label "${label.data}" extends past its own circle, '
+                  'so the Stack is clipping it.');
+        }
+      });
+    }
+
+    testWidgets('the two gauges stay side by side and the same size',
+        (tester) async {
+      // The rejected alternative, pinned: stacking the circles vertically also
+      // clears the overflow, and would leave every assertion above true. But
+      // the tab's value is the CPU-against-memory comparison, and two circles
+      // of different diameters or on different rows no longer make it.
+      await pumpNarrowest(tester, _localeFor('de'));
+
+      final first = tester.getRect(find.byType(AppGauge).at(0));
+      final second = tester.getRect(find.byType(AppGauge).at(1));
+
+      expect((first.center.dy - second.center.dy).abs(), lessThan(2.0),
+          reason: 'the gauges are on different rows (${first.center.dy} vs '
+              '${second.center.dy}), so the comparison they exist for now needs '
+              'a vertical scan. #1234 shrinks the circles instead of stacking '
+              'them precisely to avoid this.');
+      expect(second.left, greaterThanOrEqualTo(first.right - 1.0),
+          reason: 'the gauges overlap horizontally.');
+      expect((first.width - second.width).abs(), lessThan(1.0),
+          reason: 'the gauges have different diameters (${first.width} vs '
+              '${second.width}), so their arcs are no longer comparable.');
+    });
+
+    testWidgets('the ellipsis is a narrow-width net, not the normal state',
+        (tester) async {
+      // The canary #1229 taught: a fix whose safety net is always engaged has
+      // stopped being a safety net. At the preferred width the circles are back
+      // to their natural 100px, which fits `de`'s 88.1px label with room to
+      // spare — so if this ever starts failing, either the bound has begun
+      // biting at widths it should not or a translation has outgrown the circle
+      // outright, and both want a look rather than a silent ellipsis.
+      await pumpPreferred(tester, _localeFor('de'));
+      final l = await AppLocalizations.delegate.load(_localeFor('de'));
+
+      for (var i = 0; i < 2; i++) {
+        final label = centreTexts(tester, i).last;
+        expect(isClipped(tester, label), isFalse,
+            reason: 'gauge label "${label.data}" is ellipsized at the '
+                'preferred width, where the circle is at its natural size. '
+                'The centre is now degrading in the layout the grid hands the '
+                'card by default, not just at the narrowest one.');
+      }
+      expect([for (var i = 0; i < 2; i++) centreTexts(tester, i).last.data],
+          containsAll([l.cpu, l.memory]));
+    });
+  });
+}
+
+Locale _localeFor(String tag) =>
+    AppLocalizations.supportedLocales.firstWhere((l) {
+      final t = l.countryCode == null || l.countryCode!.isEmpty
+          ? l.languageCode
+          : '${l.languageCode}_${l.countryCode}';
+      return t == tag;
+    });

--- a/test/page/dashboard/views/components/usp_gauge_center_readability_test.dart
+++ b/test/page/dashboard/views/components/usp_gauge_center_readability_test.dart
@@ -24,7 +24,7 @@ import '../../../../util/dashboard/dashboard_card_probe.dart';
 /// ## Why this file exists alongside the #1183 gate
 ///
 /// `system_status`'s Monitor tab drew two `AppGauge(size: 100)` in a
-/// `spaceEvenly` row inside a box measured at 161.4px, so it overflowed by a
+/// `spaceEvenly` row inside a box measured at 157.4px, so it overflowed by a
 /// constant +43.0px in all 26 locales. #1234 fixes it by bounding the diameter
 /// with a `LayoutBuilder` — at the narrowest realization the circles come out at
 /// 72.7px each.
@@ -253,17 +253,19 @@ void main() {
                   'is a series name: it ellipsizes to one line, and the full '
                   'string stays available in the legend row below.');
 
-          // The centre is a `Stack` child with loose `size × size` constraints,
-          // and `Stack` clips by default — so a centre that outgrew its circle
-          // would vanish at the edges rather than report anything.
+          // The centre is a non-positioned `Stack` child under loose
+          // `size × size` constraints, and `AppGauge` builds that `Stack` with
+          // `clipBehavior: Clip.none` — so a centre wider than its circle is
+          // neither clipped nor reported: it paints straight over the arc and
+          // into the neighbouring gauge. Bounds have to be asserted because
+          // nothing else objects.
           final gauge = tester.getRect(find.ancestor(
               of: find.byWidget(label), matching: find.byType(AppGauge)));
           final rect = tester.getRect(find.byWidget(label));
           expect(rect.left, greaterThanOrEqualTo(gauge.left - 1.0));
           expect(rect.right, lessThanOrEqualTo(gauge.right + 1.0),
-              reason:
-                  'gauge label "${label.data}" extends past its own circle, '
-                  'so the Stack is clipping it.');
+              reason: 'gauge label "${label.data}" paints outside its own '
+                  'circle, over the arc.');
         }
       });
     }
@@ -285,8 +287,15 @@ void main() {
               '${second.center.dy}), so the comparison they exist for now needs '
               'a vertical scan. #1234 shrinks the circles instead of stacking '
               'them precisely to avoid this.');
-      expect(second.left, greaterThanOrEqualTo(first.right - 1.0),
-          reason: 'the gauges overlap horizontally.');
+      // The `AppSpacing.md` reserve exists so the two rings cannot touch, and
+      // `spaceEvenly` leaves a third of it between them: 4.0px as measured. A
+      // gap that has collapsed to nothing means the reserve was dropped or
+      // spent elsewhere, which no gate case can see — two touching circles
+      // overflow nothing.
+      expect(second.left - first.right, greaterThan(3.0),
+          reason: 'the drawn gap between the two rings is '
+              '${second.left - first.right}px; they read as one figure of eight '
+              'well before they overlap.');
       expect((first.width - second.width).abs(), lessThan(1.0),
           reason: 'the gauges have different diameters (${first.width} vs '
               '${second.width}), so their arcs are no longer comparable.');

--- a/test/page/dashboard/views/components/usp_gauge_center_readability_test.dart
+++ b/test/page/dashboard/views/components/usp_gauge_center_readability_test.dart
@@ -12,7 +12,14 @@ import 'package:ui_kit_library/ui_kit.dart';
 import '../../../../util/app_test_fonts.dart';
 import '../../../../util/dashboard/dashboard_card_probe.dart';
 
-/// Gauge-centre readability (#1234).
+/// Gauge-centre readability (#1234, extended by #1235).
+///
+/// Both cards with an `AppGauge` are guarded here, because their two fixes fail
+/// in opposite directions and the contrast is the point: `system_status`'s twin
+/// gauges are **width**-bound and shrink to fit, `network_health`'s single gauge
+/// is **height**-bound and its centre scales to fit. One `centerBuilder`
+/// ellipsizes its label and the other must never truncate its own — the
+/// difference is what the string *is*, exactly as §2.10a point 2 has it.
 ///
 /// ## Why this file exists alongside the #1183 gate
 ///
@@ -83,6 +90,34 @@ import '../../../../util/dashboard/dashboard_card_probe.dart';
 /// binding one (181–201px of height for a 72.7px circle). It is a guard against
 /// a future row span, not a live constraint, and nothing here can pin it without
 /// inventing a card height the grid never asks for.
+///
+/// ### `network_health` (#1235), same method, `network_health`'s entries stripped
+///
+///   | mutation                                            | this file | the gate |
+///   |-----------------------------------------------------|-----------|----------|
+///   | `FittedBox` removed entirely                        | 1 fail    | 3 fail   |
+///   | score + tier ellipsized instead of scaled           | 1 fail    | 2 fail   |
+///   | score font shrunk always (`titleLarge`→`bodyMedium`) | 1 fail    | green    |
+///   | `BoxFit.contain` instead of `scaleDown`             | green     | green    |
+///
+/// Row 2 is the fix #1235's own text implies ("the tier label is wider than the
+/// space inside the circle" ⇒ ellipsize it). It truncates the tier *and* leaves
+/// two of the three coordinates standing, because the overflow is vertical: one
+/// line saved in `ru` is enough, 28+16px of column in a 23px box in `de` is not.
+/// A wrong diagnosis producing a fix that is both lossy and incomplete is the
+/// cheapest possible argument for measuring first.
+///
+/// Row 3 is why the 12px legibility floor and the unscaled-at-preferred canary
+/// are in this file at all. Permanently shrinking the score clears all 209 gate
+/// cases — `scaleDown` has *removed* the overflow signal for good, so nothing in
+/// the ratchet can ever object to squeezing this centre further. The floor is the
+/// replacement signal.
+///
+/// Row 4 is an equivalent mutant, recorded so nobody reads its greenness as a
+/// gap: the centre is handed **loose** constraints, and under loose constraints
+/// `contain` never scales *up* either, so the two fits render identically here.
+/// `scaleDown` is kept as the honest spelling of the intent — it stays correct if
+/// this subtree is ever given a tight box, which `contain` would not.
 void main() {
   setUpAll(() async {
     // Real fonts: under the Ahem block font every glyph is one square em, so
@@ -90,19 +125,20 @@ void main() {
     await loadAppFonts();
   });
 
-  const cardId = 'system_status';
-  final spec = UspWidgetSpecs.all.firstWhere((s) => s.id == cardId);
-  final constraints = spec.getConstraints(DisplayMode.normal);
-
-  /// Pumps the Monitor tab at the narrowest width the grid ever gives the card's
-  /// min span — the worst case the gate measures, and the only width where the
-  /// diameter bound actually bites. One pump, as the gate does.
+  /// Pumps [cardId]'s first tab at the narrowest realization of the given span
+  /// — for `min`, the worst case the gate measures and the only width where
+  /// either fix bites. One pump, as the gate does.
   Future<void> pumpAt(
     WidgetTester tester, {
-    required int columns,
-    required String label,
+    required String cardId,
+    required bool preferred,
     required Locale locale,
   }) async {
+    final constraints = UspWidgetSpecs.all
+        .firstWhere((s) => s.id == cardId)
+        .getConstraints(DisplayMode.normal);
+    final columns =
+        preferred ? constraints.preferredColumns : constraints.minColumns;
     final narrowest = narrowestRealizationOf(columns, minScreen: 0)!;
     await probeCardOverflow(
       tester,
@@ -111,23 +147,13 @@ void main() {
         screenWidth: narrowest.screenWidth,
         cardWidth: narrowest.cardWidth,
         columnSpan: columns,
-        label: label,
+        label: preferred ? 'preferred' : 'min',
       ),
       cardHeightRows: constraints.minHeightRows,
       tabIndex: 0,
       locale: locale,
     );
   }
-
-  Future<void> pumpNarrowest(WidgetTester tester, Locale locale) =>
-      pumpAt(tester,
-          columns: constraints.minColumns, label: 'min', locale: locale);
-
-  Future<void> pumpPreferred(WidgetTester tester, Locale locale) =>
-      pumpAt(tester,
-          columns: constraints.preferredColumns,
-          label: 'preferred',
-          locale: locale);
 
   /// The `Text`s painted inside gauge [i]'s centre, in tree order: the reading
   /// first, its label second.
@@ -173,7 +199,8 @@ void main() {
     for (final tag in ['en', 'de', 'ru', 'th']) {
       testWidgets('both gauges show their full percentage in $tag',
           (tester) async {
-        await pumpNarrowest(tester, _localeFor(tag));
+        await pumpAt(tester,
+            cardId: _kSystemStatus, preferred: false, locale: _localeFor(tag));
 
         expect(find.byType(AppGauge), findsNWidgets(2),
             reason: 'the Monitor tab compares CPU against memory, so both '
@@ -202,7 +229,8 @@ void main() {
 
       testWidgets('neither gauge label wraps inside the arc in $tag',
           (tester) async {
-        await pumpNarrowest(tester, _localeFor(tag));
+        await pumpAt(tester,
+            cardId: _kSystemStatus, preferred: false, locale: _localeFor(tag));
         final l = await AppLocalizations.delegate.load(_localeFor(tag));
 
         final labels = [
@@ -246,7 +274,8 @@ void main() {
       // clears the overflow, and would leave every assertion above true. But
       // the tab's value is the CPU-against-memory comparison, and two circles
       // of different diameters or on different rows no longer make it.
-      await pumpNarrowest(tester, _localeFor('de'));
+      await pumpAt(tester,
+          cardId: _kSystemStatus, preferred: false, locale: _localeFor('de'));
 
       final first = tester.getRect(find.byType(AppGauge).at(0));
       final second = tester.getRect(find.byType(AppGauge).at(1));
@@ -271,7 +300,8 @@ void main() {
       // spare — so if this ever starts failing, either the bound has begun
       // biting at widths it should not or a translation has outgrown the circle
       // outright, and both want a look rather than a silent ellipsis.
-      await pumpPreferred(tester, _localeFor('de'));
+      await pumpAt(tester,
+          cardId: _kSystemStatus, preferred: true, locale: _localeFor('de'));
       final l = await AppLocalizations.delegate.load(_localeFor('de'));
 
       for (var i = 0; i < 2; i++) {
@@ -286,7 +316,110 @@ void main() {
           containsAll([l.cpu, l.memory]));
     });
   });
+
+  group('the health score scales instead of overflowing (#1235)', () {
+    // `network_health`'s gauge fails the opposite way round from
+    // `system_status`'s. There the binding constraint was width and the circles
+    // were shrunk to fit it; here the box is already squashed *vertically* by
+    // the layout above — `AppGauge(size: 120)` lays out at 120×67 in `en` and
+    // 120×23 in `de`, because `_MetricChip`'s three ~23.1px label columns
+    // soft-wrap to between 3 and 6 lines and eat the `Expanded`'s height. The
+    // 44px centre column then overflowed the bottom by +21/+11/+9px in
+    // `de`/`ru`/`th`, which is #1235's three coordinates.
+    //
+    // `BoxFit.scaleDown` fixes that, and in doing so takes the signal away from
+    // the gate **permanently**: a `FittedBox` always fits its child, so no
+    // amount of future height starvation can ever produce an overflow here
+    // again. This group is the replacement for the signal that fix removed, and
+    // that — not the overflow, which the gate can no longer regress on — is why
+    // it exists.
+    for (final tag in ['en', 'de', 'ru', 'th', 'fr']) {
+      testWidgets('the score and its tier both stay whole in $tag',
+          (tester) async {
+        await pumpAt(tester,
+            cardId: _kNetworkHealth, preferred: false, locale: _localeFor(tag));
+
+        final texts = centreTexts(tester, 0);
+        expect(texts, hasLength(2),
+            reason: 'the centre is the score over its tier; got '
+                '${texts.map((t) => t.data).toList()}');
+
+        final score = texts.first;
+        expect(score.data, matches(RegExp(r'^\d+$')),
+            reason: 'the first centre line should be the health score, not '
+                '"${score.data}"');
+
+        // Neither line may be truncated or broken, in any locale. This is AC 4
+        // read literally — "a tier abbreviated past recognition is worse than a
+        // smaller font" — and it is what makes `scaleDown` the right mechanism
+        // rather than the `maxLines: 1` ellipsis used inside `system_status`'s
+        // circles: a tier name is the *reading* here, not a series label, so it
+        // may shrink but may not lose characters.
+        for (final t in texts) {
+          expect(isClipped(tester, t), isFalse,
+              reason: '"${t.data}" is ellipsized inside the gauge. The centre '
+                  'is supposed to scale down, not truncate — a clipped tier is '
+                  'exactly what AC 4 rules out.');
+          expect(lineCount(tester, t), 1,
+              reason: '"${t.data}" wrapped onto ${lineCount(tester, t)} lines '
+                  'inside the gauge. `FittedBox` lays its child out unbounded, '
+                  'so a wrap here means something re-imposed a width.');
+        }
+      });
+    }
+
+    testWidgets('the score stays above the legibility floor at the narrowest',
+        (tester) async {
+      // The floor, and the honest reading of it. `de` is the worst realization
+      // in the suite: the metric row takes 96px there against `en`'s 48px, so
+      // the gauge box is 23px tall and the centre paints at scale 0.52 — a
+      // 14.6px score over an 8.4px tier. That is small, and it is a measurement
+      // of the density defect rather than a design choice: this card is being
+      // rendered at 191px when §1.2 puts its fit width at 420px, and the real
+      // remedy is #1240's threshold, at which point `scaleDown` relaxes back to
+      // 1.0 on its own.
+      //
+      // So the floor is set just under today's worst case. It is not a claim
+      // that 12px is comfortable; it is the tripwire for the squeeze getting
+      // *worse*, which is now invisible to everything else in the suite.
+      await pumpAt(tester,
+          cardId: _kNetworkHealth, preferred: false, locale: _localeFor('de'));
+
+      final score = centreTexts(tester, 0).first;
+      final painted = tester.getRect(find.byWidget(score));
+      expect(painted.height, greaterThan(12.0),
+          reason: 'the health score paints at ${painted.height}px tall, below '
+              'the 12px floor. The gauge box has been squeezed further than '
+              'the 23px #1235 measured — look at what grew above or below it, '
+              'because the FittedBox will keep absorbing this silently.');
+    });
+
+    testWidgets('the centre is unscaled at the preferred width',
+        (tester) async {
+      // Same canary as the `system_status` group: a fix whose safety net is
+      // always engaged has stopped being a safety net. At the preferred width
+      // the metric labels have room, the height comes back, and the centre must
+      // paint at its natural size — 28px of `titleLarge`. `en` and `fr` already
+      // reach scale 1.0 at the *narrowest* width, so a failure here means the
+      // squeeze has spread to the layout the grid hands the card by default.
+      await pumpAt(tester,
+          cardId: _kNetworkHealth, preferred: true, locale: _localeFor('de'));
+
+      final texts = centreTexts(tester, 0);
+      final scoreRect = tester.getRect(find.byWidget(texts.first));
+      expect(scoreRect.height, closeTo(28.0, 0.5),
+          reason: 'the health score paints at ${scoreRect.height}px instead of '
+              'its natural 28px, so the centre is being scaled down at the '
+              'preferred width and not just at the narrowest one.');
+      for (final t in texts) {
+        expect(isClipped(tester, t), isFalse);
+      }
+    });
+  });
 }
+
+const _kSystemStatus = 'system_status';
+const _kNetworkHealth = 'network_health';
 
 Locale _localeFor(String tag) =>
     AppLocalizations.supportedLocales.firstWhere((l) {

--- a/test/page/dashboard/views/components/usp_gauge_center_readability_test.dart
+++ b/test/page/dashboard/views/components/usp_gauge_center_readability_test.dart
@@ -2,7 +2,6 @@
 library;
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:privacy_gui/l10n/gen/app_localizations.dart';
 import 'package:privacy_gui/page/dashboard/models/display_mode.dart';
@@ -11,6 +10,7 @@ import 'package:ui_kit_library/ui_kit.dart';
 
 import '../../../../util/app_test_fonts.dart';
 import '../../../../util/dashboard/dashboard_card_probe.dart';
+import '../../../../util/dashboard/text_readability_probe.dart';
 
 /// Gauge-centre readability (#1234, extended by #1235).
 ///
@@ -134,8 +134,9 @@ void main() {
     required bool preferred,
     required Locale locale,
   }) async {
-    final constraints = UspWidgetSpecs.all
-        .firstWhere((s) => s.id == cardId)
+    final constraints = (UspWidgetSpecs.getById(cardId) ??
+            (throw ArgumentError.value(
+                cardId, 'cardId', 'no such card in UspWidgetSpecs.all')))
         .getConstraints(DisplayMode.normal);
     final columns =
         preferred ? constraints.preferredColumns : constraints.minColumns;
@@ -150,6 +151,14 @@ void main() {
         label: preferred ? 'preferred' : 'min',
       ),
       cardHeightRows: constraints.minHeightRows,
+      // Tab 0 only, and that is the whole of AC 1 rather than a sample of it.
+      // #1235 says "all 3 tabs", but `network_health` builds its `AppGauge` in
+      // `_HealthOverview`, which `_buildTabContent`'s `switch` reaches for
+      // `selectedTab == 0` alone — tabs 1 and 2 are `_ErrorsChart` and
+      // `_LossChart`, with no gauge and so no centre to overflow. Likewise
+      // `system_status`'s pair belongs to tab 0, Monitor. The gate still sweeps
+      // all three tabs of both cards for overflow; what this file adds is the
+      // part of AC 1 that has a gauge in it.
       tabIndex: 0,
       locale: locale,
     );
@@ -169,29 +178,6 @@ void main() {
       .where((t) => t.data != null && t.data!.isNotEmpty)
       .toList();
 
-  RenderParagraph paragraphOf(WidgetTester tester, Text text) =>
-      tester.renderObject<RenderParagraph>(find.byWidget(text));
-
-  /// Whether [text] had to drop content to fit. `didExceedMaxLines` is the
-  /// renderer's own verdict, so this does not re-derive metrics the layout
-  /// already computed.
-  bool isClipped(WidgetTester tester, Text text) =>
-      paragraphOf(tester, text).didExceedMaxLines;
-
-  /// How many lines [text] actually painted, counted off the renderer's own
-  /// glyph boxes. This is the only measurement that distinguishes "ellipsized
-  /// onto one line" — by design, for a label longer than the circle — from
-  /// "wrapped mid-word", since both leave the widget's `data` intact and both
-  /// fit inside the box the gate measures.
-  int lineCount(WidgetTester tester, Text text) {
-    final boxes = paragraphOf(tester, text).getBoxesForSelection(
-      TextSelection(baseOffset: 0, extentOffset: text.data!.length),
-    );
-    expect(boxes, isNotEmpty,
-        reason: '"${text.data}" painted no glyphs at all');
-    return boxes.map((b) => b.top.round()).toSet().length;
-  }
-
   group('the reading survives the shrunken circle (#1234 AC4)', () {
     // The gauges are the tab's headline: the label names a series, the reading
     // *is* the datum. So the two are held to different standards below — the
@@ -200,7 +186,9 @@ void main() {
       testWidgets('both gauges show their full percentage in $tag',
           (tester) async {
         await pumpAt(tester,
-            cardId: _kSystemStatus, preferred: false, locale: _localeFor(tag));
+            cardId: _kSystemStatus,
+            preferred: false,
+            locale: supportedLocaleFor(tag));
 
         expect(find.byType(AppGauge), findsNWidgets(2),
             reason: 'the Monitor tab compares CPU against memory, so both '
@@ -217,11 +205,11 @@ void main() {
           expect(reading.data, matches(RegExp(r'^\d+%$')),
               reason: 'gauge $i\'s first centre line should be the percentage, '
                   'not "${reading.data}"');
-          expect(isClipped(tester, reading), isFalse,
+          expect(tester.isTextClipped(find.byWidget(reading)), isFalse,
               reason: 'gauge $i\'s reading "${reading.data}" is clipped at the '
                   'narrowest width. The circle has been bounded below the size '
                   'of the number it exists to show.');
-          expect(lineCount(tester, reading), 1,
+          expect(tester.textLineCount(find.byWidget(reading)), 1,
               reason: 'gauge $i\'s reading "${reading.data}" wrapped onto a '
                   'second line inside the arc.');
         }
@@ -230,8 +218,10 @@ void main() {
       testWidgets('neither gauge label wraps inside the arc in $tag',
           (tester) async {
         await pumpAt(tester,
-            cardId: _kSystemStatus, preferred: false, locale: _localeFor(tag));
-        final l = await AppLocalizations.delegate.load(_localeFor(tag));
+            cardId: _kSystemStatus,
+            preferred: false,
+            locale: supportedLocaleFor(tag));
+        final l = await AppLocalizations.delegate.load(supportedLocaleFor(tag));
 
         final labels = [
           for (var i = 0; i < 2; i++) centreTexts(tester, i).last,
@@ -243,13 +233,13 @@ void main() {
         for (final label in labels) {
           // One line, clipped or not. `de`'s `Arbeitsspeicher` is 88.1px of
           // `bodySmall` inside a 72.7px circle, so the ellipsis is *expected*
-          // there and asserting `isClipped == false` would be a lie. What must
+          // there and asserting `isTextClipped == false` would be a lie. What must
           // not happen is the soft wrap: a mid-word break inside a 72.7px arc
           // costs the label its readability and the centre its shape, and every
           // gate case stays green through it.
-          expect(lineCount(tester, label), 1,
+          expect(tester.textLineCount(find.byWidget(label)), 1,
               reason: 'gauge label "${label.data}" painted '
-                  '${lineCount(tester, label)} lines inside the arc. The label '
+                  '${tester.textLineCount(find.byWidget(label))} lines inside the arc. The label '
                   'is a series name: it ellipsizes to one line, and the full '
                   'string stays available in the legend row below.');
 
@@ -277,7 +267,9 @@ void main() {
       // the tab's value is the CPU-against-memory comparison, and two circles
       // of different diameters or on different rows no longer make it.
       await pumpAt(tester,
-          cardId: _kSystemStatus, preferred: false, locale: _localeFor('de'));
+          cardId: _kSystemStatus,
+          preferred: false,
+          locale: supportedLocaleFor('de'));
 
       final first = tester.getRect(find.byType(AppGauge).at(0));
       final second = tester.getRect(find.byType(AppGauge).at(1));
@@ -310,12 +302,14 @@ void main() {
       // biting at widths it should not or a translation has outgrown the circle
       // outright, and both want a look rather than a silent ellipsis.
       await pumpAt(tester,
-          cardId: _kSystemStatus, preferred: true, locale: _localeFor('de'));
-      final l = await AppLocalizations.delegate.load(_localeFor('de'));
+          cardId: _kSystemStatus,
+          preferred: true,
+          locale: supportedLocaleFor('de'));
+      final l = await AppLocalizations.delegate.load(supportedLocaleFor('de'));
 
       for (var i = 0; i < 2; i++) {
         final label = centreTexts(tester, i).last;
-        expect(isClipped(tester, label), isFalse,
+        expect(tester.isTextClipped(find.byWidget(label)), isFalse,
             reason: 'gauge label "${label.data}" is ellipsized at the '
                 'preferred width, where the circle is at its natural size. '
                 'The centre is now degrading in the layout the grid hands the '
@@ -346,7 +340,9 @@ void main() {
       testWidgets('the score and its tier both stay whole in $tag',
           (tester) async {
         await pumpAt(tester,
-            cardId: _kNetworkHealth, preferred: false, locale: _localeFor(tag));
+            cardId: _kNetworkHealth,
+            preferred: false,
+            locale: supportedLocaleFor(tag));
 
         final texts = centreTexts(tester, 0);
         expect(texts, hasLength(2),
@@ -365,12 +361,13 @@ void main() {
         // circles: a tier name is the *reading* here, not a series label, so it
         // may shrink but may not lose characters.
         for (final t in texts) {
-          expect(isClipped(tester, t), isFalse,
+          expect(tester.isTextClipped(find.byWidget(t)), isFalse,
               reason: '"${t.data}" is ellipsized inside the gauge. The centre '
                   'is supposed to scale down, not truncate — a clipped tier is '
                   'exactly what AC 4 rules out.');
-          expect(lineCount(tester, t), 1,
-              reason: '"${t.data}" wrapped onto ${lineCount(tester, t)} lines '
+          expect(tester.textLineCount(find.byWidget(t)), 1,
+              reason:
+                  '"${t.data}" wrapped onto ${tester.textLineCount(find.byWidget(t))} lines '
                   'inside the gauge. `FittedBox` lays its child out unbounded, '
                   'so a wrap here means something re-imposed a width.');
         }
@@ -392,7 +389,9 @@ void main() {
       // that 12px is comfortable; it is the tripwire for the squeeze getting
       // *worse*, which is now invisible to everything else in the suite.
       await pumpAt(tester,
-          cardId: _kNetworkHealth, preferred: false, locale: _localeFor('de'));
+          cardId: _kNetworkHealth,
+          preferred: false,
+          locale: supportedLocaleFor('de'));
 
       final score = centreTexts(tester, 0).first;
       final painted = tester.getRect(find.byWidget(score));
@@ -412,7 +411,9 @@ void main() {
       // reach scale 1.0 at the *narrowest* width, so a failure here means the
       // squeeze has spread to the layout the grid hands the card by default.
       await pumpAt(tester,
-          cardId: _kNetworkHealth, preferred: true, locale: _localeFor('de'));
+          cardId: _kNetworkHealth,
+          preferred: true,
+          locale: supportedLocaleFor('de'));
 
       final texts = centreTexts(tester, 0);
       final scoreRect = tester.getRect(find.byWidget(texts.first));
@@ -421,7 +422,7 @@ void main() {
               'its natural 28px, so the centre is being scaled down at the '
               'preferred width and not just at the narrowest one.');
       for (final t in texts) {
-        expect(isClipped(tester, t), isFalse);
+        expect(tester.isTextClipped(find.byWidget(t)), isFalse);
       }
     });
   });
@@ -429,11 +430,3 @@ void main() {
 
 const _kSystemStatus = 'system_status';
 const _kNetworkHealth = 'network_health';
-
-Locale _localeFor(String tag) =>
-    AppLocalizations.supportedLocales.firstWhere((l) {
-      final t = l.countryCode == null || l.countryCode!.isEmpty
-          ? l.languageCode
-          : '${l.languageCode}_${l.countryCode}';
-      return t == tag;
-    });

--- a/test/page/dashboard/views/components/usp_hero_row_readability_test.dart
+++ b/test/page/dashboard/views/components/usp_hero_row_readability_test.dart
@@ -2,7 +2,6 @@
 library;
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:privacy_gui/page/dashboard/models/display_mode.dart';
 import 'package:privacy_gui/page/dashboard/models/usp_widget_specs.dart';
@@ -10,6 +9,7 @@ import 'package:ui_kit_library/ui_kit.dart';
 
 import '../../../../util/app_test_fonts.dart';
 import '../../../../util/dashboard/dashboard_card_probe.dart';
+import '../../../../util/dashboard/text_readability_probe.dart';
 
 /// Hero-row readability (#1236 AC 4, #1237 AC 5).
 ///
@@ -81,8 +81,9 @@ void main() {
     required String cardId,
     required Locale locale,
   }) async {
-    final constraints = UspWidgetSpecs.all
-        .firstWhere((s) => s.id == cardId)
+    final constraints = (UspWidgetSpecs.getById(cardId) ??
+            (throw ArgumentError.value(
+                cardId, 'cardId', 'no such card in UspWidgetSpecs.all')))
         .getConstraints(DisplayMode.normal);
     final narrowest =
         narrowestRealizationOf(constraints.minColumns, minScreen: 0)!;
@@ -101,28 +102,6 @@ void main() {
     );
   }
 
-  RenderParagraph paragraphOf(WidgetTester tester, String data) =>
-      tester.renderObject<RenderParagraph>(find.text(data));
-
-  /// Whether the renderer had to drop content to fit — its own verdict, so this
-  /// does not re-derive metrics the layout already computed.
-  bool isClipped(WidgetTester tester, String data) =>
-      paragraphOf(tester, data).didExceedMaxLines;
-
-  /// How many lines [data] actually painted on.
-  int lineCount(WidgetTester tester, String data) {
-    final boxes = paragraphOf(tester, data).getBoxesForSelection(
-      TextSelection(baseOffset: 0, extentOffset: data.length),
-    );
-    expect(boxes, isNotEmpty, reason: '"$data" painted no glyphs at all');
-    return boxes.map((b) => b.top.round()).toSet().length;
-  }
-
-  Locale localeFor(String tag) => switch (tag.split('_')) {
-        [final l, final c] => Locale(l, c),
-        _ => Locale(tag),
-      };
-
   const kLanInfo = 'lan_info';
   const kTimeSettings = 'time_settings';
 
@@ -131,13 +110,14 @@ void main() {
     // the English rendering is as much of a test case as `el` is.
     for (final tag in ['en', 'de', 'el', 'ru']) {
       testWidgets('$tag — the router IP is never cut', (tester) async {
-        await pumpNarrowest(tester, cardId: kLanInfo, locale: localeFor(tag));
+        await pumpNarrowest(tester,
+            cardId: kLanInfo, locale: supportedLocaleFor(tag));
 
         // Measured: 105.8px of `titleLarge` in a 61.4px column, so it paints on
         // two lines. Two lines is fine — `192.168.1.1` split after a dot is
         // still the address. `192.16…` is not, and that is what any `maxLines`
         // here would produce.
-        expect(isClipped(tester, '192.168.1.1'), isFalse,
+        expect(tester.isTextClipped(find.text('192.168.1.1')), isFalse,
             reason: 'the router IP was truncated. An address that has lost its '
                 'last octet cannot be typed into a browser, which is the one '
                 'thing this hero exists for (#1236 AC 4).');
@@ -145,7 +125,8 @@ void main() {
       });
 
       testWidgets('$tag — the DHCP status keeps both words', (tester) async {
-        await pumpNarrowest(tester, cardId: kLanInfo, locale: localeFor(tag));
+        await pumpNarrowest(tester,
+            cardId: kLanInfo, locale: supportedLocaleFor(tag));
 
         // The composed status, per §2.10a point 2: ~49px of column would
         // ellipsize `DHCP Enabled` to `DHCP…`, dropping the word that carries
@@ -159,7 +140,7 @@ void main() {
                 orElse: () => throw TestFailure(
                     'no DHCP status text found on the card at all'));
 
-        expect(isClipped(tester, status), isFalse,
+        expect(tester.isTextClipped(find.text(status)), isFalse,
             reason: 'the DHCP status "$status" was truncated, so the row now '
                 'shows a protocol name and no state.');
         expect(status.trim().split(RegExp(r'\s+')).length, greaterThan(1),
@@ -173,12 +154,12 @@ void main() {
     for (final tag in ['en', 'de', 'ru', 'th']) {
       testWidgets('$tag — the timezone value is never cut', (tester) async {
         await pumpNarrowest(tester,
-            cardId: kTimeSettings, locale: localeFor(tag));
+            cardId: kTimeSettings, locale: supportedLocaleFor(tag));
 
         // Measured: 137.8px of value in a 133.4px cell, so it wraps to 2 lines
         // and stays whole. `America/Los_Ang…` and `America/…` are both
         // ambiguous between real zones, which is what "identifiable" rules out.
-        expect(isClipped(tester, 'America/Los_Angeles'), isFalse,
+        expect(tester.isTextClipped(find.text('America/Los_Angeles')), isFalse,
             reason: 'the timezone name was truncated. Zone names share long '
                 'prefixes, so a cut one names a region and not a zone '
                 '(#1237 AC 5).');
@@ -190,7 +171,7 @@ void main() {
     for (final tag in ['en', 'de', 'ru']) {
       testWidgets('$tag — the badge keeps enough to read', (tester) async {
         await pumpNarrowest(tester,
-            cardId: kTimeSettings, locale: localeFor(tag));
+            cardId: kTimeSettings, locale: supportedLocaleFor(tag));
 
         // The badge label is whichever `bodySmall`-sized text sits inside the
         // capsule; find it by the widget rather than by string, since every
@@ -211,7 +192,7 @@ void main() {
         // it ellipsizes is locale-dependent (`de`'s `Synchronisiert` is 85.1px
         // in a 45.4px capsule and does; `en`'s `Synced` does not), so clipping
         // is permitted and *emptying* is not.
-        expect(lineCount(tester, data), 1,
+        expect(tester.textLineCount(find.text(data)), 1,
             reason: 'the badge label "$data" wrapped to a second line, which a '
                 'capsule cannot hold — it will paint outside its own pill.');
 
@@ -220,7 +201,7 @@ void main() {
         // which point the badge says nothing and the colour is carrying the
         // whole state. Nothing in the gate can see that happen, because a
         // narrower badge overflows *less*.
-        final painted = paragraphOf(tester, data).size.width;
+        final painted = tester.paragraphOf(find.text(data)).size.width;
         expect(painted, greaterThan(24.0),
             reason: 'the sync badge label "$data" painted only '
                 '${painted.toStringAsFixed(1)}px, so it has been squeezed past '

--- a/test/page/dashboard/views/components/usp_hero_row_readability_test.dart
+++ b/test/page/dashboard/views/components/usp_hero_row_readability_test.dart
@@ -1,0 +1,232 @@
+@Tags(['dashboard-card'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/dashboard/models/display_mode.dart';
+import 'package:privacy_gui/page/dashboard/models/usp_widget_specs.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import '../../../../util/app_test_fonts.dart';
+import '../../../../util/dashboard/dashboard_card_probe.dart';
+
+/// Hero-row readability (#1236 AC 4, #1237 AC 5).
+///
+/// The hero inner row of `lan_info` and `time_settings` is the largest shape in
+/// the #1183 baseline (48 of 84 coordinates). The gate owns the overflow: revert
+/// either `Flexible` and the coordinates come back. It cannot own the two
+/// acceptance criteria that say what the *content* must still be afterwards,
+/// because both fixes make the row fit and neither leaves anything to report:
+///
+///   - #1236 AC 4 — "Network addresses and device identifiers stay readable;
+///     truncating an IP or MAC in the middle makes it useless."
+///   - #1237 AC 5 — "Timezone names — the longest strings on this card — stay
+///     identifiable."
+///
+/// Both are satisfied by *soft-wrapping* rather than ellipsizing, and that is a
+/// choice, not a property of the widgets: adding `maxLines: 1` to any of these
+/// would leave all 1644 gate cases green while cutting `192.168.1.100 ~ 192.…`
+/// out of the middle. So the criteria get assertions.
+///
+/// The last group is the awkward one and the reason this file is not just a
+/// ratchet formality: #1237's fix *introduces* an ellipsis on the sync badge. A
+/// capsule cannot take a second line (§2.10a point 2), so that trade is
+/// deliberate, but it is exactly the trade #1236 rejected one file over — and a
+/// badge that has been squeezed to `Sync…`, or past it to `S…`, is
+/// indistinguishable from a correct one in a green gate. What is asserted is the
+/// floor: enough glyphs to key the state, plus the colour that also encodes it.
+///
+/// Tagged `dashboard-card` so it gates PRs — `run_tests.sh` excludes
+/// `golden||loc||ui`, so a `ui` tag here would block nothing.
+///
+/// ## Mutation ledger
+///
+/// Measured with the four cards' allowlist entries already deleted, i.e. against
+/// the ratchet as this branch leaves it (§2.10b point 4).
+///
+///   | mutation                                                | this file | the gate |
+///   |---------------------------------------------------------|-----------|----------|
+///   | `maxLines: 1` + ellipsis on `lan_info`'s router IP      | 4 fail    | green    |
+///   | `maxLines: 1` + ellipsis on the DHCP status label       | 4 fail    | green    |
+///   | `maxLines: 1` + ellipsis on the InfoGrid value renderer | 4 fail    | green    |
+///   | the deleted single-child `Row` restored around the badge | green     | 21 fail  |
+///
+/// The first three rows are the point: every one of them is a plausible "fix the
+/// overflow" edit, all three are invisible to the gate, and all three destroy a
+/// reading the two tickets name explicitly. Each kills exactly the group that
+/// names it — all four of its locales and nothing else — so the failure says
+/// which criterion broke, not just that something did. (Row three mutates the
+/// shared renderer at `list_blocks.dart:234`, so it ellipsizes `lan_info`'s grid
+/// values too; those assertions read the hero row, which is why only the
+/// timezone group moves.)
+///
+/// The fourth row is the boundary, and it runs the other way: restoring the
+/// defect #1237 actually fixed returns all 21 of that card's coordinates while
+/// leaving this file green. The two verifications are meant not to overlap. The
+/// gate owns the overflow outright, so this file does not restate it; what it
+/// covers is the readability the gate stays green through either way.
+void main() {
+  setUpAll(() async {
+    // Real fonts: under Ahem every glyph is one square em, so what wraps —
+    // and therefore what stays whole — is fiction.
+    await loadAppFonts();
+  });
+
+  /// Pumps [cardId]'s first tab at the narrowest realization of its `minColumns`
+  /// span: the worst case the gate measures, and the only width where the hero
+  /// row's 61.4px column bites.
+  Future<void> pumpNarrowest(
+    WidgetTester tester, {
+    required String cardId,
+    required Locale locale,
+  }) async {
+    final constraints = UspWidgetSpecs.all
+        .firstWhere((s) => s.id == cardId)
+        .getConstraints(DisplayMode.normal);
+    final narrowest =
+        narrowestRealizationOf(constraints.minColumns, minScreen: 0)!;
+    await probeCardOverflow(
+      tester,
+      cardId: cardId,
+      widthCase: CardWidthCase(
+        screenWidth: narrowest.screenWidth,
+        cardWidth: narrowest.cardWidth,
+        columnSpan: constraints.minColumns,
+        label: 'min',
+      ),
+      cardHeightRows: constraints.minHeightRows,
+      tabIndex: 0,
+      locale: locale,
+    );
+  }
+
+  RenderParagraph paragraphOf(WidgetTester tester, String data) =>
+      tester.renderObject<RenderParagraph>(find.text(data));
+
+  /// Whether the renderer had to drop content to fit — its own verdict, so this
+  /// does not re-derive metrics the layout already computed.
+  bool isClipped(WidgetTester tester, String data) =>
+      paragraphOf(tester, data).didExceedMaxLines;
+
+  /// How many lines [data] actually painted on.
+  int lineCount(WidgetTester tester, String data) {
+    final boxes = paragraphOf(tester, data).getBoxesForSelection(
+      TextSelection(baseOffset: 0, extentOffset: data.length),
+    );
+    expect(boxes, isNotEmpty, reason: '"$data" painted no glyphs at all');
+    return boxes.map((b) => b.top.round()).toSet().length;
+  }
+
+  Locale localeFor(String tag) => switch (tag.split('_')) {
+        [final l, final c] => Locale(l, c),
+        _ => Locale(tag),
+      };
+
+  const kLanInfo = 'lan_info';
+  const kTimeSettings = 'time_settings';
+
+  group('addresses and identifiers stay whole (#1236 AC4)', () {
+    // `en` is included deliberately: this shape overflowed in every locale, so
+    // the English rendering is as much of a test case as `el` is.
+    for (final tag in ['en', 'de', 'el', 'ru']) {
+      testWidgets('$tag — the router IP is never cut', (tester) async {
+        await pumpNarrowest(tester, cardId: kLanInfo, locale: localeFor(tag));
+
+        // Measured: 105.8px of `titleLarge` in a 61.4px column, so it paints on
+        // two lines. Two lines is fine — `192.168.1.1` split after a dot is
+        // still the address. `192.16…` is not, and that is what any `maxLines`
+        // here would produce.
+        expect(isClipped(tester, '192.168.1.1'), isFalse,
+            reason: 'the router IP was truncated. An address that has lost its '
+                'last octet cannot be typed into a browser, which is the one '
+                'thing this hero exists for (#1236 AC 4).');
+        expect(find.text('192.168.1.1'), findsOneWidget);
+      });
+
+      testWidgets('$tag — the DHCP status keeps both words', (tester) async {
+        await pumpNarrowest(tester, cardId: kLanInfo, locale: localeFor(tag));
+
+        // The composed status, per §2.10a point 2: ~49px of column would
+        // ellipsize `DHCP Enabled` to `DHCP…`, dropping the word that carries
+        // the state. Soft-wrap keeps it; `el` pays 81px of height for 3 runs
+        // and the card's `SingleChildScrollView` absorbs that.
+        final status = tester
+            .widgetList<Text>(find.byType(Text))
+            .map((t) => t.data)
+            .whereType<String>()
+            .firstWhere((d) => d.startsWith('DHCP '),
+                orElse: () => throw TestFailure(
+                    'no DHCP status text found on the card at all'));
+
+        expect(isClipped(tester, status), isFalse,
+            reason: 'the DHCP status "$status" was truncated, so the row now '
+                'shows a protocol name and no state.');
+        expect(status.trim().split(RegExp(r'\s+')).length, greaterThan(1),
+            reason: 'the status collapsed to a single token ("$status") — the '
+                'state word is what the row is for.');
+      });
+    }
+  });
+
+  group('the timezone name stays identifiable (#1237 AC5)', () {
+    for (final tag in ['en', 'de', 'ru', 'th']) {
+      testWidgets('$tag — the timezone value is never cut', (tester) async {
+        await pumpNarrowest(tester,
+            cardId: kTimeSettings, locale: localeFor(tag));
+
+        // Measured: 137.8px of value in a 133.4px cell, so it wraps to 2 lines
+        // and stays whole. `America/Los_Ang…` and `America/…` are both
+        // ambiguous between real zones, which is what "identifiable" rules out.
+        expect(isClipped(tester, 'America/Los_Angeles'), isFalse,
+            reason: 'the timezone name was truncated. Zone names share long '
+                'prefixes, so a cut one names a region and not a zone '
+                '(#1237 AC 5).');
+      });
+    }
+  });
+
+  group('the sync badge is squeezed, not emptied (#1237, the trade)', () {
+    for (final tag in ['en', 'de', 'ru']) {
+      testWidgets('$tag — the badge keeps enough to read', (tester) async {
+        await pumpNarrowest(tester,
+            cardId: kTimeSettings, locale: localeFor(tag));
+
+        // The badge label is whichever `bodySmall`-sized text sits inside the
+        // capsule; find it by the widget rather than by string, since every
+        // locale spells it differently.
+        final badge = tester
+            .widgetList<Text>(find.descendant(
+              of: find.byType(AppBadge),
+              matching: find.byType(Text),
+            ))
+            .where((t) => (t.data ?? '').isNotEmpty)
+            .toList();
+        expect(badge, hasLength(1),
+            reason: 'expected exactly one label inside the sync badge; got '
+                '${badge.map((t) => t.data).toList()}');
+        final data = badge.single.data!;
+
+        // One line always — a capsule cannot grow one (§2.10a point 2). Whether
+        // it ellipsizes is locale-dependent (`de`'s `Synchronisiert` is 85.1px
+        // in a 45.4px capsule and does; `en`'s `Synced` does not), so clipping
+        // is permitted and *emptying* is not.
+        expect(lineCount(tester, data), 1,
+            reason: 'the badge label "$data" wrapped to a second line, which a '
+                'capsule cannot hold — it will paint outside its own pill.');
+
+        // The floor. `de` shows 45.4px of an 85.1px string today, i.e. about
+        // half. Below ~24px there is an ellipsis and one or two glyphs, at
+        // which point the badge says nothing and the colour is carrying the
+        // whole state. Nothing in the gate can see that happen, because a
+        // narrower badge overflows *less*.
+        final painted = paragraphOf(tester, data).size.width;
+        expect(painted, greaterThan(24.0),
+            reason: 'the sync badge label "$data" painted only '
+                '${painted.toStringAsFixed(1)}px, so it has been squeezed past '
+                'the point of naming its own state. #1237 accepted an ellipsis '
+                'here; it did not accept an empty capsule.');
+      });
+    }
+  });
+}

--- a/test/util/dashboard/text_readability_probe.dart
+++ b/test/util/dashboard/text_readability_probe.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+
+/// Measurements for the readability half of the #1183 density work.
+///
+/// The overflow half belongs to the gate
+/// (`test/page/dashboard/cards/dashboard_card_overflow_test.dart`), which asks
+/// one question: did a `RenderFlex` report overflow? These helpers answer the
+/// questions it structurally cannot — whether text was *truncated* or *wrapped*
+/// to make it fit. Both of those leave every gate case green (§2.10d point 3),
+/// so any card-own fix that trades characters for space needs assertions from
+/// here instead.
+///
+/// Kept in one place because each readability test file otherwise re-derives
+/// them, and [supportedLocaleFor] in particular must not be re-derived: see its
+/// own doc for what a locally-written version silently does wrong.
+extension TextReadabilityProbe on WidgetTester {
+  /// The renderer behind [finder], which must resolve to exactly one `Text`.
+  ///
+  /// Prefer `find.byWidget(theText)` over `find.text('literal')` when the same
+  /// string can appear more than once on the card — `system_status` paints its
+  /// gauge readings again in the legend row below, so a literal finder there
+  /// matches whichever comes first in tree order.
+  RenderParagraph paragraphOf(Finder finder) =>
+      renderObject<RenderParagraph>(finder);
+
+  /// Whether the renderer had to drop content to fit.
+  ///
+  /// `didExceedMaxLines` is the layout's own verdict, so this does not re-derive
+  /// metrics that have already been computed.
+  bool isTextClipped(Finder finder) => paragraphOf(finder).didExceedMaxLines;
+
+  /// How many lines the text actually painted on, counted off the renderer's own
+  /// glyph boxes.
+  ///
+  /// This is the only measurement that separates "ellipsized onto one line" —
+  /// which is sometimes the intended trade — from "wrapped mid-word", because
+  /// both leave the widget's `data` intact and both fit inside the box the gate
+  /// measures.
+  int textLineCount(Finder finder) {
+    final paragraph = paragraphOf(finder);
+    final plain = paragraph.text.toPlainText();
+    final boxes = paragraph.getBoxesForSelection(
+      TextSelection(baseOffset: 0, extentOffset: plain.length),
+    );
+    expect(boxes, isNotEmpty, reason: '"$plain" painted no glyphs at all');
+    return boxes.map((b) => b.top.round()).toSet().length;
+  }
+}
+
+/// The supported [Locale] for a `language` or `language_COUNTRY` [tag].
+///
+/// Resolved against [AppLocalizations.supportedLocales] and **throws** when the
+/// tag is not one of them. That is the whole point of the function: parsing the
+/// tag into a `Locale` locally always succeeds, and an unsupported locale then
+/// falls back to English at load time — so a mistyped tag turns into a test that
+/// passes while asserting nothing about the locale it names. A readability suite
+/// whose entire value is per-locale coverage cannot afford to fail that way
+/// silently.
+///
+/// Measured rather than assumed. Typing one tag in the `#1236 AC 4` group as
+/// `dee` instead of `de`:
+///
+///   | resolver                                     | result             |
+///   |----------------------------------------------|--------------------|
+///   | this one                                     | 2 fail, tag named  |
+///   | a local `switch` on `tag.split('_')`         | 8 pass             |
+///
+/// The second row is the version this replaced, and its greenness is the whole
+/// argument: the suite reported full coverage of a locale it never rendered.
+Locale supportedLocaleFor(String tag) =>
+    AppLocalizations.supportedLocales.firstWhere(
+      (l) {
+        final t = l.countryCode == null || l.countryCode!.isEmpty
+            ? l.languageCode
+            : '${l.languageCode}_${l.countryCode}';
+        return t == tag;
+      },
+      orElse: () => throw ArgumentError.value(
+        tag,
+        'tag',
+        'not in AppLocalizations.supportedLocales. An unsupported locale loads '
+            'the English strings, so this test would have passed without ever '
+            'rendering the locale it names',
+      ),
+    );


### PR DESCRIPTION
Closes #1234, closes #1235, closes #1236, closes #1237. Track A of #1183.
Design of record: `doc/dashboard/dashboard_density_design.md` §1.1 (the shape
attribution these commits execute) and §2.10d (added here).

Base is `gate/1183-overflow-gate` (#1248), not `usp`, for the same reason #1262
gave: the gate, its fixture and its probe are all introduced by #1248 and are
absent on the release branches, so "N coordinates removed from
`known_overflows.json`" is not executable there. As with #1262, the closing
keywords above will not fire on merge — GitHub only honours them when the base is
the default branch — so the four tickets close when the gate branch lands.

**87 of the ratchet's 181 coordinates → 0.** The allowlist is left holding 94: 67
`firewall_overview` (#1230) and 27 `connected_devices` (#1238). 49 of those are
still card-own and clearable — #1230's three own sites carry 48, #1238's
device-count row carries 1 — and only 45 are dependency-blocked (fl_chart's 19
axis-title coordinates, and the 26 needing a ui_kit `AppListTile` change). What
this branch completes is the *four-shape* group, not Track A.

Four tickets on one branch, because they reduce to **four shapes across six sites**
— §1.1 of `doc/dashboard/dashboard_density_design.md` measured that attribution
before any code was written. Commits are organized by shape rather than by ticket,
so each one is a single reviewable idiom and its blast radius is exactly the sites
that share it:

| Commit | Shape | Sites | Coordinates |
|---|---|---|---:|
| `9fda58d1` | "View details" footer | `system_status:118`, `device_info:140` | 34→28, 2→0 |
| `abb82185` | Hero inner row | `lan_info:56`, `time_settings:108` | 27→0, 21→0 |
| `02413c24` | Legend row | `system_status:218` | 28→26 |
| `14162d36` | Twin gauge row | `system_status:196` | 26→**0** |
| `2673a09d` | Gauge centre | `network_health:150` | 3→0 |
| `60ca0256` | Ratchet fixture | — | 87→0 |
| `b0496457` | Review pass | — | — |

The legend row clearing only 2 and the gauge row then clearing 26 is not a
mis-split: both sites live under the same `min|0` key, so neither can clear it
alone. §1.1 predicted that; the per-commit measurement confirmed it.

## How this is verified

By the #1183 ratchet, not by new tests. The failing assertions were already
committed as entries in `test/fixtures/known_overflows.json`: fix the layout,
delete the entry, the gate goes green — and deleting an entry that still overflows
fails that test, so it cannot be faked.

- Overflow gate: **1644 cases green** (13 cards × widths × tabs × 26 locales)
- Full functional suite: **5392 green**
- Affected golden suites: **23 green**
- `flutter analyze`: clean on all 8 changed files

## Two tests, and why they are not ratchet duplication

A green gate is not a green acceptance criterion. Two situations here leave the
gate green through both the right and the wrong fix, and each got one assertion —
measured with these cards' allowlist entries already deleted:

**`usp_gauge_center_readability_test.dart`** — `FittedBox(fit: BoxFit.scaleDown)`
is the right fix for #1235's centre and it removes the overflow signal at that site
*permanently*: once a subtree may shrink, no future squeeze can produce a
coordinate. Measured — shrinking the score's font unconditionally clears all 209 of
that card's gate cases. So the fix ships a 12px painted floor as the replacement
for what `scaleDown` took away.

**`usp_hero_row_readability_test.dart`** — `maxLines: 1` and a soft-wrap clear the
*same* coordinates, and at three sites one of them destroys the string. Measured —
ellipsizing `lan_info`'s router IP, its DHCP status, or the shared InfoGrid value
renderer leaves all 1644 cases green while cutting a reading #1236 AC 4 and #1237
AC 5 name explicitly. Each mutation kills exactly the group that names it, four
locales each, so a failure identifies which criterion broke.

Everything else here is a plain `Flexible` or a deletion and gets no test — the
allowlist entry it removes is already its assertion.

## Two decisions worth a reviewer's attention

**The two gauges shrink rather than stack** (`14162d36`). Stacking them in a `Wrap`
was the alternative, and it fails *silently*: `RenderWrap` has no overflow
indicator of its own and the `Expanded` pins its height, so the second circle is
simply cut — measured at 108px between gauge centres in a 181px box with all 209
gate cases green. They are bound by `min(natural, (maxWidth - AppSpacing.md) / 2,
maxHeight)` instead, an upper bound rather than an allotment, so every width that
already fitted two 100px gauges is untouched. That reserve is deliberately tight:
`spaceEvenly` splits it three ways, so what is drawn between the circles is 4px.
Reserving a full 12px *between* them would cost 12px of diameter, and #1234's AC 4
is about the reading inside the circle staying legible — air between two rings is
the cheaper thing to give up.

**`time_settings` keeps `minColumns: 3`.** It is the only card in the baseline where
widening was arithmetically available (fit width 288px, so 3 → 5 would have covered
every locale). Declined: the floor is the user's — it decides how narrow they may
make the card on their own dashboard — and 5 of 12 columns is a permanent charge on
every layout to buy headroom in a handful of locales. The card-own fix cleared all
21 coordinates by *deleting* a single-child `Row` whose only effect was handing the
badge unbounded width. Reasoning is recorded at the declaration site, per #1237.

## Deliberately not fixed here

- **The Monitor legend's interval chip loses its flush-right position.** Verified
  visually in the golden diff at 500×400, not just asserted. `WrapAlignment.spaceBetween`
  was rejected because it distributes between all three children, pulling the two
  legend entries apart — a bigger change to the wide layout than moving a 20px chip.
- **Both closed cards are green at 191px and unusable there.** `time_settings`' hero
  clock paints 5 lines / 140px in every locale including `en`; `network_health`'s
  centre scales to 0.52 in `de`. Nothing overflows; everything that could give, gave.
  Direct **#1240** input, recorded in §2.10d point 5 — with the caveat that Track A
  has moved five cards' *clean* width without moving their *readable* width, so #1240
  must re-measure rather than read §1.2's column.
- **`usp_lan_info_card.dart:144` renders a hardcoded `'Enabled'`** while line 85 of
  the same file uses `loc(context).enabled`. A real bug, but gate-invisible twice
  over: a hardcoded string cannot vary in a locale sweep, and that branch is the
  `else` of `if (info.ipv6Addresses.isNotEmpty)`, which the fixture never takes.
  Verifying it needs #1267's `overrides` parameter first.
- **`detailRoute` cannot carry query parameters**, which is why two cards hand-roll
  the "View details" footer `DashboardCardTemplate` already owns. The fix was
  replicated verbatim rather than extracted — extracting would make a third copy
  while leaving the cause in place. Both are **#1245** inventory entries.


