### PR TITLE
fix(instant_safety): catch ServiceError in performFetch so the error view renders (#1274)

### DIFF
--- a/lib/framework/preservable_notifier_mixin.dart
+++ b/lib/framework/preservable_notifier_mixin.dart
@@ -81,6 +81,14 @@ class _PreservableDelegate<
   ///
   /// If the post-save re-fetch fails, the error is logged and rethrown so
   /// callers can reliably clear transient UI flags (e.g. `isSaving`).
+  ///
+  /// NOTE: that rethrow is not actually guaranteed here. `performFetch` has to
+  /// turn a failure into a status rather than throw — the initial load has no
+  /// caller to catch it — so this method returns normally even when the
+  /// re-fetch failed, and the error only reaches the caller if the notifier
+  /// inspects `status.error` after `super.save()`. `instant_safety` is
+  /// currently the only one that does. Tracked in #1279; until it is fixed,
+  /// do not rely on this paragraph.
   Future<TState> save() async {
     await _performSave();
     markAsSaved();

--- a/lib/framework/preservable_notifier_mixin.dart
+++ b/lib/framework/preservable_notifier_mixin.dart
@@ -77,18 +77,21 @@ class _PreservableDelegate<
     return s;
   }
 
-  /// Saves the current settings, marks the state as clean, and then re-fetches from source.
+  /// Saves the current settings, marks the state as clean, and then re-fetches
+  /// from source.
   ///
-  /// If the post-save re-fetch fails, the error is logged and rethrown so
-  /// callers can reliably clear transient UI flags (e.g. `isSaving`).
+  /// A failure in [performSave] propagates. A failure in the post-save
+  /// re-fetch does NOT: `performFetch` implementations have to turn a fetch
+  /// error into a status rather than throw, because the initial load runs from
+  /// `build()` with no caller to catch it. So this method returns normally even
+  /// when the confirming read failed, and the returned state carries the error
+  /// on `status.error`.
   ///
-  /// NOTE: that rethrow is not actually guaranteed here. `performFetch` has to
-  /// turn a failure into a status rather than throw — the initial load has no
-  /// caller to catch it — so this method returns normally even when the
-  /// re-fetch failed, and the error only reaches the caller if the notifier
-  /// inspects `status.error` after `super.save()`. `instant_safety` is
-  /// currently the only one that does. Tracked in #1279; until it is fixed,
-  /// do not rely on this paragraph.
+  /// Callers that need to distinguish "written and confirmed" from "written but
+  /// not confirmed" must therefore inspect `result.status.error` themselves —
+  /// `instant_safety` is currently the only one that does. Overriding `save()`
+  /// with `try/catch` alone is not enough. Moving that decision in here is
+  /// tracked in #1279.
   Future<TState> save() async {
     await _performSave();
     markAsSaved();
@@ -147,6 +150,11 @@ mixin PreservableNotifierMixin<
       _delegate.fetch(
           forceRemote: forceRemote, updateStatusOnly: updateStatusOnly);
 
+  /// Saves, marks clean, then re-fetches to confirm.
+  ///
+  /// A failed post-save re-fetch does not throw — it lands on
+  /// `status.error` of the returned state. Inspect it if the caller needs to
+  /// know the confirming read failed. See `_PreservableDelegate.save()`.
   Future<TState> save() => _delegate.save();
 
   void onSseInvalidation() => _delegate.onSseInvalidation();
@@ -182,6 +190,11 @@ mixin PreservableAutoDisposeNotifierMixin<
       _delegate.fetch(
           forceRemote: forceRemote, updateStatusOnly: updateStatusOnly);
 
+  /// Saves, marks clean, then re-fetches to confirm.
+  ///
+  /// A failed post-save re-fetch does not throw — it lands on
+  /// `status.error` of the returned state. Inspect it if the caller needs to
+  /// know the confirming read failed. See `_PreservableDelegate.save()`.
   Future<TState> save() => _delegate.save();
 
   void onSseInvalidation() => _delegate.onSseInvalidation();

--- a/lib/page/instant_safety/models/instant_safety_status.dart
+++ b/lib/page/instant_safety/models/instant_safety_status.dart
@@ -3,7 +3,15 @@ import 'package:privacy_gui/core/errors/service_error.dart';
 
 /// Transient (non-editable) status for the Instant Safety feature page.
 class InstantSafetyStatus extends Equatable {
+  /// Whether the page is still waiting for its first data.
+  ///
+  /// Defaults to `false` so that forgetting it fails safe. The View checks
+  /// this *before* [error] (`instant_safety_view.dart`), so a status that
+  /// carries an error while [isLoading] is still `true` renders an endless
+  /// loader and never reaches the error view or its Retry button. Only
+  /// `InstantSafetyFeatureState.initial()` should opt into `true`.
   final bool isLoading;
+
   final bool isSaving;
 
   /// Typed error from the last fetch. The View localizes it via
@@ -11,7 +19,7 @@ class InstantSafetyStatus extends Equatable {
   final ServiceError? error;
 
   const InstantSafetyStatus({
-    this.isLoading = true,
+    this.isLoading = false,
     this.isSaving = false,
     this.error,
   });

--- a/lib/page/instant_safety/providers/instant_safety_provider.dart
+++ b/lib/page/instant_safety/providers/instant_safety_provider.dart
@@ -71,13 +71,13 @@ class UspInstantSafetyNotifier
 
       logger.e('[USP][Safety]: Fetch failed (forceRemote: $forceRemote)',
           error: error);
-      // isLoading must be set explicitly — InstantSafetyStatus defaults it to
-      // true, so omitting it would leave the view stuck on its loader and the
-      // ServiceErrorView (and its Retry) unreachable.
-      //
       // Returning a status rather than throwing is right for the two display
       // paths (initial load, pull-to-refresh) but wrong for the post-save
       // re-fetch — save() below converts it back into a throw.
+      //
+      // isLoading stays spelled out even though it now defaults to false: the
+      // view checks it before error, so this line is what makes the error view
+      // reachable at all.
       return (
         null,
         InstantSafetyStatus(isLoading: false, error: error),

--- a/lib/page/instant_safety/providers/instant_safety_provider.dart
+++ b/lib/page/instant_safety/providers/instant_safety_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:privacy_gui/core/errors/service_error.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/framework/preservable_contract.dart';
@@ -52,14 +53,25 @@ class UspInstantSafetyNotifier
     bool forceRemote = false,
     bool updateStatusOnly = false,
   }) async {
-    final uiModel = await _svc.fetch();
+    try {
+      final uiModel = await _svc.fetch();
 
-    logger.d('[USP][Safety]: Fetched — type: ${uiModel.type}');
+      logger.d('[USP][Safety]: Fetched — type: ${uiModel.type}');
 
-    final newSettings = InstantSafetySettings(type: uiModel.type);
-    const newStatus = InstantSafetyStatus(isLoading: false);
+      final newSettings = InstantSafetySettings(type: uiModel.type);
+      const newStatus = InstantSafetyStatus(isLoading: false);
 
-    return (newSettings, newStatus);
+      return (newSettings, newStatus);
+    } on ServiceError catch (e) {
+      logger.e('[USP][Safety]: Fetch failed', error: e);
+      // isLoading must be set explicitly — InstantSafetyStatus defaults it to
+      // true, so omitting it would leave the view stuck on its loader and the
+      // ServiceErrorView (and its Retry) unreachable.
+      return (
+        null,
+        InstantSafetyStatus(isLoading: false, error: e),
+      );
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/page/instant_safety/providers/instant_safety_provider.dart
+++ b/lib/page/instant_safety/providers/instant_safety_provider.dart
@@ -62,14 +62,25 @@ class UspInstantSafetyNotifier
       const newStatus = InstantSafetyStatus(isLoading: false);
 
       return (newSettings, newStatus);
-    } on ServiceError catch (e) {
-      logger.e('[USP][Safety]: Fetch failed', error: e);
+    } catch (e) {
+      // The service maps every USP failure to ServiceError, so a non-ServiceError
+      // here came from outside that contract (e.g. the uspClientProvider null
+      // assertion in the service provider). It still has to become a status —
+      // escaping build()'s unawaited microtask is the exact hang this guards.
+      final error = e is ServiceError ? e : UnexpectedError(originalError: e);
+
+      logger.e('[USP][Safety]: Fetch failed (forceRemote: $forceRemote)',
+          error: error);
       // isLoading must be set explicitly — InstantSafetyStatus defaults it to
       // true, so omitting it would leave the view stuck on its loader and the
       // ServiceErrorView (and its Retry) unreachable.
+      //
+      // Returning a status rather than throwing is right for the two display
+      // paths (initial load, pull-to-refresh) but wrong for the post-save
+      // re-fetch — save() below converts it back into a throw.
       return (
         null,
-        InstantSafetyStatus(isLoading: false, error: e),
+        InstantSafetyStatus(isLoading: false, error: error),
       );
     }
   }
@@ -87,6 +98,21 @@ class UspInstantSafetyNotifier
     );
     try {
       final result = await super.save();
+      // performFetch turns a failed re-fetch into status.error instead of
+      // throwing (it has to, for the initial load). super.save() therefore
+      // returns normally even when the post-save re-fetch failed, which would
+      // show the "settings saved" snackbar and a full-page ServiceErrorView at
+      // once. Restore the mixin's documented contract: the SET succeeded, but
+      // the caller must still hear about the re-fetch failure.
+      final refetchError = result.status.error;
+      if (refetchError != null) {
+        // Only the refresh failed, so the page must not turn into a full-page
+        // error: settings already hold the value that was written. Clear the
+        // status and let the caller report the failure as a snackbar.
+        state = state.copyWith(status: state.status.copyWith(clearError: true));
+        throw refetchError;
+      }
+
       // Invalidate L1 LAN data to refresh applied state for menu badge.
       ref.invalidate(lanDataProvider);
       return result;

--- a/lib/page/instant_safety/providers/instant_safety_provider.dart
+++ b/lib/page/instant_safety/providers/instant_safety_provider.dart
@@ -62,15 +62,23 @@ class UspInstantSafetyNotifier
       const newStatus = InstantSafetyStatus(isLoading: false);
 
       return (newSettings, newStatus);
-    } catch (e) {
+    } catch (e, st) {
       // The service maps every USP failure to ServiceError, so a non-ServiceError
       // here came from outside that contract (e.g. the uspClientProvider null
       // assertion in the service provider). It still has to become a status —
       // escaping build()'s unawaited microtask is the exact hang this guards.
+      //
+      // The raw error goes on originalError, never into detail: for
+      // UnexpectedError alone, localizeServiceError surfaces detail to the user
+      // verbatim (service_error_localizations.dart:47), and a Dart
+      // "Bad state: ..." is neither localized nor actionable.
       final error = e is ServiceError ? e : UnexpectedError(originalError: e);
 
+      // Log the raw `e`, not the wrapped one: a detail-less UnexpectedError
+      // stringifies to a bare "Unexpected error", which would drop the only
+      // text identifying the failure. Same object when e is a ServiceError.
       logger.e('[USP][Safety]: Fetch failed (forceRemote: $forceRemote)',
-          error: error);
+          error: e, stackTrace: st);
       // Returning a status rather than throwing is right for the two display
       // paths (initial load, pull-to-refresh) but wrong for the post-save
       // re-fetch — save() below converts it back into a throw.
@@ -98,6 +106,18 @@ class UspInstantSafetyNotifier
     );
     try {
       final result = await super.save();
+
+      // Invalidate L1 LAN data to refresh applied state for menu badge.
+      //
+      // Unconditional, and before the refetchError check below: the mixin runs
+      // performSave() + markAsSaved() before its post-save re-fetch, so by the
+      // time we get here the SET has landed and L1 is stale no matter how the
+      // confirming read went. Skipping this on a failed re-fetch would leave
+      // the badge on the pre-save value with no second chance to converge —
+      // markAsSaved() has already cleaned the state, so the isDirty() guard
+      // above turns a user's retry into a no-op.
+      ref.invalidate(lanDataProvider);
+
       // performFetch turns a failed re-fetch into status.error instead of
       // throwing (it has to, for the initial load). super.save() therefore
       // returns normally even when the post-save re-fetch failed, which would
@@ -109,12 +129,15 @@ class UspInstantSafetyNotifier
         // Only the refresh failed, so the page must not turn into a full-page
         // error: settings already hold the value that was written. Clear the
         // status and let the caller report the failure as a snackbar.
+        //
+        // The View localizes this the same way it localizes a genuine save
+        // failure, so the toast reads "save failed" for a write that landed.
+        // Distinguishing the two needs a dedicated error type; tracked in
+        // #1279 with the rest of the save-contract work.
         state = state.copyWith(status: state.status.copyWith(clearError: true));
         throw refetchError;
       }
 
-      // Invalidate L1 LAN data to refresh applied state for menu badge.
-      ref.invalidate(lanDataProvider);
       return result;
     } finally {
       state = state.copyWith(

--- a/test/page/instant_safety/providers/instant_safety_provider_test.dart
+++ b/test/page/instant_safety/providers/instant_safety_provider_test.dart
@@ -61,6 +61,25 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // InstantSafetyStatus
+  // ---------------------------------------------------------------------------
+
+  group('InstantSafetyStatus', () {
+    test('isLoading defaults to false so an omitted flag fails safe', () {
+      // The view checks isLoading before error, so a default of true would turn
+      // any status that carries an error into an endless loader (#1274).
+      const status = InstantSafetyStatus(error: _fetchError);
+      expect(status.isLoading, isFalse);
+      expect(status.error, _fetchError);
+    });
+
+    test('copyWith(clearError: true) drops the error', () {
+      const status = InstantSafetyStatus(error: _fetchError);
+      expect(status.copyWith(clearError: true).error, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // InstantSafetyFeatureState
   // ---------------------------------------------------------------------------
 

--- a/test/page/instant_safety/providers/instant_safety_provider_test.dart
+++ b/test/page/instant_safety/providers/instant_safety_provider_test.dart
@@ -47,6 +47,13 @@ void main() {
       overrides: [
         uspInstantSafetyServiceProvider.overrideWithValue(mockService),
         uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+        // save() invalidates lanDataProvider, which builds it and reaches
+        // uspLanDataServiceProvider — no lanDataProvider listener needed. Today
+        // that fails safe (the real provider throws ServiceNotInitializedError
+        // because uspClientProvider is null in tests, and the throw is captured
+        // as an AsyncValue error), but the moment a test here overrides
+        // uspClientProvider it would silently hit the real service instead.
+        uspLanDataServiceProvider.overrideWithValue(mockLanService),
       ],
     );
     container.listen(uspInstantSafetyProvider, (_, __) {});
@@ -378,16 +385,12 @@ void main() {
       });
       when(() => mockService.save(any())).thenAnswer((_) async {});
 
-      final container = ProviderContainer(
-        overrides: [
-          uspInstantSafetyServiceProvider.overrideWithValue(mockService),
-          uspMutationLockProvider.overrideWithValue(UspMutationLock()),
-          uspLanDataServiceProvider.overrideWithValue(mockLanService),
-        ],
-      );
-      container.listen(uspInstantSafetyProvider, (_, __) {});
+      final container = createContainer();
       // The invalidate is observed through the L1 service: LanDataNotifier
       // calls fetch() on every build, so a rebuild shows up as a second call.
+      // The listener keeps lanDataProvider alive between the two verifies —
+      // without it the autoDispose provider is torn down after each read and
+      // the counts stop meaning "was it invalidated".
       container.listen(lanDataProvider, (_, __) {});
 
       await pumpEventQueue();

--- a/test/page/instant_safety/providers/instant_safety_provider_test.dart
+++ b/test/page/instant_safety/providers/instant_safety_provider_test.dart
@@ -10,14 +10,21 @@ import 'package:privacy_gui/page/instant_safety/models/instant_safety_status.dar
 import 'package:privacy_gui/page/instant_safety/models/safe_browsing_ui_model.dart';
 import 'package:privacy_gui/page/instant_safety/providers/instant_safety_provider.dart';
 import 'package:privacy_gui/page/instant_safety/services/instant_safety_service.dart';
+import 'package:privacy_gui/page/_shared/models/lan_info_ui_model.dart';
+import 'package:privacy_gui/page/local_network/providers/lan_data_provider.dart';
+import 'package:privacy_gui/page/local_network/services/usp_lan_data_service.dart';
 
 class MockInstantSafetyService extends Mock
     implements UspInstantSafetyService {}
 
+class MockLanDataService extends Mock implements UspLanDataService {}
+
 const _fetchError = NetworkError(detail: 'fetch failed');
+const _saveError = NetworkError(detail: 'save failed');
 
 void main() {
   late MockInstantSafetyService mockService;
+  late MockLanDataService mockLanService;
 
   setUpAll(() {
     registerFallbackValue(SafeBrowsingType.off);
@@ -25,6 +32,14 @@ void main() {
 
   setUp(() {
     mockService = MockInstantSafetyService();
+    mockLanService = MockLanDataService();
+    when(() => mockLanService.fetch()).thenAnswer((_) async =>
+        const LanInfoUIModel(
+            ipAddress: '192.168.1.1',
+            subnetMask: '255.255.255.0',
+            dhcpEnabled: true,
+            minAddress: '192.168.1.20',
+            maxAddress: '192.168.1.200'));
   });
 
   ProviderContainer createContainer() {
@@ -129,7 +144,7 @@ void main() {
               currentDnsServers: '208.67.222.222,208.67.220.220'));
 
       final container = createContainer();
-      await Future.delayed(Duration.zero);
+      await pumpEventQueue();
 
       final state = container.read(uspInstantSafetyProvider);
       expect(state.status.isLoading, isFalse);
@@ -147,7 +162,7 @@ void main() {
           (_) async => const SafeBrowsingUIModel(type: SafeBrowsingType.off));
 
       final container = createContainer();
-      await Future.delayed(Duration.zero);
+      await pumpEventQueue();
 
       container.read(uspInstantSafetyProvider.notifier).setEnabled(true);
 
@@ -162,7 +177,7 @@ void main() {
           const SafeBrowsingUIModel(type: SafeBrowsingType.openDNS));
 
       final container = createContainer();
-      await Future.delayed(Duration.zero);
+      await pumpEventQueue();
 
       container.read(uspInstantSafetyProvider.notifier).setEnabled(false);
 
@@ -175,15 +190,19 @@ void main() {
     // -----------------------------------------------------------------------
     // fetch — error path (#1274)
     //
-    // These use async mocks + pumpEventQueue() rather than a synchronous
-    // thenThrow + Duration.zero. A single Duration.zero only flushes
-    // build()'s Future.microtask while the throw is synchronous; with an
-    // async service hop the assertions would silently run against the
-    // initial isLoading == true state and still pass.
+    // Two conventions hold for every async test in this file:
     //
-    // They also let that boot microtask be the only fetch. Calling fetch()
-    // explicitly on top of it races: the later completion overwrites
-    // settings and would clobber a pending edit mid-test.
+    // 1. pumpEventQueue(), never Future.delayed(Duration.zero). A single
+    //    Duration.zero only flushes build()'s Future.microtask, so it happens
+    //    to work with a synchronous thenThrow and silently stops working the
+    //    moment the mock gains an async hop — the assertions then run against
+    //    the initial isLoading == true state and still pass. Failures are
+    //    stubbed as thenAnswer((_) async => throw ...) for the same reason:
+    //    the real service always throws across an await.
+    //
+    // 2. Let build()'s boot microtask be the only fetch. Calling fetch()
+    //    explicitly on top of it races: the later completion overwrites
+    //    settings and would clobber a pending edit mid-test.
     // -----------------------------------------------------------------------
 
     test('fetch failure surfaces the error on status', () async {
@@ -289,7 +308,7 @@ void main() {
       when(() => mockService.save(any())).thenAnswer((_) async {});
 
       final container = createContainer();
-      await Future.delayed(Duration.zero);
+      await pumpEventQueue();
 
       final notifier = container.read(uspInstantSafetyProvider.notifier);
       notifier.setEnabled(true);
@@ -304,7 +323,7 @@ void main() {
           (_) async => const SafeBrowsingUIModel(type: SafeBrowsingType.off));
 
       final container = createContainer();
-      await Future.delayed(Duration.zero);
+      await pumpEventQueue();
 
       await container.read(uspInstantSafetyProvider.notifier).save();
 
@@ -342,24 +361,64 @@ void main() {
       container.dispose();
     });
 
+    test('save invalidates L1 LAN data even when the re-fetch fails', () async {
+      // The mixin runs performSave() + markAsSaved() before its post-save
+      // re-fetch, so once save() returns the SET has landed and L1 holds a
+      // stale applied value regardless of how the confirming read went.
+      // Skipping the invalidate here would strand the menu badge on the old
+      // value: markAsSaved() has cleaned the state, so save()'s isDirty()
+      // guard makes the user's retry a silent no-op.
+      var fetchCalls = 0;
+      when(() => mockService.fetch()).thenAnswer((_) async {
+        fetchCalls++;
+        if (fetchCalls == 1) {
+          return const SafeBrowsingUIModel(type: SafeBrowsingType.off);
+        }
+        throw _fetchError;
+      });
+      when(() => mockService.save(any())).thenAnswer((_) async {});
+
+      final container = ProviderContainer(
+        overrides: [
+          uspInstantSafetyServiceProvider.overrideWithValue(mockService),
+          uspMutationLockProvider.overrideWithValue(UspMutationLock()),
+          uspLanDataServiceProvider.overrideWithValue(mockLanService),
+        ],
+      );
+      container.listen(uspInstantSafetyProvider, (_, __) {});
+      // The invalidate is observed through the L1 service: LanDataNotifier
+      // calls fetch() on every build, so a rebuild shows up as a second call.
+      container.listen(lanDataProvider, (_, __) {});
+
+      await pumpEventQueue();
+      verify(() => mockLanService.fetch()).called(1);
+
+      final notifier = container.read(uspInstantSafetyProvider.notifier);
+      notifier.setEnabled(true);
+      await expectLater(notifier.save(), throwsA(same(_fetchError)));
+      await pumpEventQueue();
+
+      verify(() => mockLanService.fetch()).called(1);
+      container.dispose();
+    });
+
     test('save resets isSaving on error', () async {
       when(() => mockService.fetch()).thenAnswer(
           (_) async => const SafeBrowsingUIModel(type: SafeBrowsingType.off));
       when(() => mockService.save(any()))
-          .thenThrow(const NetworkError(detail: 'save failed'));
+          .thenAnswer((_) async => throw _saveError);
 
       final container = createContainer();
-      await Future.delayed(Duration.zero);
+      await pumpEventQueue();
 
       final notifier = container.read(uspInstantSafetyProvider.notifier);
       notifier.setEnabled(true);
 
-      expect(
-        () => notifier.save(),
-        throwsA(isA<ServiceError>()),
-      );
+      // expectLater, not the unawaited expect(() => ...) form: this must be
+      // sequenced before the isSaving read so the assertion sees the state the
+      // finally block left, not the one before save() ran.
+      await expectLater(notifier.save(), throwsA(same(_saveError)));
 
-      await Future.delayed(Duration.zero);
       final state = container.read(uspInstantSafetyProvider);
       expect(state.status.isSaving, isFalse);
       container.dispose();

--- a/test/page/instant_safety/providers/instant_safety_provider_test.dart
+++ b/test/page/instant_safety/providers/instant_safety_provider_test.dart
@@ -14,6 +14,8 @@ import 'package:privacy_gui/page/instant_safety/services/instant_safety_service.
 class MockInstantSafetyService extends Mock
     implements UspInstantSafetyService {}
 
+const _fetchError = NetworkError(detail: 'fetch failed');
+
 void main() {
   late MockInstantSafetyService mockService;
 
@@ -153,27 +155,37 @@ void main() {
 
     // -----------------------------------------------------------------------
     // fetch — error path (#1274)
+    //
+    // These use async mocks + pumpEventQueue() rather than a synchronous
+    // thenThrow + Duration.zero. A single Duration.zero only flushes
+    // build()'s Future.microtask while the throw is synchronous; with an
+    // async service hop the assertions would silently run against the
+    // initial isLoading == true state and still pass.
+    //
+    // They also let that boot microtask be the only fetch. Calling fetch()
+    // explicitly on top of it races: the later completion overwrites
+    // settings and would clobber a pending edit mid-test.
     // -----------------------------------------------------------------------
 
     test('fetch failure surfaces the error on status', () async {
-      const error = NetworkError(detail: 'fetch failed');
-      when(() => mockService.fetch()).thenThrow(error);
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => throw _fetchError);
 
       final container = createContainer();
-      await Future.delayed(Duration.zero);
+      await pumpEventQueue();
 
       final state = container.read(uspInstantSafetyProvider);
-      expect(state.status.error, error);
+      expect(state.status.error, _fetchError);
       container.dispose();
     });
 
     test('fetch failure clears isLoading so the error view is reachable',
         () async {
       when(() => mockService.fetch())
-          .thenThrow(const NetworkError(detail: 'fetch failed'));
+          .thenAnswer((_) async => throw _fetchError);
 
       final container = createContainer();
-      await Future.delayed(Duration.zero);
+      await pumpEventQueue();
 
       // The view checks isLoading before error; leaving it true hangs the page
       // on its loader and the Retry button never renders.
@@ -184,14 +196,67 @@ void main() {
 
     test('fetch failure leaves settings untouched and clean', () async {
       when(() => mockService.fetch())
-          .thenThrow(const NetworkError(detail: 'fetch failed'));
+          .thenAnswer((_) async => throw _fetchError);
 
       final container = createContainer();
-      await Future.delayed(Duration.zero);
+      await pumpEventQueue();
 
       final state = container.read(uspInstantSafetyProvider);
       expect(state.settings.current, InstantSafetySettings.empty());
       expect(state.isDirty, isFalse);
+      container.dispose();
+    });
+
+    test('fetch failure preserves unsaved edits', () async {
+      when(() => mockService.fetch()).thenAnswer(
+          (_) async => const SafeBrowsingUIModel(type: SafeBrowsingType.off));
+
+      final container = createContainer();
+      await pumpEventQueue();
+      final notifier = container.read(uspInstantSafetyProvider.notifier);
+      notifier.setEnabled(true);
+
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => throw _fetchError);
+      await notifier.fetch(forceRemote: true);
+
+      // performFetch returns null settings on failure, so the mixin takes the
+      // status-only branch and the pending edit survives.
+      final state = container.read(uspInstantSafetyProvider);
+      expect(state.settings.current.type, SafeBrowsingType.openDNS);
+      expect(state.isDirty, isTrue);
+      container.dispose();
+    });
+
+    test('non-ServiceError is wrapped rather than left uncaught', () async {
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => throw StateError('client was null'));
+
+      final container = createContainer();
+      await pumpEventQueue();
+
+      final state = container.read(uspInstantSafetyProvider);
+      expect(state.status.error, isA<UnexpectedError>());
+      expect(state.status.isLoading, isFalse);
+      container.dispose();
+    });
+
+    test('successful retry clears a prior error', () async {
+      when(() => mockService.fetch())
+          .thenAnswer((_) async => throw _fetchError);
+
+      final container = createContainer();
+      await pumpEventQueue();
+      final notifier = container.read(uspInstantSafetyProvider.notifier);
+      expect(container.read(uspInstantSafetyProvider).status.error, isNotNull);
+
+      when(() => mockService.fetch()).thenAnswer((_) async =>
+          const SafeBrowsingUIModel(type: SafeBrowsingType.openDNS));
+      await notifier.fetch(forceRemote: true);
+
+      final state = container.read(uspInstantSafetyProvider);
+      expect(state.status.error, isNull);
+      expect(state.settings.current.type, SafeBrowsingType.openDNS);
       container.dispose();
     });
 
@@ -225,6 +290,36 @@ void main() {
       await container.read(uspInstantSafetyProvider.notifier).save();
 
       verifyNever(() => mockService.save(any()));
+      container.dispose();
+    });
+
+    test('save reports a failed post-save re-fetch without a full-page error',
+        () async {
+      var calls = 0;
+      when(() => mockService.fetch()).thenAnswer((_) async {
+        calls++;
+        if (calls == 1) {
+          return const SafeBrowsingUIModel(type: SafeBrowsingType.off);
+        }
+        throw _fetchError;
+      });
+      when(() => mockService.save(any())).thenAnswer((_) async {});
+
+      final container = createContainer();
+      await pumpEventQueue();
+      final notifier = container.read(uspInstantSafetyProvider.notifier);
+      notifier.setEnabled(true);
+
+      // The SET succeeded and only the re-fetch failed. The caller must hear
+      // about it (snackbar) — silently returning would pair a success toast
+      // with a full-page ServiceErrorView.
+      await expectLater(notifier.save(), throwsA(same(_fetchError)));
+
+      // ...and status.error must stay clear, or the page turns into an error
+      // view for a write that actually landed.
+      final state = container.read(uspInstantSafetyProvider);
+      expect(state.status.error, isNull);
+      expect(state.status.isSaving, isFalse);
       container.dispose();
     });
 

--- a/test/page/instant_safety/providers/instant_safety_provider_test.dart
+++ b/test/page/instant_safety/providers/instant_safety_provider_test.dart
@@ -152,6 +152,50 @@ void main() {
     });
 
     // -----------------------------------------------------------------------
+    // fetch — error path (#1274)
+    // -----------------------------------------------------------------------
+
+    test('fetch failure surfaces the error on status', () async {
+      const error = NetworkError(detail: 'fetch failed');
+      when(() => mockService.fetch()).thenThrow(error);
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspInstantSafetyProvider);
+      expect(state.status.error, error);
+      container.dispose();
+    });
+
+    test('fetch failure clears isLoading so the error view is reachable',
+        () async {
+      when(() => mockService.fetch())
+          .thenThrow(const NetworkError(detail: 'fetch failed'));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      // The view checks isLoading before error; leaving it true hangs the page
+      // on its loader and the Retry button never renders.
+      final state = container.read(uspInstantSafetyProvider);
+      expect(state.status.isLoading, isFalse);
+      container.dispose();
+    });
+
+    test('fetch failure leaves settings untouched and clean', () async {
+      when(() => mockService.fetch())
+          .thenThrow(const NetworkError(detail: 'fetch failed'));
+
+      final container = createContainer();
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(uspInstantSafetyProvider);
+      expect(state.settings.current, InstantSafetySettings.empty());
+      expect(state.isDirty, isFalse);
+      container.dispose();
+    });
+
+    // -----------------------------------------------------------------------
     // save
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1274

## Problem

Instant Safety's initial-load error state was unreachable. `performFetch` awaited `_svc.fetch()` with no try/catch, so a boot-time `LanNetworkInfo.fetch` failure (e.g. a required leaf faulting with USP 9998) escaped as an uncaught async exception.

`PreservableAutoDisposeNotifierMixin` does not catch by design (`preservable_notifier_mixin.dart:51-54`) — the contract is that `performFetch` returns a status carrying the error. With the exception propagating instead, `_setState` was never reached.

The symptom is worse than a blank page. `instant_safety_view.dart` checks `isLoading` (`:37`) **before** `error` (`:40`), and `isLoading` stayed at the `true` it was born with in `InstantSafetyFeatureState.initial()`. So the page **spins forever** and the Retry button never renders.

## Fix

Wrap the body in `try / on ServiceError catch`, returning `(null, InstantSafetyStatus(isLoading: false, error: e))` — mirroring `usp_local_network_notifier.dart:87-96`, which shares both the mixin and the underlying `LanNetworkInfo.fetch`.

`isLoading: false` is set explicitly and commented. `InstantSafetyStatus` defaults it to `true` (`instant_safety_status.dart:14`), so returning only `error: e` would have swapped one infinite spinner for another. Worth flagging for reviewers: three sibling notifiers (`static_routing`, `ipv6_port_service`, `wifi_advanced`) legitimately omit that argument because their status classes default it to `false` — the reference implementations are not uniform on this line.

## Scope

All 10 notifiers using `PreservableAutoDisposeNotifierMixin` were audited. Nine already had `on ServiceError catch`; `instant_safety` was the only one missing it. `save` on this same notifier already had a try/catch — only the fetch path was affected. Single-point omission, no sweep needed.

## Tests

3 new provider cases:

- `fetch failure surfaces the error on status`
- `fetch failure clears isLoading so the error view is reachable` — pins the specific regression above
- `fetch failure leaves settings untouched and clean`

**All three verified to fail without the fix** — stashed the provider change and re-ran: `error` was `null`, `isLoading` was `true`.

```
test/page/instant_safety/ + test/page/local_network/   139 passed
fvm dart format                                       2 files, 0 changed
flutter analyze (changed files)                        0 issues
```

Constitution checks pass: no `lib/generated/` import in the provider (Art. V §5.4.3), USP access via the Service layer (Art. VI), `*_provider.dart` naming (Art. III), L2 working copy correctly `AutoDispose` (Art. IV), mocktail not mockito (Art. I §1.6.1).

## Known gap (not addressed here)

The golden test (`test/golden_test/page/instant_safety/`) covers `enabled` / `disabled` / `edit_dirty` but has no error state — this fix is what makes that state reachable in the first place. Not added here because golden baselines are gitignored (`.gitignore:92`), so a new state key would first materialize in CI and carry no diff value locally. The E2E test named below is the better home for it.

## Follow-up

The E2E test in `PrivacyGUI-USP-E2E/tests/P09-instant-safety.spec.ts` ("error: shows ServiceErrorView when a required LAN pool leaf faults") can be un-skipped once this merges. That repo was not available locally, so its skip state is unverified here.
