### PR TITLE
fix(dashboard): keep each breakpoint's layout to itself, and leave edit mode on logout (#1293, #1294)

### DIFF
--- a/lib/page/dashboard/models/usp_layout_envelope.dart
+++ b/lib/page/dashboard/models/usp_layout_envelope.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+
+/// The persisted form of the USP dashboard layout: one serialised grid per
+/// breakpoint, keyed by slot count.
+///
+/// ## Why the slot count has to be recorded
+///
+/// [DashboardController.exportLayout] returns coordinates in whatever slot count
+/// the controller is on at that moment. The pref used to hold a bare list of
+/// those coordinates with no note of which grid produced them, and load always
+/// read them back as 12-column values. A save made on a phone therefore came
+/// back on a laptop as a 12-column layout of 4-column cards — a third of their
+/// width, with `minW`/`maxW` scaled down to match, which made the damage
+/// permanent because those caps then blocked any attempt to widen the cards
+/// again (#1293).
+///
+/// ## Compatibility
+///
+/// A legacy bare list decodes as the [desktopSlotCount] entry — that is what it
+/// always was, since load created a 12-slot controller before importing. The
+/// other breakpoints are left absent rather than guessed, so the caller can tell
+/// "the user arranged this" from "we derived this" and re-derive the second kind
+/// whenever the scaling rules change.
+class UspLayoutEnvelope {
+  /// Slot counts the dashboard renders and persists, matching the ui_kit
+  /// breakpoint regimes (`GridLayoutContext.currentMaxColumns`).
+  static const int desktopSlotCount = 12;
+  static const int tabletSlotCount = 8;
+  static const int mobileSlotCount = 4;
+
+  /// Ordered widest-first: the desktop entry is the source the narrower grids
+  /// are derived from, so it has to be read and seeded first.
+  static const List<int> persistedSlotCounts = [
+    desktopSlotCount,
+    tabletSlotCount,
+    mobileSlotCount,
+  ];
+
+  /// Bumped whenever the payload shape changes in a way older builds would
+  /// misread. Version 1 is the implicit version of the legacy bare list.
+  static const int currentVersion = 2;
+
+  const UspLayoutEnvelope(this.layouts);
+
+  /// Serialised layouts by slot count. Keys outside [persistedSlotCounts] are
+  /// preserved on decode so a build that renders fewer breakpoints cannot
+  /// silently discard a layout a newer build wrote.
+  final Map<int, List<dynamic>> layouts;
+
+  List<dynamic>? operator [](int slotCount) => layouts[slotCount];
+
+  List<int> get slotCounts => layouts.keys.toList();
+
+  /// Returns a copy with [slotCount]'s geometry replaced.
+  UspLayoutEnvelope withLayout(int slotCount, List<dynamic> layout) =>
+      UspLayoutEnvelope({...layouts, slotCount: layout});
+
+  String encode() => jsonEncode({
+        'version': currentVersion,
+        'layouts': {
+          for (final entry in layouts.entries)
+            entry.key.toString(): entry.value,
+        },
+      });
+
+  /// Parses [raw], or returns null when it cannot be read as layouts on known
+  /// grids.
+  ///
+  /// Null means "fall back to the default layout", so the bar is deliberately
+  /// low: anything importable is imported, including ids this build does not
+  /// ship (they may be package widgets whose specs load later). What is rejected
+  /// is only what cannot be placed at all — a payload from a future version, a
+  /// slot count that is not a number, or items that are not maps. Importing
+  /// those would either throw inside the grid or render a layout the user never
+  /// arranged, and both are worse than starting from the default.
+  static UspLayoutEnvelope? tryDecode(String raw) {
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } catch (_) {
+      return null;
+    }
+
+    // Legacy: a bare list of 12-column items.
+    if (decoded is List) {
+      if (!_isItemList(decoded)) return null;
+      return UspLayoutEnvelope({desktopSlotCount: decoded});
+    }
+
+    if (decoded is! Map) return null;
+
+    final version = decoded['version'];
+    if (version is! int || version > currentVersion) return null;
+
+    final rawLayouts = decoded['layouts'];
+    if (rawLayouts is! Map) return null;
+
+    final layouts = <int, List<dynamic>>{};
+    for (final entry in rawLayouts.entries) {
+      final slotCount = int.tryParse('${entry.key}');
+      if (slotCount == null || slotCount < 1) return null;
+      final layout = entry.value;
+      if (layout is! List || !_isItemList(layout)) return null;
+      layouts[slotCount] = layout;
+    }
+
+    return UspLayoutEnvelope(layouts);
+  }
+
+  static bool _isItemList(List<dynamic> layout) =>
+      layout.every((item) => item is Map);
+}

--- a/lib/page/dashboard/models/usp_widget_specs.dart
+++ b/lib/page/dashboard/models/usp_widget_specs.dart
@@ -1,5 +1,6 @@
 import 'package:ui_kit_library/ui_kit.dart';
 import 'package:privacy_gui/page/dashboard/models/display_mode.dart';
+import 'package:privacy_gui/page/dashboard/models/usp_layout_envelope.dart';
 import 'package:privacy_gui/page/dashboard/models/widget_spec.dart';
 import 'package:privacy_gui/page/dashboard/providers/layout_item_factory.dart';
 import 'package:sliver_dashboard/sliver_dashboard.dart';
