### PR TITLE
build(web): prune the unserved CanvasKit output, and pre-compress behind a flag

### DIFF
--- a/build_web.sh
+++ b/build_web.sh
@@ -20,6 +20,14 @@
 #            Jenkins exports build parameters as environment variables.
 #
 #   LOCALES=en ./build_web.sh 100 false "/" prod false true             # English-only
+#
+#   Compress Set to "true" to pre-compress the large static assets with brotli
+#            and delete the originals (#1282). Off unless explicitly set, because
+#            it is inert — worse, a white screen — until the firmware ships the
+#            matching lighttpd rewrite rules. Same Jenkins story as LOCALES: one
+#            boolean parameter named Compress, no shell-step change.
+#
+#   Compress=true ./build_web.sh 100 false "/" prod false true          # Pre-compressed
 
 # Detect fvm: use fvm flutter if available, otherwise use flutter directly
 if command -v fvm > /dev/null 2>&1 && [ -f ".fvmrc" ]; then
@@ -77,6 +85,155 @@ function restoreLocales() {
     exit 1
   fi
   exit $buildStatus
+}
+
+# Removes build output that is never served, so it cannot reach the router's
+# flash. This runs unconditionally: it is a property of what we ship, not an
+# option, and keeping it next to the build makes the reasoning visible to
+# whoever next wonders why a directory disappears.
+#
+# build/web/canvaskit/ is the engine's own CanvasKit output (~37 MB, including
+# ~8.6 MB of *.symbols). Nothing requests it: flutter_bootstrap.js pins
+# canvasKitBaseUrl: "./assets/", so the loader only ever fetches
+# assets/canvaskit.*, which are hand-vendored copies committed under web/assets/
+# (see #1281 and test/web/canvaskit_variant_test.dart). Shipping the directory
+# would silently give back the flash #1281 reclaimed.
+#
+# Deliberately targeted paths, not a `find -iname canvaskit` sweep from the
+# workspace root: such a sweep also matches the FVM SDK's own
+# .fvm/flutter_sdk/bin/cache/flutter_web_sdk/canvaskit when flutter_sdk is a real
+# directory rather than a symlink, and rm -rf on that breaks the next build with
+# an error pointing somewhere unrelated.
+#
+# Idempotent, so the Jenkins job's own deletion step — which 1.x still needs —
+# stays a harmless no-op on 2.x rather than something to keep in sync.
+function pruneWebOutput() {
+  echo "======== Pruning unserved build output ========"
+  local prune=(
+    build/web/canvaskit
+  )
+
+  local p
+  for p in "${prune[@]}"; do
+    if [ -e "$p" ]; then
+      echo "  removing $p ($(du -sh "$p" 2> /dev/null | cut -f1))"
+      if ! rm -rf "$p"; then
+        echo "ERROR: could not remove $p"
+        return 1
+      fi
+    else
+      echo "  already absent: $p"
+    fi
+  done
+}
+
+# Pre-compresses the large static assets with brotli and deletes the originals,
+# so the router serves compressed bytes without needing a server-side brotli
+# library (its lighttpd has none). See #1282 for the measurements.
+#
+# gzip is deliberately not used here. Its output is near-incompressible, which
+# defeats the rootfs squashfs XZ layer and makes flash LARGER (9.45 -> 10.76 MB
+# measured), while also transferring ~1.3 MB more per cold load than brotli.
+#
+# The target list is explicit rather than a glob: a rewrite rule that matches
+# every .js/.wasm would also rewrite files that have no .br sibling
+# (canvaskit.js, flutter.js, usp_client.js, usp_client_bg.wasm), and each of
+# those is a 404 and a white screen. The list and the disk must agree, so a
+# missing target is a hard failure, never a silent skip.
+#
+# Inert without the server half: pre-compressed files with no lighttpd rewrite
+# rule are just 404s. Keep this off until the firmware team ships the config.
+#
+# Two compressors are accepted because the CI agent may not have the brotli CLI
+# (the current one does not; it does have node). Node's zlib is built on the same
+# libbrotli and at q11/lgwin=24 produces output of identical size — byte-identical
+# for main.dart.js, while canvaskit.wasm differs only in the one-byte window-size
+# header, since the CLI auto-sizes lgwin down to 23 for a 7.2 MB input. Both
+# decode back to the exact original.
+#
+# lgwin must be set explicitly: Node defaults to 22 while the CLI auto-sizes to
+# the input, which costs ~7.5 KB on main.dart.js. 24 is BROTLI_MAX_WINDOW_BITS,
+# the largest window needing no client negotiation, so browsers still decode it.
+function compressWebAssets() {
+  echo "======== Pre-compressing web assets (brotli -q11) ========"
+  local targets=(
+    build/web/main.dart.js
+    build/web/assets/canvaskit.wasm
+  )
+
+  local compressor=""
+  if command -v brotli > /dev/null 2>&1; then
+    compressor="cli"
+  elif command -v node > /dev/null 2>&1; then
+    compressor="node"
+  else
+    echo "ERROR: no brotli compressor available (need the brotli CLI or node)"
+    return 1
+  fi
+  echo "  compressor: $compressor"
+
+  # Checks the whole list before touching anything, so a target name that goes
+  # stale cannot leave the tree half-compressed — which serves as a mix of
+  # rewritten and unrewritten files, i.e. a white screen rather than a failure.
+  local f
+  local missing=0
+  for f in "${targets[@]}"; do
+    if [ ! -f "$f" ]; then
+      echo "ERROR: expected compression target missing: $f"
+      missing=1
+    fi
+  done
+  if [ "$missing" -ne 0 ]; then
+    echo "ERROR: target list and build output disagree; nothing was compressed"
+    return 1
+  fi
+
+  for f in "${targets[@]}"; do
+    # -c > "$f.br" rather than brotli's in-place mode: no dependency on -k
+    # semantics, and the original is removed explicitly below.
+    if [ "$compressor" = "cli" ]; then
+      if ! brotli -q 11 -c "$f" > "$f.br"; then
+        echo "ERROR: brotli failed on $f"
+        rm -f "$f.br"
+        return 1
+      fi
+    else
+      if ! node -e '
+const fs = require("fs"), zlib = require("zlib");
+const buf = fs.readFileSync(process.argv[1]);
+fs.writeFileSync(process.argv[2], zlib.brotliCompressSync(buf, {
+  params: {
+    [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+    [zlib.constants.BROTLI_PARAM_LGWIN]: zlib.constants.BROTLI_MAX_WINDOW_BITS,
+    [zlib.constants.BROTLI_PARAM_SIZE_HINT]: buf.length,
+  },
+}));' "$f" "$f.br"; then
+        echo "ERROR: node brotli failed on $f"
+        rm -f "$f.br"
+        return 1
+      fi
+    fi
+    if ! rm "$f"; then
+      echo "ERROR: could not remove original: $f"
+      return 1
+    fi
+    echo "  $(basename "$f") -> $(basename "$f").br"
+  done
+
+  # Consistency gate. A surviving original means lighttpd would serve it
+  # unrewritten; a missing .br means a 404 and a white screen.
+  for f in "${targets[@]}"; do
+    if [ ! -f "$f.br" ]; then
+      echo "ERROR: missing $f.br after compression"
+      return 1
+    fi
+    if [ -f "$f" ]; then
+      echo "ERROR: original survived: $f"
+      return 1
+    fi
+  done
+
+  echo "Pre-compression OK: ${#targets[@]} files"
 }
 
 buildNumber=${1}
@@ -154,6 +311,23 @@ if ! buildWebApp "$buildNumber"; then
     exit 1
 fi
 
+if ! pruneWebOutput; then
+    echo Web App "$buildNumber" prune failed
+    exit 1
+fi
+
+echo "Compress files? ${Compress:-false}"
+if [ "$Compress" == "true" ]; then
+    if ! compressWebAssets; then
+        echo Web App "$buildNumber" pre-compression failed
+        exit 1
+    fi
+fi
+
+# Last, so that what it measures is exactly what gets packaged: the prune has
+# already removed the unserved directory and any pre-compression has already
+# replaced the originals.
+#
 # Reporting, not gating: a measurement that cannot run must not fail a build that
 # already succeeded.
 ./tools/measure_payload.sh || echo "could not measure the delivered payload"

--- a/tools/measure_payload.sh
+++ b/tools/measure_payload.sh
@@ -4,9 +4,14 @@
 # packaged into /www/ on the router, and therefore the only part that consumes
 # firmware flash.
 #
-# The SDK's build/web/canvaskit/ directory is excluded because CI prunes it; the
-# CanvasKit builds that actually ship live under build/web/assets/. Quoting the
+# The SDK's build/web/canvaskit/ directory is excluded because it is never served;
+# the CanvasKit builds that actually ship live under build/web/assets/. Quoting the
 # whole build/web total as a firmware size overstates it by more than 2x.
+#
+# build_web.sh deletes that directory before calling this script, so the pruned
+# line reads 0 KB there. The subtraction stays for the standalone case — a plain
+# `flutter build web` followed by running this by hand — where it is the whole
+# difference between a real payload figure and a doubled one.
 #
 # Usage:
 #   ./tools/measure_payload.sh                  # print the payload size

--- a/tools/measure_payload.sh
+++ b/tools/measure_payload.sh
@@ -42,7 +42,14 @@ payloadKB=$((totalKB - prunedKB))
 
 echo "Delivered payload: ${payloadKB} KB ($(toMB "$payloadKB") MB)"
 echo "  build output:    ${totalKB} KB"
-echo "  pruned by CI:    ${prunedKB} KB (canvaskit/)"
+# Says "already pruned" rather than "0 KB" when the directory is gone. Under
+# build_web.sh it always is, and a bare 0 there reads as "nothing was pruned"
+# immediately after the prune step reported removing 37 MB.
+if [ "$prunedKB" -eq 0 ]; then
+  echo "  canvaskit/:      already pruned"
+else
+  echo "  excluded:        ${prunedKB} KB (canvaskit/, pruned before packaging)"
+fi
 
 echo
 echo "Largest contributors:"


### PR DESCRIPTION
Moves two build steps out of the Jenkins job's shell block and into `build_web.sh`. Nothing about the delivered payload changes by default — the prune is what CI already did, and the compression is off unless asked for.

The point is where the reasoning lives. Both steps encode non-obvious decisions (why a 37 MB directory is safe to delete, why brotli and not gzip), and in a job configuration nobody diffs, those decisions are invisible to the next person who touches them.

## `pruneWebOutput()` — unconditional

Deletes `build/web/canvaskit/` (~37 MB, ~8.6 MB of it `*.symbols`). Nothing requests it: `flutter_bootstrap.js` pins `canvasKitBaseUrl: "./assets/"`, so the loader only ever fetches `assets/canvaskit.*`, which are hand-vendored copies committed under `web/assets/`. Shipping the directory would silently give back the flash #1281 reclaimed.

**The Jenkins deletion step is deliberately left alone.** 1.x still needs it, and this function is idempotent, so on 2.x it now finds nothing:

```
========== find canvaskit ============
========== find canvaskit end ============
```

Verified under `dash -xe` — what a Jenkins shell step actually runs — that this exits 0 and the build continues: `find` with no match is 0, and `xargs rm -rf` on empty input is 0 under both BSD (never invokes `rm`) and GNU xargs (invokes it once with no operands, where `-f` absorbs the missing-operand error). Confirmed end-to-end that `artifacts/` and the tarball come out complete with zero `web/canvaskit/` entries. So there is no coordinated change and no drift between the two.

It is also written as explicit paths rather than the `find . -iname 'canvaskit' | xargs rm -rf` sweep Jenkins uses. That sweep also matches the FVM SDK's own `.fvm/flutter_sdk/bin/cache/flutter_web_sdk/canvaskit` whenever `flutter_sdk` is a real directory instead of a symlink — simulated, and it does delete the SDK's web engine, breaking the *next* build with an error pointing somewhere unrelated.

## `compressWebAssets()` — off unless `Compress=true`

brotli `-q 11` over `main.dart.js` and `assets/canvaskit.wasm`, originals deleted.

**Gated off on purpose.** It is inert until the firmware team ships the matching lighttpd rewrite rules — pre-compressed files with no server rule are just 404s, i.e. a white screen. #1282 is still `blocked:fw-support`; this lands the build half so it is ready and reviewed, not so it is enabled.

`Compress` arrives as an environment variable rather than a positional argument, because Jenkins exports build parameters — the same mechanism `LOCALES` and `FlutterVersion` already use. No shell-step change needed to turn it on later.

Three things that look like over-engineering and are not:

**The whole target list is validated before any file is touched.** Compressing and deleting while walking the array means a stale target name leaves the tree half-compressed — some files `.br`, some not. Under rewrite rules that is a mix of rewritten and unrewritten URLs, which is a white screen rather than a failed build. Reproduced on the straightforward version, hence the up-front pass.

**Two compressors.** The CI agent (Ubuntu 22.04.1) has **no `brotli` binary** and no python `brotli` module; it does have `node`. Node's zlib is the same libbrotli, so this prefers the CLI and falls back to `node -e`. Output is the same size — byte-identical for `main.dart.js`; `canvaskit.wasm` differs only in the one-byte window-size header, because the CLI auto-sizes `lgwin` to 23 for a 7.2 MB input. Both decode back to the exact original bytes.

**`lgwin` is pinned to 24.** Node defaults to 22, which costs ~7.5 KB on `main.dart.js`. 24 is `BROTLI_MAX_WINDOW_BITS`, the largest window requiring no client negotiation.

**gzip is not an option here.** Its output is near-incompressible, so it defeats the rootfs squashfs XZ layer and makes flash *larger* — 9.45 → 10.76 MB measured. See #1282 for the full table.

## `tools/measure_payload.sh`

The prune and compression run *before* `measure_payload.sh`, so what it reports is what actually gets packaged. That reordering broke the report, which the second commit fixes.

A real build printed this:

```
  removing build/web/canvaskit ( 37M)
  ...
  pruned by CI:    0 KB (canvaskit/)
```

The subtraction finds nothing left to subtract, so it reports 0 — four lines after the prune said it removed 37 MB. Under `build_web.sh` the directory is always gone by then, so it now says `already pruned`; for a standalone `flutter build web` followed by running this by hand, the subtraction is still the difference between a real payload figure and a doubled one, and there the KB number is worth printing. Both branches and the optional baseline argument verified against a real build.

The stale comment claiming the directory is "excluded because CI prunes it" is updated too — that is now this script's sibling.

## Testing

Two real `flutter build web` runs through the modified script:

| Run | Result |
|---|---|
| `Compress` unset (the default) | prune removed 37 MB, payload 23.54 MB |
| `Compress=true`, clean tree | payload 12.12 MB, both targets `.br`, no originals left |

Compression ratios on real output match #1282's table exactly — `main.dart.js` 19.1%, `assets/canvaskit.wasm` → 2,248,161 bytes, the same byte count recorded there.

Against a stubbed build tree, 5 cases:

| Case | Result |
|---|---|
| Happy path (brotli CLI) | both targets `.br`, `canvaskit/` gone, round-trip md5 identical to original |
| Prune run twice | `already absent`, exit 0 — the Jenkins no-op case |
| Missing target | aborts, **nothing touched, no stray `.br`** |
| No compressor on PATH | aborts, tree intact |
| brotli CLI hidden | selects node, round-trips to exact original bytes |

Two interactions with #1244, which landed on `dev-2.7.0` after this work started:

- An unset `Compress` does not trip `[ "$Compress" == "true" ]`.
- A compression failure still propagates `exit 1` through the new `LOCALES` EXIT trap, rather than being swallowed into 0.

Both scripts pass `bash -n`. `test/tools/locale_strip_test.dart` reproduces `build_web.sh`'s EXIT-trap sequence, so it is coupled to this file — 43/43 pass. `flutter analyze` reports no new findings (this branch changes no Dart).

## Note for whoever updates the Jenkins job

The gzip block there must be **deleted**, not just left disabled — with #1281 landed, `gzip -k -9 build/web/assets/chromium/canvaskit.wasm` targets a file that no longer exists (exit 1), and the following `rm` has no `-f` (exit 1). Verified: under `-e` that aborts the build; without `-e` it silently leaves a half-compressed tree carrying both originals and `.gz` siblings.

The `Compress` **parameter definition** must stay — `build_web.sh` reads it.

Refs #1282, #1281
