### PR TITLE
fix(firewall): stack the rule metrics and guard the charts, clearing all 21 of firewall_overview's coordinates (#1230)

### DIFF
--- a/doc/dashboard/dashboard_density_design.md
+++ b/doc/dashboard/dashboard_density_design.md
@@ -1,6 +1,6 @@
 # Dashboard Card Density — Design Decisions
 
-**Last Updated: 2026-08-13** · Follow-up to #1183 · Status: **agreed; tickets #1225–#1240 published; #1225 + #1226 + #1233 + #1227 + #1228 + #1229 implemented (not yet merged), rest not started. Allowlist 560 → 181.**
+**Last Updated: 2026-08-14** · Follow-up to #1183 · Status: **agreed; tickets #1225–#1240 published; Track A implemented through #1230 (#1225, #1226, #1233, #1227, #1228, #1229, #1266, #1234, #1236, #1237, #1235, #1247, #1230 — not all merged), #1238 remaining; Track B not started. Allowlist 560 → 27.**
 
 ## Purpose
 
@@ -933,7 +933,8 @@ in one step when the gauge row followed:
 | Gauge centre | `network_health:150` | 3→0 |
 
 The ratchet now stands at **48 coordinates**, all owned by #1230 (21,
-`firewall_overview`) and #1238 (27, `connected_devices`).
+`firewall_overview`) and #1238 (27, `connected_devices`). #1230 has since cleared
+its 21 (§2.11a), leaving **27**.
 
 That 48 replaces the 94 these four tickets left behind. The 46 that went were not
 removed by any of them — they were dead exemptions, and the credit belongs to
@@ -1118,6 +1119,94 @@ the axis labels above. **Not yet measured** — unlike the four shapes, this one
 no double-factor decomposition behind it, and that measurement is #1230's first
 step.
 