@@ -539,17 +540,85 @@ abstract class UspWidgetSpecs {
   // Layout Scaling
   // ---------------------------------------------------------------------------
 
+  /// Converts a column span from a [fromCols]-wide grid to a [toCols]-wide one,
+  /// never returning less than one column or more than the grid holds.
+  ///
+  /// Every column figure in a [WidgetSpec] is written for the 12-column grid, so
+  /// anything comparing a live item against its spec has to bring the spec to the
+  /// grid the item is actually on: read literally, `stats_panel`'s
+  /// `minColumns: 6` would demand three quarters of an 8-column row, and more
+  /// columns than a 4-column grid even has.
+  static int scaleSpan(
+    int span, {
+    required int fromCols,
+    required int toCols,
+  }) =>
+      (span * toCols / fromCols).round().clamp(1, toCols);
+
+  /// The size a card has to be corrected to on a [slotCount]-wide grid, or null
+  /// when the size it already has is allowed.
+  ///
+  /// The arithmetic lives here rather than in the resize handler because the
+  /// grid-dependent part is the whole point: the column figures in
+  /// [WidgetGridConstraints] describe the 12-column grid and mean nothing until
+  /// [scaleSpan] brings them to the grid in front of the user. Row counts are
+  /// absolute — a row is the same height on every grid — so they are compared
+  /// as they are.
+  ///
+  /// Mobile widths are left alone rather than scaled: there the width is pinned
+  /// by [lockToFullWidth], so a resize cannot have changed it and "correcting"
+  /// it could only fight the lock.
+  static ({int w, int h})? correctedSize(
+    WidgetGridConstraints constraints, {
+    required int w,
+    required int h,
+    required int slotCount,
+  }) {
+    var newW = w;
+    var newH = h;
+
+    if (slotCount > UspLayoutEnvelope.mobileSlotCount) {
+      final minColumns = scaleSpan(
+        constraints.minColumns,
+        fromCols: UspLayoutEnvelope.desktopSlotCount,
+        toCols: slotCount,
+      );
+      final maxColumns = scaleSpan(
+        constraints.maxColumns,
+        fromCols: UspLayoutEnvelope.desktopSlotCount,
+        toCols: slotCount,
+      );
+      // Sequential rather than clamp(). WidgetGridConstraints asserts
+      // min <= max, but a package widget's constraints are parsed from a remote
+      // template and asserts are gone in release, so the one build where a bad
+      // template could arrive is the one where clamp() would throw — inside a
+      // gesture handler. Narrowing to the ceiling is the better failure.
+      if (newW < minColumns) newW = minColumns;
+      if (newW > maxColumns) newW = maxColumns;
+    }
+
+    if (newH < constraints.minHeightRows) newH = constraints.minHeightRows;
+    if (newH > constraints.maxHeightRows) newH = constraints.maxHeightRows;
+
+    if (newW == w && newH == h) return null;
+    return (w: newW, h: newH);
+  }
+
   /// Proportionally scales a serialised layout from [fromCols] to [toCols].
   ///
   /// * Tablet (12→8): `w=6` → `w=4`, preserving two-column pairs.
-  /// * Mobile (12→4): all items become full-width (`w=toCols`) for
-  ///   single-column stacking — `compact()` then resolves y positions.
-  /// * Constraints (minW / maxW) are scaled accordingly.
+  /// * Mobile (12→4): delegates to [lockToFullWidth] — see there for why the
+  ///   width stops being the user's to choose at all.
+  /// * Constraints (minW / maxW) are scaled with the widths.
   static List<dynamic> scaleLayout(
     List<dynamic> layout,
     int fromCols,
     int toCols,
   ) {
+    if (toCols <= UspLayoutEnvelope.mobileSlotCount) {
+      return lockToFullWidth(layout, toCols);
+    }
+
     return layout.map((item) {
       final map = Map<String, dynamic>.from(item as Map);
       final x = map['x'] as int;
@@ -557,26 +626,18 @@ abstract class UspWidgetSpecs {
       final minW = map['minW'] as int? ?? 1;
       final maxW = (map['maxW'] as num?)?.toInt() ?? fromCols;
 
-      int newW;
-      int newX;
-
-      if (toCols <= 4) {
-        // Mobile: full-width single-column
-        newW = toCols;
+      // Proportional scaling
+      var newW = scaleSpan(w, fromCols: fromCols, toCols: toCols);
+      var newX = (x * toCols / fromCols).round();
+      if (newX + newW > toCols) newX = toCols - newW;
+      if (newX < 0) {
         newX = 0;
-      } else {
-        // Proportional scaling
-        newW = (w * toCols / fromCols).round().clamp(1, toCols);
-        newX = (x * toCols / fromCols).round();
-        if (newX + newW > toCols) newX = toCols - newW;
-        if (newX < 0) {
-          newX = 0;
-          newW = toCols;
-        }
+        newW = toCols;
       }
 
-      final newMinW = (minW * toCols / fromCols).round().clamp(1, toCols);
-      final newMaxW = (maxW * toCols / fromCols).round().clamp(newMinW, toCols);
+      final newMinW = scaleSpan(minW, fromCols: fromCols, toCols: toCols);
+      final newMaxW = scaleSpan(maxW, fromCols: fromCols, toCols: toCols)
+          .clamp(newMinW, toCols);
 
       return {
         ...map,
@@ -585,6 +646,58 @@ abstract class UspWidgetSpecs {
         'minW': newMinW,
         'maxW': newMaxW.toDouble(),
       };
+    }).toList();
+  }
+
+  /// Pins every item in [layout] to the full width of a [cols]-wide grid.
+  ///
+  /// Below five columns there is no width worth choosing — every card is either
+  /// full-width or unreadably narrow — so on mobile the width stops being
+  /// editable instead of being merely defaulted. `minW == maxW == cols` is what
+  /// enforces that: `DashboardController` clamps every resize delta to
+  /// `[minW, maxW]`, so with the two equal the horizontal drag is inert and only
+  /// height and order remain editable.
+  ///
+  /// It also repairs what the old mobile seed produced. Scaling `minW`/`maxW`
+  /// proportionally gave a card with `maxW: 8` at 12 columns a `maxW` of 3 at 4
+  /// columns while its width was set to 4 — a width outside its own cap, which
+  /// the first resize would have snapped down to 3 of 4 columns.
+  static List<dynamic> lockToFullWidth(List<dynamic> layout, int cols) {
+    return layout.map((item) {
+      return {
+        ...Map<String, dynamic>.from(item as Map),
+        'x': 0,
+        'w': cols,
+        'minW': cols,
+        'maxW': cols.toDouble(),
+      };
+    }).toList();
+  }
+
+  /// Rewrites [layout] to hold exactly the cards in [reference], in that order,
+  /// keeping whatever geometry [layout] already has for the ones it knows and
+  /// scaling in the ones it does not.
+  ///
+  /// Which cards exist is a property of the dashboard, not of a breakpoint:
+  /// deleting a card on a phone deletes the card. Only geometry is per-grid, so
+  /// a stored per-grid layout can legitimately fall behind — it was written
+  /// before a card was added. Importing it as-is would be worse than useless:
+  /// `DashboardController.setSlotCount` treats the layout it is leaving as the
+  /// truth about membership, so the stale grid's missing card would be
+  /// reconciled *out* of every other breakpoint on the way back.
+  static List<dynamic> alignMembership(
+    List<dynamic> layout,
+    List<dynamic> reference, {
+    required int fromCols,
+    required int toCols,
+  }) {
+    final stored = <String, dynamic>{
+      for (final item in layout) (item as Map)['id'] as String: item,
+    };
+
+    return reference.map((refItem) {
+      final id = (refItem as Map)['id'] as String;
+      return stored[id] ?? scaleLayout([refItem], fromCols, toCols).single;
     }).toList();
   }
 

--- a/lib/page/dashboard/models/usp_widget_specs.dart
+++ b/lib/page/dashboard/models/usp_widget_specs.dart
@@ -653,10 +653,11 @@ abstract class UspWidgetSpecs {
   ///
   /// Below five columns there is no width worth choosing — every card is either
   /// full-width or unreadably narrow — so on mobile the width stops being
-  /// editable instead of being merely defaulted. `minW == maxW == cols` is what
-  /// enforces that: `DashboardController` clamps every resize delta to
-  /// `[minW, maxW]`, so with the two equal the horizontal drag is inert and only
-  /// height and order remain editable.
+  /// editable instead of being merely defaulted. `minW == maxW == cols` is half
+  /// of what enforces that: `DashboardController` clamps every resize delta to
+  /// `[minW, maxW]`, which is enough to make the right-hand handles inert. The
+  /// left-hand ones need [lockItemsToFullWidth] on top — see there for why the
+  /// caps alone cannot hold them.
   ///
   /// It also repairs what the old mobile seed produced. Scaling `minW`/`maxW`
   /// proportionally gave a card with `maxW: 8` at 12 columns a `maxW` of 3 at 4
@@ -672,6 +673,45 @@ abstract class UspWidgetSpecs {
         'maxW': cols.toDouble(),
       };
     }).toList();
+  }
+
+  /// The [lockToFullWidth] geometry applied to live items, or null when every
+  /// item already has it.
+  ///
+  /// Pinning `minW == maxW == cols` does not finish the job. A resize delta is
+  /// clamped to `[minW, maxW]`, so a right-hand handle cannot move a width that
+  /// is already both floor and ceiling — but the left-hand handles (left,
+  /// topLeft, bottomLeft) move `x` as well, and the package trims the width to
+  /// whatever is left of the row after the clamp:
+  ///
+  /// ```
+  /// newX = x + dW;  newW = (w - dW).clamp(minW, maxW)
+  /// if (newX < 0) { newW += newX; newX = 0; }
+  /// if (newX + newW > cols) newW = cols - newX
+  /// ```
+  ///
+  /// One column of drag on the left edge therefore narrows a card on a 4-column
+  /// grid to three whichever way it is dragged — to `x: 1, w: 3` inwards, and to
+  /// `x: 0, w: 3` outwards, where the row's own edge does the trimming. Neither
+  /// width was authorised, and no cap can express "x may not move", so this has
+  /// to be undone on the live layout by whoever is watching it.
+  ///
+  /// Only `x` and `w` are touched: the height is the one dimension a phone still
+  /// leaves to the user, and the caps are repaired on import by
+  /// [lockToFullWidth]. Returning null rather than an equal list is what keeps a
+  /// watcher from writing back into the layout it was just notified about.
+  static List<LayoutItem>? lockItemsToFullWidth(
+    List<LayoutItem> items,
+    int cols,
+  ) {
+    List<LayoutItem>? locked;
+    for (var i = 0; i < items.length; i++) {
+      final item = items[i];
+      if (item.x == 0 && item.w == cols) continue;
+      locked ??= List<LayoutItem>.of(items);
+      locked[i] = item.copyWith(x: 0, w: cols);
+    }
+    return locked;
   }
 
   /// Rewrites [layout] to hold exactly the cards in [reference], in that order,

--- a/lib/page/dashboard/providers/dashboard_edit_mode_provider.dart
+++ b/lib/page/dashboard/providers/dashboard_edit_mode_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/page/dashboard/models/usp_layout_preferences.dart';
 import 'package:privacy_gui/page/dashboard/providers/usp_layout_controller.dart';
 import 'package:privacy_gui/page/dashboard/providers/usp_layout_preferences_provider.dart';
+import 'package:privacy_gui/providers/auth/auth_provider.dart';
 
 /// Manages dashboard edit mode state and layout snapshots for revert on cancel.
 ///
@@ -41,7 +42,44 @@ class DashboardEditState {
 
 class DashboardEditModeNotifier extends Notifier<DashboardEditState> {
   @override
-  DashboardEditState build() => const DashboardEditState();
+  DashboardEditState build() {
+    // Logging out has to leave edit mode (#1294).
+    //
+    // Logging out from the dashboard's own top-bar menu does not navigate
+    // anywhere and does not reload the page, so the route guard in
+    // route_usp_dashboard.dart never fires and this provider — root-scoped, like
+    // the layout controller — survives untouched. The next session then opens on
+    // a grid still showing resize handles and the trash zone, holding a layout
+    // snapshot captured before the logout that a later cancel would revert into.
+    //
+    // What matters is the logged-in → logged-out edge, not the logged-out state
+    // itself: auth also reports "logged out" before anyone has logged in, and
+    // reverting on that would undo an edit the user is still making.
+    //
+    // The edge cannot be read off the callback's `previous`, because
+    // AuthNotifier.logout emits AsyncValue.loading() before the logged-out
+    // value — by the time that value lands, `previous` is a value-less loading
+    // state that says nothing about who was logged in. So the last answer is
+    // remembered here instead, and loading/error emissions leave it alone.
+    // `fireImmediately` seeds it from whatever auth already knows, which is what
+    // makes a logout still register when the dashboard was opened mid-session.
+    bool wasLoggedIn = false;
+    ref.listen(authProvider, (_, next) {
+      final loggedIn = next.valueOrNull?.isLoggedIn;
+      if (loggedIn == null) return;
+
+      final loggedOutJustNow = wasLoggedIn && !loggedIn;
+      wasLoggedIn = loggedIn;
+
+      // `state` is only readable once build has returned. The seeding call
+      // cannot reach this line: it starts from wasLoggedIn = false.
+      if (loggedOutJustNow && state.isEditing) {
+        cancelEditMode();
+      }
+    }, fireImmediately: true);
+
+    return const DashboardEditState();
+  }
 
   /// Enter edit mode and capture snapshots for potential revert.
   Future<void> enterEditMode() async {

--- a/lib/page/dashboard/providers/usp_layout_controller.dart
+++ b/lib/page/dashboard/providers/usp_layout_controller.dart
@@ -41,10 +41,14 @@ final uspSliverDashboardControllerProvider = StateNotifierProvider<
 class UspSliverDashboardControllerNotifier
     extends StateNotifier<DashboardController> {
   UspSliverDashboardControllerNotifier() : super(_createDefaultController()) {
+    _armWidthLock();
     _initializeLayout();
   }
 
   static const int _desktopSlots = UspLayoutEnvelope.desktopSlotCount;
+
+  /// Cancels the current controller's width-lock subscription.
+  VoidCallback? _widthLockGuard;
 
   static DashboardController _createDefaultController() {
     return DashboardController(
@@ -67,10 +71,10 @@ class UspSliverDashboardControllerNotifier
     // Remote mode: use fixed remote preset layout, skip persistence
     final forcedPreset = GlobalConfig.remote.forcedPreset;
     if (forcedPreset != null) {
-      state = DashboardController(
+      _swapController(DashboardController(
         initialSlotCount: _desktopSlots,
         initialLayout: forcedPreset.createLayout(),
-      );
+      ));
       _seedBreakpoints();
       return;
     }
@@ -107,7 +111,7 @@ class UspSliverDashboardControllerNotifier
     if (desktop != null) {
       newController.importLayout(desktop);
     }
-    state = newController;
+    _swapController(newController);
     _seedBreakpoints(stored: envelope);
 
     // A legacy bare list, or an envelope written before we rendered a
@@ -169,6 +173,67 @@ class UspSliverDashboardControllerNotifier
           ? UspWidgetSpecs.lockToFullWidth(layout, slotCount)
           : layout;
 
+  /// Swaps in [controller] and re-arms the width lock on it.
+  ///
+  /// The lock belongs to the instance it watches, so a swap that forgets to
+  /// re-arm leaves the phone grid horizontally editable again.
+  void _swapController(DashboardController controller) {
+    state = controller;
+    _armWidthLock();
+  }
+
+  /// Watches the current controller's layout so a horizontal change made on the
+  /// phone grid is undone before it is drawn.
+  ///
+  /// [_normalize] is applied when a layout is imported and when it is stored,
+  /// which covers everything except the case in between: a gesture writes
+  /// straight to the controller's layout beacon, and on mobile the left-hand
+  /// resize handles get past the width caps by moving `x` — see
+  /// [UspWidgetSpecs.lockItemsToFullWidth]. Nothing else re-reads the live
+  /// layout after a resize, so without this the card stays where the drag left
+  /// it until the next import.
+  ///
+  /// Subscribing is what makes the drag look inert rather than rubber-banding:
+  /// the correction is queued alongside the rebuild the same write triggers, and
+  /// runs first because this subscription is registered before any widget starts
+  /// watching. `startNow: false` because the layout as it stands has already
+  /// been normalised by whoever imported it.
+  void _armWidthLock() {
+    _widthLockGuard?.call();
+    final controller = state;
+    _widthLockGuard = controller.layout.subscribe(
+      (items) => _enforceWidthLock(controller, items),
+      startNow: false,
+    );
+  }
+
+  /// Restores the full-width geometry of [items] if a gesture broke it.
+  ///
+  /// Takes the controller it was armed on rather than reading [state]: a swap
+  /// can land between the write and this callback, and the layout being
+  /// corrected belongs to the old instance.
+  void _enforceWidthLock(
+    DashboardController controller,
+    List<LayoutItem> items,
+  ) {
+    final slotCount = controller.slotCount.value;
+    if (slotCount > UspLayoutEnvelope.mobileSlotCount) return;
+
+    final locked = UspWidgetSpecs.lockItemsToFullWidth(items, slotCount);
+    if (locked == null) return;
+
+    // Straight to the beacon rather than through importLayout: that would
+    // compact the whole grid mid-gesture, closing gaps the user is in the
+    // middle of making.
+    controller.layout.value = locked;
+  }
+
+  @override
+  void dispose() {
+    _widthLockGuard?.call();
+    super.dispose();
+  }
+
   /// Persist the layout of every breakpoint to SharedPreferences.
   Future<void> saveLayout() async {
     final envelope = UspLayoutEnvelope(_exportAllBreakpoints());
@@ -210,7 +275,7 @@ class UspSliverDashboardControllerNotifier
 
     final controller = _createDefaultController();
     controller.importLayout(layouts[_desktopSlots] ?? const []);
-    state = controller;
+    _swapController(controller);
     _seedBreakpoints(stored: UspLayoutEnvelope(layouts));
 
     if (origin != _desktopSlots) {
@@ -226,7 +291,7 @@ class UspSliverDashboardControllerNotifier
 
   /// Reset to default layout and clear persisted data.
   Future<void> resetLayout() async {
-    state = _createDefaultController();
+    _swapController(_createDefaultController());
     // Re-seed: a controller with an empty breakpoint cache falls back to
     // correctBounds at tablet width, which collapses the two-column grid.
     _seedBreakpoints();
@@ -335,10 +400,10 @@ class UspSliverDashboardControllerNotifier
   /// rather than generic 2-column packing.
   Future<void> applyPreset(UspDashboardPreset preset) async {
     final layout = preset.createLayout();
-    state = DashboardController(
+    _swapController(DashboardController(
       initialSlotCount: _desktopSlots,
       initialLayout: layout,
-    );
+    ));
     _seedBreakpoints();
     await saveLayout();
   }

--- a/lib/page/dashboard/providers/usp_layout_controller.dart
+++ b/lib/page/dashboard/providers/usp_layout_controller.dart
@@ -1,9 +1,8 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/config/global_config.dart';
 import 'package:privacy_gui/page/dashboard/models/display_mode.dart';
+import 'package:privacy_gui/page/dashboard/models/usp_layout_envelope.dart';
 import 'package:privacy_gui/page/dashboard/models/widget_spec.dart';
 import 'package:privacy_gui/page/dashboard/providers/layout_item_factory.dart';
 import 'package:privacy_gui/constants/pref_key.dart';
@@ -25,15 +24,31 @@ final uspSliverDashboardControllerProvider = StateNotifierProvider<
 /// - No A2UI widget registry
 /// - No dynamic hardware-dependent constraints
 /// - Uses [UspWidgetSpecs] exclusively
+///
+/// ## Geometry is per breakpoint, membership is not
+///
+/// The dashboard renders on three grids (12 / 8 / 4 columns, following ui_kit's
+/// breakpoints) and each keeps its own coordinates: a card made taller on a
+/// phone stays that height on the phone only. What is *not* per breakpoint is
+/// which cards exist — deleting a card on a phone deletes the card everywhere.
+///
+/// That split is why the persisted value is a [UspLayoutEnvelope] keyed by slot
+/// count instead of the bare list it used to be. `exportLayout()` always returns
+/// coordinates in the controller's current slot count, so one unkeyed list meant
+/// a save on a phone was read back as a desktop layout of third-width cards
+/// whose `minW`/`maxW` had been scaled down with them — permanently, since the
+/// caps then blocked widening them again (#1293).
 class UspSliverDashboardControllerNotifier
     extends StateNotifier<DashboardController> {
   UspSliverDashboardControllerNotifier() : super(_createDefaultController()) {
     _initializeLayout();
   }
 
+  static const int _desktopSlots = UspLayoutEnvelope.desktopSlotCount;
+
   static DashboardController _createDefaultController() {
     return DashboardController(
-      initialSlotCount: 12,
+      initialSlotCount: _desktopSlots,
       initialLayout: UspWidgetSpecs.createDefaultLayout(),
     );
   }
@@ -53,10 +68,10 @@ class UspSliverDashboardControllerNotifier
     final forcedPreset = GlobalConfig.remote.forcedPreset;
     if (forcedPreset != null) {
       state = DashboardController(
-        initialSlotCount: 12,
+        initialSlotCount: _desktopSlots,
         initialLayout: forcedPreset.createLayout(),
       );
-      _preSeedBreakpoints();
+      _seedBreakpoints();
       return;
     }
 
@@ -65,79 +80,168 @@ class UspSliverDashboardControllerNotifier
 
     if (layoutJson == null) {
       // No saved layout — persist the constructor's default for next time.
+      _seedBreakpoints();
       await saveLayout();
-      _preSeedBreakpoints();
       return;
     }
 
-    try {
-      final layoutData = jsonDecode(layoutJson) as List<dynamic>;
-
-      // Accept all saved IDs — unknown IDs may be package widgets whose
-      // specs load asynchronously. The grid renders them as "Unknown widget"
-      // if their template never loads, which is preferable to resetting
-      // the user's entire layout.
-
-      // Create a NEW controller then swap via state= so Riverpod
-      // properly notifies listeners (avoids mutating the existing
-      // controller in-place which can desync the render tree).
-      final newController = _createDefaultController();
-      newController.importLayout(layoutData);
-      state = newController;
-      _preSeedBreakpoints();
-    } catch (e) {
-      debugPrint('Failed to load USP sliver dashboard layout: $e');
-      // Keep the constructor's default — no state change needed.
+    final envelope = UspLayoutEnvelope.tryDecode(layoutJson);
+    if (envelope == null) {
+      debugPrint('Failed to load USP sliver dashboard layout: unreadable');
+      // Keep the constructor's default and overwrite the unreadable value.
+      _seedBreakpoints();
       await saveLayout();
-      _preSeedBreakpoints();
+      return;
+    }
+
+    // Accept all saved IDs — unknown IDs may be package widgets whose
+    // specs load asynchronously. The grid renders them as "Unknown widget"
+    // if their template never loads, which is preferable to resetting
+    // the user's entire layout.
+    //
+    // Create a NEW controller then swap via state= so Riverpod
+    // properly notifies listeners (avoids mutating the existing
+    // controller in-place which can desync the render tree).
+    final desktop = envelope[_desktopSlots];
+    final newController = _createDefaultController();
+    if (desktop != null) {
+      newController.importLayout(desktop);
+    }
+    state = newController;
+    _seedBreakpoints(stored: envelope);
+
+    // A legacy bare list, or an envelope written before we rendered a
+    // breakpoint, has nothing stored for the grids we just derived. Write them
+    // out now so the first edit made there has a slot of its own to land in.
+    final migrated = UspLayoutEnvelope.persistedSlotCounts
+        .any((slots) => envelope[slots] == null);
+    if (migrated) {
+      await saveLayout();
     }
   }
 
-  /// Pre-seeds the controller's internal per-slot-count layout cache with
-  /// proportionally scaled layouts for tablet (8) and mobile (4) breakpoints.
+  /// Fills the controller's per-slot-count cache for every breakpoint we render.
   ///
-  /// Without this, `DashboardController.setSlotCount` falls back to
-  /// `correctBounds` which only shifts items left without scaling widths,
-  /// breaking the two-column layout at tablet widths (w=6 can't pair in 8).
-  void _preSeedBreakpoints() {
+  /// Prefers whatever [stored] holds for a breakpoint — that geometry is the
+  /// user's — and derives the rest from the desktop layout by proportional
+  /// scaling. Without the seed, the first `setSlotCount` at tablet width falls
+  /// back to the package's `correctBounds`, which shifts items left without
+  /// scaling their widths, so a `w=6` pair cannot fit in 8 columns and the
+  /// two-column layout collapses.
+  ///
+  /// Must be called with the controller on the desktop grid (the widest one is
+  /// the source everything else is derived from); it leaves it there.
+  void _seedBreakpoints({UspLayoutEnvelope? stored}) {
     final controller = state;
-    final layout12 = controller.exportLayout();
+    final desktopLayout = controller.exportLayout();
 
-    // --- Seed 8-column (tablet) cache ---
-    controller.setSlotCount(8);
-    controller.importLayout(
-      UspWidgetSpecs.scaleLayout(layout12, 12, 8),
-    );
+    for (final slots in UspLayoutEnvelope.persistedSlotCounts) {
+      if (slots == _desktopSlots) continue;
 
-    // --- Seed 4-column (mobile) cache ---
-    controller.setSlotCount(4);
-    controller.importLayout(
-      UspWidgetSpecs.scaleLayout(layout12, 12, 4),
-    );
+      controller.setSlotCount(slots);
+      final storedLayout = stored?[slots];
+      controller.importLayout(_normalize(
+        storedLayout == null
+            ? UspWidgetSpecs.scaleLayout(desktopLayout, _desktopSlots, slots)
+            // A stored entry can predate a card the desktop grid has; align it
+            // before importing, or `setSlotCount` reads the gap as a deletion
+            // and reconciles the card out of every other breakpoint too.
+            : UspWidgetSpecs.alignMembership(
+                storedLayout,
+                desktopLayout,
+                fromCols: _desktopSlots,
+                toCols: slots,
+              ),
+        slots,
+      ));
+    }
 
-    // --- Return to 12-column (desktop) ---
-    // This finds the cached layout12 saved during the first setSlotCount(8).
-    controller.setSlotCount(12);
+    // Returns to the layout cached during the first setSlotCount above.
+    controller.setSlotCount(_desktopSlots);
   }
 
-  /// Persist current layout to SharedPreferences.
+  /// The per-grid policy a layout must satisfy before it is imported or stored.
+  ///
+  /// Only mobile has one: [UspWidgetSpecs.lockToFullWidth] pins the width so a
+  /// 4-column grid is height-and-order only. Wider grids pass through.
+  static List<dynamic> _normalize(List<dynamic> layout, int slotCount) =>
+      slotCount <= UspLayoutEnvelope.mobileSlotCount
+          ? UspWidgetSpecs.lockToFullWidth(layout, slotCount)
+          : layout;
+
+  /// Persist the layout of every breakpoint to SharedPreferences.
   Future<void> saveLayout() async {
+    final envelope = UspLayoutEnvelope(_exportAllBreakpoints());
     final prefs = await SharedPreferences.getInstance();
-    final layoutData = state.exportLayout();
-    await prefs.setString(pUspSliverDashboardLayout, jsonEncode(layoutData));
+    await prefs.setString(pUspSliverDashboardLayout, envelope.encode());
+  }
+
+  /// Reads out one layout per breakpoint by visiting each in turn.
+  ///
+  /// The controller holds a cached layout per slot count and reconciles
+  /// membership as it moves between them, so the walk is doing two jobs: it is
+  /// how the geometries we are not currently rendering are read, and it is how a
+  /// card added or deleted on this grid reaches the others. It ends where it
+  /// started, so the grid the user is looking at does not move.
+  Map<int, List<dynamic>> _exportAllBreakpoints() {
+    final controller = state;
+    final origin = controller.slotCount.value;
+    final layouts = <int, List<dynamic>>{};
+
+    for (final slots in UspLayoutEnvelope.persistedSlotCounts) {
+      controller.setSlotCount(slots);
+      layouts[slots] = _normalize(controller.exportLayout(), slots);
+    }
+
+    controller.setSlotCount(origin);
+    return layouts;
+  }
+
+  /// Swaps in a fresh controller carrying [layouts] on every breakpoint.
+  ///
+  /// Membership changes have to swap the instance rather than mutate in place:
+  /// the layout settings panel watches this provider to work out which cards are
+  /// still available to add, and `StateNotifier` only notifies listeners when
+  /// the instance changes.
+  void _replaceController(Map<int, List<dynamic>> layouts) {
+    final previous = state;
+    final origin = previous.slotCount.value;
+    final wasEditing = previous.isEditing.value;
+
+    final controller = _createDefaultController();
+    controller.importLayout(layouts[_desktopSlots] ?? const []);
+    state = controller;
+    _seedBreakpoints(stored: UspLayoutEnvelope(layouts));
+
+    if (origin != _desktopSlots) {
+      controller.setSlotCount(origin);
+    }
+    // Edit mode lives on the controller, so a fresh instance would drop the
+    // handles and the trash zone mid-session while dashboardEditModeProvider
+    // still believed we were editing.
+    if (wasEditing) {
+      controller.setEditMode(true);
+    }
   }
 
   /// Reset to default layout and clear persisted data.
   Future<void> resetLayout() async {
     state = _createDefaultController();
+    // Re-seed: a controller with an empty breakpoint cache falls back to
+    // correctBounds at tablet width, which collapses the two-column grid.
+    _seedBreakpoints();
 
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(pUspSliverDashboardLayout);
   }
 
   /// Force update an item's size (used after resize constraint enforcement).
+  ///
+  /// Geometry only, and only on the grid the user is looking at: the other
+  /// breakpoints keep the sizes they were given there.
   Future<void> updateItemSize(String id, int w, int h) async {
-    final currentLayout = state.exportLayout();
+    final controller = state;
+    final currentLayout = controller.exportLayout();
     bool changed = false;
 
     final newLayout = currentLayout.map((item) {
@@ -154,9 +258,12 @@ class UspSliverDashboardControllerNotifier
     }).toList();
 
     if (changed) {
-      final newController = _createDefaultController();
-      newController.importLayout(newLayout);
-      state = newController;
+      // In place, so the caches for the other breakpoints survive. The grid
+      // rebuilds off the controller's own layout beacon — the same path every
+      // drag and resize already uses — so no Riverpod notification is needed.
+      controller.importLayout(
+        _normalize(newLayout, controller.slotCount.value),
+      );
       await saveLayout();
     }
   }
@@ -165,8 +272,9 @@ class UspSliverDashboardControllerNotifier
   ///
   /// [spec] can be provided for package widgets not in [UspWidgetSpecs].
   Future<void> addWidget(String id, {WidgetSpec? spec}) async {
-    final currentLayout = state.exportLayout();
-    if (currentLayout.any((item) => (item as Map)['id'] == id)) {
+    final layouts = _exportAllBreakpoints();
+    final desktopLayout = layouts[_desktopSlots] ?? const [];
+    if (desktopLayout.any((item) => (item as Map)['id'] == id)) {
       return; // Already exists
     }
 
@@ -175,7 +283,7 @@ class UspSliverDashboardControllerNotifier
 
     // Calculate position at the bottom of the grid
     int maxY = 0;
-    for (final item in currentLayout) {
+    for (final item in desktopLayout) {
       final map = item as Map;
       final y = map['y'] as int;
       final h = map['h'] as int;
@@ -201,10 +309,23 @@ class UspSliverDashboardControllerNotifier
       'maxH': item.maxH,
     };
 
-    final newLayout = [...currentLayout, newItemMap];
-    final newController = _createDefaultController();
-    newController.importLayout(newLayout);
-    state = newController;
+    // Placed on each grid at that grid's own scale. Letting the package
+    // reconcile it in instead would carry the current breakpoint's width
+    // across, so a card added on a phone would arrive at desktop 4/12 wide.
+    _replaceController({
+      for (final entry in layouts.entries)
+        entry.key: [
+          ...entry.value,
+          if (entry.key == _desktopSlots)
+            newItemMap
+          else
+            UspWidgetSpecs.scaleLayout(
+              [newItemMap],
+              _desktopSlots,
+              entry.key,
+            ).single,
+        ],
+    });
     await saveLayout();
   }
 
@@ -215,24 +336,27 @@ class UspSliverDashboardControllerNotifier
   Future<void> applyPreset(UspDashboardPreset preset) async {
     final layout = preset.createLayout();
     state = DashboardController(
-      initialSlotCount: 12,
+      initialSlotCount: _desktopSlots,
       initialLayout: layout,
     );
-    _preSeedBreakpoints();
+    _seedBreakpoints();
     await saveLayout();
   }
 
   /// Remove a widget from the dashboard layout.
+  ///
+  /// Removal is global: which cards the dashboard shows is not a per-breakpoint
+  /// choice, so a card deleted on a phone is gone on a laptop too.
   Future<void> removeWidget(String id) async {
-    final currentLayout = state.exportLayout();
-    final newLayout =
-        currentLayout.where((item) => (item as Map)['id'] != id).toList();
+    final layouts = _exportAllBreakpoints();
+    final desktopLayout = layouts[_desktopSlots] ?? const [];
+    if (!desktopLayout.any((item) => (item as Map)['id'] == id)) return;
 
-    if (newLayout.length != currentLayout.length) {
-      final newController = _createDefaultController();
-      newController.importLayout(newLayout);
-      state = newController;
-      await saveLayout();
-    }
+    _replaceController({
+      for (final entry in layouts.entries)
+        entry.key:
+            entry.value.where((item) => (item as Map)['id'] != id).toList(),
+    });
+    await saveLayout();
   }
 }

--- a/lib/page/dashboard/views/usp_sliver_dashboard_view.dart
+++ b/lib/page/dashboard/views/usp_sliver_dashboard_view.dart
@@ -6,6 +6,7 @@ import 'package:privacy_gui/page/dashboard/views/components/effects/jiggle_shake
 import 'package:privacy_gui/page/dashboard/factories/usp_widget_factory.dart';
 import 'package:privacy_gui/constants/pref_key.dart';
 import 'package:privacy_gui/page/dashboard/models/usp_dashboard_preset.dart';
+import 'package:privacy_gui/page/dashboard/models/usp_widget_specs.dart';
 import 'package:privacy_gui/page/dashboard/providers/dashboard_edit_mode_provider.dart';
 import 'package:privacy_gui/page/dashboard/models/package_widget_template.dart';
 import 'package:privacy_gui/page/dashboard/providers/package_widget_loader.dart';
@@ -488,28 +489,22 @@ class _UspSliverDashboardViewState
     final constraints = spec.constraints[DisplayMode.normal];
     if (constraints == null) return;
 
-    bool violated = false;
-    int newW = item.w;
-    int newH = item.h;
+    // Which grid the card is on decides what its spec's column figures mean —
+    // see [UspWidgetSpecs.correctedSize].
+    final notifier = ref.read(uspSliverDashboardControllerProvider.notifier);
+    final corrected = UspWidgetSpecs.correctedSize(
+      constraints,
+      w: item.w,
+      h: item.h,
+      slotCount: ref.read(uspSliverDashboardControllerProvider).slotCount.value,
+    );
 
-    if (item.w < constraints.minColumns) {
-      newW = constraints.minColumns;
-      violated = true;
-    }
-    if (item.w > constraints.maxColumns) {
-      newW = constraints.maxColumns;
-      violated = true;
-    }
-    if (item.h < constraints.minHeightRows) {
-      newH = constraints.minHeightRows;
-      violated = true;
-    }
-    if (item.h > constraints.maxHeightRows) {
-      newH = constraints.maxHeightRows;
-      violated = true;
+    if (corrected == null) {
+      notifier.saveLayout();
+      return;
     }
 
-    if (violated && context.mounted) {
+    if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(loc(context).widgetResized(item.id)),
@@ -519,12 +514,9 @@ class _UspSliverDashboardViewState
       );
     }
 
-    if (violated) {
-      ref
-          .read(uspSliverDashboardControllerProvider.notifier)
-          .updateItemSize(item.id, newW, newH);
-    }
-    ref.read(uspSliverDashboardControllerProvider.notifier).saveLayout();
+    // Saves as part of correcting the size — a second saveLayout here would walk
+    // every breakpoint again for nothing.
+    notifier.updateItemSize(item.id, corrected.w, corrected.h);
   }
 
   Future<void> _openLayoutSettings(BuildContext context) async {

--- a/test/golden_test/golden_framework/mocks/mock_dashboard.dart
+++ b/test/golden_test/golden_framework/mocks/mock_dashboard.dart
@@ -131,8 +131,9 @@ List<LayoutItem> _defaultTestLayout() => [
 
 class _FixedControllerNotifier extends UspSliverDashboardControllerNotifier {
   // Inherits super() which calls _initializeLayout() — that loads the layout
-  // from SharedPreferences (seeded in initDashboardSharedPreferences) and
-  // calls _preSeedBreakpoints() to populate 4/8-column caches.
+  // from SharedPreferences (seeded in initDashboardSharedPreferences) and seeds
+  // the 4/8-column caches from it. The seeded value is a legacy bare list, which
+  // is exactly the migration path UspLayoutEnvelope has to keep working (#1293).
 }
 
 /// Initialize SharedPreferences with dashboard defaults to prevent async calls.

--- a/test/page/dashboard/models/usp_layout_envelope_test.dart
+++ b/test/page/dashboard/models/usp_layout_envelope_test.dart
@@ -1,0 +1,170 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/dashboard/models/usp_layout_envelope.dart';
+
+/// The persisted shape of the dashboard layout (#1293).
+///
+/// Before this envelope existed the pref held a bare list of layout items with
+/// no record of which grid they were measured on. `exportLayout()` always
+/// returns coordinates in the controller's *current* slot count, so a save made
+/// at mobile (4 columns) was read back as if it were desktop (12) — every card
+/// came back a third of its width, with `minW`/`maxW` scaled down too, which is
+/// permanent because those caps then block any attempt to widen the card again.
+///
+/// The envelope's whole job is to record the grid. Decoding is deliberately
+/// forgiving of *unknown* content (a saved id we no longer ship is still a
+/// layout we should honour) and deliberately strict about *unreadable* content:
+/// anything it cannot place on a known grid decodes to null, and the caller
+/// falls back to the default layout rather than importing garbage.
+void main() {
+  group('decode', () {
+    test('a legacy bare list is migrated as the desktop entry', () {
+      // The only shape that existed before #1293. It was always written by a
+      // 12-column controller at load time, so desktop is the honest reading.
+      final legacy = jsonEncode([
+        {'id': 'stats_panel', 'x': 0, 'y': 0, 'w': 12, 'h': 1},
+        {'id': 'device_info', 'x': 0, 'y': 1, 'w': 6, 'h': 3},
+      ]);
+
+      final envelope = UspLayoutEnvelope.tryDecode(legacy);
+
+      expect(envelope, isNotNull);
+      expect(envelope!.slotCounts, [UspLayoutEnvelope.desktopSlotCount]);
+      expect(envelope[UspLayoutEnvelope.desktopSlotCount], hasLength(2));
+      expect(envelope[UspLayoutEnvelope.mobileSlotCount], isNull,
+          reason: 'A legacy value says nothing about the mobile grid; the '
+              'caller must derive it, not inherit a wrong one.');
+    });
+
+    test('an empty legacy list stays an empty desktop layout', () {
+      // Not the same as unreadable: a user who deleted every card gets an empty
+      // dashboard, which is what the pre-#1293 code did too.
+      final envelope = UspLayoutEnvelope.tryDecode('[]');
+
+      expect(envelope, isNotNull);
+      expect(envelope![UspLayoutEnvelope.desktopSlotCount], isEmpty);
+    });
+
+    test('a v2 envelope round-trips every breakpoint independently', () {
+      final original = UspLayoutEnvelope({
+        12: [
+          {'id': 'device_info', 'x': 0, 'y': 0, 'w': 6, 'h': 3}
+        ],
+        8: [
+          {'id': 'device_info', 'x': 0, 'y': 0, 'w': 4, 'h': 3}
+        ],
+        4: [
+          {'id': 'device_info', 'x': 0, 'y': 0, 'w': 4, 'h': 5}
+        ],
+      });
+
+      final decoded = UspLayoutEnvelope.tryDecode(original.encode());
+
+      expect(decoded, isNotNull);
+      expect(decoded!.slotCounts, [12, 8, 4]);
+      // The point of the whole ticket: a height set at mobile does not follow
+      // the card to desktop, and a width set at desktop does not follow it down.
+      expect((decoded[12]!.single as Map)['w'], 6);
+      expect((decoded[4]!.single as Map)['w'], 4);
+      expect((decoded[4]!.single as Map)['h'], 5);
+      expect((decoded[12]!.single as Map)['h'], 3);
+    });
+
+    test('encode stamps the current version', () {
+      final json = jsonDecode(UspLayoutEnvelope(const {12: []}).encode())
+          as Map<String, dynamic>;
+
+      expect(json['version'], UspLayoutEnvelope.currentVersion);
+      expect(json['layouts'], isA<Map>());
+    });
+
+    test('slot counts survive as ints even though JSON keys are strings', () {
+      final decoded = UspLayoutEnvelope.tryDecode(jsonEncode({
+        'version': 2,
+        'layouts': {
+          '4': [
+            {'id': 'device_info', 'x': 0, 'y': 0, 'w': 4, 'h': 3}
+          ],
+        },
+      }));
+
+      expect(decoded![4], hasLength(1));
+    });
+
+    test('unknown slot counts are kept, not dropped', () {
+      // A future ui_kit breakpoint (or a 6-column tablet regime) must not lose
+      // the user's layout just because this build doesn't render it.
+      final decoded = UspLayoutEnvelope.tryDecode(jsonEncode({
+        'version': 2,
+        'layouts': {
+          '12': [],
+          '6': [
+            {'id': 'device_info', 'x': 0, 'y': 0, 'w': 3, 'h': 3}
+          ],
+        },
+      }));
+
+      expect(decoded![6], hasLength(1));
+    });
+
+    group('unreadable payloads decode to null', () {
+      final cases = <String, String>{
+        'not JSON at all': 'not json',
+        'a bare string': '"nope"',
+        'a number': '42',
+        'an object with no layouts': jsonEncode({'version': 2}),
+        'layouts that is not a map': jsonEncode({'version': 2, 'layouts': []}),
+        'a slot count that is not a number': jsonEncode({
+          'version': 2,
+          'layouts': {'desktop': []},
+        }),
+        'a layout that is not a list': jsonEncode({
+          'version': 2,
+          'layouts': {'12': {}},
+        }),
+        'a layout item that is not a map': jsonEncode({
+          'version': 2,
+          'layouts': {
+            '12': ['device_info'],
+          },
+        }),
+        'a future version': jsonEncode({
+          'version': UspLayoutEnvelope.currentVersion + 1,
+          'layouts': {'12': []},
+        }),
+      };
+
+      cases.forEach((name, raw) {
+        test(name, () {
+          expect(UspLayoutEnvelope.tryDecode(raw), isNull,
+              reason: 'Importing this would be worse than resetting: the grid '
+                  'either throws on import or renders a layout the user never '
+                  'made. Returning null lets the caller re-seed the default.');
+        });
+      });
+    });
+  });
+
+  group('withLayout', () {
+    test('replaces one breakpoint and leaves the others alone', () {
+      final envelope = UspLayoutEnvelope({
+        12: [
+          {'id': 'a', 'x': 0, 'y': 0, 'w': 6, 'h': 3}
+        ],
+        4: [
+          {'id': 'a', 'x': 0, 'y': 0, 'w': 4, 'h': 3}
+        ],
+      });
+
+      final updated = envelope.withLayout(4, [
+        {'id': 'a', 'x': 0, 'y': 0, 'w': 4, 'h': 6}
+      ]);
+
+      expect((updated[4]!.single as Map)['h'], 6);
+      expect((updated[12]!.single as Map)['h'], 3);
+      expect(envelope[4]!.single, containsPair('h', 3),
+          reason: 'withLayout must not mutate the receiver.');
+    });
+  });
+}

--- a/test/page/dashboard/models/usp_widget_specs_test.dart
+++ b/test/page/dashboard/models/usp_widget_specs_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:privacy_gui/page/dashboard/models/display_mode.dart';
 import 'package:privacy_gui/page/dashboard/models/usp_widget_specs.dart';
+import 'package:sliver_dashboard/sliver_dashboard.dart';
 import 'package:ui_kit_library/ui_kit.dart';
 
 void main() {
@@ -475,6 +476,70 @@ void main() {
         UspWidgetSpecs.correctedSize(wide, w: 8, h: 0, slotCount: 8),
         (w: 8, h: 1),
       );
+    });
+  });
+
+  group('lockItemsToFullWidth', () {
+    const full = LayoutItem(id: 'a', x: 0, y: 0, w: 4, h: 2);
+
+    test('a locked layout needs no rewrite', () {
+      // Null, not an equal list: the caller is a listener on the very layout it
+      // would be writing back into.
+      expect(UspWidgetSpecs.lockItemsToFullWidth([full], 4), isNull);
+    });
+
+    test('a card the left edge displaced is put back', () {
+      // x=1, w=3 is what dragging the left edge inwards by a column leaves.
+      final locked = UspWidgetSpecs.lockItemsToFullWidth(
+        [full.copyWith(x: 1, w: 3)],
+        4,
+      );
+      expect(locked, isNotNull);
+      expect(locked!.single.x, 0);
+      expect(locked.single.w, 4);
+    });
+
+    test('a card narrowed without moving is put back too', () {
+      // Dragging the same edge outwards keeps x at 0 — the row's own edge does
+      // the trimming instead — so a displaced x cannot be the thing looked for.
+      final locked = UspWidgetSpecs.lockItemsToFullWidth(
+        [full.copyWith(w: 3)],
+        4,
+      );
+      expect(locked, isNotNull);
+      expect(locked!.single.w, 4);
+    });
+
+    test('a card moved without narrowing is put back too', () {
+      final locked = UspWidgetSpecs.lockItemsToFullWidth(
+        [full.copyWith(x: 1)],
+        4,
+      );
+      expect(locked, isNotNull);
+      expect(locked!.single.x, 0);
+    });
+
+    test('the height is not the width lock\'s business', () {
+      final locked = UspWidgetSpecs.lockItemsToFullWidth(
+        [full.copyWith(x: 1, w: 3, h: 7)],
+        4,
+      );
+      expect(locked!.single.h, 7);
+    });
+
+    test('the row a card sits on is not the width lock\'s business', () {
+      final locked = UspWidgetSpecs.lockItemsToFullWidth(
+        [full.copyWith(x: 1, w: 3, y: 5)],
+        4,
+      );
+      expect(locked!.single.y, 5);
+    });
+
+    test('cards that are already locked keep their identity', () {
+      final displaced = full.copyWith(id: 'b', x: 1, w: 3);
+      final locked = UspWidgetSpecs.lockItemsToFullWidth([full, displaced], 4);
+      expect(identical(locked!.first, full), isTrue);
+      expect(locked.last.x, 0);
     });
   });
 }

--- a/test/page/dashboard/models/usp_widget_specs_test.dart
+++ b/test/page/dashboard/models/usp_widget_specs_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:privacy_gui/page/dashboard/models/display_mode.dart';
 import 'package:privacy_gui/page/dashboard/models/usp_widget_specs.dart';
+import 'package:ui_kit_library/ui_kit.dart';
 
 void main() {
   group('Registry', () {
@@ -382,6 +383,98 @@ void main() {
       expect(layout[0].x, 0);
       expect(layout[1].id, 'network_status');
       expect(layout[1].x, 6);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Constraints are written for 12 columns and have to be read on the grid the
+  // user is actually looking at (#1293).
+  // ---------------------------------------------------------------------------
+  group('scaleSpan', () {
+    test('halves nothing on the grid it was written for', () {
+      expect(UspWidgetSpecs.scaleSpan(6, fromCols: 12, toCols: 12), 6);
+    });
+
+    test('12→8 keeps the proportion', () {
+      expect(UspWidgetSpecs.scaleSpan(6, fromCols: 12, toCols: 8), 4);
+      expect(UspWidgetSpecs.scaleSpan(12, fromCols: 12, toCols: 8), 8);
+    });
+
+    test('never scales a card out of existence', () {
+      // 1 of 12 rounds to 0 of 4, which is not a width any grid can hold.
+      expect(UspWidgetSpecs.scaleSpan(1, fromCols: 12, toCols: 4), 1);
+    });
+
+    test('never returns more columns than the grid has', () {
+      expect(UspWidgetSpecs.scaleSpan(12, fromCols: 8, toCols: 4), 4);
+    });
+  });
+
+  group('correctedSize', () {
+    // stats_panel: the widest floor in the catalogue, and the reason this
+    // scaling has to exist at all.
+    const wide = WidgetGridConstraints(
+      minColumns: 6,
+      maxColumns: 12,
+      preferredColumns: 12,
+      heightStrategy: HeightStrategy.strict(1),
+      minHeightRows: 1,
+      maxHeightRows: 2,
+    );
+
+    test('a size within its spec needs no correction', () {
+      expect(
+        UspWidgetSpecs.correctedSize(wide, w: 8, h: 1, slotCount: 12),
+        isNull,
+      );
+    });
+
+    test('a too-narrow card is widened to its floor', () {
+      expect(
+        UspWidgetSpecs.correctedSize(wide, w: 3, h: 1, slotCount: 12),
+        (w: 6, h: 1),
+      );
+    });
+
+    test('on a tablet the floor is scaled, not taken literally', () {
+      // The bug: `minColumns: 6` enforced as-is gives this card six of the
+      // tablet's eight columns — three quarters of the row for what is supposed
+      // to be a half-width floor.
+      expect(
+        UspWidgetSpecs.correctedSize(wide, w: 2, h: 1, slotCount: 8),
+        (w: 4, h: 1),
+      );
+    });
+
+    test('on a tablet the ceiling is scaled too', () {
+      expect(
+        UspWidgetSpecs.correctedSize(wide, w: 9, h: 1, slotCount: 8),
+        (w: 8, h: 1),
+      );
+    });
+
+    test('a phone never has a width corrected onto it', () {
+      // Taken literally the floor is wider than the whole grid, so the old code
+      // wrote w=6 into a 4-column layout. Mobile widths are pinned by
+      // lockToFullWidth, so there is nothing here to enforce.
+      expect(
+        UspWidgetSpecs.correctedSize(wide, w: 4, h: 1, slotCount: 4),
+        isNull,
+      );
+    });
+
+    test('a phone still has its height corrected', () {
+      expect(
+        UspWidgetSpecs.correctedSize(wide, w: 4, h: 5, slotCount: 4),
+        (w: 4, h: 2),
+      );
+    });
+
+    test('rows are absolute — the height floor is not scaled', () {
+      expect(
+        UspWidgetSpecs.correctedSize(wide, w: 8, h: 0, slotCount: 8),
+        (w: 8, h: 1),
+      );
     });
   });
 }

--- a/test/page/dashboard/providers/dashboard_edit_mode_provider_test.dart
+++ b/test/page/dashboard/providers/dashboard_edit_mode_provider_test.dart
@@ -4,6 +4,7 @@ import 'package:privacy_gui/page/dashboard/models/usp_layout_preferences.dart';
 import 'package:privacy_gui/page/dashboard/providers/dashboard_edit_mode_provider.dart';
 import 'package:privacy_gui/page/dashboard/providers/usp_layout_controller.dart';
 import 'package:privacy_gui/page/dashboard/providers/usp_layout_preferences_provider.dart';
+import 'package:privacy_gui/providers/auth/auth_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 Future<void> pumpAsync() async {
@@ -15,9 +16,10 @@ void main() {
 
   Future<ProviderContainer> createContainer({
     Map<String, Object> initialValues = const {},
+    List<Override> overrides = const [],
   }) async {
     SharedPreferences.setMockInitialValues(initialValues);
-    final container = ProviderContainer();
+    final container = ProviderContainer(overrides: overrides);
     container.read(uspSliverDashboardControllerProvider);
     await container.read(uspLayoutPreferencesProvider.notifier).initialized;
     await pumpAsync();
@@ -227,4 +229,136 @@ void main() {
       }
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // #1294 — logging out must leave edit mode
+  // ---------------------------------------------------------------------------
+  group('logout leaves edit mode', () {
+    /// A logged-in [AuthNotifier] whose logout can be driven without the USP /
+    /// SSE / credential-store machinery the real one needs.
+    ///
+    /// It reproduces the exact emission sequence of [AuthNotifier.logout]:
+    /// `AsyncValue.loading()` first, then `AsyncValue.data(AuthState.empty())`.
+    /// That middle `loading` is why a listener cannot compare
+    /// `previous.isLoggedIn` with `next.isLoggedIn` — by the time the logged-out
+    /// data arrives, `previous` is a value-less loading state.
+    ///
+    /// Both providers are read before the test acts: in production the dashboard
+    /// is on screen (so the edit-mode notifier is alive and listening) and auth
+    /// has resolved (so the fake has an element to push state through).
+    Future<ProviderContainer> containerWithAuth(_FakeAuthNotifier auth) async {
+      final container = await createContainer(
+        overrides: [authProvider.overrideWith(() => auth)],
+      );
+      await container.read(authProvider.future);
+      container.read(dashboardEditModeProvider);
+      return container;
+    }
+
+    test('a logout while editing exits edit mode', () async {
+      // The reported bug: log out from the dashboard's own top-bar menu (which
+      // does not navigate anywhere), log back in, and the grid is still in edit
+      // mode with the trash zone and resize handles showing — because both the
+      // edit-mode provider and the controller are root-scoped and survive a
+      // logout that never reloads the page.
+      final auth = _FakeAuthNotifier();
+      final container = await containerWithAuth(auth);
+      addTearDown(container.dispose);
+
+      await container.read(dashboardEditModeProvider.notifier).enterEditMode();
+      expect(container.read(dashboardEditModeProvider).isEditing, isTrue);
+
+      auth.logOut();
+      await pumpAsync();
+
+      final state = container.read(dashboardEditModeProvider);
+      expect(state.isEditing, isFalse);
+      expect(state.layoutSnapshot, isNull,
+          reason: 'A stale snapshot would be reverted into the next session.');
+      expect(
+          container.read(uspSliverDashboardControllerProvider).isEditing.value,
+          isFalse,
+          reason: 'The grid itself must also drop out of edit mode — the '
+              'handles and trash zone are driven by the controller, not by '
+              'this provider.');
+    });
+
+    test('the pre-edit layout is restored, matching the tab-switch policy',
+        () async {
+      // #1037 chose silent discard for leaving the dashboard mid-edit. A logout
+      // is a harder exit than a tab switch, so it reverts the same way rather
+      // than committing half-finished dragging.
+      final auth = _FakeAuthNotifier();
+      final container = await containerWithAuth(auth);
+      addTearDown(container.dispose);
+
+      final controller = container.read(uspSliverDashboardControllerProvider);
+      final originalCount = controller.exportLayout().length;
+      await container.read(dashboardEditModeProvider.notifier).enterEditMode();
+      controller.removeItems(['stats_panel']);
+      expect(controller.exportLayout().length, lessThan(originalCount));
+
+      auth.logOut();
+      await pumpAsync();
+
+      expect(
+          container
+              .read(uspSliverDashboardControllerProvider)
+              .exportLayout()
+              .length,
+          originalCount);
+    });
+
+    test('a logout while not editing changes nothing', () async {
+      final auth = _FakeAuthNotifier();
+      final container = await containerWithAuth(auth);
+      addTearDown(container.dispose);
+
+      final before =
+          container.read(uspSliverDashboardControllerProvider).exportLayout();
+
+      auth.logOut();
+      await pumpAsync();
+
+      expect(container.read(dashboardEditModeProvider).isEditing, isFalse);
+      expect(
+          container
+              .read(uspSliverDashboardControllerProvider)
+              .exportLayout()
+              .length,
+          before.length,
+          reason: 'The reset must be idempotent: it fires on every logout, '
+              'including the ones that happen with the dashboard closed.');
+    });
+
+    test('logging back in does not re-enter edit mode', () async {
+      final auth = _FakeAuthNotifier();
+      final container = await containerWithAuth(auth);
+      addTearDown(container.dispose);
+
+      await container.read(dashboardEditModeProvider.notifier).enterEditMode();
+      auth.logOut();
+      await pumpAsync();
+      auth.logIn();
+      await pumpAsync();
+
+      expect(container.read(dashboardEditModeProvider).isEditing, isFalse);
+    });
+  });
+}
+
+/// Drives [authProvider] through login/logout without the real dependencies.
+class _FakeAuthNotifier extends AuthNotifier {
+  @override
+  Future<AuthState> build() async =>
+      const AuthState(loginType: LoginType.local);
+
+  void logOut() {
+    state = const AsyncValue.loading();
+    state = AsyncValue.data(AuthState.empty());
+  }
+
+  void logIn() {
+    state = const AsyncValue.data(AuthState(loginType: LoginType.local));
+  }
 }

--- a/test/page/dashboard/providers/usp_layout_breakpoint_persistence_test.dart
+++ b/test/page/dashboard/providers/usp_layout_breakpoint_persistence_test.dart
@@ -1,0 +1,441 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/constants/pref_key.dart';
+import 'package:privacy_gui/page/dashboard/models/usp_layout_envelope.dart';
+import 'package:privacy_gui/page/dashboard/providers/usp_layout_controller.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Per-breakpoint layout persistence, and the mobile full-width lock (#1293).
+///
+/// ## The bug
+///
+/// `DashboardController.exportLayout()` returns coordinates in whatever slot
+/// count the controller is currently on, and the pref used to be a bare list
+/// with no record of that. So the dashboard wrote 4-column coordinates at
+/// mobile and read them back as 12-column ones at desktop: every card came back
+/// a third of its width. Worse, the mobile seed also scales `minW`/`maxW` down,
+/// so the narrow widths were then *capped* narrow — the user could not drag them
+/// back even manually. Resizing on a phone permanently wrecked the desktop
+/// dashboard.
+///
+/// ## The fix, in two halves
+///
+/// 1. The pref is an envelope keyed by slot count, so each breakpoint keeps its
+///    own geometry and a save at one never speaks for another.
+/// 2. At 4 columns the width is not the user's to change: every card is pinned
+///    full-width (`x=0, w=4, minW=maxW=4`), leaving height and order editable.
+///    The package clamps resize deltas to `[minW, maxW]`
+///    (`dashboard_controller_impl.dart`), so pinning those two *is* the lock.
+///
+/// Membership is deliberately **not** per-breakpoint: deleting a card on a phone
+/// deletes the card, not just its phone placement. Only geometry is per-grid.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  /// Wait for the notifier's async init/save chains to settle.
+  Future<void> pumpAsync() => Future.delayed(const Duration(milliseconds: 100));
+
+  Future<ProviderContainer> boot({
+    Map<String, Object>? initialValues,
+  }) async {
+    if (initialValues != null) {
+      SharedPreferences.setMockInitialValues(initialValues);
+    }
+    final container = ProviderContainer();
+    container.read(uspSliverDashboardControllerProvider);
+    await pumpAsync();
+    return container;
+  }
+
+  /// Reboots the app against whatever is already in the mock pref store — the
+  /// "close the tab and come back on a laptop" path.
+  Future<ProviderContainer> reboot() async {
+    final container = ProviderContainer();
+    container.read(uspSliverDashboardControllerProvider);
+    await pumpAsync();
+    return container;
+  }
+
+  Future<UspLayoutEnvelope> storedEnvelope() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(pUspSliverDashboardLayout);
+    expect(raw, isNotNull, reason: 'Nothing was persisted.');
+    final envelope = UspLayoutEnvelope.tryDecode(raw!);
+    expect(envelope, isNotNull, reason: 'Persisted value is unreadable: $raw');
+    return envelope!;
+  }
+
+  /// The geometry keys only. `moved` and friends are engine bookkeeping that
+  /// flips on compaction, so comparing whole maps would compare noise.
+  List<Map<String, Object?>> geometryOf(List<dynamic> layout) => layout
+      .map((item) => {
+            for (final k in ['id', 'x', 'y', 'w', 'h', 'minW', 'maxW'])
+              k: (item as Map)[k],
+          })
+      .toList();
+
+  Map<String, Object?> itemNamed(List<dynamic> layout, String id) =>
+      (layout.firstWhere((item) => (item as Map)['id'] == id) as Map)
+          .cast<String, Object?>();
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  // ---------------------------------------------------------------------------
+  // The regression this ticket is about
+  // ---------------------------------------------------------------------------
+  group('a save at one breakpoint cannot rewrite another', () {
+    test('editing on mobile leaves the desktop layout byte-identical',
+        () async {
+      final first = await boot();
+      final desktopBefore = geometryOf(
+          first.read(uspSliverDashboardControllerProvider).exportLayout());
+
+      // Narrow the window to phone width, then do the one edit mobile allows:
+      // make a card taller.
+      first.read(uspSliverDashboardControllerProvider).setSlotCount(4);
+      await first
+          .read(uspSliverDashboardControllerProvider.notifier)
+          .updateItemSize('device_info', 4, 5);
+      first.dispose();
+
+      final second = await reboot();
+      addTearDown(second.dispose);
+
+      expect(
+        geometryOf(
+            second.read(uspSliverDashboardControllerProvider).exportLayout()),
+        desktopBefore,
+        reason: 'A phone edit rewrote the desktop grid. This is #1293: the '
+            'desktop cards come back at mobile widths, with minW/maxW capped '
+            'there too, so they cannot even be dragged back.',
+      );
+    });
+
+    test('the mobile edit itself survives the reboot', () async {
+      final first = await boot();
+      first.read(uspSliverDashboardControllerProvider).setSlotCount(4);
+      await first
+          .read(uspSliverDashboardControllerProvider.notifier)
+          .updateItemSize('device_info', 4, 5);
+      first.dispose();
+
+      final second = await reboot();
+      addTearDown(second.dispose);
+      final controller = second.read(uspSliverDashboardControllerProvider);
+      controller.setSlotCount(4);
+
+      expect(itemNamed(controller.exportLayout(), 'device_info')['h'], 5,
+          reason: 'Per-breakpoint storage is only worth having if the '
+              'breakpoint that was edited actually keeps its edit.');
+    });
+
+    test('a desktop resize does not disturb a stored mobile layout', () async {
+      final first = await boot();
+      first.read(uspSliverDashboardControllerProvider).setSlotCount(4);
+      await first
+          .read(uspSliverDashboardControllerProvider.notifier)
+          .updateItemSize('device_info', 4, 5);
+      first.read(uspSliverDashboardControllerProvider).setSlotCount(12);
+      await first
+          .read(uspSliverDashboardControllerProvider.notifier)
+          .updateItemSize('device_info', 8, 3);
+      first.dispose();
+
+      final envelope = await storedEnvelope();
+      expect(itemNamed(envelope[4]!, 'device_info')['h'], 5);
+      expect(itemNamed(envelope[4]!, 'device_info')['w'], 4);
+      expect(itemNamed(envelope[12]!, 'device_info')['w'], 8);
+      expect(itemNamed(envelope[12]!, 'device_info')['h'], 3);
+    });
+
+    test('saving repeatedly at mobile does not drift the desktop entry',
+        () async {
+      // Every save visits all three grids to read them out of the controller,
+      // so a rounding or compaction wobble in that walk would creep the desktop
+      // layout one row at a time across a session.
+      final container = await boot();
+      addTearDown(container.dispose);
+      final notifier =
+          container.read(uspSliverDashboardControllerProvider.notifier);
+
+      container.read(uspSliverDashboardControllerProvider).setSlotCount(4);
+      await notifier.saveLayout();
+      final afterFirst = geometryOf((await storedEnvelope())[12]!);
+
+      for (var i = 0; i < 3; i++) {
+        await notifier.saveLayout();
+      }
+
+      expect(geometryOf((await storedEnvelope())[12]!), afterFirst);
+    });
+
+    test('the walk leaves the controller on the breakpoint it started on',
+        () async {
+      final container = await boot();
+      addTearDown(container.dispose);
+      final controller = container.read(uspSliverDashboardControllerProvider);
+
+      controller.setSlotCount(8);
+      await container
+          .read(uspSliverDashboardControllerProvider.notifier)
+          .saveLayout();
+
+      expect(controller.slotCount.value, 8,
+          reason: 'Saving must not move the grid the user is looking at.');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Mobile is height-and-order only
+  // ---------------------------------------------------------------------------
+  group('mobile pins every card full-width', () {
+    test('the seeded mobile layout is a locked single column', () async {
+      final container = await boot();
+      addTearDown(container.dispose);
+      final controller = container.read(uspSliverDashboardControllerProvider);
+      controller.setSlotCount(4);
+
+      for (final item in controller.exportLayout()) {
+        expect(item['x'], 0, reason: '${item['id']} is not at the left edge');
+        expect(item['w'], 4, reason: '${item['id']} is not full-width');
+        expect(item['minW'], 4,
+            reason: '${item['id']} can still be shrunk: the package clamps a '
+                'resize to [minW, maxW], so minW must equal the slot count');
+        expect(item['maxW'], 4.0,
+            reason: '${item['id']} can still be widened past the grid');
+      }
+    });
+
+    test('a stored mobile layout with loose widths is re-locked on load',
+        () async {
+      // What every existing install has: a mobile entry written before the lock
+      // (or derived by the old scaler, which left w=4 with maxW=3 — a width
+      // already outside its own cap).
+      final container = await boot(initialValues: {
+        pUspSliverDashboardLayout: UspLayoutEnvelope({
+          12: [
+            _item('stats_panel', w: 12, h: 1, minW: 6, maxW: 12),
+            _item('device_info', y: 1, w: 6, h: 3, minW: 3, maxW: 8),
+          ],
+          4: [
+            _item('stats_panel', w: 2, h: 1, minW: 2, maxW: 4),
+            _item('device_info', x: 2, y: 1, w: 1, h: 3, minW: 1, maxW: 3),
+          ],
+        }).encode(),
+      });
+      addTearDown(container.dispose);
+
+      final controller = container.read(uspSliverDashboardControllerProvider);
+      controller.setSlotCount(4);
+
+      for (final item in controller.exportLayout()) {
+        expect(item['w'], 4, reason: '${item['id']} kept a stale narrow width');
+        expect(item['minW'], 4);
+        expect(item['maxW'], 4.0);
+      }
+    });
+
+    test('what we persist for mobile is locked too', () async {
+      final container = await boot();
+      addTearDown(container.dispose);
+
+      for (final item in (await storedEnvelope())[4]!) {
+        expect((item as Map)['w'], 4);
+        expect(item['minW'], 4);
+      }
+    });
+
+    test('tablet keeps proportional widths — the lock is mobile-only',
+        () async {
+      final container = await boot();
+      addTearDown(container.dispose);
+      final controller = container.read(uspSliverDashboardControllerProvider);
+      controller.setSlotCount(8);
+
+      final widths =
+          controller.exportLayout().map((item) => item['w'] as int).toSet();
+      expect(widths, isNot({8}),
+          reason: 'Tablet is a two-column grid; pinning it full-width would '
+              'throw away the pairing that #1293 is trying to protect.');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Membership is global, geometry is per-grid
+  // ---------------------------------------------------------------------------
+  group('adding and removing cards reaches every breakpoint', () {
+    test('removing a card on mobile removes it everywhere', () async {
+      final container = await boot();
+      addTearDown(container.dispose);
+      container.read(uspSliverDashboardControllerProvider).setSlotCount(4);
+
+      await container
+          .read(uspSliverDashboardControllerProvider.notifier)
+          .removeWidget('device_info');
+
+      final envelope = await storedEnvelope();
+      for (final slots in [12, 8, 4]) {
+        expect(
+          envelope[slots]!.map((item) => (item as Map)['id']),
+          isNot(contains('device_info')),
+          reason: 'device_info survived at $slots columns. Deleting a card on '
+              'a phone must delete the card, not just its phone placement.',
+        );
+      }
+    });
+
+    test('adding a card on mobile gives desktop its desktop width', () async {
+      final container = await boot();
+      addTearDown(container.dispose);
+      final notifier =
+          container.read(uspSliverDashboardControllerProvider.notifier);
+      container.read(uspSliverDashboardControllerProvider).setSlotCount(4);
+      await notifier.removeWidget('port_forwarding');
+
+      await notifier.addWidget('port_forwarding');
+
+      final envelope = await storedEnvelope();
+      expect(itemNamed(envelope[4]!, 'port_forwarding')['w'], 4);
+      expect(
+        itemNamed(envelope[12]!, 'port_forwarding')['w'],
+        greaterThan(4),
+        reason: 'A card added while on a phone came back to desktop stuck at '
+            'phone width — the package reconciles new items by carrying the '
+            'current width across, so the notifier has to place it per grid.',
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Migration and recovery
+  // ---------------------------------------------------------------------------
+  group('reading what is already on disk', () {
+    test('a legacy bare list loads as the desktop layout', () async {
+      final container = await boot(initialValues: {
+        pUspSliverDashboardLayout: jsonEncode([
+          _item('stats_panel', w: 12, h: 1, minW: 6, maxW: 12),
+          _item('device_info', y: 1, w: 6, h: 3, minW: 3, maxW: 8),
+        ]),
+      });
+      addTearDown(container.dispose);
+
+      final controller = container.read(uspSliverDashboardControllerProvider);
+      final layout = controller.exportLayout();
+      expect(layout, hasLength(2));
+      expect(itemNamed(layout, 'device_info')['w'], 6);
+    });
+
+    test('a legacy value is upgraded in place on the first save', () async {
+      final container = await boot(initialValues: {
+        pUspSliverDashboardLayout: jsonEncode([
+          _item('device_info', w: 6, h: 3, minW: 3, maxW: 8),
+        ]),
+      });
+      addTearDown(container.dispose);
+
+      await container
+          .read(uspSliverDashboardControllerProvider.notifier)
+          .saveLayout();
+
+      final envelope = await storedEnvelope();
+      expect(envelope.slotCounts, containsAll([12, 8, 4]),
+          reason: 'After one save the install should be fully migrated, so a '
+              'later mobile visit has somewhere of its own to write.');
+    });
+
+    test('an unreadable pref falls back to the default and rewrites it',
+        () async {
+      final container = await boot(initialValues: {
+        pUspSliverDashboardLayout: '{"version": 99}',
+      });
+      addTearDown(container.dispose);
+
+      expect(
+          container.read(uspSliverDashboardControllerProvider).exportLayout(),
+          hasLength(18));
+      expect((await storedEnvelope()).slotCounts, containsAll([12, 8, 4]));
+    });
+
+    test('a mobile entry missing a card the desktop has re-derives it',
+        () async {
+      // The shape a partial migration leaves behind: desktop has been edited
+      // since the mobile entry was written.
+      final container = await boot(initialValues: {
+        pUspSliverDashboardLayout: UspLayoutEnvelope({
+          12: [
+            _item('stats_panel', w: 12, h: 1, minW: 6, maxW: 12),
+            _item('device_info', y: 1, w: 6, h: 3, minW: 3, maxW: 8),
+          ],
+          4: [
+            _item('stats_panel', w: 4, h: 1, minW: 4, maxW: 4),
+          ],
+        }).encode(),
+      });
+      addTearDown(container.dispose);
+
+      final controller = container.read(uspSliverDashboardControllerProvider);
+      controller.setSlotCount(4);
+      expect(
+        controller.exportLayout().map((item) => item['id']),
+        containsAll(['stats_panel', 'device_info']),
+        reason: 'A card absent from the stored mobile entry must be scaled in, '
+            'not dropped — and it must not then be reconciled *out* of the '
+            'desktop layout on the way back up.',
+      );
+
+      controller.setSlotCount(12);
+      expect(controller.exportLayout(), hasLength(2),
+          reason: 'Returning to desktop must not lose a card because the '
+              'mobile entry was stale.');
+    });
+
+    test('resetLayout re-seeds every breakpoint', () async {
+      final container = await boot();
+      addTearDown(container.dispose);
+      final controller = container.read(uspSliverDashboardControllerProvider);
+
+      await container
+          .read(uspSliverDashboardControllerProvider.notifier)
+          .resetLayout();
+      container.read(uspSliverDashboardControllerProvider).setSlotCount(8);
+
+      final widths = container
+          .read(uspSliverDashboardControllerProvider)
+          .exportLayout()
+          .map((item) => item['w'] as int)
+          .toSet();
+      expect(widths, isNot({8}),
+          reason: 'After a reset the tablet cache is empty, so setSlotCount '
+              'falls back to correctBounds, which only shifts items left '
+              'without scaling — the two-column tablet grid collapses. '
+              'resetLayout has to re-seed like init does.');
+      expect(controller, isNotNull);
+    });
+  });
+}
+
+/// A layout item map in the shape `exportLayout()` produces.
+Map<String, dynamic> _item(
+  String id, {
+  int x = 0,
+  int y = 0,
+  int w = 6,
+  int h = 3,
+  int minW = 3,
+  double maxW = 8.0,
+  int minH = 1,
+  double maxH = 8.0,
+}) =>
+    {
+      'id': id,
+      'x': x,
+      'y': y,
+      'w': w,
+      'h': h,
+      'minW': minW,
+      'maxW': maxW,
+      'minH': minH,
+      'maxH': maxH,
+    };

--- a/test/page/dashboard/providers/usp_layout_controller_test.dart
+++ b/test/page/dashboard/providers/usp_layout_controller_test.dart
@@ -7,6 +7,7 @@ import 'package:privacy_gui/page/dashboard/models/usp_dashboard_preset.dart';
 import 'package:privacy_gui/page/dashboard/models/usp_layout_envelope.dart';
 import 'package:privacy_gui/page/dashboard/providers/usp_layout_controller.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sliver_dashboard/sliver_dashboard.dart';
 
 /// Wait for async initialization chains (SharedPreferences) to settle.
 Future<void> pumpAsync() async {
@@ -413,6 +414,126 @@ void main() {
           container.read(uspSliverDashboardControllerProvider);
       // No change since ID not found → changed remains false
       expect(identical(controllerBefore, controllerAfter), isTrue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Mobile width lock
+  //
+  // The phone grid is height-and-order only, and the width caps cannot enforce
+  // that on their own: the left-hand resize handles move `x`, and the package
+  // then trims `w` to whatever is left of the row (#1293).
+  //
+  // These tests stand in for that gesture by writing the geometry it produces
+  // straight to the layout beacon — which is the last thing
+  // `DashboardController.onResizeUpdate` does — because the call that reaches it
+  // sits behind the package's internal-only extension.
+  // ---------------------------------------------------------------------------
+  group('mobile width lock', () {
+    /// What one column of drag on [id]'s left edge leaves behind on a 4-column
+    /// grid. Either way the card ends up a column narrower; dragging inwards
+    /// moves it as well, dragging outwards runs into the row's own edge and the
+    /// package trims the width there instead.
+    void dragLeftEdge(
+      DashboardController controller,
+      String id, {
+      bool inwards = true,
+    }) {
+      controller.layout.value = [
+        for (final item in controller.layout.value)
+          if (item.id == id) item.copyWith(x: inwards ? 1 : 0, w: 3) else item,
+      ];
+    }
+
+    LayoutItem itemById(DashboardController controller, String id) =>
+        controller.layout.value.firstWhere((item) => item.id == id);
+
+    test('a left-edge resize on the phone grid is undone', () async {
+      final container = await createInitializedContainer();
+      addTearDown(container.dispose);
+
+      final controller = container.read(uspSliverDashboardControllerProvider);
+      controller.setSlotCount(UspLayoutEnvelope.mobileSlotCount);
+      expect(itemById(controller, 'device_info').x, 0,
+          reason: 'the phone grid starts out locked');
+
+      dragLeftEdge(controller, 'device_info');
+      await pumpAsync();
+
+      final item = itemById(controller, 'device_info');
+      expect(item.x, 0);
+      expect(item.w, UspLayoutEnvelope.mobileSlotCount);
+    });
+
+    test('a left-edge resize that only narrows is undone as well', () async {
+      final container = await createInitializedContainer();
+      addTearDown(container.dispose);
+
+      final controller = container.read(uspSliverDashboardControllerProvider);
+      controller.setSlotCount(UspLayoutEnvelope.mobileSlotCount);
+
+      dragLeftEdge(controller, 'device_info', inwards: false);
+      await pumpAsync();
+
+      expect(itemById(controller, 'device_info').w,
+          UspLayoutEnvelope.mobileSlotCount);
+    });
+
+    test('the same resize stands on the desktop grid', () async {
+      final container = await createInitializedContainer();
+      addTearDown(container.dispose);
+
+      // Width is the user's to choose everywhere above mobile, so the guard has
+      // to keep its hands off this one.
+      final controller = container.read(uspSliverDashboardControllerProvider);
+      dragLeftEdge(controller, 'device_info');
+      await pumpAsync();
+
+      final item = itemById(controller, 'device_info');
+      expect(item.x, 1);
+      expect(item.w, 3);
+    });
+
+    test('a height resize on the phone grid is left alone', () async {
+      final container = await createInitializedContainer();
+      addTearDown(container.dispose);
+
+      final controller = container.read(uspSliverDashboardControllerProvider);
+      controller.setSlotCount(UspLayoutEnvelope.mobileSlotCount);
+      final originalH = itemById(controller, 'device_info').h;
+
+      controller.layout.value = [
+        for (final item in controller.layout.value)
+          if (item.id == 'device_info')
+            item.copyWith(h: originalH + 2)
+          else
+            item,
+      ];
+      await pumpAsync();
+
+      // The one dimension a phone still lets the user choose.
+      final item = itemById(controller, 'device_info');
+      expect(item.h, originalH + 2);
+      expect(item.x, 0);
+      expect(item.w, UspLayoutEnvelope.mobileSlotCount);
+    });
+
+    test('a preset re-arms the lock on the controller it swaps in', () async {
+      final container = await createInitializedContainer();
+      addTearDown(container.dispose);
+
+      // The lock is a subscription on one controller's layout, so every swap has
+      // to re-arm it or the phone grid quietly becomes editable again.
+      await container
+          .read(uspSliverDashboardControllerProvider.notifier)
+          .applyPreset(UspDashboardPreset.essential);
+
+      final controller = container.read(uspSliverDashboardControllerProvider);
+      controller.setSlotCount(UspLayoutEnvelope.mobileSlotCount);
+      dragLeftEdge(controller, 'device_info');
+      await pumpAsync();
+
+      expect(itemById(controller, 'device_info').x, 0);
     });
   });
 

--- a/test/page/dashboard/providers/usp_layout_controller_test.dart
+++ b/test/page/dashboard/providers/usp_layout_controller_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/constants/pref_key.dart';
 import 'package:privacy_gui/page/dashboard/models/usp_dashboard_preset.dart';
+import 'package:privacy_gui/page/dashboard/models/usp_layout_envelope.dart';
 import 'package:privacy_gui/page/dashboard/providers/usp_layout_controller.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -35,6 +36,19 @@ Map<String, dynamic> _layoutItem(
     'minH': minH,
     'maxH': maxH,
   };
+}
+
+/// The desktop grid out of a persisted layout envelope.
+///
+/// The pref holds one layout per breakpoint keyed by slot count (#1293), so
+/// "what got saved" has to name a grid; every test here arranges and asserts on
+/// the desktop one. Read straight out of the JSON rather than through
+/// [UspLayoutEnvelope.tryDecode] so a decoder bug cannot hide behind these
+/// assertions — the envelope's own shape is covered in
+/// test/page/dashboard/models/usp_layout_envelope_test.dart.
+List<dynamic> _savedDesktopLayout(String raw) {
+  final layouts = (jsonDecode(raw) as Map)['layouts'] as Map;
+  return layouts['${UspLayoutEnvelope.desktopSlotCount}'] as List;
 }
 
 void main() {
@@ -133,7 +147,7 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       final saved = prefs.getString(pUspSliverDashboardLayout);
       expect(saved, isNotNull);
-      final decoded = jsonDecode(saved!) as List;
+      final decoded = _savedDesktopLayout(saved!);
       final ids = decoded.map((item) => (item as Map)['id']).toSet();
       // Unknown IDs preserved — may be package widgets
       expect(ids, contains('unknown_widget_xyz'));
@@ -159,7 +173,7 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       final saved = prefs.getString(pUspSliverDashboardLayout);
       expect(saved, isNotNull);
-      final decoded = jsonDecode(saved!) as List;
+      final decoded = _savedDesktopLayout(saved!);
       expect(decoded.length, 18);
     });
 
@@ -232,7 +246,7 @@ void main() {
       final saved = prefs.getString(pUspSliverDashboardLayout);
       expect(saved, isNotNull);
 
-      final decoded = jsonDecode(saved!) as List;
+      final decoded = _savedDesktopLayout(saved!);
       final first = decoded.first as Map<String, dynamic>;
       expect(first.containsKey('id'), isTrue);
       expect(first.containsKey('x'), isTrue);
@@ -352,7 +366,7 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       final saved = prefs.getString(pUspSliverDashboardLayout);
       expect(saved, isNotNull);
-      final decoded = jsonDecode(saved!) as List;
+      final decoded = _savedDesktopLayout(saved!);
       final item =
           decoded.firstWhere((i) => (i as Map)['id'] == 'device_info') as Map;
       expect(item['w'], 8);
@@ -607,7 +621,7 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       final saved = prefs.getString(pUspSliverDashboardLayout);
       expect(saved, isNotNull);
-      final decoded = jsonDecode(saved!) as List;
+      final decoded = _savedDesktopLayout(saved!);
       expect(decoded.length, 6);
     });
 
@@ -664,7 +678,7 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       final saved = prefs.getString(pUspSliverDashboardLayout);
       expect(saved, isNotNull);
-      final decoded = jsonDecode(saved!) as List;
+      final decoded = _savedDesktopLayout(saved!);
       final ids = decoded.map((i) => (i as Map)['id']).toSet();
       expect(ids.contains('device_info'), isFalse);
     });
@@ -864,7 +878,7 @@ void main() {
       // Verify the persisted data matches
       final prefs = await SharedPreferences.getInstance();
       final savedJson = prefs.getString(pUspSliverDashboardLayout)!;
-      final decoded = jsonDecode(savedJson) as List;
+      final decoded = _savedDesktopLayout(savedJson);
       expect(decoded.length, 6);
       final ids = decoded.map((i) => (i as Map)['id']).toSet();
       expect(ids.contains('stats_panel'), isTrue);
@@ -880,7 +894,7 @@ void main() {
 
       final prefs = await SharedPreferences.getInstance();
       final saved = prefs.getString(pUspSliverDashboardLayout);
-      final decoded = jsonDecode(saved!) as List;
+      final decoded = _savedDesktopLayout(saved!);
       final item =
           decoded.firstWhere((i) => (i as Map)['id'] == 'device_info') as Map;
       expect(item['w'], 8);


### PR DESCRIPTION
Closes #1293
Closes #1294

> **Stacked PR — do not squash-merge.** This targets `gate/1183-overflow-gate` (#1248), and #1299 is stacked on top of *this* branch. Squashing rewrites the SHAs the upper branch was cut from, which turns #1299 into a duplicate diff with false conflicts. Merge bottom-up with a **merge commit** or **rebase merge**: #1248 first, then this, then #1299.

## #1293 — resizing a card on a phone wrecked the desktop dashboard, permanently

Two separate defects hid behind one report.

**The layout pref had no idea which grid wrote it.** `exportLayout()` returns coordinates in whatever slot count the controller is currently on, and the pref was a bare list, always read back as 12 columns. A save at mobile came back at desktop as third-width cards whose `minW`/`maxW` had been scaled down with them — and those caps then blocked widening them again, which is what made it permanent.

The pref becomes an envelope keyed by slot count (`UspLayoutEnvelope`; legacy bare lists decode as the desktop entry, so no one loses their dashboard on upgrade), and save/load walk every breakpoint on the live controller so geometry stays per-grid. Membership deliberately does *not* — deleting a card on a phone deletes the card. `alignMembership` covers the case the package would otherwise get wrong: a stored narrower entry written before a card existed would reconcile that card *out* of the wider grids.

Resize enforcement also moves out of the view into `UspWidgetSpecs.correctedSize`, which scales the spec's 12-column figures to the grid actually in front of the user. Read literally, `stats_panel`'s `minColumns: 6` was being enforced as six of a tablet's *eight* columns, and as a width wider than a 4-column grid has.

**On a phone, width is not supposed to be editable at all — and pinning the caps only half achieved that.** At 4 columns every card is pinned full-width (`minW == maxW == slotCount`), leaving height and order. That holds the right-hand handles, because `sliver_dashboard` clamps a resize delta to `[minW, maxW]` and a width that is already both floor and ceiling cannot move. The left-hand handles move `x` as well, and the package fits the item to the row *after* that clamp:

```
newX = x + dW;  newW = (w - dW).clamp(minW, maxW)
if (newX < 0) { newW += newX; newX = 0; }
if (newX + newW > cols) newW = cols - newX
```

so one column of drag on a card's left edge narrows it to three either way — to `x: 1, w: 3` inwards, and to `x: 0, w: 3` outwards, where the row's own edge does the trimming. No cap can express "x may not move", and the package builds all eight handles unconditionally (its one switch, `isResizable`, would take the height with it), so the correction has to happen on the live layout.

`UspSliverDashboardControllerNotifier` now subscribes to the controller's layout beacon and puts any horizontal change on the phone grid back. Subscribing rather than snapping back at gesture end is what makes the drag look *inert* instead of rubber-banding: the correction is queued alongside the rebuild the same write triggers and runs first, because it is registered at construction, before any widget starts watching. The write goes straight to the beacon — `importLayout` would compact the whole grid mid-gesture and close gaps the user is still making. Height and ordering are untouched. The lock belongs to the instance it watches, so every controller swap goes through `_swapController`, which re-arms it.

## #1294 — a new session opened mid-edit, holding the previous session's snapshot

Logging out from the dashboard's own menu neither navigates nor reloads, so the `onExit` route guard never fires and the root-scoped edit state survived. `DashboardEditModeNotifier` now watches for the logged-in → logged-out edge and reverts, matching #1037's silent-discard policy. The edge is tracked locally because `logout()` emits a value-less `AsyncLoading` before the logged-out value.

## Verification

Run on this branch's head (`eda9f28c`):

- `./run_tests.sh` — **6531 passed**
- `flutter test --tags dashboard-card` — **2744 passed**
- `flutter test test/golden_test/page/dashboard/localizations/usp_dashboard_view_test.dart --tags golden` — **6 passed**
- `flutter analyze` — no errors or warnings in changed files

New coverage: `usp_layout_envelope_test.dart`, `usp_widget_specs_test.dart`, `usp_layout_breakpoint_persistence_test.dart` (the round-trip across all three breakpoints, plus the legacy-bare-list migration), and additions to `usp_layout_controller_test.dart` and `dashboard_edit_mode_provider_test.dart`.
