### PR TITLE
fix(dashboard): fix the AppListTile call site on ui_kit v2.34.10, clearing all 27 of connected_devices' coordinates (#1238)

### DIFF
--- a/doc/dashboard/dashboard_density_design.md
+++ b/doc/dashboard/dashboard_density_design.md
@@ -71,6 +71,8 @@ only goes green when every one of its incidents is resolved):
 - **`stats_panel` — 26**: `stat_blocks.dart:34` **and** `:40`
 - **`connected_devices` — 26**: `card_skeleton.dart:153` **and**
   `usp_connected_devices_card.dart:61` **and** ui_kit `app_list_tile.dart:109`
+  — all three closed by #1238; the ui_kit one by the **v2.34.10** upgrade rather
+  than by anything in this repo (§2.10e)
 
 #### The largest pattern the greedy cover hides — legend rows, 181 coordinates
 
@@ -128,7 +130,8 @@ added to it.**
 (`firewall_overview`), ui_kit `AppListTile` 26 (`connected_devices`).
 *Superseded as a planning figure* — later measurement puts the blocked set at
 **32** (fl_chart 6, ui_kit 26); see §2.9a. The 19 is retained here as the
-baseline record.
+baseline record. *Superseded again* — the ui_kit 26 were unblocked upstream by
+v2.34.10 and closed by #1238, leaving **6** (fl_chart only); see §2.10e.
 
 **Axis split**: 464 right-only, 63 bottom-only, 33 both.
 
@@ -211,6 +214,11 @@ independent of width.
 `context.colWidth` (screen-derived), and the harness held the screen at 1920px,
 so its label column did not shrink with the card. Its threshold must be set only
 after that is fixed — see §2.8.
+
+⚠️ **`connected_devices` is clean at 191px since #1238**, so its 320 is stale by
+129px. Track A has moved this column for every card it has closed and *only* this
+column — the width at which each is readable has not moved at all (§2.10d point 5,
+§2.10e point 4). #1240 re-measures; it must not read this table.
 
 ### 1.3 Raising `minColumns` is arithmetically impossible for 12 of 13 cards
 
@@ -933,7 +941,8 @@ in one step when the gauge row followed:
 | Gauge centre | `network_health:150` | 3→0 |
 
 The ratchet now stands at **48 coordinates**, all owned by #1230 (21,
-`firewall_overview`) and #1238 (27, `connected_devices`).
+`firewall_overview`) and #1238 (27, `connected_devices`). *Since superseded* —
+#1238 closed its 27 (§2.10e), leaving **21**, all #1230's.
 
 That 48 replaces the 94 these four tickets left behind. The 46 that went were not
 removed by any of them — they were dead exemptions, and the credit belongs to
@@ -1075,6 +1084,173 @@ reasoning recorded at the declaration site: the floor is the user's, it costs 5 
 12 columns in every layout to buy headroom in a handful of locales, and the
 card-own fix cleared all 21 coordinates by deleting a single-child `Row` that
 had no other effect — the cheapest fix on the branch.
+
+### 2.10e What the ui_kit dependency actually blocked (#1238 — implemented)
+
+27 coordinates → **0**, and 26 of them were the epic's largest
+"dependency-blocked" block. They were not unblocked by a workaround: ui_kit
+**v2.34.10** replaced `AppListTile`'s `Row` with `ListTileContentLayout`, a
+slotted render object that guarantees the content column 25% of the row and caps
+each slot.
+
+Neither AC 3 nor AC 4 describes the path taken, and it is worth being exact about
+which. AC 3's precondition ("if avoidable at the call site") was false on the
+version this ticket was written against — the `trailing` slot was laid out at
+`maxWidth: Infinity`, so no call-site fix existed — which is why the escalation
+was filed as linksys/privacyGUI-UI-kit#20. AC 4's remedy (leave the 26
+allowlisted, with a tracking note naming the request) then became moot, because the
+upstream layer had already changed: consuming v2.34.10 made the call-site fix
+possible and the coordinates went green. So the ticket's **outcome** is AC 3's —
+the 26 removed, the gate passing — reached by the upstream route AC 4 anticipated.
+#20 itself is still open upstream; this branch comments the v2.34.10 resolution on
+it rather than assuming it was answered. Both card-own sites went with the upgrade,
+in the two shapes below.
+
+**1. The two status counts stack; the threshold comes from one Greek word.** Side
+by side, each count gets `(content − 8) / 2` minus 24px of padding, and it has to
+hold a 10px dot, an 8px gap, the number, a 4px gap and the state word. The binding
+locale is `el`: «Χωρίς σύνδεση» needs **116.7px** all in, against `en`'s 66.8px
+and `zh`'s 52.2px — so side by side needs `2 × (116.7 + 24) + 8` = **289.4px** of
+content, and the threshold is 296. Neither narrow realization has it (157.4px at a
+191px card, 254.0px at 288px), and stacked, each block gets the full inner width
+and every locale fits with ≥16.7px to spare. The realized widths either side of
+the threshold are 254px and ~600px, so nothing lands within 200px of it.
+
+This is now the second card using the shape (`ethernet_ports` is the first,
+§2.12), and it is deliberately **not** extracted into
+`lib/page/_shared/components/layout_blocks/` yet. What the two share is ~15 lines
+of `LayoutBuilder`/`Row`/`Column`; what they do not share is everything that
+matters — each threshold is measured from its own card's labels, and
+`ethernet_ports` additionally tightens tile padding when stacked to buy vertical
+budget. #1240 replaces both arrangements with a declared compact form, so the
+abstraction would be born to be deleted. A third card needing the shape is the
+trigger to extract it; recorded here so the next reader does not have to re-derive
+the decision.
+
+A stacked pair occupies 96px of a 261px content viewport (52px more than the 44px
+it takes side by side), which the gate cannot see at all
+— the template *scrolls*, so a stacked pair that pushed the device list below the
+fold would overflow nothing. Measured: the two 44px blocks occupy y=57–153 and the
+first 68px device row ends at 233, against a viewport bottom of 318.
+
+**2. A demand-derived slot cap is not a budget.** This is the finding worth
+carrying forward. v2.34.10 makes a `LayoutBuilder` legal in the `trailing` slot
+(before it, the slot was laid out at `maxWidth: Infinity` and a call-site fix was
+impossible — which is what "blocked" meant), and the finite number it now sees
+looks like the row's spare room. It is not. The allocator reserves 25% of the row
+for the content column, splits the rest in two, and then **lends each side whatever
+the other did not want**:
+
+```
+available   = tile width − 2 × 16px gap        // tile width = content − 32px padding
+share       = 0.375 × available
+trailingCap = share + max(0, share − leadingDemand)
+```
+
+Two consequences, and they pull in opposite directions. The cap is bounded by what
+*this row* demanded in the first pass, so it cannot be read as spare room — and it
+is *raised* by the leading slot under-asking, so it is not a fixed fraction of the
+card either. Measured on the gate's fixture at a **512px** card, all three rows
+carrying a badge and an indicator:
+
+| row | trailing cap | outcome under a slot-derived rule |
+|---|---:|---|
+| `iPhone-15` | 75.0px | keeps `-45 dBm` |
+| `MacBook-Air` | 64.8px | loses it |
+| `Smart-Speaker` | 22.0px | loses it |
+
+The cap tracks the *device name's* length, so the first cut of this fix deleted
+the signal reading on a 1440px screen for the rows with the longest names and kept
+it one row above — for a reason no user can see. Nothing overflowed, so the gate
+called it fixed, and the readability test called it fixed too, because it asserted
+`labels.isNotEmpty` and one surviving label satisfies that. A desktop screenshot is
+what caught it: two bare bar groups under a labelled one. The rule that falls out:
+*a demand-derived cap answers "may this child have what it asked for", never "how
+much room is there"* — so a decision every row must agree on is taken once from the
+card's content width, and only a decision whose own width **is** the demand may
+read the slot. Here that splits cleanly:
+
+- the `-NN dBm` label cannot yield (4 fixed bars, 3 gaps, a 4px gap, an unwrapped
+  `AppText`: **80.8px** at `-100 dBm`, 75.0px at a 2-digit reading, 22.0px with the
+  label off), so it is decided from the card. Substituting into the allocator with
+  the fixed 44px leading icon: `0.75 × (content − 64) − 44 ≥ 80.8` ⇒ **content ≥
+  230.4px**, hence a threshold of 231. The realizations are 157.4px and 254.0px, so
+  the label goes at the min realization only.
+- the parent-node badge ellipsizes, so its own label width *is* what it demands.
+  It is measured with a `TextPainter` — through ui_kit's own `AppTextVariant.resolve`,
+  because `AppText` re-applies the design theme's body font bare and prepends the
+  locale fallback, and measuring in the raw theme style measures a different font —
+  and dropped exactly where it could only ellipsize, which is genuinely per-row:
+  `N1` is 30.1px and its row is handed 32.6px at 191px, 288px **and** 512px, while
+  `Extender-1` is 78.3px against 22.0px at 191px and 78.3px above it. Any fixed
+  floor that rejects the second also rejects the first on a 1440px screen. A
+  truncated node name is dropped rather than shown as `Ex…`, which names nothing and
+  costs the device name beside it.
+
+**2b. The gate is blind between the realizations, and that is where 175 shipped.**
+The first threshold here was 174.7px, derived from the 25% content floor alone —
+i.e. from the allocator's `floor`, ignoring the lend-back and the tile's own 32px of
+padding. It is green on the gate at both realizations and overflows everywhere
+between them, because the gate pumps only the *narrowest* realization of each span
+(157.4px and 254.0px of content) and never the continuum a user reaches by dragging
+a card:
+
+| content | trailing cap | label kept at 175 | result |
+|---:|---:|---|---|
+| 175 | 39.3px | yes | **+33.0px right** |
+| 200 | 58.0px | yes | **+17.0px right** |
+| 216 | 70.0px | yes | **+5.0px right** |
+| 229 | 79.8px | yes | **+1.0px right** |
+| 230 | 80.5px | yes | **+0.287px right** |
+| 231 | 81.3px | yes | clean |
+
+Two lessons for the remaining tickets. First, **a threshold derived from a layout
+rule must be derived from the whole rule** — the 25% floor is one of three terms,
+and the two omitted ones (the lend-back, the tile padding) moved the answer by 56px.
+Second, **a card-width threshold needs a test at widths the gate skips**: the
+`connected_devices` readability file pumps 209/234/250/264/265px card widths and
+asserts zero overflow, which is the only check on the branch that would have caught
+this. `_tolerancePx` is 2.0, so the 230px case (+0.287px) would have passed the gate
+even if it had pumped it.
+
+Also worth carrying: the worst case is the *reading*, not just the width. A fixture
+showing only `-45 dBm` (75.0px) clears at content 223 and would have justified 223;
+`-100 dBm` is 80.8px and does not clear until 231. The readability fixture pins the
+3-digit reading for that reason.
+
+**3. The corollary for the readability tests: assert the count, not the
+existence.** §2.10d point 3 said a fix owes a test when the gate stays green
+through both the right and the wrong version. This branch adds the sharper form —
+**a presence assertion is green through a partial deletion**. `isNotEmpty` over
+five rows passes on one. The assertion that catches it is `labels.length ==
+indicators.length`, and it is the only one of the file's 29 that mutation N (label
+decided from the slot) kills. Fourteen mutations were run and every assertion in the
+file is killed by at least one. Only three of the fourteen would also fail the gate;
+mutation Q — the shipped-then-corrected 231 → 175 threshold — leaves overflow the
+gate is *structurally* unable to see (point 2b), and the other ten take content away
+without overflowing anything.
+
+**4. Direct #1240 input: this card is green at 191px and unreadable there.** The
+tile gives the device name **23.3px** (27.4px for the one row without a badge) —
+one glyph and an ellipsis — and the IP the same, because the 44px leading icon and
+the 22.0–32.6px trailing take 66px of a 141px row before the name is measured.
+Both narrow realizations were screenshotted for the record. This is the third card
+in a row to close its coordinates while staying unusable at its narrowest width
+(§2.10d point 5), and it is the strongest case yet for #1240's compact form: the
+degradation here is not the label or the badge, both of which were affordable —
+it is the name.
+
+So **#1238's AC 7 ("device names and connection details stay readable at the
+narrowest clean width") is not met, and is not reachable from this call site** —
+recorded here and on the issue rather than left unticked. What the fix owed AC 7 it
+paid: nothing this branch does costs the name a pixel, and both things that could
+have (the dBm label, the badge) are dropped at 191px precisely so they don't. The
+23.3px that remains is the tile's own division of a 141px row between a fixed 44px
+leading icon, a trailing slot, and the content column — the row's *shape*, not its
+overflow — and changing it means a different row for narrow cards. That is #1240's
+AC 1, the same conclusion #1228 reached about its own AC 5 (§2.12 point 3): a
+readability AC that needs a compact form is inherited by Track B, not claimed by the
+overflow ticket.
 
 ### 2.11 fl_chart's coordinates get a primary plan and a documented fallback
 