+Measured since, and both guessed levers were wrong: the declared height stayed at
+3 rows and the caption goes only because the whole donut does. The cause is a
+width one. See **§2.11a**.
+
+### 2.11a What the two height sites taught us (#1230 — implemented)
+
+All **21** cleared, not the 15 §2.11 scoped: fl_chart's 6 went with them, from the
+call site, with the package untouched. `minHeightRows` stays 3. Five things only
+showed up in the measurement.
+
+1. **Both bottom overflows had a *width* cause, and neither of §2.11's guessed
+   levers was one of them.** The card's height was never short. What overflowed is
+   the three-across metric grid: at the narrowest realization the tab body is
+   **157.4px wide and 205px tall** (203px where the tab bar wraps), and three
+   `InfoGrid` tiles leave each label `(157.4 − 16) / 3 − 24` = **23.1px** of text —
+   one character per line, `ru` wanting **8 lines** (129px) for one label. Those
+   three tiles measured **108px** in `en` and up to **173px** in `ru`, inside a
+   205px viewport that already owed 20px to gaps and 36px to the legend, so 15 of
+   the 26 locales overflowed and the outer `Column` (`:136`) reported up to +26px.
+   Stacking the metrics into full-width rows — a *width* decision — is what closes
+   a *height* overflow: each label gets 111.4-127.6px and the whole stack
+   112-130px, which the donut's `Expanded` absorbs. §1.8's "a
+   bottom overflow is often a width symptom" holds here in its strongest form, and
+   the ticket's AC 4 (do not raise the declared height) was never a constraint to
+   work around — it was the diagnosis.
+2. **Nested sites are mutually exclusive, which is why the two counts summed to 15
+   over 15 locales rather than 26.** `RenderFlex` reports where it is asked to
+   paint: where the grid grew tall enough to starve the donut's `Expanded` to 0,
+   the inner `centerWidget` (`:157`) had no box to overflow and only `:136`
+   reported (7 locales, grids of 156-173px); where the grid left the `Expanded`
+   20-25px, `:157` overflowed by exactly `40 − slot` — +15px to +21px, the caption
+   needing 40px — and the outer `Column` fit (8 locales). One site per locale,
+   never both. So
+   §2.11's "they must be measured together" was not caution, it was necessary:
+   fixing either alone moves the report to the other instead of clearing it.
+3. **fl_chart's 6 were not dependency-blocked; they were unmeasured.** §1.1
+   counted them as third-party and §2.11 reserved a fallback allowlist entry with
+   a tracking note for them. Measured, fl_chart's bottom `SideTitles` asks a
+   constant `reservedSize: 22` whatever the chart's height is, and `AppBarChart`'s
+   vertical path does not override it, so the strip's own `Flex` overflows by
+   `22 − slot`: +5px at 17px slots, +10px in `ru`'s 12px. Two call-site levers
+   close that, and the cheaper-looking one is the worse one. `AppBarChart.xLabels`
+   is nullable and its vertical path passes `showTitles: xLabels != null`, so
+   `xLabels: null` deletes the 22px strip outright — measured, that alone takes all
+   105 of this card's gate cases green with no height guard at all. It is not what
+   shipped: the value axis keeps drawing, so in `ru`'s 12px slot its "2" and "0"
+   overlap above two 8px pills, and the only threshold that would admit the
+   labelless chart where it reads (`en`, 37px) and reject it where it does not
+   (`da`, 17px) sits between 37 and 40px — a knife edge between two shipped
+   locales. So the card declines to draw a chart with no room to be one: below
+   **70px** (22px axis + 24px always-on value labels + 24px
+   `AppBarChart.minBarArea`, leaving every locale 33px clear) it is not built,
+   which is §2.11's Primary path applied one level up. Either way the fallback note
+   was never needed and `known_overflows.json` now holds nothing for this card.
+   Generalisation: a "third-party site" names where the exception is *thrown*, not
+   where the fix has to live.
+4. **Suppression is a fix the gate actively rewards, and the ratchet has no
+   vocabulary to constrain it.** Every earlier Track A ticket made a row give or
+   rearranged one; #1230 is the first to *remove* content below a threshold, and
+   absent content never overflows. A threshold accidentally set above the height
+   the dashboard actually gives the card leaves all 105 of its gate cases green
+   (2 widths × 2 tabs × 26 locales, plus the tab-registry check) and the card blank — verified, not feared: `_kProtocolChartMinHeight` 70 → 200 and
+   `_kDonutMinRingThickness` 10 → 60 each delete a chart at the shipped height
+   with the gate still green. So the guard test asserts *presence* at the 4 rows
+   `HeightStrategy.strict(4)` gives (chart slot 148-173px) as well as absence at
+   the 3 rows the gate pumps (12-37px). Any later ticket that clears a coordinate
+   by not drawing something owes the same pair.
+5. **Where a card overflows, look for what it also clips.** ui_kit's `AppPieChart`
+   takes the ring radius from the call site but the centre-hole radius from the
+   theme (`ChartStyle.pieCenterRadius`, 60px here), so the drawn diameter is
+   `2 × (centre + ring)` and does not follow `size`. The card's `size: 160` with
+   the default 40px ring drew a **200px donut into a 160px box** — 20px clipped off
+   every side at *every* width including desktop, invisible to the gate because a
+   clip is not an overflow. Sizing the ring from the slot fixes it and makes the
+   suppression threshold exact. Second instance of the pattern §2.10d found in
+   `network_health`'s gauge centre.
+
+The claims the gate cannot make — both arrangements legible, both charts present
+at the shipped height, the donut never wider than its box — are covered by
+`test/page/dashboard/views/components/firewall_overview_readability_test.dart`,
+tagged `dashboard-card` so it gates; each of its six groups was verified to fail
+under a mutation of the code it guards (seven mutations, tabulated in the file,
+five of which leave the #1183 gate green). It also re-asserts plain overflow at
+every realization it pumps, which is not redundant with the gate: the gate pumps
+`minHeightRows` only, and the shipped 4 rows is the one height at which the donut's
+caption and fl_chart's axis strip are built at all — the two sites #1230 fixed were
+otherwise measured by nothing at the height they actually render.
+
 ### 2.12 What the first *rearrangement* taught us (#1228 — implemented)
 
 All 52 coordinates cleared as predicted (278 → 226). #1226/#1233/#1227 all made
@@ -1226,10 +1315,11 @@ addition — it changes no card's rendering until a threshold is declared.
 | #1237 | `time_settings` card-own (§2.10d) — **implemented** | 21 |
 | #1235 | `network_health` gauge centre (§2.10d) — **implemented** | 3 |
 | #1247 | `firewall_overview` `MapsToRow` — side effect, not its brief (§2.9a) — **implemented** | 46 |
-| #1230 | `firewall_overview` remaining ×2 sites (§2.11) | 15 |
+| #1230 | `firewall_overview` remaining ×2 sites (§2.11, §2.11a) — **implemented** | 21 |
 | #1238 | `connected_devices` card-own (§2.6) | 1 |
 
-Ceiling **528 / 560**. The other 32 are the dependency-blocked ones (§1.1).
+Ceiling **534 / 560**. The other 26 are the dependency-blocked ones (§2.6) —
+fl_chart's 6 left that set when #1230 closed them from the call site (§2.11a).
 
 After #1234–#1237, and after #1247's side effect was collected (§2.9a), the
 allowlist holds **48** coordinates: 21 `firewall_overview` (#1230) and 27
@@ -1248,6 +1338,11 @@ other **32** are dependency-blocked: fl_chart's 6 and the 26 that cannot go gree
 without a ui_kit change (they need the card's own two rows fixed as well, so
 "blocked" means necessary-but-not-sufficient, not untouched).
 
+Measured since: #1230 cleared all **21**, fl_chart's 6 included, by declining to
+draw a chart into a slot shorter than its own axis strip (§2.11a). So 22 of the 48
+were clearable here, not 16, and the allowlist now holds **27** — all
+`connected_devices`, all #1238's.
+
 Two figures earlier in this document are contradicted by that attribution, both
 downward:
 
@@ -1265,15 +1360,20 @@ downward:
   19 is left as written because its table is a record of what was believed at
   baseline and its rows sum to 560.
 
-So the dependency-blocked share of the baseline is **32 of 560, not 45**, and
-`firewall_overview` is a *height* problem now — all 21 of its coordinates are
-bottom overflows, a different class from the four width shapes these tickets
-settled. #1230 is still the largest single block of clearable coordinates left,
-at 15 rather than 48.
+So the dependency-blocked share of the baseline is **26 of 560, not 45** — 32
+until #1230 measured fl_chart's 6 and closed them at the call site (§2.11a) — and
+`firewall_overview` was a *height* problem, all 21 of its coordinates bottom
+overflows, a different class from the four width shapes these tickets settled.
+#1230 closed all 21; what is left is #1238's 27.
 
-Their `tracking` notes are left as the epic requires: a ticket touches only the
-notes of cards it closes, so both cards keep the `baseline #1183` default until
-their own ticket names an owner.
+Neither card kept the epic's `baseline #1183` default in the end, and the rule
+that a ticket touches only the notes of the cards it closes is why. `#1230` closed
+`firewall_overview` outright, so both its keys and its note are gone from
+`known_overflows.json` — including the fl_chart fallback entry §2.11 had reserved,
+which measurement made unnecessary (§2.11a). `connected_devices`' note is now the
+file's only one: it names the upstream blocker (linksys/privacyGUI-UI-kit#20) for
+26 of its 27 coordinates and points the two card-own sites at #1238, which is the
+ticket that will delete it.
 
 #1266 is in this track despite clearing nothing: it is the only entry that *adds*
 coordinates (3, by localizing a hardcoded string) and removes them again in the

--- a/doc/dashboard/dashboard_density_design.md
+++ b/doc/dashboard/dashboard_density_design.md
@@ -1192,7 +1192,11 @@ showed up in the measurement.
    `2 × (centre + ring)` and does not follow `size`. The card's `size: 160` with
    the default 40px ring drew a **200px donut into a 160px box** — 20px clipped off
    every side at *every* width including desktop, invisible to the gate because a
-   clip is not an overflow. Sizing the ring from the slot fixes it and makes the
+   clip is not an overflow. Measured by pixel extent, the painted diameter is 200px
+   at every `size` from 120 to 300, so `size` does not bound the drawing in either
+   direction; filed upstream as linksys/privacyGUI-UI-kit#22, and the app's other
+   four `AppPieChart` call sites (`size: 180` ×2, `size: 120`, one caller-supplied)
+   still paint 200px. Sizing the ring from the slot fixes it here and makes the
    suppression threshold exact. Second instance of the pattern §2.10d found in
    `network_health`'s gauge centre.
 
@@ -1206,6 +1210,12 @@ every realization it pumps, which is not redundant with the gate: the gate pumps
 `minHeightRows` only, and the shipped 4 rows is the one height at which the donut's
 caption and fl_chart's axis strip are built at all — the two sites #1230 fixed were
 otherwise measured by nothing at the height they actually render.
+
+Two follow-ups left open rather than folded into #1230: the narrow arrangement's
+tile is `_InfoGridTile` in a `Row`, which `layout_blocks` has no variant for and
+`ethernet_ports` hand-rolls too (**#1275**), and the helpers these readability
+tests share are now cloned across up to seven files (noted on **#1238**, the next
+card to need them).
 
 ### 2.12 What the first *rearrangement* taught us (#1228 — implemented)
 

--- a/doc/dashboard/dashboard_density_design.md
+++ b/doc/dashboard/dashboard_density_design.md
@@ -1126,7 +1126,7 @@ width one. See **§2.11a**.
 ### 2.11a What the two height sites taught us (#1230 — implemented)
 
 All **21** cleared, not the 15 §2.11 scoped: fl_chart's 6 went with them, from the
-call site, with the package untouched. `minHeightRows` stays 3. Five things only
+call site, with the package untouched. `minHeightRows` stays 3. Six things only
 showed up in the measurement.
 
 1. **Both bottom overflows had a *width* cause, and neither of §2.11's guessed
@@ -1186,36 +1186,78 @@ showed up in the measurement.
    `HeightStrategy.strict(4)` gives (chart slot 148-173px) as well as absence at
    the 3 rows the gate pumps (12-37px). Any later ticket that clears a coordinate
    by not drawing something owes the same pair.
-5. **Where a card overflows, look for what it also clips.** ui_kit's `AppPieChart`
-   takes the ring radius from the call site but the centre-hole radius from the
-   theme (`ChartStyle.pieCenterRadius`, 60px here), so the drawn diameter is
-   `2 × (centre + ring)` and does not follow `size`. The card's `size: 160` with
+5. **Where a card overflows, look for what it also clips.** ui_kit ≤ v2.34.10's
+   `AppPieChart` took the ring radius from the call site but the centre-hole radius
+   from the theme (`ChartStyle.pieCenterRadius`, 60px here), so the drawn diameter
+   was `2 × (centre + ring)` and did not follow `size`. The card's `size: 160` with
    the default 40px ring drew a **200px donut into a 160px box** — 20px clipped off
    every side at *every* width including desktop, invisible to the gate because a
-   clip is not an overflow. Measured by pixel extent, the painted diameter is 200px
-   at every `size` from 120 to 300, so `size` does not bound the drawing in either
-   direction; filed upstream as linksys/privacyGUI-UI-kit#22, and the app's other
-   four `AppPieChart` call sites (`size: 180` ×2, `size: 120`, one caller-supplied)
-   still paint 200px. Sizing the ring from the slot fixes it here and makes the
-   suppression threshold exact. Second instance of the pattern §2.10d found in
-   `network_health`'s gauge centre.
+   clip is not an overflow. Measured by pixel extent, the painted diameter was 200px
+   at every `size` from 120 to 300, so `size` bounded the drawing in neither
+   direction; filed upstream as linksys/privacyGUI-UI-kit#22 and **fixed in
+   v2.34.11**, which derives both radii from the box. This branch bumps to it and
+   deletes the `sectionRadius: size / 2 - pieCenterRadius` workaround the fix makes
+   redundant — ui_kit's own dartdoc says the two now draw identically. Measured
+   after removal: 191px card → 153px box, **57.4px hole + 19.1px ring**; 288px and
+   512px → 160px box, 60px hole + 20px ring; the caption's half-diagonal is 32.0px
+   at all three, so it clears even the shrunk hole by 25.4px. The one thing the
+   upstream fix changes for a *tight* box is which radius gives: it shrinks the
+   **hole**, not the ring, so a `centerWidget` sized against the themed value can
+   overhang — which is the second reason `_kDonutMinRingThickness` suppresses rather
+   than shrinks. The card's cap is now written as a ring thickness measured outward
+   from the same themed hole as that floor, so no theme's `pieCenterRadius` can
+   invert the two and close the window (a flat 160px would leave `neumorphic`'s 65px
+   hole only 150-160px, and any hole past 70px nothing at all). The app's other four
+   `AppPieChart` call sites (`size: 180` ×2, `size: 120`, one caller-supplied) are
+   fixed by the bump without touching them. Second instance of the pattern §2.10d
+   found in `network_health`'s gauge centre.
+6. **AC 5 is a claim about the card, and a tab with no coordinates on it can still
+   fail it.** Both #1230 sites are on the Rules tab, so the Ports tab was outside
+   the coordinate list entirely — and its port-forwarding rows fit at 191px, which
+   the gate reads as fine. Swept across all 26 locales, its localized text is clean
+   (6 locales wrap the heading to 2 lines, `pt_PT` wanting 230.1px of a 157.4px
+   row; nothing clips). Its **mapping target does not read**: 36.9-38.5px of room
+   for 82.3-103.7px of "host:port", so every rule shows about two characters of its
+   destination in every locale. The cause is not this card. `MapsToRow` gives its
+   source and target a `Flexible` each, and `RenderFlex` splits the room **evenly**
+   between equal flexes without handing back what the shorter half declines —
+   measured, the source takes its 30.7px and the target still gets exactly half,
+   38.5px of the pair's 77px. So the target's ceiling is half the mapping row
+   whatever else that row spends, and no width this card can give it is enough:
+   103.7px of target needs 227.4px of mapping, more than a 191px card is wide. Both
+   card-side fixes were measured and neither suffices alone — putting the mapping on
+   a full-width line of its own still leaves the target 68.7px, and it costs 20px a
+   rule, which overflows the 3-row minimum AC 4 forbids raising by +11px to +36px
+   unless the DMZ list goes with it. What clears it is the combination: that line,
+   the DMZ list dropped at narrow width, **and** `MapsToRow` giving its bounded half
+   its intrinsic width instead of half the row — measured green on this card's whole
+   readability suite. That last part contradicts the widget's own docstring
+   ("[target] is the part that ellipsizes, since the source is short and bounded
+   while the target is not") and is shared with seven other call sites, so it is a
+   `row_blocks.dart` change and not #1230's; the readability suite records the
+   limitation as a failing-when-fixed expectation rather than a comment. **A shared
+   layout block's flex distribution is a density decision** — the even split is
+   invisible until a card is narrow enough for the two halves to want different
+   amounts, and then it is the whole difference between "19…" and the address.
 
-The claims the gate cannot make — both arrangements legible, both charts present
-at the shipped height, the donut never wider than its box — are covered by
+The claims the gate cannot make — both arrangements legible, both tabs legible in
+all 26 locales, both charts present at the shipped height, the donut never wider
+than its box, no slice label painted into the ring — are covered by
 `test/page/dashboard/views/components/firewall_overview_readability_test.dart`,
-tagged `dashboard-card` so it gates; each of its six groups was verified to fail
-under a mutation of the code it guards (seven mutations, tabulated in the file,
-five of which leave the #1183 gate green). It also re-asserts plain overflow at
+tagged `dashboard-card` so it gates; each of its eight groups was verified to fail
+under a mutation of the code it guards (eleven mutations, tabulated in the file,
+seven of which leave the #1183 gate green). It also re-asserts plain overflow at
 every realization it pumps, which is not redundant with the gate: the gate pumps
 `minHeightRows` only, and the shipped 4 rows is the one height at which the donut's
 caption and fl_chart's axis strip are built at all — the two sites #1230 fixed were
 otherwise measured by nothing at the height they actually render.
 
-Two follow-ups left open rather than folded into #1230: the narrow arrangement's
+Three follow-ups left open rather than folded into #1230: the narrow arrangement's
 tile is `_InfoGridTile` in a `Row`, which `layout_blocks` has no variant for and
-`ethernet_ports` hand-rolls too (**#1275**), and the helpers these readability
+`ethernet_ports` hand-rolls too (**#1275**); the helpers these readability
 tests share are now cloned across up to seven files (noted on **#1238**, the next
-card to need them).
+card to need them); and `MapsToRow`'s even flex split (item 6), which no card can
+work around and which needs the shared block changed.
 
 ### 2.12 What the first *rearrangement* taught us (#1228 — implemented)
 

--- a/lib/page/firewall/cards/usp_firewall_overview_card.dart
+++ b/lib/page/firewall/cards/usp_firewall_overview_card.dart
@@ -109,7 +109,10 @@ const double _kMetricsSideBySideMinWidth = 328;
 /// centre-hole radius from the theme (`ChartStyle.pieCenterRadius`, 60px here),
 /// so the drawn diameter is `2 × (centre + ring)` and does **not** follow the
 /// `size` box. The old `size: 160` with the default 40px ring therefore drew a
-/// 200px donut into a 160px box and the `Stack` clipped 20px off every side.
+/// 200px donut into a 160px box — measured, the painted extent is 200px at every
+/// `size` from 120 to 300 — and the card surface clipped 20px off every side.
+/// Filed upstream as linksys/privacyGUI-UI-kit#22; the other four `AppPieChart`
+/// call sites in this app still paint 200px.
 /// [_TargetDonut] sizes the ring from the slot it is actually given instead, and
 /// draws nothing once that slot cannot hold this much ring — a 140px square with
 /// this theme. That guard is also what makes the donut's `centerWidget` Column
@@ -282,6 +285,11 @@ class _RuleMetric {
 ///
 /// Label left, value right, and the label is what yields: the number *is* the
 /// metric, while a wrapped or ellipsized label still names which one it is.
+///
+/// Composition-wise this is `_InfoGridTile` in a `Row` at 8px padding, which
+/// `layout_blocks` has no variant for; `usp_ethernet_ports_card.dart`'s
+/// `_SummaryTile` is the same shape again. Folding all three into a shared
+/// compact variant is #1275.
 class _StackedMetrics extends StatelessWidget {
   const _StackedMetrics({required this.metrics});
 

--- a/lib/page/firewall/cards/usp_firewall_overview_card.dart
+++ b/lib/page/firewall/cards/usp_firewall_overview_card.dart
@@ -7,6 +7,7 @@ import 'package:privacy_gui/page/_shared/providers/card_tab_state_provider.dart'
 import 'package:privacy_gui/page/_shared/components/usp_status_dot.dart';
 import 'package:privacy_gui/page/_shared/components/dashboard_card_template.dart';
 import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
+import 'package:privacy_gui/page/_shared/models/port_forwarding_rule_ui_model.dart';
 import 'package:privacy_gui/page/firewall/providers/firewall_data_provider.dart';
 import 'package:privacy_gui/page/_shared/components/card_skeleton.dart';
 import 'package:privacy_gui/page/port_forwarding/providers/port_forwarding_data_provider.dart';
@@ -105,32 +106,53 @@ const double _kMetricsSideBySideMinWidth = 328;
 
 /// Thinnest ring the target-distribution donut is drawn with, in logical px.
 ///
-/// ui_kit's `AppPieChart` takes the section radius from the call site but the
-/// centre-hole radius from the theme (`ChartStyle.pieCenterRadius`, 60px here),
-/// so the drawn diameter is `2 × (centre + ring)` and does **not** follow the
-/// `size` box. The old `size: 160` with the default 40px ring therefore drew a
-/// 200px donut into a 160px box — measured, the painted extent is 200px at every
-/// `size` from 120 to 300 — and the card surface clipped 20px off every side.
-/// Filed upstream as linksys/privacyGUI-UI-kit#22; the other four `AppPieChart`
-/// call sites in this app still paint 200px.
-/// [_TargetDonut] sizes the ring from the slot it is actually given instead, and
-/// draws nothing once that slot cannot hold this much ring — a 140px square with
-/// this theme. That guard is also what makes the donut's `centerWidget` Column
-/// unreachable at the realizations that used to overflow it: the caption is 40px
-/// tall, and the `Expanded` holding it was 20-25px in the 8 locales that reported
-/// there (`ar el fr fr_CA pt pt_PT tr vi`), so the overflow was exactly
-/// `40 − slot` — +15px to +21px.
+/// Below this [_TargetDonut] draws nothing — a 140px square with this theme's
+/// 60px hole. Two things make suppression the right call rather than shrinking:
+///
+/// * **The caption.** ui_kit v2.34.11 derives both radii from the box, and in a
+///   box too small for the themed hole it shrinks the *hole* rather than the
+///   ring — so a `centerWidget` sized against the themed value can overhang a
+///   tight one, which ui_kit documents on `centerWidget` itself. This card's
+///   caption is a 40px-tall count and word, and this floor is what keeps it
+///   inside the hole it is centred in.
+/// * **The overflow.** Suppression is also what makes that caption unreachable
+///   at the realizations that used to overflow it: the caption is 40px tall, and
+///   the `Expanded` holding it was 20-25px in the 8 locales that reported there
+///   (`ar el fr fr_CA pt pt_PT tr vi`), so the overflow was exactly `40 − slot`
+///   — +15px to +21px.
 ///
 /// The other 7 (`es es_AR fi id nb pl ru`) never reported here at all: their grid
 /// grew to 156-173px, which starves this `Expanded` to 0, and `RenderFlex` skips
 /// an empty box — so the outer `Column` reported instead, by +7px to +26px. One
 /// site per locale, never both, which is why the two sites sum to 15 coordinates
 /// over 15 locales rather than 26 (#1230).
+///
+/// ## What this guard used to also carry
+///
+/// ui_kit ≤ v2.34.10 took the section radius from the call site but the
+/// centre-hole radius from the theme, so the drawn diameter was
+/// `2 × (centre + ring)` and did **not** follow the `size` box: `size: 160` with
+/// the default 40px ring drew a 200px donut — measured, 200px at every `size`
+/// from 120 to 300 — and the card surface clipped 20px off every side. Filed as
+/// linksys/privacyGUI-UI-kit#22 and fixed in v2.34.11, which derives the drawing
+/// from the box. The `sectionRadius: diameter / 2 - centreRadius` this card
+/// carried against the old behaviour is gone with the bump: the drawn diameter is
+/// the box by construction now, and the only thing left to decide here is whether
+/// a donut is worth drawing at all.
 const double _kDonutMinRingThickness = 10;
 
-/// Diameter the donut is drawn at when the slot is at least this big, preserving
-/// the card's designed size.
-const double _kDonutMaxDiameter = 160;
+/// Ring thickness the donut is drawn with when the slot allows it, in logical px.
+///
+/// The donut's diameter is `2 × (centre + this)` — 160px against this theme's
+/// 60px hole, the card's designed size — capped by the slot it is given.
+///
+/// Written as a ring rather than as a flat 160px diameter so it cannot contradict
+/// [_kDonutMinRingThickness]: both are measured outward from the same themed hole,
+/// so the cap is always the wider of the two. A flat 160 silently narrows the
+/// window instead — a 65px hole under `neumorphic` would leave only 150-160px —
+/// and past a 70px hole closes it altogether, drawing no donut in any locale at
+/// any width with nothing failing to say so (#1230).
+const double _kDonutDesignRingThickness = 20;
 
 /// Localizes a firewall rule target value for display. The raw value (from the
 /// device) is still used as the aggregation map key; only the legend label is
@@ -173,7 +195,7 @@ class _RulesTab extends StatelessWidget {
     if (ruleSummaries.isEmpty) {
       return Center(
         child: AppText.bodyMedium(
-          'No firewall rules configured',
+          loc(context).noFirewallRulesConfigured,
           color: colorScheme.onSurfaceVariant,
         ),
       );
@@ -340,10 +362,10 @@ class _StackedMetrics extends StatelessWidget {
 /// The target-distribution donut, sized to the slot the tab has left for it —
 /// and absent when that slot is too small to draw a ring in.
 ///
-/// Absent rather than shrunk because the centre-hole radius is a theme value the
-/// call site cannot lower (see [_kDonutMinRingThickness]), so below ~140px there
-/// is no donut to draw, only a clipped arc. The legend underneath keeps carrying
-/// every target and its count, so nothing is lost but the picture.
+/// Absent rather than shrunk because below ~140px what is left is not a smaller
+/// donut but an outline with a caption spilling out of its hole (see
+/// [_kDonutMinRingThickness]). The legend underneath keeps carrying every target
+/// and its count, so nothing is lost but the picture.
 class _TargetDonut extends StatelessWidget {
   const _TargetDonut({required this.sections, required this.total});
 
@@ -355,13 +377,17 @@ class _TargetDonut extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final centreRadius = AppDesignTheme.of(context).chartStyle.pieCenterRadius;
 
     return LayoutBuilder(
       builder: (context, constraints) {
+        // Read here rather than in the outer build so the size the donut asks
+        // for and the floor that admits it come off the same theme in the same
+        // place — they are two readings of one hole and must not drift apart.
+        final centreRadius =
+            AppDesignTheme.of(context).chartStyle.pieCenterRadius;
         final diameter = math.min(
           math.min(constraints.maxWidth, constraints.maxHeight),
-          _kDonutMaxDiameter,
+          2 * (centreRadius + _kDonutDesignRingThickness),
         );
         if (diameter < 2 * (centreRadius + _kDonutMinRingThickness)) {
           return const SizedBox.shrink();
@@ -373,9 +399,9 @@ class _TargetDonut extends StatelessWidget {
             // The legend already names every slice; a title painted inside a
             // 20px ring would be a clipped duplicate of it.
             showLabels: false,
-            // Keeps the drawn diameter equal to the box, which the ui_kit
-            // default does not — see [_kDonutMinRingThickness].
-            sectionRadius: diameter / 2 - centreRadius,
+            // No `sectionRadius`: since v2.34.11 ui_kit derives the ring from
+            // this box, so asking for one only makes it thinner than it needs to
+            // be — see [_kDonutMinRingThickness].
             size: diameter,
             centerWidget: Column(
               mainAxisSize: MainAxisSize.min,
@@ -432,7 +458,7 @@ class _TargetDonut extends StatelessWidget {
 const double _kProtocolChartMinHeight = 70;
 
 class _PortsTab extends StatelessWidget {
-  final List portForwardingRules;
+  final List<PortForwardingRuleUIModel> portForwardingRules;
   final List<DmzEntrySummary> dmzSummaries;
 
   const _PortsTab({
@@ -456,7 +482,7 @@ class _PortsTab extends StatelessWidget {
     // Protocol distribution
     final protocolCounts = <String, int>{};
     for (final rule in portForwardingRules) {
-      final proto = rule.protocol as String;
+      final proto = rule.protocol;
       protocolCounts[proto] = (protocolCounts[proto] ?? 0) + 1;
     }
 

--- a/lib/page/firewall/cards/usp_firewall_overview_card.dart
+++ b/lib/page/firewall/cards/usp_firewall_overview_card.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
@@ -59,6 +61,73 @@ class UspFirewallOverviewCard extends ConsumerWidget {
 // =============================================================================
 // Tab 1: Rules — target distribution donut + summary
 // =============================================================================
+
+/// Content width below which the three rule metrics stack into full-width rows
+/// instead of sitting three across.
+///
+/// Derived, not chosen. `InfoGrid` spends 8px between tiles and each tile spends
+/// 24px on [LayoutBlock] padding, so a tile's text column is
+/// `(content − 16) / 3 − 24`.
+///
+/// The binding label is not the widest one. `ru`'s "ПРАВИЛА БРАНДМАУЭРА" is the
+/// longest single line at 143.2px, but it breaks between its two words and fits
+/// two lines from **71.8px**; the tightest two-line fit belongs to `es`
+/// "REENVÍO DE PUERTOS" at **73.8px**. Three tiles of that need 310px of
+/// content, so this sits at 328 — 80.0px of text per tile, ~6px of slack so a
+/// string change cannot silently drop a label onto a third line.
+///
+/// Below that the grid does not merely get tight, it stops being readable and
+/// stops fitting. At the narrowest width the grid ever yields — a 191px card,
+/// 157.4px of content — a tile is 47.1px wide and has **23.1px** of text, which
+/// is one character per line in every locale (`ru` takes 8 lines, 129px, and `es`
+/// 5). Measured, that grid stood 108px tall in `en` and up to **173px** in `ru`,
+/// against a tab viewport of **205px** (203px where the tab bar wraps) that also
+/// owes 20px to the two gaps and 36px to the legend. 15 of the 26 locales
+/// overflowed — the 15 `firewall_overview|min|0` coordinates (#1230) — and which
+/// site reported depended on how tall the grid grew: see
+/// [_kDonutMinRingThickness].
+///
+/// Stacked, the same 157px card gives each label 111.4-127.6px on one line plus
+/// a second line to wrap into, which holds every locale unbroken except `fi`
+/// (PALOMUURISÄÄNNÖT, 131.0px) and `nb` (BRANNMURREGLER, 118.6px) — single-word
+/// labels that wrap mid-word rather than clip mid-glyph. No value of this
+/// threshold buys those two an unbroken line: the grid wraps `fi` mid-word as
+/// well at the width it actually runs at (a 1440px desktop leaves each tile
+/// 130.0px for a 131.0px word), while the stacked form already holds it unbroken
+/// from a 288px card. A single-word label that outgrows a full-width row is
+/// #1240's compact-forms problem, not this constant's.
+///
+/// This threshold decides *arrangement*, not survival: both forms are
+/// overflow-safe on their own, so getting it wrong costs a wrap, never a clip.
+/// It is a local degradation, not a form selection — Track B (#1240) may later
+/// replace it with a declared `normalAbove` threshold.
+const double _kMetricsSideBySideMinWidth = 328;
+
+/// Thinnest ring the target-distribution donut is drawn with, in logical px.
+///
+/// ui_kit's `AppPieChart` takes the section radius from the call site but the
+/// centre-hole radius from the theme (`ChartStyle.pieCenterRadius`, 60px here),
+/// so the drawn diameter is `2 × (centre + ring)` and does **not** follow the
+/// `size` box. The old `size: 160` with the default 40px ring therefore drew a
+/// 200px donut into a 160px box and the `Stack` clipped 20px off every side.
+/// [_TargetDonut] sizes the ring from the slot it is actually given instead, and
+/// draws nothing once that slot cannot hold this much ring — a 140px square with
+/// this theme. That guard is also what makes the donut's `centerWidget` Column
+/// unreachable at the realizations that used to overflow it: the caption is 40px
+/// tall, and the `Expanded` holding it was 20-25px in the 8 locales that reported
+/// there (`ar el fr fr_CA pt pt_PT tr vi`), so the overflow was exactly
+/// `40 − slot` — +15px to +21px.
+///
+/// The other 7 (`es es_AR fi id nb pl ru`) never reported here at all: their grid
+/// grew to 156-173px, which starves this `Expanded` to 0, and `RenderFlex` skips
+/// an empty box — so the outer `Column` reported instead, by +7px to +26px. One
+/// site per locale, never both, which is why the two sites sum to 15 coordinates
+/// over 15 locales rather than 26 (#1230).
+const double _kDonutMinRingThickness = 10;
+
+/// Diameter the donut is drawn at when the slot is at least this big, preserving
+/// the card's designed size.
+const double _kDonutMaxDiameter = 160;
 
 /// Localizes a firewall rule target value for display. The raw value (from the
 /// device) is still used as the aggregation map key; only the legend label is
@@ -133,67 +202,184 @@ class _RulesTab extends StatelessWidget {
       );
     }).toList();
 
-    return Column(
-      children: [
-        // Summary stats row - using InfoGrid pattern
-        InfoGrid(
-          items: [
-            InfoGridItem(
-                label: loc(context).fwRules,
-                value: '$activeCount/${ruleSummaries.length}'),
-            InfoGridItem(
-                label: loc(context).portFwd, value: '$portForwardingCount'),
-            InfoGridItem(label: 'DMZ', value: '$dmzCount'),
-          ],
-          crossAxisCount: 3,
-        ),
-        AppGap.md(),
-        // Donut chart
-        Expanded(
-          child: Center(
-            child: AppPieChart(
+    final metrics = <_RuleMetric>[
+      _RuleMetric(
+        label: loc(context).fwRules,
+        value: '$activeCount/${ruleSummaries.length}',
+      ),
+      _RuleMetric(label: loc(context).portFwd, value: '$portForwardingCount'),
+      _RuleMetric(label: 'DMZ', value: '$dmzCount'),
+    ];
+
+    return LayoutBuilder(
+      builder: (context, constraints) => Column(
+        children: [
+          // Summary stats — three across while the labels have room for it, and
+          // stacked full-width rows below that (see
+          // [_kMetricsSideBySideMinWidth]).
+          if (constraints.maxWidth >= _kMetricsSideBySideMinWidth)
+            InfoGrid(
+              items: [
+                for (final m in metrics)
+                  InfoGridItem(label: m.label, value: m.value),
+              ],
+              crossAxisCount: 3,
+            )
+          else
+            _StackedMetrics(metrics: metrics),
+          AppGap.md(),
+          // Donut chart — drawn only when the slot left over can hold one.
+          Expanded(
+            child: _TargetDonut(
               sections: sections,
-              donut: true,
-              centerWidget: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  AppText.titleMedium('${ruleSummaries.length}'),
-                  AppText.labelSmall(loc(context).rules,
-                      color: colorScheme.onSurfaceVariant),
-                ],
-              ),
-              size: 160,
+              total: '${ruleSummaries.length}',
             ),
           ),
-        ),
-        AppGap.sm(),
-        // Legend
-        Wrap(
-          spacing: 12,
-          runSpacing: 4,
-          alignment: WrapAlignment.center,
-          children: [
-            for (var i = 0; i < targetCounts.length; i++)
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Container(
-                    width: 8,
-                    height: 8,
-                    decoration: BoxDecoration(
-                      color: seriesColors[i % seriesColors.length],
-                      shape: BoxShape.circle,
+          AppGap.sm(),
+          // Legend
+          Wrap(
+            spacing: 12,
+            runSpacing: 4,
+            alignment: WrapAlignment.center,
+            children: [
+              for (var i = 0; i < targetCounts.length; i++)
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      width: 8,
+                      height: 8,
+                      decoration: BoxDecoration(
+                        color: seriesColors[i % seriesColors.length],
+                        shape: BoxShape.circle,
+                      ),
                     ),
+                    AppGap.xs(),
+                    AppText.labelSmall(
+                      '${_localizeTarget(context, targetCounts.keys.elementAt(i))}: ${targetCounts.values.elementAt(i)}',
+                    ),
+                  ],
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One Rules-tab metric. The label and the value travel together through both
+/// arrangements, so they are one type rather than two parallel lists.
+class _RuleMetric {
+  const _RuleMetric({required this.label, required this.value});
+
+  final String label;
+  final String value;
+}
+
+/// The three metrics as full-width rows, for cards narrower than
+/// [_kMetricsSideBySideMinWidth].
+///
+/// Label left, value right, and the label is what yields: the number *is* the
+/// metric, while a wrapped or ellipsized label still names which one it is.
+class _StackedMetrics extends StatelessWidget {
+  const _StackedMetrics({required this.metrics});
+
+  final List<_RuleMetric> metrics;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (var i = 0; i < metrics.length; i++) ...[
+          if (i > 0) AppGap.sm(),
+          LayoutBlock(
+            // 8px, not the block's default 12px: three rows, the 20px of gaps
+            // after them and the 36px legend all have to fit the 205px the tab
+            // gets at the card's 3-row minimum (203px where the tab bar wraps).
+            // At 8px the stack measures 112px (`en`) to 130px (`ru`, where one
+            // label takes two lines); the donut's `Expanded` absorbs the
+            // remaining 17-37px and draws nothing in it, which is why the legend
+            // lands exactly on the content edge. At the block's 12px default each
+            // row grows 8px, the stack becomes 136-154px, and the legend is
+            // pushed 3-7px past that edge onto the footer the template does not
+            // scroll (#1230).
+            padding: BlockConstants.paddingSm,
+            child: Row(
+              children: [
+                Expanded(
+                  child: AppText.labelSmall(
+                    metrics[i].label.toUpperCase(),
+                    color: colorScheme.onSurfaceVariant,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                  AppGap.xs(),
-                  AppText.labelSmall(
-                    '${_localizeTarget(context, targetCounts.keys.elementAt(i))}: ${targetCounts.values.elementAt(i)}',
-                  ),
-                ],
-              ),
-          ],
-        ),
+                ),
+                AppGap.sm(),
+                AppText.labelMedium(metrics[i].value),
+              ],
+            ),
+          ),
+        ],
       ],
+    );
+  }
+}
+
+/// The target-distribution donut, sized to the slot the tab has left for it —
+/// and absent when that slot is too small to draw a ring in.
+///
+/// Absent rather than shrunk because the centre-hole radius is a theme value the
+/// call site cannot lower (see [_kDonutMinRingThickness]), so below ~140px there
+/// is no donut to draw, only a clipped arc. The legend underneath keeps carrying
+/// every target and its count, so nothing is lost but the picture.
+class _TargetDonut extends StatelessWidget {
+  const _TargetDonut({required this.sections, required this.total});
+
+  final List<AppPieSection> sections;
+
+  /// Rule count shown in the centre of the donut.
+  final String total;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final centreRadius = AppDesignTheme.of(context).chartStyle.pieCenterRadius;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final diameter = math.min(
+          math.min(constraints.maxWidth, constraints.maxHeight),
+          _kDonutMaxDiameter,
+        );
+        if (diameter < 2 * (centreRadius + _kDonutMinRingThickness)) {
+          return const SizedBox.shrink();
+        }
+        return Center(
+          child: AppPieChart(
+            sections: sections,
+            donut: true,
+            // The legend already names every slice; a title painted inside a
+            // 20px ring would be a clipped duplicate of it.
+            showLabels: false,
+            // Keeps the drawn diameter equal to the box, which the ui_kit
+            // default does not — see [_kDonutMinRingThickness].
+            sectionRadius: diameter / 2 - centreRadius,
+            size: diameter,
+            centerWidget: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AppText.titleMedium(total),
+                AppText.labelSmall(loc(context).rules,
+                    color: colorScheme.onSurfaceVariant),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 }
@@ -201,6 +387,41 @@ class _RulesTab extends StatelessWidget {
 // =============================================================================
 // Tab 2: Ports — forwarding list + protocol bar chart
 // =============================================================================
+
+/// Slot height below which the protocol bar chart is not drawn.
+///
+/// Derived from what the chart spends before it draws a single bar:
+///
+/// * **22px** for the bottom axis strip. That is fl_chart's `SideTitles`
+///   default `reservedSize`, and `AppBarChart`'s vertical path does not override
+///   it — so the strip asks for 22px whatever the chart's height is, and its own
+///   `Flex` (fl_chart `side_titles_widget.dart:245`) overflows by `22 − slot`
+///   when the slot is shorter. That is exactly the 6 `firewall_overview|min|1`
+///   coordinates: +5px in `da`/`pl`/`pt`/`pt_PT`/`sv` (17px slots) and +10px in
+///   `ru` (12px) (#1230).
+/// * **24px** for the always-on value labels, which fl_chart paints above the
+///   tallest bar (`tooltipMargin: 4` + 2×2 padding + a 16px label line).
+/// * **24px** of bars, which is `AppBarChart`'s own `minBarArea` — the number its
+///   horizontal path uses to decide when a chart has room for axis labels at all.
+///
+/// Measured slots: 12-37px at the card's 3-row minimum (at both 191px and 288px,
+/// the only two widths the grid realizes for it) and 148-173px at the 4 rows its
+/// `HeightStrategy.strict(4)` actually gives it. So this suppresses the chart at
+/// the minimum height, keeps it at the shipped height, and no locale sits near
+/// the boundary.
+///
+/// #1230's plan preferred suppressing the *axis labels* rather than the chart, and
+/// that lever does exist: `AppBarChart.xLabels` is nullable and its vertical path
+/// passes `showTitles: xLabels != null`, so `xLabels: null` removes the 22px strip
+/// entirely. Measured — with no height guard at all, that alone takes every one of
+/// the card's 105 gate cases green. It is not taken because of what it leaves on
+/// screen: the value axis keeps drawing, so at `ru`'s 12px slot its "2" and "0"
+/// labels overlap each other above two 8px pills, and the only threshold that
+/// would admit the labelless chart where it does read (`en`, 37px) and reject it
+/// where it does not (`da`, 17px) sits between 37 and 40px — a knife edge between
+/// two shipped locales, where 70px leaves every locale 33px clear. The picture is
+/// dropped and the list above it keeps the information.
+const double _kProtocolChartMinHeight = 70;
 
 class _PortsTab extends StatelessWidget {
   final List portForwardingRules;
@@ -273,22 +494,32 @@ class _PortsTab extends StatelessWidget {
                 ],
               )),
         ],
-        // Protocol distribution bar chart
+        // Protocol distribution bar chart — only when the list above leaves a
+        // slot that can hold one (see [_kProtocolChartMinHeight]).
         if (protocolCounts.isNotEmpty) ...[
           AppGap.md(),
           Expanded(
-            child: AppBarChart(
-              series: [
-                AppChartSeries(
-                  label: loc(context).rules,
-                  data: protocolCounts.values.map((v) => v.toDouble()).toList(),
-                  color: colorScheme.primary,
-                ),
-              ],
-              xLabels: protocolCounts.keys.toList(),
-              showValueLabels: true,
-              valueLabelFormatter: (v) => '${v.toInt()}',
-              showTooltip: false,
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                if (constraints.maxHeight < _kProtocolChartMinHeight) {
+                  return const SizedBox.shrink();
+                }
+                return AppBarChart(
+                  series: [
+                    AppChartSeries(
+                      label: loc(context).rules,
+                      data: protocolCounts.values
+                          .map((v) => v.toDouble())
+                          .toList(),
+                      color: colorScheme.primary,
+                    ),
+                  ],
+                  xLabels: protocolCounts.keys.toList(),
+                  showValueLabels: true,
+                  valueLabelFormatter: (v) => '${v.toInt()}',
+                  showTooltip: false,
+                );
+              },
             ),
           ),
         ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,11 +59,11 @@ dependencies:
   ui_kit_library:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.34.5
+      ref: v2.34.11
   generative_ui:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.34.5
+      ref: v2.34.11
       path: generative_ui
   flutter_blue_plus: ^1.4.0
   crypto: ^3.0.2

--- a/test/fixtures/known_overflows.json
+++ b/test/fixtures/known_overflows.json
@@ -1,15 +1,9 @@
 {
   "tracking": {
-    "connected_devices": "26 of these 27 coordinates need three sites fixed together, and one of them is upstream: ui_kit AppListTile lays `trailing` out as a non-flex child with maxWidth: Infinity, so it paints at intrinsic width and the tile's Row overflows by +25.6px while the Expanded title column is starved to 0px first. Filed as linksys/privacyGUI-UI-kit#20. Not avoidable from the call site: the slot is never told the budget, so a LayoutBuilder there sees infinity and only a hardcoded magic number can fit. Measured — substituting a narrower trailing variant (75.0 -> 16.5px) fixed one row and moved the binding constraint to the next-widest trailing child, leaving the count at 27. The two card-own sites (usp_connected_devices_card.dart:61 and :79, #1226's unconstrained centred-Row shape) are tracked by #1238; `preferred|0 el` is the single coordinate that needs only :79 and has no upstream dependency.",
-    "firewall_overview": "Two groups, and they are not the same kind of problem. `min|0` (15 coordinates) is card-own and clearable here: usp_firewall_overview_card.dart:157 carries 8 (the donut's centerWidget Column, bottom 15-31px) and :136 carries 7 (the card's outer Column, bottom 7-26px). Both are HEIGHT overflows, so none of the four width shapes from #1234-#1237 apply -- see doc/dashboard/dashboard_density_design.md section 2.11. Tracked by #1230, whose first step is measuring them together, because :136 is the Column that holds the donut whose centre label is :157. `min|1` (6 coordinates, da pl pt pt_PT ru sv) is upstream: fl_chart side_titles_widget.dart:245, bottom 5-10px. Those 6 were masked until #1247 fixed the card-own MapsToRow above them, which is why section 1.1 records fl_chart at 19."
+    "connected_devices": "26 of these 27 coordinates need three sites fixed together, and one of them is upstream: ui_kit AppListTile lays `trailing` out as a non-flex child with maxWidth: Infinity, so it paints at intrinsic width and the tile's Row overflows by +25.6px while the Expanded title column is starved to 0px first. Filed as linksys/privacyGUI-UI-kit#20. Not avoidable from the call site: the slot is never told the budget, so a LayoutBuilder there sees infinity and only a hardcoded magic number can fit. Measured — substituting a narrower trailing variant (75.0 -> 16.5px) fixed one row and moved the binding constraint to the next-widest trailing child, leaving the count at 27. The two card-own sites (usp_connected_devices_card.dart:61 and :79, #1226's unconstrained centred-Row shape) are tracked by #1238; `preferred|0 el` is the single coordinate that needs only :79 and has no upstream dependency."
   },
   "allowlist": {
     "connected_devices|min|0": ["*"],
-    "connected_devices|preferred|0": ["el"],
-    "firewall_overview|min|0": [
-      "ar", "el", "es", "es_AR", "fi", "fr", "fr_CA", "id", "nb", "pl",
-      "pt", "pt_PT", "ru", "tr", "vi"
-    ],
-    "firewall_overview|min|1": ["da", "pl", "pt", "pt_PT", "ru", "sv"]
+    "connected_devices|preferred|0": ["el"]
   }
 }

--- a/test/page/dashboard/views/components/firewall_overview_readability_test.dart
+++ b/test/page/dashboard/views/components/firewall_overview_readability_test.dart
@@ -34,23 +34,34 @@ import '../../../../util/dashboard/dashboard_card_probe.dart';
 ///     gate green and the card empty. Nothing in `known_overflows.json` can
 ///     express "the picture is still there at 4 rows".
 ///
+/// AC 5 is a claim about the whole card, so the Ports tab is swept for the same
+/// two failures even though none of the 21 coordinates were there — its rows fit
+/// at 191px, and fitting is not reading. One thing on it does not read, and the
+/// cause is outside this card; the last test in the file records it with its
+/// measurement rather than leaving it to a comment.
+///
 /// So each group below asserts on the rendered tree. Each was run against a
 /// mutation of the code it guards, and each fired:
 ///
 ///   | mutation                                       | what failed                                                  |
 ///   |------------------------------------------------|--------------------------------------------------------------|
-///   | `_kMetricsSideBySideMinWidth` 328 → 0 (i.e. the pre-#1230 card) | 33: shredded text (26 — every locale), three across @min and @preferred (2), footer + donut + ring + legend @min (5); 10 of the 33 trip `pumpAt`'s overflow first, by +7px to +26px |
-///   | `_kMetricsSideBySideMinWidth` 328 → 600        | three across @desktop (1)                                    |
-///   | `_kProtocolChartMinHeight` 70 → 200            | chart drawn @shipped height (3)                              |
-///   | `_kDonutMinRingThickness` 10 → 60              | donut drawn @shipped height (3), ring fits its box (3)        |
-///   | `sectionRadius:` → ui_kit's default 40         | ring fits its box (3)                                        |
-///   | `_StackedMetrics` padding `sm` → block default | 12: `pumpAt` overflow @min in 6 locales (+3px `fi` to +7px `ru`, 10 tests), donut starved out even @shipped height (2) |
-///   | stacked label `maxLines` 2 → 1                 | shredded text (5 — `es`, `es-AR`, `fi`, `nb`, `ru`)           |
+///   | 1. `_kMetricsSideBySideMinWidth` 328 → 0 (i.e. the pre-#1230 card) | 33: shredded text (26 — every locale), three across @min and @preferred (2), footer + donut + ring + legend @min (5); 10 of the 33 trip `pumpAt`'s overflow first, by +7px to +26px |
+///   | 2. `_kMetricsSideBySideMinWidth` 328 → 600     | three across @desktop (1)                                    |
+///   | 3. `_kProtocolChartMinHeight` 70 → 200         | chart drawn @shipped height (3)                              |
+///   | 4. `_kDonutMinRingThickness` 10 → 60           | donut drawn @shipped height (3), ring fits its box (3)        |
+///   | 5. `size: diameter` → the themed design diameter, ignoring the slot | ring fits its box (1 — @min only; 191px is the one width whose slot, 157.4px, is under the 160px this theme designs for) |
+///   | 6. `showLabels: false` → `true`                | ring fits its box (3)                                        |
+///   | 7. `_StackedMetrics` padding `sm` → block default | 12: `pumpAt` overflow @min in 6 locales (+3px `fi` to +7px `ru`, 10 tests), donut starved out even @shipped height (2) |
+///   | 8. stacked label `maxLines` 2 → 1              | shredded text (5 — `es`, `es-AR`, `fi`, `nb`, `ru`)          |
+///   | 9. Ports heading `maxLines: 1`                 | Ports tab shredded text (6 — `da`, `pl`, `pt`, `pt-PT`, `ru`, `sv`, the locales whose heading wraps) |
+///   | 10. the mapping on a full-width line of its own | 29: `pumpAt` overflow @min in all 26 locales (+11px to +36px bottom) and @preferred in one, chart suppression @min (2) — the +20px a rule costs is what AC 4 forbids |
+///   | 11. 10, plus the DMZ list dropped, plus `MapsToRow`'s source given its intrinsic width instead of half the row | mapping target ratchet (1), and nothing else — the combination that would let this card show a target whole, measured clean |
 ///
-/// Five of those seven leave the #1183 gate green while the card loses a chart
-/// (2, 3, 4), draws a donut 40px wider than its box (5), or clips five locales'
-/// labels mid-glyph (7) — clipping and absence are not overflow. Only 1 and 6
-/// report an overflow, and 1 is simply the pre-#1230 card.
+/// Seven of those eleven leave the #1183 gate green while the card loses a chart
+/// (3, 4), asks for a 160px donut in a 157.4px slot (5), prints a clipped slice
+/// label into a 20px ring (6), or clips text mid-glyph (8, 9) — clipping and
+/// absence are not overflow. Only 1, 7 and 10 report an overflow, and 1 is simply
+/// the pre-#1230 card.
 ///
 /// Overflow itself is the gate's job — both `firewall_overview` keys are gone
 /// from `known_overflows.json` — with one exception, in `pumpAt`: the gate pumps
@@ -193,6 +204,80 @@ void main() {
     return tester.getRect(wrap);
   }
 
+  /// Every [Text] in the Ports tab's own content, tab bar and footer excluded.
+  ///
+  /// Anchored on a `MapsToRow` and walked up to the innermost enclosing [Column],
+  /// which is the tab's root: taking the whole card instead would measure the tab
+  /// labels and the detail link, which the template owns and which every card
+  /// shares — a failure there is not this card's to fix.
+  Finder portsTabTexts() => find.descendant(
+        of: find
+            .ancestor(
+                of: find.byType(MapsToRow).first, matching: find.byType(Column))
+            .first,
+        matching: find.byType(Text),
+      );
+
+  /// The two halves of every mapping row, in tree order: `source -> target`.
+  ///
+  /// `MapsToRow` renders exactly two [Text]s and the count is asserted here, so a
+  /// third one appearing inside it cannot quietly be read as a target.
+  ({List<Text> sources, List<Text> targets}) mappingHalves(
+      WidgetTester tester) {
+    final rows = find.byType(MapsToRow);
+    expect(rows, findsWidgets,
+        reason: 'the Ports tab renders one MapsToRow per port-forwarding rule; '
+            'without any there is nothing here to measure');
+    final sources = <Text>[];
+    final targets = <Text>[];
+    for (var i = 0; i < rows.evaluate().length; i++) {
+      final texts =
+          find.descendant(of: rows.at(i), matching: find.byType(Text));
+      expect(texts, findsNWidgets(2),
+          reason: 'MapsToRow $i must render exactly a source and a target');
+      sources.add(tester.widget<Text>(texts.first));
+      targets.add(tester.widget<Text>(texts.last));
+    }
+    return (sources: sources, targets: targets);
+  }
+
+  /// The card's `_kDonutMinRingThickness`, mirrored — it is private to `lib/`.
+  const minRingThicknessPx = 10.0;
+
+  /// What fl_chart was actually handed: the hole and ring radii in logical px,
+  /// and the per-slice titles.
+  ///
+  /// Since ui_kit v2.34.11 both radii are derived from the box inside
+  /// `AppPieChart`, so the card's own arguments no longer describe the drawing:
+  /// reading `AppPieChart.sectionRadius` back would assert only that this file
+  /// agrees with itself. The titles come from here for a related reason —
+  /// `showLabels` becomes `title: ''` on every section and fl_chart paints slice
+  /// labels onto its canvas rather than as [Text] widgets, so nothing in the
+  /// widget tree can see them.
+  ///
+  /// fl_chart is ui_kit's dependency and not this app's, so its types are reached
+  /// dynamically rather than imported — the price of measuring the drawing instead
+  /// of the request.
+  ({double hole, double ring, List<String> titles}) drawnDonut(
+      WidgetTester tester) {
+    final pie = find.byWidgetPredicate(
+        (w) => w.runtimeType.toString() == 'PieChart',
+        description: 'fl_chart PieChart');
+    expect(pie, findsOneWidget,
+        reason: 'AppPieChart draws through exactly one fl_chart PieChart; '
+            'without it there is nothing here to measure');
+    final dynamic data = (tester.widget(pie) as dynamic).data;
+    final sections = data.sections as List;
+    final rings =
+        sections.map<double>((s) => (s as dynamic).radius as double).toList();
+    return (
+      hole: data.centerSpaceRadius as double,
+      ring: rings.reduce(math.max),
+      titles:
+          sections.map<String>((s) => (s as dynamic).title as String).toList(),
+    );
+  }
+
   group('the rule metrics stack where three across cannot read (#1230)', () {
     for (final wc in narrowCases) {
       testWidgets('@${wc.label} ${wc.widthKey}px the three metrics stack',
@@ -314,6 +399,148 @@ void main() {
           }
         }
       });
+    }
+  });
+
+  group('no Ports tab text is shredded at the narrowest width (#1230)', () {
+    // AC 5 is about the card, and the card has two tabs. The sweep above covers
+    // the Rules tab because that is where the 15 card-own coordinates were; this
+    // one covers the other half of the same claim, where the gate again says
+    // nothing — the Ports tab's rows fit at 191px, and fitting is not reading.
+    //
+    // Everything the tab renders except the mapping target: the heading and the
+    // DMZ target line are localized, and the port numbers and protocol badges are
+    // not but a clipped port number is as unreadable as a clipped word. The one
+    // thing *allowed* to wrap is the heading — 6 locales do, `pt_PT` wanting
+    // 230.1px of a 157.4px row — so the same two-line budget as the metrics
+    // applies.
+    //
+    // The mapping *target* is excluded, and not because it passes: at 191px it
+    // gets 36.9-38.5px for 82.3-103.7px of text and is ellipsized in every locale.
+    // That belongs to the test below it rather than here, for two reasons. It is
+    // an IP and a port, byte-identical in all 26 locales, so a localization sweep
+    // is the wrong instrument — one measurement proves as much as 26. And the
+    // ellipsis is `MapsToRow`'s documented contract ("[target] is the part that
+    // ellipsizes, since the source is short and bounded while the target is not"),
+    // shared with seven other call sites; asserting it whole here would fail this
+    // card for a decision taken in `row_blocks.dart`.
+    const maxLines = 2;
+
+    for (final locale in AppLocalizations.supportedLocales) {
+      final tag = locale.toLanguageTag();
+      testWidgets('@${narrowest.widthKey}px $tag renders every row whole',
+          (tester) async {
+        await pumpAt(tester,
+            widthCase: narrowest, rows: minRows, tabIndex: 1, locale: locale);
+
+        final targets = mappingHalves(tester).targets;
+        final texts = portsTabTexts();
+        expect(texts, findsWidgets,
+            reason: 'the Ports tab rendered no text at all — the fixture must '
+                'carry port-forwarding rules for this to measure anything');
+
+        for (var i = 0; i < texts.evaluate().length; i++) {
+          final widget = tester.widget<Text>(texts.at(i));
+          if (targets.any((t) => identical(t, widget))) continue;
+          final content = widget.data ?? '';
+          if (content.isEmpty) continue;
+          final paragraph = tester.renderObject<RenderParagraph>(texts.at(i));
+          final room = paragraph.size.width;
+
+          final wanted = TextPainter(
+            text: TextSpan(text: content, style: paragraph.text.style),
+            textDirection: paragraph.textDirection,
+            textScaler: paragraph.textScaler,
+            locale: locale,
+          )..layout(maxWidth: room);
+          final lines = wanted.computeLineMetrics().length;
+          wanted.dispose();
+
+          expect(
+            lines,
+            lessThanOrEqualTo(maxLines),
+            reason: '"$content" needs $lines lines in the '
+                '${room.toStringAsFixed(1)}px it is given on the Ports tab at '
+                '${narrowest.widthKey}px. Beyond $maxLines the row is a column '
+                'of fragments (#1230).',
+          );
+          expect(
+            paragraph.didExceedMaxLines,
+            isFalse,
+            reason: '"$content" is ellipsized on the Ports tab at '
+                '${narrowest.widthKey}px (${room.toStringAsFixed(1)}px of room, '
+                '$lines lines wanted) — clipped, which the gate cannot see '
+                '(#1230).',
+          );
+        }
+      });
+    }
+  });
+
+  testWidgets(
+      '@${narrowest.widthKey}px the mapping target is the one thing the row '
+      'cannot show whole (#1230)', (tester) async {
+    // The measurement the sweep above deliberately does not make, kept as a
+    // ratchet rather than left to a comment. `en` alone: the strings are IPs and
+    // ports, identical in every locale.
+    //
+    // The cause is not this card's leading. `MapsToRow` gives its two halves a
+    // `Flexible` each and `RenderFlex` splits the room **evenly** between equal
+    // flexes without handing back what the shorter one declines — measured: the
+    // source takes its 30.7px and the target still gets exactly half, 38.5px of
+    // the 77px the pair has. So the target's ceiling is half the row, whatever
+    // else the row spends, and "192.168.1.105:27015" wants 103.7px: reading it
+    // whole needs 227.4px of mapping, more than the whole 191px card. Measured
+    // against the two card-side fixes and neither is enough on its own — the
+    // mapping on a full-width line of its own still leaves the target 68.7px
+    // (half of 137.4), and it costs 20px a rule, which overflows the 3-row
+    // minimum this ticket may not raise (AC 4) by +11px to +36px unless the DMZ
+    // list goes too.
+    //
+    // That makes it a `row_blocks.dart` decision, not a #1230 one, and it
+    // contradicts `MapsToRow`'s own docstring: "[target] is the part that
+    // ellipsizes, since the source is short and bounded while the target is not"
+    // describes a layout that gives the bounded half its intrinsic width, not
+    // half the row. Seven other call sites share it. This expectation is what
+    // stops the limitation from being forgotten; the header table records the
+    // combination that clears it.
+    //
+    // Both halves are asserted, in opposite directions. The source is the rule's
+    // identity — which external port this row is about — and must survive; if it
+    // ever ellipsizes the row has stopped saying anything at all.
+    await pumpAt(tester,
+        widthCase: narrowest,
+        rows: minRows,
+        tabIndex: 1,
+        locale: const Locale('en'));
+
+    final rows = find.byType(MapsToRow);
+    final halves = mappingHalves(tester);
+
+    for (var i = 0; i < halves.sources.length; i++) {
+      final texts =
+          find.descendant(of: rows.at(i), matching: find.byType(Text));
+      final source = tester.renderObject<RenderParagraph>(texts.first);
+      expect(
+        source.didExceedMaxLines,
+        isFalse,
+        reason:
+            '"${halves.sources[i].data}" — the external port of rule $i — is '
+            'ellipsized at ${narrowest.widthKey}px. It is 28.7-33.3px of text: '
+            'if the leading dot and badge have grown enough to clip it, the row '
+            'no longer identifies its rule (#1230).',
+      );
+
+      final target = tester.renderObject<RenderParagraph>(texts.last);
+      expect(
+        target.didExceedMaxLines,
+        isTrue,
+        reason: '"${halves.targets[i].data}" now renders whole at '
+            '${narrowest.widthKey}px — the known limitation this expectation '
+            'records is fixed. Delete this test and drop the mapping-target '
+            'exclusion from the sweep above, which then covers it in all 26 '
+            'locales (#1230).',
+      );
     }
   });
 
@@ -447,11 +674,15 @@ void main() {
 
   group('the donut is never drawn larger than the box it was given (#1230)',
       () {
-    // ui_kit takes the section radius from the call site and the centre-hole
-    // radius from the theme, so the drawn diameter is `2 × (centre + ring)` and
-    // ignores `size`. The default 40px ring against this theme's 60px centre
-    // draws 200px into a 160px box — clipped on every side, and clipping is not
-    // overflow, so the gate reports nothing.
+    // Measured on what fl_chart was handed, not on what this card passed in.
+    // ui_kit ≤ v2.34.10 took the ring from the call site and the hole from the
+    // theme, so the drawn diameter was `2 × (centre + ring)` and ignored `size` —
+    // the default 40px ring against a 60px hole drew 200px into a 160px box,
+    // clipped on every side, and clipping is not overflow so the gate reported
+    // nothing. v2.34.11 derives both radii from the box
+    // (linksys/privacyGUI-UI-kit#22), which is why the `sectionRadius` this card
+    // used to compute is gone — and why reading the card's own inputs back would
+    // now assert nothing about what is painted.
     for (final wc in [...narrowCases, desktopCase]) {
       testWidgets('@${wc.label} ${wc.widthKey}px the ring fits the box',
           (tester) async {
@@ -462,24 +693,75 @@ void main() {
             locale: const Locale('ru'));
 
         final finder = find.byType(AppPieChart);
-        final chart = tester.widget<AppPieChart>(finder);
         final box = tester.getRect(finder);
-        final centreRadius = AppDesignTheme.of(tester.element(finder))
-            .chartStyle
-            .pieCenterRadius;
-        final sectionRadius = chart.sectionRadius;
-        expect(sectionRadius, isNotNull,
-            reason: 'the ring thickness must be sized from the slot, not left '
-                'to ui_kit\'s default, or the drawn donut ignores its box');
+        final slot = tester.getRect(
+            find.ancestor(of: finder, matching: find.byType(Center)).first);
+        final geometry = drawnDonut(tester);
+        final drawn = 2 * (geometry.hole + geometry.ring);
 
-        final drawn = 2 * (centreRadius + sectionRadius!);
+        expect(
+          math.max(box.width, box.height),
+          lessThanOrEqualTo(math.min(slot.width, slot.height) + 0.01),
+          reason: 'the donut asked for a '
+              '${box.width.toStringAsFixed(1)}x${box.height.toStringAsFixed(1)} '
+              'box inside a '
+              '${slot.width.toStringAsFixed(1)}x${slot.height.toStringAsFixed(1)} '
+              'slot — the size must come from the slot, not from the theme '
+              '(#1230)',
+        );
         expect(
           drawn,
           lessThanOrEqualTo(math.min(box.width, box.height) + 0.01),
-          reason: 'the donut draws ${drawn.toStringAsFixed(1)}px into a '
+          reason: 'the donut draws ${drawn.toStringAsFixed(1)}px '
+              '(${geometry.hole.toStringAsFixed(1)}px hole + '
+              '${geometry.ring.toStringAsFixed(1)}px ring) into a '
               '${box.width.toStringAsFixed(1)}x${box.height.toStringAsFixed(1)} '
               'box, so the ring is clipped (#1230)',
         );
+        expect(
+          geometry.ring,
+          greaterThanOrEqualTo(minRingThicknessPx - 0.01),
+          reason: 'the ring is ${geometry.ring.toStringAsFixed(1)}px thick, '
+              'below the ${minRingThicknessPx.toStringAsFixed(0)}px the card '
+              'draws a donut for at all — at this thickness it reads as an '
+              'outline and should have been suppressed instead (#1230)',
+        );
+
+        expect(
+          geometry.titles,
+          everyElement(isEmpty),
+          reason: 'a slice label is painted inside the ring, which at '
+              '${geometry.ring.toStringAsFixed(1)}px would be a clipped '
+              'duplicate of the legend below — `showLabels: false` is what '
+              'suppresses it, and fl_chart paints these onto its canvas rather '
+              'than as widgets, so the tree cannot see them (#1230)',
+        );
+
+        // v2.34.11 shrinks the *hole* when the box cannot hold the themed
+        // radius, so the caption is no longer guaranteed the 60px it is sized
+        // against — ui_kit says as much on `centerWidget`. The caption is the
+        // only text inside the chart, so its two [Text]s are the whole of what
+        // must fit in the hole.
+        final texts = find.descendant(of: finder, matching: find.byType(Text));
+        expect(texts, findsNWidgets(2),
+            reason: 'the only text inside the donut is its own caption — a '
+                'count and the word for it. ${texts.evaluate().length} found, '
+                'so the caption has changed and the radius measured below is no '
+                'longer the one that matters (#1230)');
+        var caption = tester.getRect(texts.at(0));
+        for (var i = 1; i < texts.evaluate().length; i++) {
+          caption = caption.expandToInclude(tester.getRect(texts.at(i)));
+        }
+        final halfDiagonal = math.sqrt(
+            math.pow(caption.width / 2, 2) + math.pow(caption.height / 2, 2));
+        expect(
+          halfDiagonal,
+          lessThanOrEqualTo(geometry.hole + 0.01),
+          reason: 'the caption needs a ${halfDiagonal.toStringAsFixed(1)}px '
+              'radius and the hole is ${geometry.hole.toStringAsFixed(1)}px, so '
+              'it spills onto the ring it is centred in (#1230)',
+        );
+
         expect(box.bottom, lessThanOrEqualTo(contentBottom(tester) + 0.01),
             reason: 'the donut must sit above the footer rule');
       });

--- a/test/page/dashboard/views/components/firewall_overview_readability_test.dart
+++ b/test/page/dashboard/views/components/firewall_overview_readability_test.dart
@@ -278,6 +278,125 @@ void main() {
     );
   }
 
+  testWidgets('the fonts these measurements were taken in are the app\'s own',
+      (tester) async {
+    // Every claim in this file is a claim about pixels, so every one of them
+    // rests on the card having been laid out in the fonts it ships with. Two
+    // things can take that away, and neither shows up as a failure anywhere
+    // else — the suite would stay green while measuring a different typeface.
+    //
+    //   - The font *file* is gone: a ui_kit ref bump moves the pub-cache path,
+    //     or an `.otf` gets renamed. `loadAppFonts` throws on that, which is the
+    //     right place for it — one check protects every caller — and it is not
+    //     catchable from here, because `FontLoader` registers the family even
+    //     with no bytes in it, after which the engine serves its own block font.
+    //   - The *family name* no longer matches: the file loads under a name
+    //     nothing asks for, the style's family is unresolvable, and the engine
+    //     substitutes silently. That is this test.
+    //
+    // Two measurements, because the substitution has two shapes. Both were taken
+    // by renaming `loadAppFonts`'s registration to
+    // `NeueHaasGrotTextRoundRENAMED` and reading what the card then measured:
+    //
+    //   - Nothing to substitute — none of this card's styles carries a
+    //     `fontFamilyFallback` — so the block font is what gets served, at one em
+    //     per glyph: `192.168.1.101:80` went from 83.3px to exactly 192.0px
+    //     (12.0 x 16 characters). Across the whole Ports tab the mutation
+    //     measured 1.000-1.045 em per glyph, so the assertion is a ratio rather
+    //     than an exact signature — the real font is at 0.43 em, nowhere near.
+    //   - Something to substitute — `lib/app.dart` does hand the text theme a CJK
+    //     `fontFamilyFallback`, and if it reaches these styles the same rename
+    //     lands on Noto instead, which measures like any proportional font and
+    //     would slip past a ratio check. So the width is also required to differ
+    //     from what Noto measures the same string at (95.2px against NeueHaas's
+    //     83.3px — both real fonts, ~14% apart, and only one of them the app's).
+    //
+    // `en`, and the mapping target specifically, because it is pure ASCII: for
+    // Cyrillic, Arabic, Thai and CJK the app falls back to Noto *by design*, and
+    // one em per ideograph is what CJK legitimately measures — both assertions
+    // would be backwards there.
+    //
+    // Pumped through the probe rather than `pumpAt`, dropping the overflow
+    // incidents: a wrong typeface reflows the card, so `pumpAt` would fail on the
+    // overflow before reaching the identification, which is the one failure that
+    // says *why*. Overflow at this coordinate is asserted below, so ignoring it
+    // here loses nothing.
+    await probeCardOverflow(
+      tester,
+      cardId: cardId,
+      widthCase: narrowest,
+      cardHeightRows: minRows,
+      tabIndex: 1,
+      locale: const Locale('en'),
+    );
+
+    final target = find
+        .descendant(
+            of: find.byType(MapsToRow).first, matching: find.byType(Text))
+        .last;
+    final paragraph = tester.renderObject<RenderParagraph>(target);
+    final content = tester.widget<Text>(target).data ?? '';
+    final style = paragraph.text.style;
+    expect(style?.fontSize, isNotNull,
+        reason: 'the mapping target must carry a resolved style with a font '
+            'size, or there is nothing here to identify');
+
+    double widthUnder(TextStyle textStyle) {
+      final painter = TextPainter(
+        text: TextSpan(text: content, style: textStyle),
+        textDirection: paragraph.textDirection,
+        textScaler: paragraph.textScaler,
+      )..layout();
+      final width = painter.maxIntrinsicWidth;
+      painter.dispose();
+      return width;
+    }
+
+    final measured = widthUnder(style!);
+    // `copyWith` keeps the style's `package` and the `fontFamily` getter
+    // re-composes the prefix, so this asks for whichever of `NotoSans` /
+    // `packages/ui_kit_library/NotoSans` the style's own package implies —
+    // `loadAppFonts` registers both.
+    final noto = widthUnder(
+      style.copyWith(fontFamily: 'NotoSans', fontFamilyFallback: const []),
+    );
+    final oneEm = style.fontSize! * content.length;
+
+    expect(
+      measured,
+      lessThan(oneEm * 0.9),
+      reason: '"$content" measured ${measured.toStringAsFixed(1)}px, which is '
+          '${(measured / oneEm).toStringAsFixed(3)} em per glyph — a block font, '
+          'not a proportional one. The style asks for '
+          '${style.fontFamily} and nothing is registered under that name, so '
+          'every pixel in this file is fiction. `loadAppFonts` throws when a '
+          'font *file* is missing, so what is left is a name mismatch: check '
+          'that ui_kit still calls its family NeueHaasGrotTextRound (#1230).',
+    );
+
+    expect(
+      noto,
+      lessThan(oneEm * 0.9),
+      reason: 'the reference measurement is itself fictional: "$content" under '
+          'NotoSans came out at ${noto.toStringAsFixed(1)}px, '
+          '${(noto / oneEm).toStringAsFixed(3)} em per glyph. The Noto files '
+          'under test/fonts/ did not load, so the check below cannot identify '
+          'anything (#1230).',
+    );
+
+    expect(
+      measured,
+      isNot(closeTo(noto, 0.5)),
+      reason: '"$content" measured ${measured.toStringAsFixed(1)}px, which is '
+          'what NotoSans measures it at — the app\'s own family did not '
+          'resolve and the engine fell back to the CJK fallback chain. It is a '
+          'real font, so the numbers look plausible, but they are the wrong '
+          'typeface: check that ui_kit still calls its family '
+          'NeueHaasGrotTextRound and that `loadAppFonts` registers that name '
+          '(#1230).',
+    );
+  });
+
   group('the rule metrics stack where three across cannot read (#1230)', () {
     for (final wc in narrowCases) {
       testWidgets('@${wc.label} ${wc.widthKey}px the three metrics stack',
@@ -532,6 +651,7 @@ void main() {
       );
 
       final target = tester.renderObject<RenderParagraph>(texts.last);
+
       expect(
         target.didExceedMaxLines,
         isTrue,

--- a/test/page/dashboard/views/components/firewall_overview_readability_test.dart
+++ b/test/page/dashboard/views/components/firewall_overview_readability_test.dart
@@ -336,7 +336,12 @@ void main() {
             reason: 'at the height the dashboard actually gives this card '
                 '($shippedRows rows) the target-distribution donut must be '
                 'drawn — the ring guard is for slots that cannot hold one, not '
-                'for the shipped card (#1230)');
+                'for the shipped card (#1230). `ru` is the locale to assert on: '
+                'measured across all 26, its two-line label makes it the only '
+                'one under 157px here, and the box it gets at the narrowest '
+                'width is 153px against a 140px floor. 13px is the whole '
+                'margin, so anything that grows the metrics or the legend by '
+                'more than that deletes the donut silently');
       });
 
       testWidgets(
@@ -365,9 +370,11 @@ void main() {
             tabIndex: 0,
             locale: const Locale('ru'));
         expect(find.byType(AppPieChart), findsNothing,
-            reason: 'at the declared minimum height the donut slot is 9-25px '
-                'tall, which is a clipped arc and a caption that does not fit — '
-                'so nothing is drawn (#1230)');
+            reason: 'at the declared minimum height the donut slot measures '
+                '17-37px at 191px and 52-57px at 288px across the 26 locales, '
+                'against the 140px this theme needs for a ring at all — a '
+                'clipped arc and a caption that does not fit, so nothing is '
+                'drawn (#1230)');
       });
 
       testWidgets(

--- a/test/page/dashboard/views/components/firewall_overview_readability_test.dart
+++ b/test/page/dashboard/views/components/firewall_overview_readability_test.dart
@@ -1,0 +1,481 @@
+@Tags(['dashboard-card'])
+library;
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
+import 'package:privacy_gui/page/dashboard/models/display_mode.dart';
+import 'package:privacy_gui/page/dashboard/models/usp_widget_specs.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import '../../../../util/app_test_fonts.dart';
+import '../../../../util/dashboard/dashboard_card_probe.dart';
+
+/// Firewall Overview readability (#1230).
+///
+/// ## Why this file exists alongside the #1183 gate
+///
+/// #1230 clears 21 coordinates two ways the gate cannot audit, both of which are
+/// *removals*:
+///
+///   - The three rule metrics stop sitting three across once the card is too
+///     narrow for that, and stack into full-width rows instead. The gate only
+///     knows whether a row fits; three tiles of one character per line fit
+///     perfectly (23.1px of text each at the narrowest realization, `ru` taking
+///     8 lines to render one label).
+///   - The donut and the protocol bar chart are **not drawn at all** when the
+///     slot left for them cannot hold one. Absent content never overflows, so
+///     the gate rewards deleting a chart exactly as much as fixing it — a
+///     threshold accidentally set above the card's shipped height would leave the
+///     gate green and the card empty. Nothing in `known_overflows.json` can
+///     express "the picture is still there at 4 rows".
+///
+/// So each group below asserts on the rendered tree. Each was run against a
+/// mutation of the code it guards, and each fired:
+///
+///   | mutation                                       | what failed                                                  |
+///   |------------------------------------------------|--------------------------------------------------------------|
+///   | `_kMetricsSideBySideMinWidth` 328 → 0 (i.e. the pre-#1230 card) | 33: shredded text (26 — every locale), three across @min and @preferred (2), footer + donut + ring + legend @min (5); 10 of the 33 trip `pumpAt`'s overflow first, by +7px to +26px |
+///   | `_kMetricsSideBySideMinWidth` 328 → 600        | three across @desktop (1)                                    |
+///   | `_kProtocolChartMinHeight` 70 → 200            | chart drawn @shipped height (3)                              |
+///   | `_kDonutMinRingThickness` 10 → 60              | donut drawn @shipped height (3), ring fits its box (3)        |
+///   | `sectionRadius:` → ui_kit's default 40         | ring fits its box (3)                                        |
+///   | `_StackedMetrics` padding `sm` → block default | 12: `pumpAt` overflow @min in 6 locales (+3px `fi` to +7px `ru`, 10 tests), donut starved out even @shipped height (2) |
+///   | stacked label `maxLines` 2 → 1                 | shredded text (5 — `es`, `es-AR`, `fi`, `nb`, `ru`)           |
+///
+/// Five of those seven leave the #1183 gate green while the card loses a chart
+/// (2, 3, 4), draws a donut 40px wider than its box (5), or clips five locales'
+/// labels mid-glyph (7) — clipping and absence are not overflow. Only 1 and 6
+/// report an overflow, and 1 is simply the pre-#1230 card.
+///
+/// Overflow itself is the gate's job — both `firewall_overview` keys are gone
+/// from `known_overflows.json` — with one exception, in `pumpAt`: the gate pumps
+/// `minHeightRows` only, and at that height both #1230 sites are suppressed, so
+/// the height where they actually render would otherwise be measured by nothing.
+///
+/// Tagged `dashboard-card` so it gates PRs: `run_tests.sh` excludes
+/// `golden||loc||ui`, so a `ui`-tagged test here would block nothing.
+void main() {
+  setUpAll(() async {
+    // Real fonts: under the Ahem block font every glyph is one square em, so
+    // what does and does not fit — and therefore what ellipsizes — is fiction.
+    await loadAppFonts();
+  });
+
+  const cardId = 'firewall_overview';
+  final spec = UspWidgetSpecs.all.firstWhere((s) => s.id == cardId);
+  final constraints = spec.getConstraints(DisplayMode.normal);
+
+  /// The height the gate pumps: the card's declared minimum. #1230 keeps this at
+  /// 3 rows rather than raising it (ticket AC 4), so this is the height the
+  /// suppression thresholds actually fire at.
+  final minRows = constraints.minHeightRows;
+
+  /// The height the dashboard actually gives the card — `HeightStrategy.strict(4)`
+  /// — read from the spec so this test follows the card if the strategy changes.
+  final shippedRows = constraints.getPreferredHeightCells();
+
+  /// The width cases the gate measures, narrowest first. Sourced from the same
+  /// helper the gate uses, so this test cannot drift from the enforced widths.
+  final narrowCases = widthCasesFor(spec);
+  final narrowest =
+      narrowCases.reduce((a, b) => a.cardWidth <= b.cardWidth ? a : b);
+
+  /// A mainstream desktop realization — 1440px screen, the card's preferred span.
+  final desktopCase = CardWidthCase(
+    screenWidth: 1440,
+    cardWidth: cardWidthAt(1440, constraints.preferredColumns),
+    columnSpan: constraints.preferredColumns,
+    label: 'desktop',
+  );
+
+  /// The #1183 gate's overflow tolerance, mirrored so the two agree on what
+  /// counts. Sub-pixel shaping differences between local macOS and CI are below
+  /// it; anything above is a real overflow.
+  const gateTolerancePx = 2.0;
+
+  /// Pumps the card once, as the gate does — one pump, real fonts — and fails on
+  /// any overflow the gate would report.
+  ///
+  /// That last part is not redundant with the gate: the gate only ever pumps
+  /// `minHeightRows`, and the shipped height is the only one where the donut's
+  /// caption and fl_chart's axis strip are built at all. Without this, the two
+  /// #1230 sites are overflow-checked only at the height where the content they
+  /// live in is absent.
+  Future<void> pumpAt(
+    WidgetTester tester, {
+    required CardWidthCase widthCase,
+    required int rows,
+    required int tabIndex,
+    required Locale locale,
+  }) async {
+    final incidents = await probeCardOverflow(
+      tester,
+      cardId: cardId,
+      widthCase: widthCase,
+      cardHeightRows: rows,
+      tabIndex: tabIndex,
+      locale: locale,
+    );
+    final significant =
+        incidents.where((i) => i.pixels > gateTolerancePx).toList();
+    expect(
+      significant.map((i) => '+${i.pixels}px ${i.side}').toList(),
+      isEmpty,
+      reason: '$cardId overflowed at ${widthCase.widthKey}px / $rows rows / '
+          'tab $tabIndex / ${locale.toLanguageTag()}. The gate pumps '
+          '$minRows rows only, so at $shippedRows rows this assertion is the '
+          'only thing measuring it (#1230).',
+    );
+  }
+
+  /// The three rule metrics, in order. Both arrangements render each metric as a
+  /// [LayoutBlock] — the stacked rows are blocks, and so is `InfoGrid`'s tile —
+  /// so their rectangles say which arrangement is on screen without either
+  /// private widget having to be reachable from here.
+  List<Rect> metricRects(WidgetTester tester) {
+    final finder = find.byType(LayoutBlock);
+    final rects = [
+      for (var i = 0; i < finder.evaluate().length; i++)
+        tester.getRect(finder.at(i)),
+    ];
+    expect(rects.length, 3,
+        reason: 'expected exactly the three rule metrics (rules, port '
+            'forwarding, DMZ); found ${rects.length}');
+    return rects;
+  }
+
+  /// Bottom edge of the card's content area. The template gives tab content a
+  /// fixed `Expanded` and does **not** scroll it, so content that does not fit
+  /// is laid out over the footer instead of being clipped — visible here, and
+  /// invisible to a width-only measurement.
+  ///
+  /// Measured as the top of the footer's own `Padding`, not the top of its
+  /// divider: the footer holds the rule 12px below where the content ends, and
+  /// borrowing those 12px would hide exactly the amount of growth this is meant
+  /// to catch.
+  double contentBottom(WidgetTester tester) {
+    final divider = find.byType(AppDivider);
+    expect(divider, findsWidgets,
+        reason: 'the detail footer draws an AppDivider above its link; without '
+            'it there is no way to locate the footer from here');
+    final footer =
+        find.ancestor(of: divider.first, matching: find.byType(Padding)).first;
+    return tester.getRect(footer).top;
+  }
+
+  /// Every [Text] under the i-th metric, in tree order: label first, value
+  /// second, in both arrangements.
+  Finder metricTexts(int index) => find.descendant(
+        of: find.byType(LayoutBlock).at(index),
+        matching: find.byType(Text),
+      );
+
+  /// The legend's `target: count` entries.
+  Finder legendEntries() =>
+      find.byWidgetPredicate((w) => w is Text && (w.data ?? '').contains(':'),
+          description: 'legend entry');
+
+  /// The legend row itself, found through an entry rather than by taking the
+  /// first [Wrap] in the tree — the tab bar is a `Wrap` too, and measuring it
+  /// instead would make every "the legend fits" assertion pass against a row
+  /// that is nowhere near the bottom of the card. `find.ancestor` returns
+  /// ancestors innermost-first, so the first match is the legend's own `Wrap`.
+  Rect legendRect(WidgetTester tester) {
+    final entries = legendEntries();
+    expect(entries, findsWidgets, reason: 'the legend rendered no entries');
+    final wrap =
+        find.ancestor(of: entries.first, matching: find.byType(Wrap)).first;
+    return tester.getRect(wrap);
+  }
+
+  group('the rule metrics stack where three across cannot read (#1230)', () {
+    for (final wc in narrowCases) {
+      testWidgets('@${wc.label} ${wc.widthKey}px the three metrics stack',
+          (tester) async {
+        await pumpAt(tester,
+            widthCase: wc,
+            rows: minRows,
+            tabIndex: 0,
+            locale: const Locale('ru'));
+
+        final metrics = metricRects(tester);
+        for (var i = 1; i < metrics.length; i++) {
+          expect(
+            metrics[i].top,
+            greaterThanOrEqualTo(metrics[i - 1].bottom),
+            reason: 'at ${wc.widthKey}px three across leaves each label 23.1px '
+                'of text — one character per line. Metric $i must start below '
+                'metric ${i - 1}, not beside it (#1230).',
+          );
+        }
+        for (final m in metrics) {
+          expect(m.width, closeTo(metrics.first.width, 0.01),
+              reason: 'stacked metrics each take the full content width');
+        }
+      });
+    }
+  });
+
+  group('three across survives where it fits (#1230)', () {
+    // Stacking is a narrow-width degradation, not a redesign: the designed grid
+    // is what a mainstream desktop card still shows. A threshold raised past the
+    // desktop realization would fail here.
+    testWidgets('@desktop ${desktopCase.widthKey}px the metrics share a row',
+        (tester) async {
+      await pumpAt(tester,
+          widthCase: desktopCase,
+          rows: shippedRows,
+          tabIndex: 0,
+          locale: const Locale('ru'));
+
+      final metrics = metricRects(tester);
+      for (var i = 1; i < metrics.length; i++) {
+        expect(metrics[i].top, closeTo(metrics.first.top, 0.01),
+            reason: 'at ${desktopCase.widthKey}px all three metrics must still '
+                'sit on one row');
+        expect(metrics[i].left, greaterThan(metrics[i - 1].right),
+            reason: 'metric $i must start after metric ${i - 1} ends');
+      }
+    });
+  });
+
+  group('no metric text is shredded at the narrowest width (#1230)', () {
+    // The AC that the gate cannot express: "legible at 191px, not merely
+    // overflow-free — no one-character-per-line label stacks, no clipped
+    // mid-glyph text". Every shipped locale, because this is a claim about
+    // localized strings and a sample would only prove it for the samples —
+    // measured at the narrowest realization alone, since the budget grows with
+    // the card and a wider case cannot fail where this one passes.
+    //
+    // Two independent failures, so two assertions:
+    //
+    //   - **Line count.** Re-laid out with a `TextPainter` at exactly the room
+    //     the widget got, with no line cap, so it reports the lines the text
+    //     *wants* rather than the lines it was allowed. This is what catches the
+    //     unreadable case: three across gives each label 23.1px, which is one
+    //     character per line — `ru` wants 8 lines — while `InfoGrid`'s tile sets
+    //     no `maxLines` at all, so nothing is formally truncated and every
+    //     ellipsis-based check passes. Stacked, the budget is 111.4-127.6px
+    //     against a widest label of 143.2px (`ru`), so the worst case is a
+    //     second line.
+    //   - **Ellipsis.** The stacked row caps the label at two lines, which is
+    //     only safe while two lines are enough; capping it at one would clip
+    //     `ru`/`fi`/`nb`/`es` mid-glyph, and a clip is not an overflow.
+    const maxLabelLines = 2;
+
+    for (final locale in AppLocalizations.supportedLocales) {
+      final tag = locale.toLanguageTag();
+      testWidgets('@${narrowest.widthKey}px $tag renders label and value whole',
+          (tester) async {
+        await pumpAt(tester,
+            widthCase: narrowest, rows: minRows, tabIndex: 0, locale: locale);
+
+        for (var i = 0; i < 3; i++) {
+          final texts = metricTexts(i);
+          expect(texts, findsNWidgets(2),
+              reason: 'metric $i must render exactly a label and a value');
+          for (var t = 0; t < 2; t++) {
+            final paragraph = tester.renderObject<RenderParagraph>(texts.at(t));
+            final content = tester.widget<Text>(texts.at(t)).data ?? '';
+            final room = paragraph.size.width;
+
+            final wanted = TextPainter(
+              text: TextSpan(text: content, style: paragraph.text.style),
+              textDirection: paragraph.textDirection,
+              textScaler: paragraph.textScaler,
+              locale: locale,
+            )..layout(maxWidth: room);
+            final lines = wanted.computeLineMetrics().length;
+            wanted.dispose();
+
+            expect(
+              lines,
+              lessThanOrEqualTo(maxLabelLines),
+              reason: '"$content" needs $lines lines in the '
+                  '${room.toStringAsFixed(1)}px it is given at '
+                  '${narrowest.widthKey}px. Beyond $maxLabelLines the text is a '
+                  'column of fragments, not a label — at this width the metrics '
+                  'must be stacked, which gives every shipped locale a budget '
+                  'it can wrap into (#1230).',
+            );
+            expect(
+              paragraph.didExceedMaxLines,
+              isFalse,
+              reason: '"$content" is ellipsized at ${narrowest.widthKey}px '
+                  '(${room.toStringAsFixed(1)}px of room, $lines lines wanted). '
+                  'Stacked labels must be allowed the lines they need rather '
+                  'than clipped mid-glyph (#1230).',
+            );
+          }
+        }
+      });
+    }
+  });
+
+  group('the height guards give the picture back at the shipped height (#1230)',
+      () {
+    // Suppressing a chart is how #1230 clears both the donut's overflow and
+    // fl_chart's bottom-axis strip, and suppression is exactly what the gate
+    // cannot see: an absent chart overflows nothing. These are the assertions
+    // that stop the fix from degenerating into "delete the charts".
+    for (final wc in [...narrowCases, desktopCase]) {
+      testWidgets(
+          '@${wc.label} ${wc.widthKey}px $shippedRows rows draws the '
+          'donut and the bar chart', (tester) async {
+        await pumpAt(tester,
+            widthCase: wc,
+            rows: shippedRows,
+            tabIndex: 0,
+            locale: const Locale('ru'));
+        expect(find.byType(AppPieChart), findsOneWidget,
+            reason: 'at the height the dashboard actually gives this card '
+                '($shippedRows rows) the target-distribution donut must be '
+                'drawn — the ring guard is for slots that cannot hold one, not '
+                'for the shipped card (#1230)');
+      });
+
+      testWidgets(
+          '@${wc.label} ${wc.widthKey}px $shippedRows rows draws the '
+          'protocol chart', (tester) async {
+        await pumpAt(tester,
+            widthCase: wc,
+            rows: shippedRows,
+            tabIndex: 1,
+            locale: const Locale('ru'));
+        expect(find.byType(AppBarChart), findsOneWidget,
+            reason: 'at $shippedRows rows the Ports tab must still draw its '
+                'protocol distribution chart; the height guard exists only to '
+                'keep fl_chart from painting a 22px axis strip into a 12px slot '
+                '(#1230)');
+      });
+    }
+
+    for (final wc in narrowCases) {
+      testWidgets(
+          '@${wc.label} ${wc.widthKey}px $minRows rows suppresses the donut',
+          (tester) async {
+        await pumpAt(tester,
+            widthCase: wc,
+            rows: minRows,
+            tabIndex: 0,
+            locale: const Locale('ru'));
+        expect(find.byType(AppPieChart), findsNothing,
+            reason: 'at the declared minimum height the donut slot is 9-25px '
+                'tall, which is a clipped arc and a caption that does not fit — '
+                'so nothing is drawn (#1230)');
+      });
+
+      testWidgets(
+          '@${wc.label} ${wc.widthKey}px $minRows rows suppresses the chart',
+          (tester) async {
+        await pumpAt(tester,
+            widthCase: wc,
+            rows: minRows,
+            tabIndex: 1,
+            locale: const Locale('ru'));
+        expect(find.byType(AppBarChart), findsNothing,
+            reason: 'at the declared minimum height the chart slot is 12-37px, '
+                'below the 22px fl_chart spends on the bottom axis alone '
+                '(#1230)');
+      });
+    }
+  });
+
+  group('the legend carries every target while the donut is suppressed (#1230)',
+      () {
+    // The donut may be absent; the information may not. This is the claim that
+    // makes suppression an acceptable degradation rather than a data loss.
+    for (final wc in narrowCases) {
+      testWidgets('@${wc.label} ${wc.widthKey}px every target is still named',
+          (tester) async {
+        await pumpAt(tester,
+            widthCase: wc,
+            rows: minRows,
+            tabIndex: 0,
+            locale: const Locale('ru'));
+
+        // Three targets in the kitchen-sink fixture (Drop 3, Accept 1,
+        // Reject 1), each rendered as `TARGET: count` in the legend.
+        expect(legendEntries(), findsNWidgets(3),
+            reason: 'with the donut suppressed the legend is the only thing '
+                'left naming each rule target and its count (#1230)');
+      });
+    }
+  });
+
+  group('the content clears the footer at the minimum height (#1230)', () {
+    // The stacked rows tighten their padding to 8px rather than take the block
+    // default, and this is where that stops being a preference: at the card's
+    // declared minimum height the Rules tab is *exactly* full — the legend's
+    // bottom edge is the content's bottom edge to the pixel (318.0 in `fi`).
+    // Restoring the default padding grows the three rows by 24px and pushes the
+    // legend 3px past the footer, which the template neither scrolls nor clips.
+    for (final wc in narrowCases) {
+      testWidgets('@${wc.label} ${wc.widthKey}px the metrics and legend fit',
+          (tester) async {
+        await pumpAt(tester,
+            widthCase: wc,
+            rows: minRows,
+            tabIndex: 0,
+            locale: const Locale('fi'));
+
+        final bottom = contentBottom(tester);
+        expect(metricRects(tester).last.bottom, lessThanOrEqualTo(bottom),
+            reason: 'the third metric row runs past the footer rule at '
+                '$bottom; the stacked rows must fit the height the card gives '
+                'its content (#1230)');
+        expect(legendRect(tester).bottom, lessThanOrEqualTo(bottom),
+            reason:
+                'the legend runs past the footer rule at $bottom — with the '
+                'donut suppressed it is the only thing naming each target, so '
+                'it is the one row that must not be pushed off (#1230)');
+      });
+    }
+  });
+
+  group('the donut is never drawn larger than the box it was given (#1230)',
+      () {
+    // ui_kit takes the section radius from the call site and the centre-hole
+    // radius from the theme, so the drawn diameter is `2 × (centre + ring)` and
+    // ignores `size`. The default 40px ring against this theme's 60px centre
+    // draws 200px into a 160px box — clipped on every side, and clipping is not
+    // overflow, so the gate reports nothing.
+    for (final wc in [...narrowCases, desktopCase]) {
+      testWidgets('@${wc.label} ${wc.widthKey}px the ring fits the box',
+          (tester) async {
+        await pumpAt(tester,
+            widthCase: wc,
+            rows: shippedRows,
+            tabIndex: 0,
+            locale: const Locale('ru'));
+
+        final finder = find.byType(AppPieChart);
+        final chart = tester.widget<AppPieChart>(finder);
+        final box = tester.getRect(finder);
+        final centreRadius = AppDesignTheme.of(tester.element(finder))
+            .chartStyle
+            .pieCenterRadius;
+        final sectionRadius = chart.sectionRadius;
+        expect(sectionRadius, isNotNull,
+            reason: 'the ring thickness must be sized from the slot, not left '
+                'to ui_kit\'s default, or the drawn donut ignores its box');
+
+        final drawn = 2 * (centreRadius + sectionRadius!);
+        expect(
+          drawn,
+          lessThanOrEqualTo(math.min(box.width, box.height) + 0.01),
+          reason: 'the donut draws ${drawn.toStringAsFixed(1)}px into a '
+              '${box.width.toStringAsFixed(1)}x${box.height.toStringAsFixed(1)} '
+              'box, so the ring is clipped (#1230)',
+        );
+        expect(box.bottom, lessThanOrEqualTo(contentBottom(tester) + 0.01),
+            reason: 'the donut must sit above the footer rule');
+      });
+    }
+  });
+}

--- a/test/util/app_test_fonts.dart
+++ b/test/util/app_test_fonts.dart
@@ -19,10 +19,22 @@ import 'package:flutter_test/flutter_test.dart';
 ///   than the golden-tagged set) can't inherit it. Extracting the logic here
 ///   lets both callers share one implementation — call it from `setUpAll`.
 ///
-/// Idempotent-ish: safe to call once per test file in `setUpAll`. Missing font
-/// files are skipped silently (CI without the ui_kit checkout still runs, just
-/// with fewer fallbacks) — the primary NeueHaas + NotoSans covers Latin scripts,
-/// which is what the long-word overflow locales (de/fi/ru/fr) need.
+/// Idempotent-ish: safe to call once per test file in `setUpAll`.
+///
+/// A MISSING TEXT FONT THROWS, IT IS NOT SKIPPED
+///   This used to skip missing files silently so that "CI without the ui_kit
+///   checkout" could still run. That is not a state worth running in: it is the
+///   state where every pixel measurement is quietly Ahem's, and a suite that
+///   passes there passes for the wrong reason. Nor is it a real condition —
+///   `ui_kit_library` is a pub dependency, present after `flutter pub get`, and
+///   the five Noto files are committed under `test/fonts/`. What *is* real is a
+///   ui_kit ref bump moving the pub-cache path (resolved here from
+///   `package_config.json`) or renaming an `.otf`, which is exactly the failure
+///   that must be loud.
+///
+///   The icon fonts stay tolerant: glyph advances in an icon font are one em by
+///   definition and Flutter sizes icons from the widget, so a missing icon font
+///   costs a tofu box, not a wrong measurement.
 import 'package:privacy_gui/localization/fallback_font_resolver.dart';
 
 Future<void> loadAppFonts() async {
@@ -30,6 +42,9 @@ Future<void> loadAppFonts() async {
   FallbackFontResolver.install();
 
   final uiKitRoot = _resolveUiKitPath();
+
+  /// Text fonts whose absence would silently turn every measurement into Ahem's.
+  final missing = <String>[];
 
   // Primary font, shipped inside the ui_kit_library package.
   final mainFont = FontLoader('packages/ui_kit_library/NeueHaasGrotTextRound');
@@ -43,7 +58,11 @@ Future<void> loadAppFonts() async {
     if (boldFile.existsSync()) {
       mainFont.addFont(
           Future.value(ByteData.view(boldFile.readAsBytesSync().buffer)));
+    } else {
+      missing.add(boldFile.path);
     }
+  } else {
+    missing.add(mainFontFile.path);
   }
   await mainFont.load();
 
@@ -69,6 +88,12 @@ Future<void> loadAppFonts() async {
   }
 
   // CJK / Arabic / Thai / Russian fallbacks mapping.
+  //
+  // NotoSansTC/JP/HK all point at the SC file. Measured, that substitution is
+  // metric-neutral for these scripts — one CJK string came out at 177.6px under
+  // SC, TC and KR alike, because the advance is one em per ideograph in all of
+  // them — so it changes no measurement; it only avoids committing three more
+  // multi-megabyte files.
   final fontMap = <String, String>{
     'NotoSans': 'test/fonts/NotoSans-Regular.ttf',
     'NotoSansLatinExt': 'test/fonts/NotoSans-Regular.ttf',
@@ -83,7 +108,10 @@ Future<void> loadAppFonts() async {
 
   for (final entry in fontMap.entries) {
     final file = File(entry.value);
-    if (!file.existsSync()) continue;
+    if (!file.existsSync()) {
+      missing.add(file.path);
+      continue;
+    }
     final bytes = file.readAsBytesSync();
 
     final loaderPkg = FontLoader('packages/ui_kit_library/${entry.key}');
@@ -107,6 +135,19 @@ Future<void> loadAppFonts() async {
       }
     }
     await fallbackLoader.load();
+  }
+
+  if (missing.isNotEmpty) {
+    throw StateError(
+      'loadAppFonts() could not find ${missing.length} text font file(s):\n'
+      '  ${missing.join('\n  ')}\n'
+      'Without them the test engine substitutes its own block font — every '
+      'glyph one em wide — so any test that measures text passes or fails on '
+      'fictional metrics. Fix the paths rather than tolerating this: the ui_kit '
+      'fonts live in the pub-cache checkout resolved from '
+      '.dart_tool/package_config.json (a ref bump moves it, so run '
+      '"flutter pub get"), and the Noto files are committed under test/fonts/.',
+    );
   }
 }
 


### PR DESCRIPTION
Closes #1230. Part of #1183 (T11). Also bumps `ui_kit_library`/`generative_ui` **v2.34.5 → v2.34.11**, which fixes the `AppPieChart` bug this PR found upstream (privacyGUI-UI-kit#22) and lets the card-side workaround be deleted.

`firewall_overview` held 21 of the epic's coordinates: 15 card-own (`min|0`, 15 of 26 locales) and 6 fl_chart (`min|1`). All 21 are now fixed at the source and **both `firewall_overview` keys are deleted from `known_overflows.json`** — nothing is re-allowlisted. `minHeightRows` stays at 3 (AC 4), fl_chart is untouched (AC 6).

## What actually overflowed

At the narrowest realization the grid ever yields — a 191.375px card, **157.4px** of tab content in a **205px** viewport — `InfoGrid(crossAxisCount: 3)` gave each rule metric a 47.1px tile with **23.1px** of text. That is one character per line: `ru` took 8 lines to render one label, `es` 5. The grid stood 108px tall in `en` and up to **173px** in `ru`, against a viewport that also owes 20px to two gaps and 36px to the legend.

Which site reported depended on how tall the grid grew, and the two are mutually exclusive because `RenderFlex` skips an empty box:

- 8 locales (`ar el fr fr_CA pt pt_PT tr vi`) reported at the donut's `centerWidget`: the caption is 40px, the slot was 20-25px, overflow exactly `40 − slot` (+15px to +21px).
- 7 locales (`es es_AR fi id nb pl ru`) starved that slot to 0px, so the outer `Column` reported instead (+7px to +26px).

15 locales, 15 coordinates. On the Ports tab, `AppBarChart`'s vertical path passes fl_chart's default `reservedSize` for the bottom axis strip — 22px asked for whatever the chart's height is — so its own `Flex` overflowed by `22 − slot`: +5px at 17px slots (`da pl pt pt_PT sv`), +10px at `ru`'s 12px. 6 coordinates.

## The fix

Three call-site constants, all in `lib/page/firewall/cards/usp_firewall_overview_card.dart`:

| constant | value | what it does |
|---|---|---|
| `_kMetricsSideBySideMinWidth` | 328 | below it the three metrics stack into full-width rows instead of sitting three across |
| `_kDonutMinRingThickness` | 10 | the donut sizes its ring from the slot it is given, and draws nothing once that slot cannot hold this much ring |
| `_kProtocolChartMinHeight` | 70 | the protocol chart is not built at all in a slot this short |

**Stacking** (the 15): the same 157px card gives each label 111.4-127.6px on one line plus a second to wrap into, which holds every locale unbroken except `fi` (PALOMUURISÄÄNNÖT, 131.0px) and `nb` (BRANNMURREGLER, 118.6px) — single-word labels that wrap mid-word rather than clip mid-glyph, and no value of this threshold buys them an unbroken line (a 1440px desktop leaves the *grid* 130.0px for `fi`'s 131.0px word). That is #1240's compact-forms problem. 328 is bound by `es` at 73.8px; the threshold decides arrangement, not survival — both forms are overflow-safe, so getting it wrong costs a wrap, never a clip.

The stacked rows use `BlockConstants.paddingSm` (8px) rather than the block default 12px: measured, 12px re-overflows 6 locales (+3px `fi` to +7px `ru`) and starves the donut out even at the shipped height.

**Charts** (the 6): #1230's plan preferred suppressing the axis *labels*, and that lever does exist — `AppBarChart.xLabels` is nullable and the vertical path passes `showTitles: xLabels != null`, so `xLabels: null` drops the 22px strip and, measured, takes all 105 of this card's gate cases green with no height guard at all. It is not taken because of what it leaves on screen: the value axis keeps drawing, so at `ru`'s 12px slot its "2" and "0" labels overlap each other above two 8px pills. The only threshold that would admit the labelless chart where it reads (`en`, 37px) and reject it where it does not (`da`, 17px) sits between 37 and 40px — a knife edge between two shipped locales, where 70px leaves every locale 33px clear. The picture is dropped; the list above it keeps the information, and the donut's legend keeps naming every target and its count.

Both guards fire only at the 3-row minimum. At the 4 rows `HeightStrategy.strict(4)` actually gives this card, both pictures are drawn in all 26 locales at all three widths.

## Why there is a second test file

The #1183 gate cannot audit either half of this fix, and both are *removals*:

- Three tiles of one character per line **fit perfectly**. Shredded text is not overflow.
- Absent content never overflows, so the gate rewards deleting a chart exactly as much as fixing it. A threshold accidentally set above the card's shipped height would leave the gate green and the card empty, and nothing in `known_overflows.json` can express "the picture is still there at 4 rows".

So `test/page/dashboard/views/components/firewall_overview_readability_test.dart` (**74 tests**, tagged `dashboard-card` so it gates PRs) asserts on the rendered tree: the card was laid out in the app's own fonts and not the engine's block font, no metric label is broken mid-word in any of the 26 locales, the arrangement is stacked below the threshold and three-across above it, both pictures are present at the shipped height and absent at the minimum, the legend carries every target while the donut is suppressed, the content clears the footer, the ring is never drawn larger than its box, and no slice label is painted inside it.

AC 5 is a claim about the whole card, so the **Ports tab** is now swept for the same two failures even though none of the 21 coordinates were there — its rows fit at 191px, and fitting is not reading. That sweep found one thing that does not read, and the cause is outside this card (below).

Every assertion was run against a mutation of the code it guards, and every one fired:

| mutation | what failed |
|---|---|
| 1. `_kMetricsSideBySideMinWidth` 328 → 0 (the pre-#1230 card) | 33 |
| 2. `_kMetricsSideBySideMinWidth` 328 → 600 | 1 |
| 3. `_kProtocolChartMinHeight` 70 → 200 | 3 |
| 4. `_kDonutMinRingThickness` 10 → 60 | 6 |
| 5. `size: diameter` → the themed design diameter, ignoring the slot | 1 (@min only — 191px is the one width whose 157.4px slot is under the 160px this theme designs for) |
| 6. `showLabels: false` → `true` | 3 |
| 7. `_StackedMetrics` padding `sm` → block default | 12 |
| 8. stacked label `maxLines` 2 → 1 | 5 |
| 9. Ports heading `maxLines: 1` | 6 (`da pl pt pt_PT ru sv` — the locales whose heading wraps) |
| 10. the mapping on a full-width line of its own | 29 (overflow @min in all 26 locales, +11px to +36px) |
| 11. 10, plus the DMZ list dropped, plus `MapsToRow`'s source given its intrinsic width | 1 — the mapping-target ratchet, and nothing else |
| 12. ui_kit's font family renamed in `loadAppFonts` | 1 — the font identification, at 1.000 em per glyph |
| 13. the app's family registered against Noto's bytes | 1 — the same test's Noto net |
| 14. the `NotoSans` reference family renamed | 1 — the reference self-check |
| 15. the ui_kit font path broken | the whole file, at `setUpAll` |

Seven of the first eleven leave the #1183 gate green while the card loses a chart (3, 4), asks for a 160px donut in a 157.4px slot (5), prints a clipped slice label into a 20px ring (6), or clips text mid-glyph (8, 9). Only 1, 7 and 10 report an overflow, and 1 is simply the pre-#1230 card. 12-15 are a different kind: they do not break the card, they break the *measuring instrument* — see below.

Mutation 6 is worth naming: the previous revision of this file claimed an "exactly 2 texts" assertion guarded `showLabels: false`, and it did not — fl_chart paints slice labels onto its canvas, not as `Text` widgets, so flipping the flag fired nothing. The suite now reads each `PieChartSectionData.title` and requires it empty, which is what actually guards it. Overflow itself stays the gate's job, with one exception carried in this file's `pumpAt`: the gate pumps `minHeightRows` only, so the shipped height — the only one where the donut's caption and the axis strip are built at all — would otherwise be measured by nothing.

## The upstream bug this PR found is now fixed

`AppPieChart` took the section radius from the call site but the centre-hole radius from the theme, so the drawn diameter was `2 × (centre + ring)` and did not follow the `size` box. The old `size: 160` with the default 40px ring drew a **200px** donut into a 160px box and the card surface clipped 20px off every side — measured, the painted extent was 200px at every `size` from 120 to 300.

Filed as **linksys/privacyGUI-UI-kit#22**, fixed in **v2.34.11**, and this PR takes the bump: both radii are now derived from the box. **The card-side workaround is deleted** — `sectionRadius:` is gone from the call, along with the arithmetic that computed it. The four other `AppPieChart` call sites in this app are fixed by the bump alone, with no change of their own.

What remains at the call site is a *themed floor*, not a workaround. `_TargetDonut` reads `ChartStyle.pieCenterRadius` inside its `LayoutBuilder` (flat 60.0, neumorphic 65.0, pixel and brutal 50.0), sizes the box to `min(box, 2 × (centreRadius + 20))`, and returns `SizedBox.shrink()` below `2 × (centreRadius + 10)` so no theme's centre radius can invert the ring-thickness floor. Measured under v2.34.11:

| card width | drawn box | hole | ring |
|---|---|---|---|
| 191px (the 3-row minimum) | 153.0px | 57.4px | 19.1px |
| 288px | 160.0px | 60.0px | 20.0px |
| 512px | 160.0px | 60.0px | 20.0px |

Note *which* radius v2.34.11 shrinks: the hole, not the ring. At 191px the caption's half-diagonal is 32.0px against a 57.4px hole — 25.4px clear — so the drawn-vs-box assertion still has something to fail on, and does (mutation 5 below).

The bump changed three unrelated dashboard goldens for the better (`card_traffic_analysis`'s y-axis labels stopped wrapping, `card_wifi_status`'s access-point names stopped wrapping and its channel value joined the value column, `card_device_analytics`'s donut lost its 20px clip). Baselines are gitignored, so nothing is committed; regenerated locally and green. The whole `--tags golden` suite is `+73 -284` both before and after the bump — the bump adds no golden failure. Those 284 are stale local baselines in the whole-suite harness, unrelated to this branch.

## The measurements are now proven to be real-font measurements

Every assertion in this file is a claim about pixels, and nothing in it checked that the pixels came from NeueHaas rather than the test engine's block font — under which every glyph is one square em, so what fits and what ellipsizes is fiction that stays internally consistent and green. Two holes, both closed and both mutation-verified:

- **`loadAppFonts` threw nothing when a font file was missing** — it skipped silently, on the rationale that "CI without the ui_kit checkout" should still run. That is not a state worth running in, and it is not a real one either: `ui_kit_library` is a pub dependency and the five Noto files are committed under `test/fonts/`. What *is* real is a ui_kit ref bump moving the pub-cache path, which is exactly the failure that must be loud. It now collects the missing paths and throws at `setUpAll`. Icon fonts stay tolerant — advances in an icon font are one em by definition, so a missing one costs a tofu box, not a wrong measurement. This helper is shared with the golden pipeline and five other readability suites; all were re-run.

- **A new first test identifies the typeface the card was actually laid out in**, on the pure-ASCII mapping target (for Cyrillic, Arabic, Thai and CJK the app falls back to Noto *by design*, and one em per ideograph is what CJK legitimately measures, so the check would be backwards there). Three assertions, because renaming the family registration produces three different lies:

  | what breaks | what it measures | which net catches it |
  |---|---|---|
  | family unresolvable, no `fontFamilyFallback` on the style | block font: `192.168.1.101:80` at **192.0px** = 12.0 × 16 chars, and 1.000-1.045 em per glyph across the whole tab | width must be under 0.9 em per glyph (the real font is at **0.43** — 83.3px) |
  | family unresolvable, a fallback list present (`lib/app.dart` supplies one for CJK) | Noto: **95.2px**, a real proportional font, plausible enough to slip past a ratio check | width must differ from what Noto measures the same string at |
  | the Noto reference itself did not load | the reference is one em per glyph, so it identifies nothing | the reference is range-checked before it is used |

  The first net is the one a naive version of this test got wrong: an *exact* one-em signature was written first, and measurement showed the substitute block font sits at 1.000-1.045 em, so half the strings on the tab slipped through. Hence a ratio.

  It pumps through the probe rather than this file's `pumpAt`, dropping the overflow incidents: a wrong typeface reflows the card, so `pumpAt` would fail on the overflow first and hide the identification — the one failure that says *why*. Overflow at that coordinate is asserted by the tests below it.

## Follow-ups left open, not silently dropped

- **#1275** — `_StackedMetrics` is `_InfoGridTile` in a `Row` at 8px padding, a shape `layout_blocks` has no variant for, and `usp_ethernet_ports_card.dart`'s `_SummaryTile` is the same shape a third time. The ticket carries the measurements a shared compact variant must preserve.
- **#1286 (`MapsToRow`'s even split)** — the Ports-tab sweep found the one thing a 191px card cannot show whole, and it is not this card's doing. `MapsToRow` (`lib/page/_shared/components/layout_blocks/row_blocks.dart:148`) wraps both halves in equal-flex `Flexible`s, so `RenderFlex` splits the pair evenly and the shorter child's unused share is **not** redistributed: the target gets exactly half — **38.5px** — for 82.3-103.7px of `IP:port`, however short the source is (measured: a 30.7px source still leaves the target 38.5px of a 77px pair). Its own docstring claims the opposite, that the target is the part that ellipsizes "since the source is short and bounded while the target is not". Showing it whole needs 227.4px in a 191px card.

  Both card-side fixes were measured and are insufficient: putting the mapping on its own full-width line costs the +20px per rule that AC 4 forbids and overflows all 26 locales by +11px to +36px (mutation 10); dropping the DMZ list on top of that clears the overflow but leaves the target at 68.7px, still short. Only fixing the split itself works (mutation 11) — and that file is shared with seven other call sites (statistics, port-forwarding cards and tabs, the AI registry), so it is not a change this single-card PR can justify. The last test in the file is a **ratchet**: it asserts the source is never ellipsized and the target *is*, and tells whoever fixes `row_blocks.dart` to delete it. Filed as **#1286**, with the three options costed. The cleanest (one `InlineSpan` run instead of two `Flexible`s) has its mechanism in ui_kit already — `AppStyledText` is a `RichText` that takes `maxLines`/`overflow` — but it emits only `TextSpan`s from a fixed tag vocabulary (so the arrow, which must come from the icon font because U+2192 has no glyph in the app's font set, cannot sit inside the run), takes no size or colour, and skips `AppText`'s per-locale fallback injection. The upstream ask was filed as **linksys/privacyGUI-UI-kit#23** (`AppText.rich(List<InlineSpan>)`, reusing `AppText`'s existing variant/colour/locale-fallback resolution) and **landed in v2.35.0 while this PR was open**, closing all three gaps — spans take a `WidgetSpan`'d arrow, the rich path carries `variant`/`color`, and the locale fallback is the same merge. #1286's recommendation is updated to that fix rather than the layout-side one.

  **This PR deliberately stays at v2.34.11.** v2.35.1 also takes privacyGUI-UI-kit#24, which makes `AppStyledText` apply the locale fallback: inert upstream (ui_kit injects no resolver) but not here, since this app installs one — so the three `AppStyledText` call sites move their non-Latin rendering to the bundled subset and the `remote_assistance` CJK baselines shift. That is the movement #1285 already owns, so the bump belongs with it in one PR. Verified inert for *this* PR's numbers first rather than assumed: at v2.35.1 this file's 74 tests and the gate's 1644 are green with no measurement moved, and the rewrite of `AppTextVariantX.resolve` behind it is a no-op in this app for the two reasons recorded on #1285.

- **#1285** — building the font guard above turned up a production defect this PR does not touch: `lib/app.dart:185` hands `ThemeData.textTheme.apply()` an already package-prefixed fallback family, and because ui_kit's text styles carry `package: 'ui_kit_library'` the `fontFamilyFallback` getter prefixes it a second time — `packages/ui_kit_library/packages/ui_kit_library/NotoSansTC`, which matches nothing registered. Measured, not inferred. So in every non-Latin locale the bundled subset never draws raw `Text`; the engine falls through to the system font, which is why it has never looked broken. Three test harnesses copy the same line, including `dashboard_card_probe.dart:326` behind this gate, so the fix will move CJK baselines and wants its own PR. Dates from `5beff305`, not from this branch.

- **#1238** — three helpers in the new test (`pumpAt`, `desktopCase`, `loadAppFonts` setup) duplicate what a sibling readability test will need; the extraction plan is noted on that issue.

## Verification

- **`./tool/run_overflow_test.sh`** (the #1183 gate): **1644 pass**, exit 0
- **`./run_tests.sh`** (full functional suite): **5525 pass**, exit 0
- this file: **74 pass**; firewall provider/service tests: **42 pass**
- every other `loadAppFonts` caller, re-run after making it throw (6 readability suites + the shared row/info-row tests + the 1899-test overflow file): all pass. Golden pipeline: no loader error, tally unchanged.
- dashboard card goldens (`test/golden_test/page/dashboard/cards/localizations/`, 33 tests): regenerated for the bump and green. Baselines are gitignored, so nothing is committed. Note the harness's 500×400 box is 128px shorter than this card's shipped 528px, so the donut is suppressed in that golden by design — the 26-locale × 3-width sweep confirms it is drawn at 153.0-160.0px at the height the dashboard actually gives the card.
- whole `--tags golden` suite: `+73 -284` **both** at v2.34.5 and at v2.34.11, same failing set — the bump introduces no golden failure; those 284 are pre-existing stale local baselines in the whole-suite harness.
- `dart format` clean, `flutter analyze` on both changed files: no issues.

## AC checklist

- [x] **AC1** both own sites clean at the narrowest realization, 26 locales, both tabs
- [x] **AC2** the 15 `firewall_overview|min|0` coordinates removed and the gate passes
- [x] **AC3** the 6 fl_chart coordinates closed by call-site constraint, not allowlisted
- [x] **AC4** resolved by constraining width-driven content; `minHeightRows` still 3
- [x] **AC5** legible at 191px, not merely overflow-free — guarded by 74 tree assertions across both tabs, the first of which proves the other 73 measured the app's own fonts. One exception, documented and ratcheted rather than hidden: the port-forwarding mapping target ellipsizes, because `MapsToRow` splits its row evenly (see follow-ups).
- [x] **AC6** fl_chart not forked, patched, or vendored