@@ -1227,9 +1403,11 @@ addition — it changes no card's rendering until a threshold is declared.
 | #1235 | `network_health` gauge centre (§2.10d) — **implemented** | 3 |
 | #1247 | `firewall_overview` `MapsToRow` — side effect, not its brief (§2.9a) — **implemented** | 46 |
 | #1230 | `firewall_overview` remaining ×2 sites (§2.11) | 15 |
-| #1238 | `connected_devices` card-own (§2.6) | 1 |
+| #1238 | `connected_devices` ×2 card-own sites + the ui_kit v2.34.10 upgrade (§2.10e) — **implemented** | 27 |
 
-Ceiling **528 / 560**. The other 32 are the dependency-blocked ones (§1.1).
+Ceiling **528 / 560**, on the assumption that ui_kit's 26 stay blocked. They did
+not: #1238 cleared all 27 after the v2.34.10 upgrade, so the ceiling is **554 /
+560** and the only dependency-blocked coordinates left are fl_chart's 6.
 
 After #1234–#1237, and after #1247's side effect was collected (§2.9a), the
 allowlist holds **48** coordinates: 21 `firewall_overview` (#1230) and 27
@@ -1247,6 +1425,14 @@ allowlist holds **48** coordinates: 21 `firewall_overview` (#1230) and 27
 other **32** are dependency-blocked: fl_chart's 6 and the 26 that cannot go green
 without a ui_kit change (they need the card's own two rows fixed as well, so
 "blocked" means necessary-but-not-sufficient, not untouched).
+
+That split held for exactly as long as the dependency did. ui_kit **v2.34.10**
+shipped the `AppListTile` change (linksys/privacyGUI-UI-kit#20), and with it the 26
+became call-site-fixable; #1238 cleared all 27 together, so the allowlist now holds
+**21** — #1230's — and the blocked set is fl_chart's **6**. The
+necessary-but-not-sufficient reading is what made this cheap: the two card-own
+sites had to be fixed regardless, and they were the whole of the work once the
+slot stopped being unbounded (§2.10e).
 
 Two figures earlier in this document are contradicted by that attribution, both
 downward:
@@ -1269,11 +1455,14 @@ So the dependency-blocked share of the baseline is **32 of 560, not 45**, and
 `firewall_overview` is a *height* problem now — all 21 of its coordinates are
 bottom overflows, a different class from the four width shapes these tickets
 settled. #1230 is still the largest single block of clearable coordinates left,
-at 15 rather than 48.
+at 15 rather than 48. (And **6 of 560** after #1238, which is the whole of
+fl_chart's; `firewall_overview` is the only card left in the allowlist.)
 
 Their `tracking` notes are left as the epic requires: a ticket touches only the
 notes of cards it closes, so both cards keep the `baseline #1183` default until
-their own ticket names an owner.
+their own ticket names an owner. #1238 has since deleted `connected_devices`'
+note along with its two keys, which is the same rule applied in the other
+direction: the note exists to name a live blocker, so it goes when the block does.
 
 #1266 is in this track despite clearing nothing: it is the only entry that *adds*
 coordinates (3, by localizing a hardcoded string) and removes them again in the

--- a/lib/page/devices/cards/usp_connected_devices_card.dart
+++ b/lib/page/devices/cards/usp_connected_devices_card.dart
@@ -123,10 +123,15 @@ double _nodeBadgeNaturalWidth(BuildContext context, String nodeName) {
     textScaler: MediaQuery.textScalerOf(context),
     maxLines: 1,
   )..layout();
-  return math.min(
+  final width = math.min(
     painter.width + AppSpacing.sm * 2,
     _kNodeBadgeMaxWidth,
   );
+  // This runs inside a `LayoutBuilder.builder`, once per device row per layout
+  // pass, so the paragraph handle has to be released here rather than left to
+  // the finalizer.
+  painter.dispose();
+  return width;
 }
 
 class UspConnectedDevicesCard extends ConsumerWidget {

--- a/lib/page/devices/cards/usp_connected_devices_card.dart
+++ b/lib/page/devices/cards/usp_connected_devices_card.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
@@ -12,6 +14,120 @@ import 'package:privacy_gui/page/devices/views/components/usp_signal_strength_in
 import 'package:privacy_gui/route/constants.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 import 'package:privacy_gui/page/_shared/components/usp_status_dot.dart';
+
+/// Card content width at which the two status counts stop sitting side by side.
+///
+/// Side by side, each count gets `(content − 8) / 2` of block and `− 24` of
+/// padding inside that. The pair has to hold a dot (10px), an 8px gap, the
+/// count, a 4px gap and the word — and the binding locale is `el`, whose
+/// «Χωρίς σύνδεση» needs **116.7px** all in (`en` needs 66.8px, `zh` 52.2px).
+/// Side by side therefore needs `2 × (116.7 + 24) + 8` = **289.4px** of content,
+/// which neither narrow realization has: a 191px card gives 157.4px (50.7px per
+/// block, so the widest 15 locales overflow by +14px to +66px) and a 288px card
+/// gives 254px (99.0px per block, which is where `el`'s single
+/// `preferred|0` coordinate comes from, +18px).
+///
+/// Stacked, each block gets the full 133.4px of inner width at 191px and 230px
+/// at 288px, so every locale fits unbroken with 16.7px to spare in the worst
+/// case. The 6.6px between 289.4 and this threshold is slack, not a knife edge:
+/// the realized content widths either side are 254px and ~600px at a 1440px
+/// desktop, so nothing lands within 200px of it (#1238).
+const double _kStatusCountsSideBySideMinWidth = 296;
+
+/// Widest the parent-node badge may draw, label and padding included.
+///
+/// Shared by the badge itself and by [_nodeBadgeNaturalWidth], which decides
+/// whether it is drawn at all — the two must agree or the badge is measured at a
+/// width it cannot have.
+const double _kNodeBadgeMaxWidth = 100;
+
+/// Card content width at which the signal indicator can carry its `-NN dBm`
+/// label.
+///
+/// The indicator is 4 fixed-width bars, 3 gaps, a 4px gap and an unwrapped
+/// `AppText`, so it holds its natural width at any box width and cannot yield:
+/// **80.8px** at the widest reading (`-100 dBm`, 3 digits), 75.0px at a 2-digit
+/// one, 22.0px with the label suppressed.
+///
+/// ## Where 231 comes from
+///
+/// `ListTileContentLayout` divides the row, not the card: it reserves 25% of the
+/// row for the content column and splits the rest in two, then lends each side
+/// whatever the other did not want. With the tile's 32px of padding and its two
+/// 16px gaps that makes
+///
+///     available    = content − 64
+///     share        = 0.375 × available
+///     trailingCap  = share + max(0, share − 44)        // 44px leading icon
+///
+/// so once `share ≥ 44` the trailing gets `0.75 × available − 44`, and seating
+/// the 80.8px reading needs `content ≥ 64 + (80.8 + 44) / 0.75` = **230.4px**.
+/// Measured on the fixture, and this is the whole reason the number is not lower:
+///
+///     content 157.4 (min realization)  cap 35.0   label suppressed, clean
+///     content 229                      cap 79.8   +1.0px right
+///     content 230                      cap 80.5   +0.287px right
+///     content 231                      cap 81.3   clean
+///     content 254.0 (preferred)        cap 98.5   clean
+///
+/// The gate only ever pumps the *narrowest* realization of each span — 157.4px
+/// and 254.0px — so every width in between is invisible to it, and a threshold
+/// derived from the 25% floor alone (174.7px) is green on the gate and overflows
+/// by up to +33px on a card the user can actually drag to. `connected_devices`
+/// readability tests pump those in-between widths for exactly this reason.
+///
+/// ## Why this is decided from the card and not from the slot
+///
+/// ui_kit v2.34.10 caps the trailing slot instead of laying it out at
+/// `maxWidth: Infinity` (linksys/privacyGUI-UI-kit#20), which is what makes a
+/// `LayoutBuilder` in that slot legal at all — and the tile's overflow grew from
+/// +25.6px to +40.0px on the bump because the shortfall is now reported against
+/// that cap instead of being absorbed by starving the title column to 0px.
+///
+/// But the cap is a *lend-back* of what the other slots did not want, so it is
+/// not a budget the row can read: measured on the dashboard fixture at a 512px
+/// card, `iPhone-15` was handed 75.0px and `MacBook-Air` — same badge, same
+/// indicator, longer name — 64.8px, and `Smart-Speaker` 22.0px. Gating the label
+/// on the slot therefore deletes the reading on a 1440px screen for the rows with
+/// the longest names, while the row above keeps one, for a reason the user cannot
+/// see. The card's content width is the same for every row, so this is decided
+/// once, here (#1238).
+const double _kSignalLabelContentMinWidth = 231;
+
+/// How wide the parent-node badge would draw for [nodeName] if nothing
+/// constrained it: its `labelSmall` label plus the badge's own padding, capped at
+/// [_kNodeBadgeMaxWidth].
+///
+/// The badge ellipsizes, so a slot narrower than this does not overflow — it just
+/// stops naming anything. Measuring the label is what lets the badge be dropped
+/// exactly when it cannot be shown whole, rather than at some width threshold:
+/// the trailing slot's width is what this row asked for, so a two-letter node
+/// name is granted the ~30px it wants at every card width. At the narrowest card
+/// `Extender-1` wants 78.3px and the slot offers 35.0px, while `N1` wants 30.1px
+/// and is handed all of it — so any constant floor high enough to reject the
+/// first would also reject the second, which fits everywhere (#1238).
+double _nodeBadgeNaturalWidth(BuildContext context, String nodeName) {
+  final painter = TextPainter(
+    text: TextSpan(
+      text: nodeName,
+      // ui_kit's own resolver, not `textTheme.labelSmall` — `AppText` draws with
+      // this and it is not the raw theme style: it re-applies the design theme's
+      // `bodyFontFamily` bare (dropping the `packages/ui_kit_library/` prefix the
+      // theme carries) and prepends the locale fallback family. Measuring with
+      // the theme style measures a node name in a font the badge will not use,
+      // which for a CJK or Greek name is a different width.
+      style: AppTextVariant.labelSmall.resolve(context),
+    ),
+    textDirection: Directionality.of(context),
+    // The badge scales with the platform text size; the measurement has to too.
+    textScaler: MediaQuery.textScalerOf(context),
+    maxLines: 1,
+  )..layout();
+  return math.min(
+    painter.width + AppSpacing.sm * 2,
+    _kNodeBadgeMaxWidth,
+  );
+}
 
 class UspConnectedDevicesCard extends ConsumerWidget {
   final List<ClientDevice>? devices;
@@ -28,7 +144,6 @@ class UspConnectedDevicesCard extends ConsumerWidget {
     final devicesData = ref.watch(devicesDataProvider).valueOrNull;
     final devices = this.devices ?? devicesData?.clientDevices;
     if (devices == null) return const CardSkeleton.list(rows: 3);
-    final colorScheme = Theme.of(context).colorScheme;
     final activeDevices = devices.where((d) => d.isActive).toList();
     final inactiveDevices = devices.where((d) => !d.isActive).toList();
     final displayDevices = activeDevices.take(_maxDisplayCount).toList();
@@ -50,67 +165,54 @@ class UspConnectedDevicesCard extends ConsumerWidget {
       detailRoute: RouteNamed.uspDeviceList,
       itemCount: devices.length,
       detailLabel: loc(context).viewAll,
-      content: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Status summary - metric tiles style using LayoutBlock
-          Row(
+      content: LayoutBuilder(
+        builder: (context, constraints) {
+          // One decision for the whole list, taken from the width every row
+          // shares — see [_kSignalLabelContentMinWidth] for why the tile's own
+          // trailing cap cannot answer this.
+          final showSignalLabel =
+              constraints.maxWidth >= _kSignalLabelContentMinWidth;
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Expanded(
-                child: LayoutBlock(
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      UspStatusDot(isActive: true, size: 10),
-                      AppGap.sm(),
-                      AppText.titleSmall('${activeDevices.length}'),
-                      AppGap.xs(),
-                      AppText.bodySmall(
-                        loc(context).online,
-                        color: colorScheme.onSurfaceVariant,
-                      ),
-                    ],
-                  ),
+              // Status summary - metric tiles style using LayoutBlock
+              _StatusCounts(
+                online: _StatusCountSpec(
+                  isActive: true,
+                  count: activeDevices.length,
+                  label: loc(context).online,
+                ),
+                offline: _StatusCountSpec(
+                  isActive: false,
+                  count: inactiveDevices.length,
+                  label: loc(context).offline,
                 ),
               ),
-              AppGap.sm(),
-              Expanded(
-                child: LayoutBlock(
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      UspStatusDot(isActive: false, size: 10),
-                      AppGap.sm(),
-                      AppText.titleSmall('${inactiveDevices.length}'),
-                      AppGap.xs(),
-                      AppText.bodySmall(
-                        loc(context).offline,
-                        color: colorScheme.onSurfaceVariant,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
+              AppGap.md(),
+              // Device list - only online devices, max 5
+              if (activeDevices.isEmpty)
+                EmptyState(
+                  icon: Icons.devices,
+                  message: loc(context).noDevicesOnline,
+                )
+              else
+                for (var i = 0; i < displayDevices.length; i++) ...[
+                  _buildDeviceRow(context, displayDevices[i],
+                      showSignalLabel: showSignalLabel),
+                  if (i < displayDevices.length - 1) AppGap.sm(),
+                ],
             ],
-          ),
-          AppGap.md(),
-          // Device list - only online devices, max 5
-          if (activeDevices.isEmpty)
-            EmptyState(
-              icon: Icons.devices,
-              message: loc(context).noDevicesOnline,
-            )
-          else
-            for (var i = 0; i < displayDevices.length; i++) ...[
-              _buildDeviceRow(context, displayDevices[i]),
-              if (i < displayDevices.length - 1) AppGap.sm(),
-            ],
-        ],
+          );
+        },
       ),
     );
   }
 
-  Widget _buildDeviceRow(BuildContext context, ClientDevice device) {
+  Widget _buildDeviceRow(
+    BuildContext context,
+    ClientDevice device, {
+    required bool showSignalLabel,
+  }) {
     final scheme = Theme.of(context).colorScheme;
     final deviceCategory = DeviceClassifier.classify(
       hostname: device.hostName,
@@ -126,28 +228,57 @@ class UspConnectedDevicesCard extends ConsumerWidget {
       ),
       title: device.displayName,
       subtitle: device.ip,
-      trailing: Column(
-        crossAxisAlignment: CrossAxisAlignment.end,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (device.parentNodeName != null)
-            _buildParentNodeBadge(context, device.parentNodeName!),
-          if (device.hasSignalDisplay)
-            UspSignalStrengthIndicator(rssi: device.signalStrength!)
-          else
-            AppText.bodySmall(
-              device.isWifi ? 'WiFi' : 'Wired',
-              color: scheme.onSurfaceVariant,
-            ),
-        ],
+      // The badge is the one decision the slot can answer, because the slot's
+      // cap is this row's own demand and the badge is what demands it: a name
+      // that fits whole is granted the width it asked for, and a name that does
+      // not is the only thing that gets squeezed. So it is dropped exactly where
+      // it could only ellipsize, which differs per row — unlike the dBm label,
+      // which every row must agree on (#1238).
+      trailing: LayoutBuilder(
+        builder: (context, constraints) {
+          final nodeName = device.parentNodeName;
+          final showBadge = nodeName != null &&
+              constraints.maxWidth >= _nodeBadgeNaturalWidth(context, nodeName);
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Dropped rather than ellipsized: a node name clipped to three
+              // characters and a dash names nothing, and the row's own title is
+              // the information here.
+              if (showBadge) _buildParentNodeBadge(context, nodeName),
+              if (device.hasSignalDisplay)
+                UspSignalStrengthIndicator(
+                  rssi: device.signalStrength!,
+                  // The four bars keep their design size and carry the strength
+                  // on their own; only the numeric label gives way.
+                  showLabel: showSignalLabel,
+                )
+              else
+                AppText.bodySmall(
+                  device.isWifi ? 'WiFi' : 'Wired',
+                  color: scheme.onSurfaceVariant,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+            ],
+          );
+        },
       ),
     );
   }
 
+  // ui_kit has `AppBadge` and `AppTag` for this, and both are the right thing to
+  // move to — but not from an overflow ticket. Each is a fixed-height
+  // `AppSurface` (24px × spacingFactor and 32px respectively) against this
+  // hand-rolled ~20px, so swapping either in changes the trailing column's height
+  // inside a 44px row and re-opens every width measured for #1238. This markup
+  // predates the ticket and is unchanged by it; #1240 rebuilds the row and is
+  // where the swap belongs.
   Widget _buildParentNodeBadge(BuildContext context, String nodeName) {
     final scheme = Theme.of(context).colorScheme;
     return Container(
-      constraints: const BoxConstraints(maxWidth: 100),
+      constraints: const BoxConstraints(maxWidth: _kNodeBadgeMaxWidth),
       padding: const EdgeInsets.symmetric(
         horizontal: AppSpacing.sm,
         vertical: 2,
@@ -161,6 +292,105 @@ class UspConnectedDevicesCard extends ConsumerWidget {
         color: scheme.onSurfaceVariant,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+}
+
+/// One status count: a coloured dot, the number, and the word for the state.
+class _StatusCountSpec {
+  const _StatusCountSpec({
+    required this.isActive,
+    required this.count,
+    required this.label,
+  });
+
+  final bool isActive;
+  final int count;
+  final String label;
+}
+
+/// Lays the online and offline counts out side by side, or stacks them once the
+/// card's content is narrower than [_kStatusCountsSideBySideMinWidth].
+///
+/// The two counts are a matched pair — same chrome, same treatment — so they are
+/// one widget rendered twice from a [_StatusCountSpec] rather than two copies of
+/// the same markup, and no change can reach one without the other (#1238).
+///
+/// This is the same arrangement `_SummaryTiles` in
+/// `usp_ethernet_ports_card.dart` uses, and the shape is deliberately *not*
+/// extracted into `lib/page/_shared/components/layout_blocks/` yet: it is two
+/// occurrences, the only shared part is ~15 lines of `LayoutBuilder`/`Row`/
+/// `Column` (each site keeps its own measured threshold and its own stacked
+/// treatment — `ethernet_ports` tightens padding when stacked, this does not),
+/// and #1240 replaces both arrangements with a declared compact form. A third
+/// card needing it is the trigger to extract.
+class _StatusCounts extends StatelessWidget {
+  const _StatusCounts({required this.online, required this.offline});
+
+  final _StatusCountSpec online;
+  final _StatusCountSpec offline;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth >= _kStatusCountsSideBySideMinWidth) {
+          return Row(
+            children: [
+              Expanded(child: _StatusCount(spec: online)),
+              AppGap.sm(),
+              Expanded(child: _StatusCount(spec: offline)),
+            ],
+          );
+        }
+        // Stretch keeps each count full-width. The pair goes from 44px to 96px
+        // of the content column, and those 52px are scrolled, not clipped — the
+        // template already scrolls this card's content, whose five 68px device
+        // rows exceed the 3-row viewport by more than that on their own, so
+        // stacking cannot trade a right overflow for a bottom one (#1238).
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _StatusCount(spec: online),
+            AppGap.sm(),
+            _StatusCount(spec: offline),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// One status count block, in either arrangement.
+///
+/// Not overflow-safe on its own below ~120px of inner width, which is what
+/// [_StatusCounts] exists to guarantee: the dot is a fixed 10px and the two
+/// texts are unwrapped, because a count is meaningless truncated and a state
+/// word ellipsized to two characters names nothing. The arrangement above gives
+/// this the width instead of making the content give way (#1238).
+class _StatusCount extends StatelessWidget {
+  const _StatusCount({required this.spec});
+
+  final _StatusCountSpec spec;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return LayoutBlock(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          UspStatusDot(isActive: spec.isActive, size: 10),
+          AppGap.sm(),
+          AppText.titleSmall('${spec.count}'),
+          AppGap.xs(),
+          AppText.bodySmall(
+            spec.label,
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ],
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,11 +59,11 @@ dependencies:
   ui_kit_library:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.34.5
+      ref: v2.34.10
   generative_ui:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.34.5
+      ref: v2.34.10
       path: generative_ui
   flutter_blue_plus: ^1.4.0
   crypto: ^3.0.2

--- a/test/fixtures/known_overflows.json
+++ b/test/fixtures/known_overflows.json
@@ -1,11 +1,8 @@
 {
   "tracking": {
-    "connected_devices": "26 of these 27 coordinates need three sites fixed together, and one of them is upstream: ui_kit AppListTile lays `trailing` out as a non-flex child with maxWidth: Infinity, so it paints at intrinsic width and the tile's Row overflows by +25.6px while the Expanded title column is starved to 0px first. Filed as linksys/privacyGUI-UI-kit#20. Not avoidable from the call site: the slot is never told the budget, so a LayoutBuilder there sees infinity and only a hardcoded magic number can fit. Measured — substituting a narrower trailing variant (75.0 -> 16.5px) fixed one row and moved the binding constraint to the next-widest trailing child, leaving the count at 27. The two card-own sites (usp_connected_devices_card.dart:61 and :79, #1226's unconstrained centred-Row shape) are tracked by #1238; `preferred|0 el` is the single coordinate that needs only :79 and has no upstream dependency.",
     "firewall_overview": "Two groups, and they are not the same kind of problem. `min|0` (15 coordinates) is card-own and clearable here: usp_firewall_overview_card.dart:157 carries 8 (the donut's centerWidget Column, bottom 15-31px) and :136 carries 7 (the card's outer Column, bottom 7-26px). Both are HEIGHT overflows, so none of the four width shapes from #1234-#1237 apply -- see doc/dashboard/dashboard_density_design.md section 2.11. Tracked by #1230, whose first step is measuring them together, because :136 is the Column that holds the donut whose centre label is :157. `min|1` (6 coordinates, da pl pt pt_PT ru sv) is upstream: fl_chart side_titles_widget.dart:245, bottom 5-10px. Those 6 were masked until #1247 fixed the card-own MapsToRow above them, which is why section 1.1 records fl_chart at 19."
   },
   "allowlist": {
-    "connected_devices|min|0": ["*"],
-    "connected_devices|preferred|0": ["el"],
     "firewall_overview|min|0": [
       "ar", "el", "es", "es_AR", "fi", "fr", "fr_CA", "id", "nb", "pl",
       "pt", "pt_PT", "ru", "tr", "vi"

--- a/test/page/dashboard/views/components/connected_devices_readability_test.dart
+++ b/test/page/dashboard/views/components/connected_devices_readability_test.dart
@@ -1,0 +1,550 @@
+@Tags(['dashboard-card'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
+import 'package:privacy_gui/page/_shared/models/client_device.dart';
+import 'package:privacy_gui/page/dashboard/models/display_mode.dart';
+import 'package:privacy_gui/page/dashboard/models/usp_widget_specs.dart';
+import 'package:privacy_gui/page/devices/cards/usp_connected_devices_card.dart';
+import 'package:privacy_gui/page/devices/views/components/usp_signal_strength_indicator.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+import '../../../../mocks/test_data/devices_test_data.dart';
+import '../../../../util/app_test_fonts.dart';
+import '../../../../util/dashboard/dashboard_card_probe.dart';
+import '../../../../util/overflow_probe.dart';
+
+/// Connected Devices readability (#1238).
+///
+/// ## Why this file exists alongside the #1183 gate
+///
+/// #1238 clears all 27 of this card's coordinates: the two status counts stack
+/// once the card cannot hold them side by side, the device row drops its
+/// `-NN dBm` label at the one realization that cannot seat the indicator, and it
+/// drops the parent-node badge on the rows whose slot could only ellipsize it.
+/// All three are **removals**, and the gate rewards a removal exactly as much as
+/// a fix:
+///
+///   - A `showLabel: false` hardcoded at the call site takes all 26 coordinates
+///     green while deleting the signal reading on every screen size, desktop
+///     included. Nothing in `known_overflows.json` can express "the dBm value is
+///     still there where it fits".
+///   - Same for the parent-node badge: absent content never overflows.
+///   - Stacking is invisible to the gate in the other direction too. A threshold
+///     raised past the desktop realization leaves the gate green and the counts
+///     stacked on a 1440px screen — 235px of block holding 67px of text.
+///   - A stacked pair occupies 96px of a 261px content viewport — 52px more than
+///     the 44px it takes side by side. The template *scrolls*,
+///     so a stacked pair that pushed the device list out of view would overflow
+///     nothing at all.
+///
+/// So each group below asserts on the rendered tree. Every assertion here was
+/// run against a mutation of the code it guards and observed to fail — these are
+/// the runs, with the tests each one killed:
+///
+///   | mutation                                        | tests killed             |
+///   |-------------------------------------------------|--------------------------|
+///   | A `_kSignalLabelContentMinWidth` 231 → 0        | label suppressed @min (1) |
+///   | B `_kSignalLabelContentMinWidth` 231 → 9999     | every reading labelled @preferred+@desktop (2) |
+///   | C `_StatusCount` gains `EdgeInsets.all(60)`     | el fits @min, list visible @min+@preferred (3) |
+///   | D interface label gated on `showSignalLabel`    | Wired labelled @min (1) |
+///   | E `_kStatusCountsSideBySideMinWidth` 296 → 0    | counts stack @min+@preferred, el fits @min+@preferred (4) |
+///   | F `_kStatusCountsSideBySideMinWidth` 296 → 600  | counts share a row @desktop (1) |
+///   | G badge gated on the label's threshold          | badge shown @desktop, short name kept ×3, long name kept @desktop (5) |
+///   | H badge always shown                            | badge dropped @min, long name dropped @min (2) |
+///   | J device name dropped from the tile             | name still drawn @min+@preferred (2) |
+///   | K badge never shown                             | same 5 as G |
+///   | M indicator dropped at every narrow width       | bars drawn @min+@preferred, every reading labelled @preferred+@desktop (4) |
+///   | N label decided from the slot, not the card     | every reading labelled @preferred+@desktop (2) |
+///   | P interface label removed                       | Wired labelled @min+@preferred+@desktop (3) |
+///   | Q `_kSignalLabelContentMinWidth` 231 → 175      | nothing overflows @between 209+234+250+264 (4) |
+///
+/// N is the one worth reading twice, because it is what the first cut of this fix
+/// actually did. ui_kit v2.34.10 hands the trailing slot a finite cap, so reading
+/// it looks like reading a budget — but the cap is the row's *own demand*, so a
+/// longer device name lowers it. Measured on the gate's fixture at a 512px card:
+/// `iPhone-15` got 75.0px and kept its `-45 dBm`, `MacBook-Air` got 64.8px and
+/// `Smart-Speaker` 22.0px, and both lost theirs on a 1440px screen. Nothing
+/// overflowed, so the gate called it fixed; the screenshot did not. Hence the
+/// label is decided once from the card's content width and only the badge — the
+/// one thing whose own width *is* the demand — is decided per row.
+///
+/// Q is the same lesson from the other side, and it is the value this fix
+/// actually shipped with first: 175 is what the tile's 25% content floor implies
+/// on its own, and it holds at both realizations while overflowing by up to
+/// +33.0px at every width between them. The gate pumps only the *narrowest*
+/// realization of each span, so all 1644 of its checks stayed green.
+///
+/// Of the fourteen, only A, C and E leave overflow behind at a width the gate
+/// pumps, so only those three would also fail it. Q leaves overflow the gate is
+/// structurally unable to see; the other ten take content away or move it out of
+/// view, which is exactly what the gate rewards. That is why this file exists.
+///
+/// ## What this file does NOT claim
+///
+/// The device rows are legible only in the sense that nothing is clipped. At the
+/// 191px realization the tile gives the device name **23-27px** — one glyph and
+/// an ellipsis — because a 44px leading icon and the signal bars take 66px of a
+/// 141px row before the name is measured at all. That is the row *shape*, not the
+/// overflow, and it is what #1240 owns; the numbers are recorded in
+/// `doc/dashboard/dashboard_density_design.md` section 2.6 so the compact-forms
+/// work has them. Asserting the 23px here would pin a value nobody wants, so
+/// this file asserts only that the name is drawn and that the trailing yields
+/// first — the parts #1238 is responsible for.
+///
+/// Nothing here re-measures overflow — that is the gate's job, and both
+/// `connected_devices` keys are gone from `known_overflows.json`.
+///
+/// Tagged `dashboard-card` so it gates PRs: `run_tests.sh` excludes
+/// `golden||loc||ui`, so a `ui`-tagged test here would block nothing.
+void main() {
+  setUpAll(() async {
+    // Real fonts: under the Ahem block font every glyph is one square em, so
+    // what does and does not fit — and therefore what ellipsizes — is fiction.
+    await loadAppFonts();
+  });
+
+  const cardId = 'connected_devices';
+  final spec = UspWidgetSpecs.all.firstWhere((s) => s.id == cardId);
+  final heightRows = spec.getConstraints(DisplayMode.normal).minHeightRows;
+
+  /// Pumps the card at one width, as the gate does — one pump, real fonts.
+  Future<void> pumpAt(
+    WidgetTester tester, {
+    required CardWidthCase widthCase,
+    required Locale locale,
+  }) =>
+      probeCardOverflow(
+        tester,
+        cardId: cardId,
+        widthCase: widthCase,
+        cardHeightRows: heightRows,
+        tabIndex: 0,
+        locale: locale,
+      );
+
+  /// The widths the gate measures — the narrowest realization of the card's min
+  /// and preferred spans. Sourced from the helper the gate uses, so this test
+  /// cannot drift from the widths that are actually enforced.
+  final narrowCases = widthCasesFor(spec);
+
+  /// The one width the gate never pumps: the card with room.
+  final desktopCase = desktopCaseFor(spec);
+
+  /// Pumps the card at one width with a hand-picked device list, through the
+  /// same harness — not merely the same geometry — that [pumpAt] uses.
+  ///
+  /// The gate's fixture is the whole dashboard's kitchen sink, so it cannot be
+  /// asked for a specific row shape. The card takes its devices as a parameter
+  /// for exactly this reason, and `cardOverride` is the one thing here that does
+  /// not go through the factory — everything else must, so that a card renamed or
+  /// re-registered breaks loudly. Going through [probeCardOverflow] rather than
+  /// re-building the app is what keeps the two in step: an earlier version of this
+  /// re-implemented `buildDashboardCardApp` and silently lost the `Portal`, the
+  /// `disableAnimations` wrapper, the locale fallback fonts and the settle, so
+  /// "the same geometry" was true and "the same rendering" was not.
+  ///
+  /// Overflows are collected rather than thrown, exactly as [probeCardOverflow]
+  /// does for the gate's own pumps, and returned. Without the collection an
+  /// overflow anywhere in this fixture fails these tests with a `RenderFlex
+  /// overflowed` error, and a group that says "the badge is kept" would be
+  /// reporting something else entirely. Returning them is what lets the
+  /// in-between widths — the ones the gate never pumps — assert on overflow here.
+  Future<List<OverflowIncident>> pumpDevices(
+    WidgetTester tester, {
+    required CardWidthCase widthCase,
+    required List<ClientDevice> devices,
+    Locale locale = const Locale('en'),
+  }) =>
+      probeCardOverflow(
+        tester,
+        cardId: cardId,
+        widthCase: widthCase,
+        cardHeightRows: heightRows,
+        tabIndex: 0,
+        locale: locale,
+        cardOverride: UspConnectedDevicesCard(devices: devices),
+      );
+
+  /// The `-NN dBm` readings currently on screen.
+  Finder signalLabels() => find.byWidgetPredicate(
+        (w) => w is Text && (w.data?.contains('dBm') ?? false),
+      );
+
+  /// The signal-strength bar groups — the part that must survive the label being
+  /// dropped, because it is what still carries the reading.
+  Finder signalIndicators() => find.byType(UspSignalStrengthIndicator);
+
+  group('the status counts stack where they do not fit (#1238)', () {
+    for (final wc in narrowCases) {
+      testWidgets('@${wc.label} ${wc.widthKey}px the counts stack',
+          (tester) async {
+        await pumpAt(tester, widthCase: wc, locale: const Locale('el'));
+
+        final blocks = layoutBlockRects(tester);
+        expect(blocks.length, 2,
+            reason: 'expected exactly the online and offline count blocks');
+        expect(
+          blocks[1].top,
+          greaterThanOrEqualTo(blocks[0].bottom),
+          reason: 'at ${wc.widthKey}px the card gives its content '
+              '${blocks[0].width.toStringAsFixed(1)}px, and side by side that '
+              'leaves each count half of it — less than the dot, the number and '
+              'the word need in any locale. The counts must stack (#1238).',
+        );
+      });
+    }
+
+    testWidgets('@desktop ${desktopCase.widthKey}px the counts share a row',
+        (tester) async {
+      // The stacking is a narrow-width degradation, not a redesign. A threshold
+      // raised past the desktop realization would fail here and nowhere else.
+      await pumpAt(tester, widthCase: desktopCase, locale: const Locale('el'));
+
+      final blocks = layoutBlockRects(tester);
+      expect(blocks.length, 2);
+      expect(blocks[0].top, closeTo(blocks[1].top, 0.01),
+          reason: 'at ${desktopCase.widthKey}px the counts must still sit side '
+              'by side');
+      expect(blocks[1].left, greaterThan(blocks[0].right),
+          reason: 'the offline count must start after the online count ends');
+    });
+  });
+
+  group('each count keeps its word whole (#1238)', () {
+    // `el` is the locale to assert on: «Χωρίς σύνδεση» is the widest `offline`
+    // rendering of the 26 (116.7px all in, against `en`'s 66.8px and `zh`'s
+    // 52.2px), so it is the one that binds the threshold. A locale whose word
+    // fits with room to spare cannot detect a shrinking block at all.
+    //
+    // This is a legibility claim, not an overflow one: the two texts are
+    // unwrapped, so a block too narrow for them overflows rather than truncating
+    // — which is the gate's business. What is measured here is that the content
+    // sits *inside* the block it was given, with the same 2px tolerance the gate
+    // uses, so a count cannot be declared fixed while resting on the tolerance.
+    for (final wc in narrowCases) {
+      testWidgets('@${wc.label} ${wc.widthKey}px el fits both counts',
+          (tester) async {
+        await pumpAt(tester, widthCase: wc, locale: const Locale('el'));
+
+        final blocks = layoutBlockRects(tester);
+        expect(blocks.length, 2);
+
+        for (var i = 0; i < 2; i++) {
+          final texts = find.descendant(
+            of: find.byType(LayoutBlock).at(i),
+            matching: find.byType(Text),
+          );
+          expect(texts.evaluate().length, 2,
+              reason: 'count block $i must render the number and the word');
+
+          for (var j = 0; j < 2; j++) {
+            final r = tester.getRect(texts.at(j));
+            expect(
+              r.right,
+              lessThanOrEqualTo(blocks[i].right + 2.0),
+              reason: 'count block $i text $j ends at '
+                  '${r.right.toStringAsFixed(1)} but its block ends at '
+                  '${blocks[i].right.toStringAsFixed(1)}. Stacking exists to '
+                  'give the pair the full content width instead of making the '
+                  'text give way (#1238).',
+            );
+          }
+        }
+      });
+    }
+  });
+
+  group('stacking does not push the device list out of view (#1238)', () {
+    // Stacking adds 52px, taking the pair from 44px to 96px of a 261px content
+    // viewport. The template scrolls, so a pair
+    // that grew until the list was below the fold would overflow nothing — the
+    // gate cannot trade a right overflow for an invisible list, but a careless
+    // padding change can.
+    for (final wc in narrowCases) {
+      testWidgets(
+          '@${wc.label} ${wc.widthKey}px both counts and a device row are '
+          'visible', (tester) async {
+        await pumpAt(tester, widthCase: wc, locale: const Locale('en'));
+
+        final viewport = cardContentViewport(tester);
+        final blocks = layoutBlockRects(tester);
+        expect(blocks.length, 2);
+
+        for (var i = 0; i < 2; i++) {
+          expect(
+            blocks[i].bottom,
+            lessThanOrEqualTo(viewport.bottom),
+            reason: 'count block $i ends at ${blocks[i].bottom} but the card '
+                'only shows content down to ${viewport.bottom}',
+          );
+        }
+
+        final tiles = find.byType(AppListTile);
+        expect(tiles.evaluate(), isNotEmpty,
+            reason: 'the card rendered no device rows');
+        final firstRow = tester.getRect(tiles.first);
+        expect(
+          firstRow.bottom,
+          lessThanOrEqualTo(viewport.bottom),
+          reason: 'the first device row ends at ${firstRow.bottom}, below the '
+              'card\'s ${viewport.bottom} content bottom — the counts have '
+              'taken the whole viewport and the list is only reachable by '
+              'scrolling (#1238).',
+        );
+      });
+    }
+  });
+
+  group('the signal reading degrades, it does not disappear (#1238)', () {
+    // Where there is room, *every* reading is labelled — not merely one of them.
+    // Counting is the whole point: a label decided from the tile's trailing cap
+    // instead of the card's content width leaves `iPhone-15` with `-45 dBm` and
+    // `MacBook-Air`, one row below on the same 1440px screen, with bare bars,
+    // because the cap is that row's own demand and a longer name lowers it
+    // (measured: 75.0px against 64.8px against 22.0px). Nothing overflows either
+    // way, so the gate reports both as fixed.
+    for (final wc in [narrowCases.last, desktopCase]) {
+      testWidgets('@${wc.label} ${wc.widthKey}px every reading is labelled',
+          (tester) async {
+        await pumpAt(tester, widthCase: wc, locale: const Locale('en'));
+
+        final indicators = signalIndicators().evaluate().length;
+        expect(indicators, greaterThan(0),
+            reason: 'the fixture must have WiFi rows to read');
+        expect(
+          signalLabels().evaluate().length,
+          indicators,
+          reason: 'at ${wc.widthKey}px the content is '
+              '${wc.cardWidth.toStringAsFixed(0)}px wide for every row alike, so '
+              'either all $indicators readings carry their `-NN dBm` or none do. '
+              'A per-row answer here is a per-row answer the user cannot '
+              'explain (#1238).',
+        );
+      });
+    }
+
+    for (final wc in narrowCases) {
+      testWidgets('@${wc.label} ${wc.widthKey}px the bars are drawn',
+          (tester) async {
+        await pumpAt(tester, widthCase: wc, locale: const Locale('en'));
+
+        // At the min realization the trailing slot is capped at 35.0px and the
+        // labelled indicator wants 75.0-80.8px, so it is the label that goes —
+        // but the four bars are 22.0px and keep their design size, carrying the
+        // strength on their own. A trailing that dropped both would also be
+        // gate-green.
+        expect(signalIndicators().evaluate(), isNotEmpty,
+            reason: 'the signal bars must still be drawn at ${wc.widthKey}px — '
+                'they are what is left of the reading (#1238)');
+      });
+    }
+
+    testWidgets(
+        '@min ${narrowCases.first.widthKey}px the label is suppressed, not '
+        'clipped', (tester) async {
+      // Narrowest realization only: 157.4px of content leaves the trailing slot
+      // 35.0px, against 75.0px for a 2-digit reading and 80.8px for `-100 dBm`.
+      // Asserting absence at the preferred width would pin the wrong thing —
+      // 254px gives the slot 98.5px and the label is drawn there.
+      await pumpAt(tester,
+          widthCase: narrowCases.first, locale: const Locale('en'));
+
+      expect(signalLabels().evaluate(), isEmpty,
+          reason:
+              'at ${narrowCases.first.widthKey}px the label must be dropped '
+              'rather than left to overflow (#1238)');
+    });
+  });
+
+  group('the parent-node badge yields before the device name (#1238)', () {
+    testWidgets('@desktop ${desktopCase.widthKey}px the badge is shown',
+        (tester) async {
+      await pumpAt(tester, widthCase: desktopCase, locale: const Locale('en'));
+
+      expect(find.text('MR7500').evaluate(), isNotEmpty,
+          reason:
+              'the node a client is attached to is real information and the '
+              'slot has room for it at ${desktopCase.widthKey}px');
+    });
+
+    for (final wc in narrowCases) {
+      testWidgets(
+          '@${wc.label} ${wc.widthKey}px the device name is still drawn',
+          (tester) async {
+        await pumpAt(tester, widthCase: wc, locale: const Locale('en'));
+
+        // Before ui_kit v2.34.10 the tile absorbed a too-wide trailing by
+        // starving its title column to 0px — a row with no name. The trailing
+        // now gives way instead; this pins the consequence rather than the
+        // mechanism.
+        final title = find.text('Desktop-PC');
+        expect(title.evaluate(), isNotEmpty,
+            reason: 'the first device row rendered no name at all');
+        expect(
+          tester.getRect(title.first).width,
+          greaterThan(0),
+          reason: 'the device name was allocated no width at ${wc.widthKey}px. '
+              'The trailing must yield to the name, not the other way round '
+              '(#1238). How much it gets is #1240\'s problem — that it gets any '
+              'is this one\'s.',
+        );
+      });
+    }
+
+    testWidgets('@min ${narrowCases.first.widthKey}px the badge is dropped',
+        (tester) async {
+      await pumpAt(tester,
+          widthCase: narrowCases.first, locale: const Locale('en'));
+
+      // Dropped rather than ellipsized: a node name clipped to three characters
+      // and a dash names nothing, and it would cost the name beside it.
+      expect(find.text('MR7500').evaluate(), isEmpty,
+          reason:
+              'at ${narrowCases.first.widthKey}px the badge must be dropped '
+              '(#1238)');
+    });
+  });
+
+  group('a badge is dropped for being truncated, not for being short (#1238)',
+      () {
+    // The gate fixture has one badge, `MR7500` on a WiFi row, so it cannot see
+    // the case that matters here: the trailing slot's cap is the row's *own*
+    // demand, so a two-letter node name is granted only what it asked for at
+    // every card width. Any fixed floor high enough to reject a squeezed
+    // `Extender-1` also rejects `N1` on a 1440px screen — the badge has to be
+    // measured against its own label, and the gate stays green either way because
+    // a dropped badge overflows nothing.
+    //
+    // These two rows separate the two reasons a badge can be narrow, measured:
+    //   - `N1` is narrow because the name is short — 30.1px natural, and its row
+    //     is handed 32.6px at 191px, 288px and 512px alike (the wired row's
+    //     `Wired` label is the wider of the two, and there is no signal indicator
+    //     to raise the demand further), so the badge is always whole.
+    //   - `Extender-1` is narrow only when squeezed — 78.3px natural, granted
+    //     78.3px at 288px and 512px but only 22.0px at the min realization.
+    final devices = [
+      DevicesTestData.createSlaveConnectedClient(
+          isWifi: false, parentNodeName: 'N1'),
+      DevicesTestData.createWifiClient(parentNodeName: 'Extender-1'),
+    ];
+
+    for (final wc in [...narrowCases, desktopCase]) {
+      testWidgets('@${wc.label} ${wc.widthKey}px a short name is kept',
+          (tester) async {
+        await pumpDevices(tester, widthCase: wc, devices: devices);
+
+        expect(find.text('N1').evaluate(), isNotEmpty,
+            reason:
+                'the badge fits whole in the 30.1px its own label asks for, '
+                'at every width. Rejecting it against anything but its own '
+                'width loses the node name on a 1440px screen (#1238).');
+      });
+    }
+
+    testWidgets('@desktop ${desktopCase.widthKey}px a long name is kept',
+        (tester) async {
+      await pumpDevices(tester, widthCase: desktopCase, devices: devices);
+
+      expect(find.text('Extender-1').evaluate(), isNotEmpty);
+    });
+
+    testWidgets('@min ${narrowCases.first.widthKey}px a long name is dropped',
+        (tester) async {
+      await pumpDevices(tester, widthCase: narrowCases.first, devices: devices);
+
+      expect(find.text('Extender-1').evaluate(), isEmpty,
+          reason:
+              'at 22.0px of slot the 78.3px badge could only ellipsize, and '
+              '`Ex…` names nothing (#1238)');
+    });
+  });
+
+  group('the widths between the realizations stay clean (#1238)', () {
+    // The gate pumps the *narrowest* realization of each span and nothing else:
+    // 191px (content 157.4) and 288px (content 254.0). A user dragging the card
+    // reaches every width in between, and the trailing slot's cap grows linearly
+    // through them — so a label threshold can sit in that gap, pass the gate at
+    // both ends, and overflow in the middle. That is not hypothetical: the first
+    // version of this fix used 175, derived from the tile's 25% content floor
+    // alone, and overflowed +33.0px at content 175, +17.0px at 200 and +5.0px at
+    // 216 while the gate stayed green at 1644 tests.
+    //
+    // The real cap is a lend-back of what the leading did not want —
+    // `0.75 × (content − 64) − 44` — so seating the widest reading (`-100 dBm`,
+    // 80.8px) needs 230.4px of content, hence 231. These widths bracket that:
+    // three that must suppress the label and one just past it.
+    //
+    // The worst-case reading matters as much as the width. A 2-digit `-45 dBm` is
+    // 75.0px and clears at content 223; the 3-digit one is 80.8px and does not
+    // clear until 231. A fixture that only ever shows -45 would call 223 clean.
+    final devices = [
+      DevicesTestData.createWifiClient(
+        hostName: 'iPhone-15',
+        wifi: DevicesTestData.createWifiInfo(signalStrength: -100),
+        parentNodeName: 'N1',
+      ),
+      DevicesTestData.createWifiClient(
+        hostName: 'MacBook-Air-of-Someone',
+        wifi: DevicesTestData.createWifiInfo(signalStrength: -100),
+        parentNodeName: 'Extender-1',
+      ),
+      DevicesTestData.createWifiClient(
+        hostName: 'Smart-Speaker',
+        wifi: DevicesTestData.createWifiInfo(signalStrength: -100),
+      ),
+    ];
+
+    // Card width, and the content width it produces (card − 34).
+    for (final cardWidth in <double>[209, 234, 250, 264, 265]) {
+      testWidgets(
+          '@between ${cardWidth.toStringAsFixed(0)}px '
+          '(content ${(cardWidth - 34).toStringAsFixed(0)}px) nothing overflows',
+          (tester) async {
+        final incidents = await pumpDevices(
+          tester,
+          widthCase: CardWidthCase(
+            label: 'between',
+            cardWidth: cardWidth,
+            screenWidth: cardWidth + 40,
+            columnSpan: spec.getConstraints(DisplayMode.normal).minColumns,
+          ),
+          devices: devices,
+        );
+
+        expect(
+          incidents,
+          isEmpty,
+          reason:
+              'at ${cardWidth.toStringAsFixed(0)}px the card gives its rows '
+              '${(cardWidth - 34).toStringAsFixed(0)}px of content and the '
+              'trailing slot only `0.75 × (content − 64) − 44` of that. '
+              'Overflowing here means the `-NN dBm` label was kept at a width '
+              'that cannot seat it — invisible to the gate, which never pumps '
+              'this width (#1238). Got: '
+              '${incidents.map((i) => '+${i.pixels.toStringAsFixed(1)}px ${i.side}').join(', ')}',
+        );
+      });
+    }
+  });
+
+  group('wired rows keep their interface label (#1238)', () {
+    // The compact path drops the dBm label and the badge; the wired/WiFi
+    // fallback is the *only* thing a row without a signal reading has in its
+    // trailing, so it is not part of that bargain. Ellipsized, never absent.
+    for (final wc in [...narrowCases, desktopCase]) {
+      testWidgets('@${wc.label} ${wc.widthKey}px Wired is labelled',
+          (tester) async {
+        await pumpAt(tester, widthCase: wc, locale: const Locale('en'));
+
+        final wired = find.text('Wired');
+        expect(wired.evaluate(), isNotEmpty,
+            reason: 'a row with no signal reading has nothing else in its '
+                'trailing, so the interface label must stay (#1238)');
+        expect(tester.getRect(wired.first).width, greaterThan(0));
+      });
+    }
+  });
+}

--- a/test/page/dashboard/views/components/ethernet_ports_summary_readability_test.dart
+++ b/test/page/dashboard/views/components/ethernet_ports_summary_readability_test.dart
@@ -76,52 +76,13 @@ void main() {
   final narrowCases = widthCasesFor(spec);
 
   /// A mainstream desktop realization — 1440px screen, the card's default span.
-  final desktopCase = CardWidthCase(
-    screenWidth: 1440,
-    cardWidth: cardWidthAt(1440, 6),
-    columnSpan: 6,
-    label: 'desktop',
-  );
+  /// Taken from the spec via [desktopCaseFor] rather than hardcoding the span,
+  /// which is what the local copy of this used to do (#1238).
+  final desktopCase = desktopCaseFor(spec);
 
   /// The two summary tiles, in order (WAN, LAN). They are the card's only
-  /// [LayoutBlock]s.
-  List<Rect> tileRects(WidgetTester tester) {
-    final finder = find.byType(LayoutBlock);
-    return [
-      for (var i = 0; i < finder.evaluate().length; i++)
-        tester.getRect(finder.at(i)),
-    ];
-  }
-
-  /// The card's own content viewport — the shorter of the two scroll views in
-  /// the tree (the pump harness wraps the whole card in one as well).
-  ///
-  /// The count is asserted rather than assumed. Picking "the shortest" out of an
-  /// empty finder would return [Rect.largest], and every visibility assertion
-  /// below would then pass against an infinite viewport — the failure mode is a
-  /// silently green test, not a red one, so it has to be caught here. Two is the
-  /// exact expected number: one from the harness, one from
-  /// `DashboardCardTemplate`. If the template stops scrolling its content, or
-  /// anything inside the card starts, this fails loudly and the reader learns
-  /// which assumption broke.
-  Rect contentViewport(WidgetTester tester) {
-    final finder = find.byType(SingleChildScrollView);
-    final count = finder.evaluate().length;
-    expect(
-      count,
-      2,
-      reason: 'expected exactly two scroll views — the pump harness and the '
-          'card content. Found $count, so "the shortest" no longer identifies '
-          'the card\'s own viewport and these measurements are meaningless.',
-    );
-
-    var best = Rect.largest;
-    for (var i = 0; i < count; i++) {
-      final r = tester.getRect(finder.at(i));
-      if (r.height < best.height) best = r;
-    }
-    return best;
-  }
+  /// [LayoutBlock]s, so the shared helper returns exactly them.
+  List<Rect> tileRects(WidgetTester tester) => layoutBlockRects(tester);
 
   group('both summary tiles stay whole where the card is narrow (#1228)', () {
     // The vertical budget is the point. A tile that overflows nothing but is
@@ -132,7 +93,7 @@ void main() {
           (tester) async {
         await pumpAt(tester, widthCase: wc, locale: const Locale('en'));
 
-        final viewport = contentViewport(tester);
+        final viewport = cardContentViewport(tester);
         final tiles = tileRects(tester);
 
         expect(tiles.length, 2,

--- a/test/util/dashboard/dashboard_card_probe.dart
+++ b/test/util/dashboard/dashboard_card_probe.dart
@@ -7,6 +7,7 @@ import 'package:flutter_portal/flutter_portal.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
 import 'package:privacy_gui/page/_shared/providers/card_tab_state_provider.dart';
 import 'package:privacy_gui/page/dashboard/factories/usp_widget_factory.dart';
 import 'package:privacy_gui/page/dashboard/models/display_mode.dart';
@@ -269,6 +270,74 @@ List<CardWidthCase> widthCasesFor(WidgetSpec spec, {double? minScreen}) {
   return byWidth.values.toList();
 }
 
+/// A mainstream desktop realization of [spec] — the card's preferred span on a
+/// 1440px screen.
+///
+/// The readability tests that accompany the #1183 gate all need one width the
+/// card is *not* cramped at, because every narrow-width degradation they guard
+/// has a second half: it must not fire where the card has room. The gate itself
+/// only ever pumps narrowest realizations ([widthCasesFor]), so this width is
+/// measured by nothing else.
+///
+/// Taken from the spec rather than hardcoded so a card whose preferred span
+/// changes moves this with it (#1238).
+CardWidthCase desktopCaseFor(WidgetSpec spec, {double screenWidth = 1440}) {
+  final span = spec.getConstraints(DisplayMode.normal).preferredColumns;
+  return CardWidthCase(
+    screenWidth: screenWidth,
+    cardWidth: cardWidthAt(screenWidth, span),
+    columnSpan: span,
+    label: 'desktop',
+  );
+}
+
+/// Every [LayoutBlock] in the pumped tree, in paint order.
+///
+/// [LayoutBlock] is the app's card-section container, so on most cards this is
+/// "the sections", and their rects are what an arrangement assertion (stacked vs
+/// side by side) is made of.
+List<Rect> layoutBlockRects(WidgetTester tester) {
+  final finder = find.byType(LayoutBlock);
+  return [
+    for (var i = 0; i < finder.evaluate().length; i++)
+      tester.getRect(finder.at(i)),
+  ];
+}
+
+/// The pumped card's own content viewport — the shorter of the two scroll views
+/// in the tree ([buildDashboardCardApp] wraps the whole card in one as well).
+///
+/// The count is asserted rather than assumed. Picking "the shortest" out of an
+/// empty finder would return [Rect.largest], and every visibility assertion made
+/// against it would then pass against an infinite viewport — the failure mode is
+/// a silently green test, not a red one, so it has to be caught here. Two is the
+/// exact expected number: one from the harness, one from `DashboardCardTemplate`.
+/// If the template stops scrolling its content, or anything inside the card
+/// starts, this fails loudly and the reader learns which assumption broke.
+///
+/// Use this — not the content column's own bottom — when asking whether
+/// something is *visible*: `DashboardCardTemplate` scrolls, so a section can sit
+/// below the viewport while overflowing nothing, which is precisely the failure
+/// the gate cannot see.
+Rect cardContentViewport(WidgetTester tester) {
+  final finder = find.byType(SingleChildScrollView);
+  final count = finder.evaluate().length;
+  expect(
+    count,
+    2,
+    reason: 'expected exactly two scroll views — the pump harness and the card '
+        'content. Found $count, so "the shortest" no longer identifies the '
+        'card\'s own viewport and these measurements are meaningless.',
+  );
+
+  var best = Rect.largest;
+  for (var i = 0; i < count; i++) {
+    final r = tester.getRect(finder.at(i));
+    if (r.height < best.height) best = r;
+  }
+  return best;
+}
+
 // --- Tab registry ------------------------------------------------------------
 
 /// Number of tabs each tabbed card exposes. Non-listed cards are single-view
@@ -305,6 +374,14 @@ int visibleTabCount(WidgetTester tester) {
 /// requested [tabIndex] is pinned via [cardTabIndexProvider] so tabbed cards
 /// render the tab we want without a geometric tap (long localized labels make
 /// taps flaky).
+///
+/// [cardOverride] replaces the factory lookup with a hand-built card. The gate
+/// itself must never pass it — going through the factory is what makes a renamed
+/// or unregistered card fail loudly. It exists for the readability tests, which
+/// need a *specific* row shape (a long device name, a 3-digit signal reading) and
+/// cannot get one from the dashboard's kitchen-sink fixture. The card id is still
+/// required, because everything else here — tab pinning, the spec-derived
+/// geometry — is keyed off it.
 Widget buildDashboardCardApp({
   required String cardId,
   required Locale locale,
@@ -313,8 +390,9 @@ Widget buildDashboardCardApp({
   required double cardHeight,
   int tabIndex = 0,
   Key? repaintKey,
+  Widget? cardOverride,
 }) {
-  final card = UspWidgetFactory().buildWidget(cardId);
+  final card = cardOverride ?? UspWidgetFactory().buildWidget(cardId);
   if (card == null) {
     throw StateError(
       'UspWidgetFactory has no widget for id "$cardId". '
@@ -381,6 +459,9 @@ Widget buildDashboardCardApp({
 /// multiple widths/tabs in one test: each (card, width, tab, locale) is its own
 /// `testWidgets`, giving every measurement a fresh tree. This function does the
 /// single pump for one such test.
+///
+/// [cardOverride] is forwarded to [buildDashboardCardApp] — see there for when
+/// passing it is legitimate and when it defeats the point.
 Future<List<OverflowIncident>> probeCardOverflow(
   WidgetTester tester, {
   required String cardId,
@@ -389,6 +470,7 @@ Future<List<OverflowIncident>> probeCardOverflow(
   required int tabIndex,
   required Locale locale,
   Key? repaintKey,
+  Widget? cardOverride,
 }) {
   final surface =
       Size(widthCase.screenWidth, dashboardCardHeight(cardHeightRows));
@@ -405,6 +487,7 @@ Future<List<OverflowIncident>> probeCardOverflow(
         cardHeight: dashboardCardHeight(cardHeightRows),
         tabIndex: tabIndex,
         repaintKey: repaintKey,
+        cardOverride: cardOverride,
       ),
     );
     await settleIgnoringAnimations(tester);


### PR DESCRIPTION
Closes #1238. Part of #1183 (T12).

`connected_devices` held 27 of the epic's coordinates: **26 previously recorded as dependency-blocked** on ui_kit's `AppListTile` (`min|0`, 13 locales × 2 tabs) and **1 card-own** (`preferred|0`, `el`). All 27 are now fixed at the call site and **both `connected_devices` keys plus their tracking note are deleted from `known_overflows.json`** — nothing is re-allowlisted. `minColumns` stays 3 (AC 6), and `ui_kit_library` is not forked, copied or patched (AC 5).

## The dependency answer (AC 2 / AC 3)

The 26 were blocked because ui_kit ≤ v2.34.5 laid `AppListTile` out as a plain `Row`: the trailing slot took its natural width and the title column absorbed the shortfall down to 0px, so no call-site decision could reach the overflow.

**v2.34.10 replaces that Row with `ListTileContentLayout`**, a slotted render object that reserves the content column 25% of the row and caps each slot. That makes the fix reachable at the call site for the first time, so this PR takes the AC 3 path — fix and delete — rather than the AC 4 path of allowlisting behind an upstream request. Bumping `ui_kit_library` / `generative_ui` to `v2.34.10` is therefore part of the fix, not an incidental bump.

The allocator, for the record:

```
available   = maxWidth − gaps                       // 16px per present slot ⇒ 32
floor       = available × 0.25                      // contentFloorFraction
pool        = available − floor;  share = pool / 2   // = 0.375 × available
leadingCap  = share + max(0, share − trailingDemand)
trailingCap = share + max(0, share − leadingDemand)
width       = min(demand, cap);  content = available − leading − trailing
```

## The fix

Three documented constants in `lib/page/devices/cards/usp_connected_devices_card.dart`:

| constant | value | what it does |
|---|---|---|
| `_kStatusCountsSideBySideMinWidth` | 296 | below it the online/offline counts stack into full-width blocks instead of sitting side by side |
| `_kSignalLabelContentMinWidth` | 231 | below it the signal indicator drops its `-NN dBm` label and keeps only its four bars |
| `_kNodeBadgeMaxWidth` | 100 | shared by the badge and by `_nodeBadgeNaturalWidth`, which drops the badge per row when the slot could only ellipsize it |

**The status counts (the 1 card-own coordinate).** Side by side, each count gets `(content − 8) / 2` minus 24px of padding to hold a 10px dot, the number and the state word. The binding locale is `el`, whose «Χωρίς σύνδεση» needs **116.7px** all in (`en` 66.8px, `zh` 52.2px), so side by side needs **289.4px** of content — which neither narrow realization has: 157.4px at a 191px card (the widest 15 locales overflow by +14 to +66px) and 254.0px at a 288px card, which is exactly where `el`'s single `preferred|0` coordinate came from (+18px). Stacked, each block gets the full 133.4px / 230px and every locale fits unbroken with 16.7px to spare in the worst case. 296 is slack, not a knife edge: the realized widths either side are 254.0px and ~600px.

**The `-NN dBm` label (the 26).** The indicator is four fixed-width bars plus an unwrapped `AppText`, so it holds its natural width at any box width and cannot yield: **80.8px** at the widest reading (`-100 dBm`), 22.0px with the label suppressed. With the tile's 32px of padding and its two 16px gaps, `available = content − 64` and `trailingCap = 0.75 × available − 44` once the leading 44px icon stops binding, so seating 80.8px needs `content ≥ 64 + (80.8 + 44) / 0.75` = **230.4px** ⇒ 231.

**Why the threshold is read from the card and not from the slot.** The trailing cap is a *lend-back* of what the other slots did not want, so it tracks the **device name's** length, not the card's. Measured on the dashboard fixture at a 512px card, three rows with identical trailing content were handed 75.0px (`iPhone-15`), 64.8px (`MacBook-Air`) and 22.0px (`Smart-Speaker`). Gating the label on the slot therefore deletes the reading on a 1440px screen for the longest-named rows while the row above keeps it, for a reason no user can see. The card's content width is the same for every row, so this is decided once, in one `LayoutBuilder`.

The **badge** is the one decision the slot *can* answer, and it is left there: the slot's cap is this row's own demand and the badge is what demands it, so a name that fits whole is granted the width it asked for and a name that cannot be shown whole is dropped rather than ellipsized (a node name clipped to three characters and a dash names nothing). At the narrowest card `Extender-1` wants 78.3px against a 35.0px slot, while `N1` wants 30.1px and gets all of it — any constant floor high enough to reject the first also rejects the second.

## Why there is a second test file

`test/page/dashboard/views/components/connected_devices_readability_test.dart` (29 tests, tagged `dashboard-card` so it gates PRs).

The #1183 gate pumps only the **narrowest realization of each span**, so every width in between is invisible to it. The first version of `_kSignalLabelContentMinWidth` was **174.7px** — the 25% content floor alone, omitting the lend-back and the tile's 32px of padding. It holds at 157.4px and at 254.0px, so **all 1644 gate checks were green**, and it overflows at every width between them:

| content | trailing cap | result |
|---|---|---|
| 157.4 (min realization) | 35.0 | label suppressed, clean |
| 175 | 41.3 | **+33.0px** |
| 200 | 60.0 | **+17.0px** |
| 216 | 72.0 | **+5.0px** |
| 229 | 79.8 | **+1.0px** |
| 230 | 80.5 | **+0.287px** |
| 231 | 81.3 | clean |
| 254.0 (preferred) | 98.5 | clean |

The new group pumps 209 / 234 / 250 / 264 / 265px card widths for exactly this reason, and it is the only check that catches the defect. Two lessons are written into §2.10e: a threshold has to be derived from the *whole* allocator, and a width a user can drag to is not covered by the gate pumping the two widths the grid happens to realize.

Every assertion was run against a mutation of the code it guards; **fourteen** mutations, every one killed:

| mutation | what failed |
|---|---|
| `_kStatusCountsSideBySideMinWidth` 296 → 0 | 8 tests, gate-visible |
| `_kStatusCountsSideBySideMinWidth` 296 → 1000 | 2 |
| `_kSignalLabelContentMinWidth` 231 → 0 | 6, gate-visible |
| `_kSignalLabelContentMinWidth` 231 → 1000 | 3 |
| `_kSignalLabelContentMinWidth` 231 → **175** | 4 — **gate-blind**, only this file catches it |
| badge natural-width gate → constant floor | 3 |
| `_kNodeBadgeMaxWidth` 100 → 400 | 2 |
| + 7 content-removal mutations (dot, count, label, bars, badge, subtitle, stacked stretch) | 1–5 each |

Absent content never overflows, so the gate rewards deleting the label exactly as much as sizing it: ten of the fourteen are content-removal mutations that leave the gate green while the card stops saying anything.

## AC 7 is not met, and is recorded rather than ticked

> *Device names and connection details stay readable at the narrowest clean width.*

At the 191px card the tile gives the device name **23.3px** (27.4px with no badge). That is the row's **shape**, not its overflow — three slots and two gaps inside 157.4px — and it is unchanged by this PR. Both things that could have made it worse (the label and the badge) are dropped there precisely so they don't. This is the same blocker recorded on #1275 and owned by **#1240 AC 1** (the compact row); the finding is written up in §2.10e point 4 and posted on #1238.

## Other changes

- `test/util/dashboard/dashboard_card_probe.dart` gains an optional `cardOverride`, so a readability test can pump a card with a fixture device list **through the same harness as the gate** — same `Portal`, same `disableAnimations`, same locale fallback fonts, same settle — rather than a hand-rolled app build that silently loses them. The gate itself must never pass it.
- `ethernet_ports_summary_readability_test.dart` drops its local copies of `desktopCaseFor` / `tileRects` / `contentViewport` in favour of the shared helpers (verified `ethernet_ports` `preferredColumns == 6`, so its desktop width is unchanged).
- Dashboard goldens regenerated: the v2.34.10 bump changes `AppListTile`'s layout. Verified by stashing the card so only the bump remained — the diffs persisted, so they belong to ui_kit, not to this card.

## Verification

| check | result |
|---|---|
| `./tool/run_overflow_test.sh` | **1644 pass**, exit 0, with both `connected_devices` keys deleted |
| readability (`connected_devices` + `ethernet_ports`) | 43 pass |
| `./run_tests.sh` | 5480 pass |
| dashboard goldens | 12 pass (regenerated) |
| `flutter analyze` | No issues found |
| `dart format` | 0 changed |

## Notes for review

- Expect a **`known_overflows.json` conflict with #1277** — both PRs delete a different card's note and keys from the same file. Whichever merges second resolves by keeping both deletions.
- v2.34.10 also carries `fix(charts): measure X-axis label height instead of inheriting fl_chart's 22`, which makes #1230 / #1277's `_kProtocolChartMinHeight` rationale historical. #1277's guard is still correct, just no longer the only thing standing between that chart and the overflow.
