### PR TITLE
fix(dashboard): stack the DHCP Active Leases row and declare its threshold (#1321)

### DIFF
--- a/lib/page/dashboard/models/usp_widget_specs.dart
+++ b/lib/page/dashboard/models/usp_widget_specs.dart
@@ -337,6 +337,79 @@ abstract class UspWidgetSpecs {
   static const dhcpReservations = WidgetSpec(
     id: 'dhcp_reservations',
     displayName: 'DHCP Reservations',
+    // Measured floor, #1321: the narrowest width at which the **normal** Active
+    // Leases row seats an IP *and* a lease duration side by side — measured
+    // against the widest row the product can produce, not against the fixture.
+    //
+    // ## What "widest" means here, and why it is not the fixture
+    //
+    // Both operands are bounded, so both are measured at their bound. This is
+    // the criterion `usp_dhcp_reservations_density_test.dart` inherits from
+    // #1289: a bounded token must never be clipped, an unbounded one may.
+    //
+    //  - the IP is a 15-character IPv4 quad. The pool is user-editable
+    //    (`AppIpv4TextField`, Local Network page), so `192.168.100.200` is an
+    //    ordinary address rather than a corner case, and the fixture's
+    //    `192.168.1.102` is two characters short of the format.
+    //  - the lease is `leaseTimeFormatted`'s widest bucket. `validateLeaseTime`
+    //    caps a pool's lease at 525600 minutes
+    //    (`usp_local_network_service.dart:197`), so `364d 23h` is the widest
+    //    string the getter can render for a lease this product accepts.
+    //
+    // 1px sweeps of the pinned normal form, `en`, three lease rows per shape:
+    //
+    // | row content                   | first width with no clipping |
+    // |-------------------------------|------------------------------|
+    // | fixture IP + `23h 59m`        | 329                          |
+    // | fixture IP + `364d 23h`       | 330–336                      |
+    // | 15-char quad + `23h 59m`      | 361–369                      |
+    // | **15-char quad + `364d 23h`** | **369** (368 clips 0.7px)    |
+    //
+    // Row 1 is what this threshold was set to first, and the table is why it
+    // moved: of the 40px between, 25 are the two extra address characters and 5
+    // are the exotic lease. The number is driven by the *address format*, which
+    // is what the row exists to show — a lease nobody configured is not what
+    // makes 369 the floor.
+    //
+    // ## Why 369 and not the 368 that "widest failing + 1" gives
+    //
+    // Every other threshold in this file is the widest *failing* width plus one,
+    // where failing means "over `kOverflowTolerancePx`". That derivation puts
+    // this one at 368 — and 368 still clips, by 0.7px, which only the 2.0px
+    // tolerance absorbs. The tolerance exists for rasterizer drift between the
+    // mac and ubuntu font stacks (`overflow_probe.dart:4-15`), so a threshold
+    // set inside it spends the very margin the tolerance is there to provide.
+    // 369 is the narrowest width where the row does not clip at all, which is
+    // the claim a threshold should be making, and it costs 1px.
+    //
+    // ## What the bands buy
+    //
+    // `widthCasesFor` realizes exactly two widths here — 260.500px (the
+    // 4-column floor, @601px screen) and 288.000px (6- and 8-column spans both
+    // clamped to the 4-column mobile grid, @320px). **Both were shipping
+    // broken**: the normal row overflowed by 51.0px and 31.0px against an
+    // unexpired lease, with the duration clipped off the right edge on a real
+    // router. This threshold puts both in compact, and it stays below
+    // `desktopCaseFor` (512.000px) so the side-by-side row is intact wherever
+    // there is room for it.
+    //
+    // The compact form holds **both** operands across the whole band, and it
+    // does so by stacking them rather than dropping either half: at the worst
+    // case above it is clean at 200, 260.5, 288, 330, 350, 367 and 368px in
+    // `en`, and at 367px — the band's top edge — in all 26 locales. The
+    // side-by-side row needs ~126px of trailing slot at the fixture's content
+    // and ~166px at the bound; stacked it needs `max(IP, lease)` ≈ 93px, which
+    // is what makes [200, 369) safe to *declare* rather than a band that happens
+    // to work at the two widths the grid realizes. `DeviceRow.compact`'s 60px is
+    // spent on the same row and is not enough on its own — it clears 252px, not
+    // 200px.
+    //
+    // The cost of the band is one 8px dot per row. `build` filters to
+    // `isOnline == true` before building any lease row, so that dot is always
+    // the success colour: it is the only thing on this row that can be spent
+    // without losing information, which is what makes 369 cheap to declare and
+    // would not be true of a card whose leading slot carried a state.
+    normalAbove: 369,
     constraints: {
       DisplayMode.normal: WidgetGridConstraints(
         minColumns: 4,
@@ -746,7 +819,7 @@ abstract class UspWidgetSpecs {
   /// and a content line — and it is deliberately not a *measured* raise: the
   /// compact form is shorter than normal, so a number above what each card
   /// already declares could only be invented, and §2.4 is explicit that an
-  /// unmeasured constant must not be frozen into the code. Every one of the six
+  /// unmeasured constant must not be frozen into the code. Every one of the seven
   /// compact consumers already declares `minHeightRows` of 2 or 3, so today this
   /// floor is the mechanism without the raise; the raise it would apply is real
   /// the moment a card declares less.
@@ -757,10 +830,10 @@ abstract class UspWidgetSpecs {
   ///
   /// [CardDensity.normal] appears only alongside something to return *from* — on
   /// its own it is not a choice, just the status quo with a control attached.
-  /// [CardDensity.compact] appears only for the six cards that read the density
+  /// [CardDensity.compact] appears only for the seven cards that read the density
   /// (`normalAbove != null` is the existing predicate); offered anywhere else it
   /// would render exactly the normal form, which is a control that visibly does
-  /// nothing. Building compact forms for the other twelve is card-own design work
+  /// nothing. Building compact forms for the other eleven is card-own design work
   /// at #1288-#1291's scale and is out of this ticket's scope.
   static List<CardDensity> selectableForms(String id) {
     final spec = getById(id);

--- a/lib/page/local_network/cards/usp_dhcp_reservations_card.dart
+++ b/lib/page/local_network/cards/usp_dhcp_reservations_card.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:privacy_gui/localization/localization_hook.dart';
+import 'package:privacy_gui/page/_shared/components/card_density_scope.dart';
+import 'package:privacy_gui/page/_shared/models/card_density.dart';
 import 'package:privacy_gui/page/_shared/models/dhcp_client_ui_model.dart';
 import 'package:privacy_gui/page/_shared/models/dhcp_reservation_ui_model.dart';
 import 'package:privacy_gui/components/shortcuts/dialogs.dart';
@@ -27,6 +29,7 @@ class UspDhcpReservationsCard extends ConsumerWidget {
     // Dashboard shows only online clients (based on Hosts.Active, not DHCP lease).
     final onlineClients = clients.where((c) => c.isOnline == true).toList();
     final isLoading = ref.watch(uspMutationLoadingProvider) == 'dhcp';
+    final compact = CardDensityScope.of(context) == CardDensity.compact;
 
     return DashboardCardTemplate.multiSection(
       title: 'DHCP',
@@ -64,7 +67,7 @@ class UspDhcpReservationsCard extends ConsumerWidget {
           content: Column(
             children: [
               for (var i = 0; i < onlineClients.length; i++) ...[
-                _buildClientRow(context, onlineClients[i]),
+                _buildClientRow(context, onlineClients[i], compact: compact),
                 if (i < onlineClients.length - 1) AppGap.sm(),
               ],
             ],
@@ -100,12 +103,44 @@ class UspDhcpReservationsCard extends ConsumerWidget {
     );
   }
 
-  Widget _buildClientRow(BuildContext context, DhcpClientUIModel client) {
+  /// The Active Leases row.
+  ///
+  /// **Why this row has a compact form (#1321).** The trailing slot carries an IP
+  /// *and* a lease duration, and `AppListTile` hands `trailing` through
+  /// unconstrained, so the row overflowed by 50.0px at 260.5px and 29.0px at
+  /// 288.0px — both widths the #1183 gate sweeps — with the lease clipped at the
+  /// right edge on a real router. Neither operand can give: the IP is what the row
+  /// exists to show, and an ellipsized `10h…` is the defect that was reported, not
+  /// a fix for it.
+  ///
+  /// So the compact form **stacks** them instead of dropping either. That is the
+  /// half of the fix that matters at the narrow end: [DeviceRow.compact] returns
+  /// 60px (the 44px icon block plus the 16px gap ui_kit adds per occupied slot),
+  /// which alone clears 252px and not the 200px the band starts at. Stacked, the
+  /// slot's demand falls from IP + gap + lease to `max(IP, lease)` — the address
+  /// at every reachable content, since the widest lease a pool can hand out
+  /// (`364d 23h`, capped by `validateLeaseTime`) is narrower than a 15-character
+  /// quad. The band is therefore bounded by the address alone, which is why
+  /// `normalAbove: 369` covers it from 200px up.
+  ///
+  /// The icon the compact form drops is the only part of this row that can go
+  /// without loss: [build] filters to `isOnline == true` before building any row,
+  /// so the dot is **always** the success colour here and the ternary below has
+  /// one reachable branch. It is kept for the normal form because the row is a
+  /// live lease and the dot says so at a glance — it carries no information the
+  /// caller cannot already infer, which is exactly what makes it the right thing
+  /// to spend.
+  Widget _buildClientRow(
+    BuildContext context,
+    DhcpClientUIModel client, {
+    required bool compact,
+  }) {
     final colorScheme = Theme.of(context).colorScheme;
     final appColors = Theme.of(context).extension<AppColorScheme>();
     final lease = client.leaseTimeFormatted;
 
     return DeviceRow(
+      compact: compact,
       icon: Container(
         width: 8,
         height: 8,
@@ -118,16 +153,28 @@ class UspDhcpReservationsCard extends ConsumerWidget {
       ),
       title: client.displayName,
       subtitle: client.hostName.isNotEmpty ? client.mac : null,
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          AppText.bodySmall(client.ip, color: colorScheme.onSurfaceVariant),
-          if (lease.isNotEmpty) ...[
-            AppGap.md(),
-            AppText.bodySmall(lease, color: colorScheme.onSurfaceVariant),
-          ],
-        ],
-      ),
+      trailing: compact
+          ? Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                AppText.bodySmall(client.ip,
+                    color: colorScheme.onSurfaceVariant),
+                if (lease.isNotEmpty)
+                  AppText.bodySmall(lease, color: colorScheme.onSurfaceVariant),
+              ],
+            )
+          : Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AppText.bodySmall(client.ip,
+                    color: colorScheme.onSurfaceVariant),
+                if (lease.isNotEmpty) ...[
+                  AppGap.md(),
+                  AppText.bodySmall(lease, color: colorScheme.onSurfaceVariant),
+                ],
+              ],
+            ),
     );
   }
 

--- a/test/golden_test/page/dashboard/cards/fixtures/cards_test_data.dart
+++ b/test/golden_test/page/dashboard/cards/fixtures/cards_test_data.dart
@@ -353,6 +353,40 @@ final testDhcpReservations = [
   ),
 ];
 
+/// Active DHCP leases, with **now-relative** expiries (#1321).
+///
+/// These were `DateTime(2024, 6, 16, ...)`, and that is how #1183's gate came to
+/// sweep this card at two widths it was overflowing at. `leaseTimeFormatted`
+/// returns the empty string for a lease that is both expired and still active
+/// (`dhcp_client_ui_model.dart:44-46`), so every one of these rendered an
+/// IP-only trailing slot — about 50px narrower than any live router's — and the
+/// gate measured a row production does not have. The fixture went dead on
+/// 2024-06-16 on the wall clock, with nobody touching it, and the gate was built
+/// after that date, so it had never once rendered a lease string.
+///
+/// The offsets are width-maximal, not arbitrary. `leaseTimeFormatted` buckets
+/// into `Nd Nh` / `Nh Nm` / `Nm`, and measured as an overflow delta in the
+/// normal form at 300px, `23h 59m` is the widest string the getter can produce —
+/// 5.0px wider than the `days` bucket's own widest (`10d 23h`) and 22.0px wider
+/// than a bare `59m`. The first client carries it so the gate sweeps the worst
+/// case; the other two are shorter on purpose, so a row that only breaks at the
+/// maximum is still distinguishable from one that breaks everywhere.
+///
+/// The trailing `seconds: 59` is load-bearing: without it the few milliseconds
+/// between construction and layout drop `23h 59m` to `23h 58m`, which is a
+/// narrower string, and the fixture would quietly stop measuring the maximum it
+/// was written to measure.
+///
+/// **Known consequence.** A now-relative expiry makes the rendered string change
+/// with the wall clock, so the `card_dhcp_reservations` golden gains a cell that
+/// churns between baseline generation and verification. This is the sibling
+/// fixture's existing behaviour rather than a new class of problem —
+/// `test/golden_test/page/dhcp/fixtures/dhcp_test_data.dart:27` has shipped
+/// `DateTime.now().add(...)` behind a golden that renders `leaseExpiryFormatted`,
+/// an absolute `yyyy-MM-dd HH:mm` stamp, which churns every minute. The systemic
+/// fix is a clock seam (`clock.now()` in the model, `withClock` in the golden
+/// harness) covering both files; it is deliberately not done here, because a
+/// production model change is outside what this ticket measured.
 final testDhcpClients = [
   DhcpClientUIModel(
     mac: 'AA:BB:CC:DD:EE:02',
@@ -360,7 +394,9 @@ final testDhcpClients = [
     leaseActive: true,
     isOnline: true,
     hostName: 'iPhone-15',
-    leaseExpiry: DateTime(2024, 6, 16, 14, 30),
+    // `23h 59m` — the widest string leaseTimeFormatted can render.
+    leaseExpiry:
+        DateTime.now().add(const Duration(hours: 23, minutes: 59, seconds: 59)),
   ),
   DhcpClientUIModel(
     mac: 'AA:BB:CC:DD:EE:03',
@@ -368,7 +404,9 @@ final testDhcpClients = [
     leaseActive: true,
     isOnline: true,
     hostName: 'MacBook-Air',
-    leaseExpiry: DateTime(2024, 6, 16, 10, 00),
+    // `10h 30m`
+    leaseExpiry:
+        DateTime.now().add(const Duration(hours: 10, minutes: 30, seconds: 59)),
   ),
   DhcpClientUIModel(
     mac: 'AA:BB:CC:DD:EE:04',
@@ -376,7 +414,9 @@ final testDhcpClients = [
     leaseActive: true,
     isOnline: true,
     hostName: 'Smart-Speaker',
-    leaseExpiry: DateTime(2024, 6, 16, 8, 00),
+    // `6h 15m`
+    leaseExpiry:
+        DateTime.now().add(const Duration(hours: 6, minutes: 15, seconds: 59)),
   ),
 ];
 
@@ -791,7 +831,38 @@ final testFirewallEmptyData = FirewallData(
 // System Monitor
 // ---------------------------------------------------------------------------
 
-final _baseTime = DateTime(2024, 6, 15, 14, 0, 0);
+/// The clock every history series here hangs off — **now-relative, truncated to
+/// the hour** (#1321).
+///
+/// This was `DateTime(2024, 6, 15, 14, 0, 0)`, the second member of the same
+/// class as [testDhcpClients]: a fixture whose renderer compares it against
+/// `DateTime.now()`. `usp_device_analytics_card.dart:350-357` and `:425-431` build
+/// a 24-slot axis ending at the *current* hour and look each slot up by exact
+/// `DateTime` equality, so none of the 12 `hourlyHistory` entries matched any
+/// slot and both the trend chart and the heatmap rendered as all-zero. The gate
+/// swept four tabs of that card against an empty chart.
+///
+/// Unlike the lease row, this one was never a *bug* — 4 tabs × {stale fixture,
+/// now-relative fixture} at 260.5px measure clean either way, because a zero bar
+/// and a full bar occupy the same box. It is a coverage weakness, and it is fixed
+/// here because a fixture that renders nothing is the thing #1321 is about.
+///
+/// **Truncating to the hour is what makes it work**, not a tidiness choice: the
+/// lookup is `==` against `DateTime(now.year, now.month, now.day, now.hour)`, so
+/// a `_baseTime` carrying minutes or seconds would still miss every slot and the
+/// charts would stay empty while looking fixed.
+///
+/// This adds no churn class to the `device_analytics` golden that the card does
+/// not already have. Its heatmap axis renders wall-clock hour labels — `'00'`,
+/// `'06'`, `'12'`, `'18'` at slot positions derived from `DateTime.now()`
+/// (`:448`) — so that image already moves once an hour on its own, regardless of
+/// what this fixture holds.
+final _baseTime = _currentHour();
+
+DateTime _currentHour() {
+  final now = DateTime.now();
+  return DateTime(now.year, now.month, now.day, now.hour);
+}
 
 final testSystemMonitorWithHistory = SystemMonitorState(
   history: List.generate(

--- a/test/page/_shared/models/card_form_choice_test.dart
+++ b/test/page/_shared/models/card_form_choice_test.dart
@@ -43,23 +43,27 @@ import 'package:privacy_gui/page/dashboard/models/usp_widget_specs.dart';
 /// | 13 | normal restores the minima but not the maxima | normal restores the handles and the spec bounds |
 /// | 14 | normal's `maxW` not scaled to the grid | a card parked outside its spec bounds is pulled inside them |
 /// | 15 | `_applyFloors` drops the `maxW < minW` repair | a raised floor never ends up above its own ceiling |
-/// | 16 | `selectableForms` drops the `spec.normalAbove != null` guard | 4, incl. offers compact only to the six cards that read it |
+/// | 16 | `selectableForms` drops the `spec.normalAbove != null` guard | 4, incl. offers compact only to the seven cards that read it |
 /// | 17 | `cardsWithoutPopupForm` emptied | 3, incl. offers popup to every card built through the template |
 /// | 18 | `selectableForms` returns `[normal]` instead of `const []` when nothing else applies | stats_panel offers no form at all |
 /// | 19 | `CardForms.props` → `[]` (equality on type alone) | a pick that differs anywhere is a different value |
 /// | 20 | `CardForms` drops `Equatable` (back to identity) | a rebuilt CardForms equals the one it was rebuilt from |
 /// | 21 | `CardFormChoice.props` → `[density]` | the restore size is part of what makes a choice equal |
+/// | 22 | compact's `specMinW` reads the raw 12-column figure instead of `_scaleFromTwelfths(constraints.minColumns, …)` | so is the spec's own floor, which is also written in twelfths |
 ///
-/// ### One survivor, and why it is left alive
+/// ### The survivor that stopped surviving (#1321)
 ///
-/// Replacing compact's `specMinW = _scaleFromTwelfths(constraints.minColumns, …)`
-/// with the raw 12-column figure survives. It is an *equivalent* mutation on today's
-/// data, not a gap: every one of the six compact consumers declares `minColumns: 3`,
-/// and `minW` is the max of the scaled spec floor and the scaled compact floor, which
-/// the compact floor wins on all three grids. The scaling there is defensive —
-/// it becomes observable the first time a card declares a `minColumns` above 4 —
-/// and writing a test that only passes because of a card that does not exist would
-/// be worse than recording this.
+/// Row 22 was recorded here as the table's one survivor, and as an *equivalent*
+/// mutation rather than a gap: `minW` is the max of the scaled spec floor and the
+/// scaled compact floor, every compact consumer declared `minColumns: 3`, and the
+/// compact floor won on all three grids either way. The note said it would become
+/// observable the first time a card declared a `minColumns` above 3, and that
+/// writing a test against a card that did not exist would be worse than recording
+/// it.
+///
+/// `dhcp_reservations` is that card — `minColumns: 4`, so on the 8-column grid its
+/// spec floor and the compact floor agree at 3 only if both are scaled — and the
+/// test named in row 22 is the one that was owed. The survivor list is empty.
 void main() {
   const desktop = UspLayoutEnvelope.desktopSlotCount;
   const tablet = UspLayoutEnvelope.tabletSlotCount;
@@ -282,6 +286,23 @@ void main() {
               'floor claims half the row.');
     });
 
+    test('so is the spec\'s own floor, which is also written in twelfths', () {
+      // The other half of the scaling, and until #1321 it could not be observed:
+      // `minW` is the max of the scaled spec floor and the scaled compact floor,
+      // and every compact consumer declared `minColumns: 3`, which the compact
+      // floor wins on every grid whether the spec figure is scaled or not.
+      // `dhcp_reservations` declares 4 — the same figure as the floor — so on the
+      // 8-column grid the two agree at 3 only if both are scaled. Read raw, the
+      // spec side claims 4 of 8 columns: half the row, for the form whose job is
+      // to need less.
+      final compacted = applyTo(item('dhcp_reservations', w: 4, minW: 2),
+          density: CardDensity.compact, cols: tablet);
+
+      expect(compacted['minW'], 3,
+          reason: 'A spec column figure is twelfths at every site that reads '
+              'one, including the one it is compared against its own grid at.');
+    });
+
     test('floors the height as well as the width', () {
       final compacted = applyTo(item('device_info', h: 1, minH: 1),
           density: CardDensity.compact, cols: desktop);
@@ -374,7 +395,7 @@ void main() {
   // Which cards get a control at all
   // ---------------------------------------------------------------------------
   group('selectableForms', () {
-    test('offers compact only to the six cards that read it', () {
+    test('offers compact only to the seven cards that read it', () {
       final withCompact = UspWidgetSpecs.all
           .map((spec) => spec.id)
           .where((id) =>
@@ -389,11 +410,12 @@ void main() {
           'ethernet_ports',
           'connected_devices',
           'time_settings',
+          'dhcp_reservations',
           'network_health',
         ],
         reason: 'A compact entry on a card that ignores the density renders '
             'exactly the normal form — a control that visibly does nothing. '
-            'Building compact forms for the other twelve is #1288-#1291-scale '
+            'Building compact forms for the other eleven is #1288-#1291-scale '
             'card-own design work and out of scope.',
       );
     });

--- a/test/page/dashboard/cards/dashboard_card_forced_form_overflow_test.dart
+++ b/test/page/dashboard/cards/dashboard_card_forced_form_overflow_test.dart
@@ -44,12 +44,23 @@ import '../../../util/dashboard/dashboard_card_probe.dart';
 ///
 /// **A forced compact card cannot go below 4 columns**, which realizes at 260.5px.
 /// The #1183 gate pumps only each spec's min / preferred / max spans — 3, 6 and 8
-/// for all six compact consumers — so the span this ticket makes their floor is
-/// pumped by nothing. And for two of the six the automatic rule would not select
-/// compact there at all: 260.5px is above `lan_info`'s 250 and `time_settings`'
-/// 256, so those two render their compact form at that width only because the user
-/// asked, which is exactly the "width the automatic rule would not select" the AC
-/// names. The inventory below pins which two, rather than leaving it as prose.
+/// for six of the seven compact consumers — so the span this ticket makes their
+/// floor is pumped by nothing. And for two of the seven the automatic rule would
+/// not select compact there at all: 260.5px is above `lan_info`'s 250 and
+/// `time_settings`' 256, so those two render their compact form at that width only
+/// because the user asked, which is exactly the "width the automatic rule would
+/// not select" the AC names. The inventory below pins which two, rather than
+/// leaving it as prose.
+///
+/// The seventh is `dhcp_reservations`, and it is the exception that made the
+/// inventory a partition rather than an emptiness. #1321 gave it a threshold, and
+/// its `minColumns` is 4 — so the gate's own min-span case *is* this floor, in the
+/// compact form, in all 26 locales, at the same 3 rows. Its three cases below are
+/// therefore duplicates. They are kept because the sweep is generated from "the
+/// cards a user can pick compact for", which is the honest definition of what this
+/// file covers; excluding a card because another file happens to reach the same
+/// coordinate opens a hole the moment a `normalAbove` or a `minColumns` moves, and
+/// three cases is not a price worth that.
 ///
 /// ## What is deliberately not swept
 ///
@@ -146,7 +157,8 @@ CardWidthCase? _caseForSpan(int span, String label) {
 /// `max` of the two, because [UspWidgetSpecs.compactMinHeightRows] is a floor
 /// rather than a pin and every compact consumer already declares 2 or 3. Pumping
 /// the constant alone would measure a shorter card than the floor actually permits
-/// for four of the six.
+/// for four of the seven (`connected_devices`, `time_settings`,
+/// `dhcp_reservations`, `network_health`, all at 3).
 int _compactFloorRows(WidgetSpec spec) => math.max(
       spec.getConstraints(DisplayMode.normal).minHeightRows,
       UspWidgetSpecs.compactMinHeightRows,
@@ -220,20 +232,73 @@ void main() {
               'instead');
     });
 
-    test('compact\'s new floor is a span the gate never pumps', () {
+    test('compact\'s floor is a span the gate pumps for one card only', () {
+      // This began as `a span the gate never pumps`, which held while every
+      // compact consumer declared min/preferred/max 3/6/8 — the inventory #1299
+      // measured. #1321 broke it: `dhcp_reservations` is the first card to declare
+      // a threshold *and* floor itself at 4 columns, so the gate's min-span case
+      // is this file's compact floor.
+      //
+      // The claim is a three-way partition rather than an emptiness, and every
+      // side is pinned, because which side a card sits on decides what this file
+      // is the *only* coverage for. `notPumped` is exclusive coverage on the width;
+      // `pumpedInNormal` is exclusive coverage on the form (the gate reaches the
+      // width and production renders normal there, so only a pick shows compact);
+      // `pumpedInCompact` is duplicated, and the header says why it is kept.
+      final notPumped = <String>[];
+      final pumpedInCompact = <String>[];
+      final pumpedInNormal = <String>[];
+
       for (final spec in _specsOffering(CardDensity.compact)) {
-        expect(
-          widthCasesFor(spec).map((c) => c.columnSpan),
-          isNot(contains(UspWidgetSpecs.compactMinColumns)),
-          reason: '${spec.id}: the gate pumps min/preferred/max spans, and '
-              '#1299 makes ${UspWidgetSpecs.compactMinColumns} columns the '
-              'floor of the compact form. If the spec now declares that span, '
-              'the gate covers this width and the sweep below is redundant',
-        );
+        final spans = widthCasesFor(spec).map((c) => c.columnSpan);
+        if (!spans.contains(UspWidgetSpecs.compactMinColumns)) {
+          notPumped.add(spec.id);
+        } else if (densityForWidth(
+                width: compactCase.cardWidth, normalAbove: spec.normalAbove) ==
+            CardDensity.compact) {
+          pumpedInCompact.add(spec.id);
+        } else {
+          pumpedInNormal.add(spec.id);
+        }
       }
+
+      expect(
+        notPumped,
+        [
+          'device_info',
+          'lan_info',
+          'ethernet_ports',
+          'connected_devices',
+          'time_settings',
+          'network_health',
+        ],
+        reason: 'these declare no ${UspWidgetSpecs.compactMinColumns}-column '
+            'span, so ${compactCase.widthKey}px is a width no sweep but this one '
+            'reaches. An id leaving this list has not lost coverage — it has '
+            'moved to one of the two below, and the reason has to be read',
+      );
+      expect(
+        pumpedInCompact,
+        ['dhcp_reservations'],
+        reason: 'the gate already pumps these at ${compactCase.widthKey}px in '
+            'the compact form, so their cases below are duplicates rather than '
+            'coverage. A list growing here is fine; a list growing to include '
+            'every card means this file\'s compact sweep has stopped adding '
+            'anything and should be reconsidered',
+      );
+      expect(
+        pumpedInNormal,
+        isEmpty,
+        reason: 'a card here declares the floor span but sits above its own '
+            'threshold at ${compactCase.widthKey}px, so the gate measures its '
+            'normal form and only a pick reaches the compact one. Nothing is '
+            'wrong with that — it is the strongest case for this sweep — but it '
+            'is a shape #1299 never measured, so it is pinned rather than '
+            'assumed away',
+      );
     });
 
-    test('and for two of the six the rule there would say normal', () {
+    test('and for two of the seven the rule there would say normal', () {
       // Which cards make this file's compact sweep *forced* rather than merely
       // un-pumped. Named rather than counted: the two are the cards whose
       // threshold sits below the 4-column realization, and a spec edit that moves
@@ -250,7 +315,7 @@ void main() {
           reason: 'at ${compactCase.widthKey}px these are the cards production '
               'would render in their normal form, so a pick is the only way to '
               'see their compact form at this width — AC 11\'s "a width the '
-              'automatic rule would not select". The other four are already in '
+              'automatic rule would not select". The other five are already in '
               'their compact band here, and are swept for the geometry alone');
     });
   });
@@ -371,8 +436,8 @@ void main() {
             density: CardDensity.compact,
           );
 
-          // The compact form has no widget of its own to find — each of the six
-          // cards arranges its own — so the structural claim available here is
+          // The compact form has no widget of its own to find — each of the
+          // seven cards arranges its own — so the structural claim available here is
           // that the card still went through the template that reads the density.
           expect(
             find.byType(DashboardCardTemplate),

--- a/test/page/dashboard/cards/dashboard_card_overflow_test.dart
+++ b/test/page/dashboard/cards/dashboard_card_overflow_test.dart
@@ -89,6 +89,11 @@ List<Locale> get _targetLocales {
 /// drift apart — see [kOverflowTolerancePx] for why it is 2.0 (#1270).
 const double _tolerancePx = kOverflowTolerancePx;
 
+/// The fixture every case in this file pumps, named once so #1319 — which moves
+/// it out of `test/golden_test/` — has one line to change.
+const String _sharedFixturePath =
+    'test/golden_test/page/dashboard/cards/fixtures/cards_test_data.dart';
+
 Map<String, String> _trackingByCard = {};
 Map<String, Set<String>> _knownOverflowAllowlist = {};
 
@@ -487,11 +492,13 @@ void main() {
   // ─── The normal band (#1318) ──────────────────────────────────────────────
   //
   // The sweep above pumps the widths the grid produces for each span, and claims
-  // that is exhaustive because overflow is monotonic in width. Since #1288/#1290
-  // six cards declare a `normalAbove`, so their narrowest realization renders a
-  // *different form* — popup at 191.4px for all six, compact at 288.0px for the
-  // three whose threshold is above it — and a different form is not a narrower
-  // instance of the same one. For those three **this sweep is the only place the
+  // that is exhaustive because overflow is monotonic in width. Since
+  // #1288/#1290/#1321 seven cards declare a `normalAbove`, so their narrowest
+  // realization renders a *different form* — popup at 191.4px for six of them,
+  // 260.5px compact for `dhcp_reservations`, whose `minColumns: 4` puts its own
+  // floor above `kPopupBelow`; and compact at 288.0px for the four whose threshold
+  // is above it — and a different form is not a narrower instance of the same one.
+  // For those four **this sweep is the only place the
   // grid's own widths reach the normal form at all**; what the gate had otherwise
   // is `dashboard_card_popup_overflow_test`'s two dialog groups, which render it at
   // the fixed `kCardPresentationWidth` (400px, above every threshold), tab 0 only,
@@ -500,7 +507,7 @@ void main() {
   // tab, `de`, 500px, +41px): tab 2 in `de` used to be covered by transitivity from
   // the 191.4px normal case, and #1288 removed that without replacing it.
   //
-  // So each of the six is swept once more, at [normalBandCaseFor] — the narrowest
+  // So each of the seven is swept once more, at [normalBandCaseFor] — the narrowest
   // width the grid produces at or above its own threshold. One width, because
   // monotonicity is intact *within* a form: see that function for the argument, and
   // `the gate's own widths cannot reach the normal band` below for the half of it
@@ -531,18 +538,19 @@ void main() {
   //
   // | # | assertion | mutation | killed by |
   // |---|---|---|---|
-  // | 1 | the per-case overflow `fail` | `usp_network_health_card`: the `if (!compact)` metric row gives its three `_MetricChip`s a fixed `width: 140` instead of `Expanded` — a width the desktop realization has room for and this card's own threshold does not | 26 of 26 `network_health` tab0 cases. Of the 3213 other cases carrying the `dashboard-card` tag, the 1698-case main sweep saw **nothing**; only the two dialog groups (6, at 400px) and `usp_network_health_density_test`'s pinned-normal assertions (4) did |
-  // | 2 | `the six cards that declare a threshold` + `each threshold is realizable` + the selected-form table | delete `normalAbove: 366` from `network_health`'s spec | all 3 meta-tests. The sweep itself goes 208 → 130 cases and stays green, which is exactly the silent narrowing they exist to convert into a failure |
-  // | 3 | `selectedCardDensity(…) == normal` | `normalBandCaseFor` accepts widths 100px below the threshold | 208 of 208 sweep cases, plus `each threshold is realizable` |
+  // | 1 | the per-case overflow `fail` | `usp_network_health_card`: the `if (!compact)` metric row gives its three `_MetricChip`s a fixed `width: 140` instead of `Expanded` — a width the desktop realization has room for and this card's own threshold does not | 26 of 26 `network_health` tab0 cases. Of the 3258 other cases carrying the `dashboard-card` tag, the 1698-case main sweep saw **nothing**; only the two dialog groups (6, at 400px) and `usp_network_health_density_test`'s pinned-normal assertions (4) did |
+  // | 2 | `the seven cards that declare a threshold` + `each threshold is realizable` + the selected-form table | delete `normalAbove: 366` from `network_health`'s spec | all 3 meta-tests. The sweep itself goes 234 → 156 cases and stays green, which is exactly the silent narrowing they exist to convert into a failure |
+  // | 3 | `selectedCardDensity(…) == normal` | `normalBandCaseFor` accepts widths 100px below the threshold | 234 of 234 sweep cases, plus `each threshold is realizable` |
   // | 4 | `widest lessThanOrEqualTo 288.0` | `kMinSupportedScreenWidth` 320 → 480 (the plausible version of this: dropping 320px support) | `the gate's own widths cannot reach the normal band` alone — `widest` becomes 448.0 |
-  // | 5 | the 8-coordinate count | drop `'network_health': 3` from `kTabbedCardTabCounts` | `the six cards that declare a threshold` (8 → 6) |
+  // | 5 | the 9-coordinate count | drop `'network_health': 3` from `kTabbedCardTabCounts` | `the seven cards that declare a threshold` (9 → 7) |
   final normalBandSpecs =
       UspWidgetSpecs.all.where((s) => s.normalAbove != null).toList();
 
   group('normal band coverage', () {
     // The inventory, asserted rather than narrated — the counts in the comment
     // above are the whole justification for this sweep's existence and its size.
-    test('the six cards that declare a threshold, at 8 card x tab coordinates',
+    test(
+        'the seven cards that declare a threshold, at 9 card x tab coordinates',
         () {
       expect(
         {for (final s in normalBandSpecs) s.id: s.normalAbove},
@@ -552,6 +560,7 @@ void main() {
           'ethernet_ports': 386.0,
           'connected_devices': 336.0,
           'time_settings': 256.0,
+          'dhcp_reservations': 369.0,
           'network_health': 366.0,
         },
         reason: 'a card that gains or loses a `normalAbove` changes what this '
@@ -560,8 +569,8 @@ void main() {
       );
       expect(
         normalBandSpecs.fold<int>(0, (n, s) => n + tabCountFor(s.id)),
-        8,
-        reason: 'five single-view cards plus network_health\'s three tabs',
+        9,
+        reason: 'six single-view cards plus network_health\'s three tabs',
       );
       // #1183's motivating coordinate, named so a change that drops it is a
       // failure rather than a silent narrowing.
@@ -579,8 +588,8 @@ void main() {
     // generator the main sweep uses tops out at 288.0px, because spans 5 upward all
     // realize 288.0px at the 320px screen floor — a card spanning the whole
     // 4-column mobile grid is full width. So no coordinate `widthCasesFor` can
-    // produce reaches a threshold above 288, and the three cards below are outside
-    // its range by construction rather than by sampling. If a wider realization
+    // produce reaches a threshold above 288, and the four cards below that declare
+    // one are outside its range by construction rather than by sampling. If a wider realization
     // ever appears this fails, instead of the sweep quietly duplicating coverage.
     test('the gate\'s own widths cannot reach the normal band', () {
       // Every span any card declares — the generator's whole domain, taken from
@@ -616,6 +625,10 @@ void main() {
         'ethernet_ports': ['191=popup', '288=compact'],
         'connected_devices': ['191=popup', '288=compact'],
         'time_settings': ['191=popup', '288=normal'],
+        // The one card whose narrowest realization is not the 3-column floor:
+        // `minColumns: 4` keeps it above `kPopupBelow`, so it has no popup form
+        // to reach by width and *both* its realizations go to compact (#1321).
+        'dhcp_reservations': ['261=compact', '288=compact'],
         'network_health': ['191=popup', '288=compact'],
       });
     });
@@ -637,6 +650,7 @@ void main() {
           'ethernet_ports': '386.0@552x3',
           'connected_devices': '336.0@2096x3',
           'time_settings': '256.0@1120x3',
+          'dhcp_reservations': '369.0@401x4',
           'network_health': '366.0@2216x3',
         },
         reason:
@@ -739,6 +753,97 @@ void main() {
   //     from a default-profile one at the same coordinate — a worse outcome than
   //     its absence. Profile sweeps are measured by reading the failure, which
   //     names the profile.
+  // AC6 as a guard rather than an enumeration (#1321).
+  //
+  // A list of "the absolute dates as of today" is a comment that goes stale the
+  // next time someone adds a fixture, which is the failure mode this whole ticket
+  // is about. The property is mechanically checkable instead: no `DateTime(<int>`
+  // literal anywhere in the shared fixture. `DateTime(now.year, …)` is untouched,
+  // because it starts from the clock rather than from a constant — which is the
+  // distinction that matters, not whether the constructor is called.
+  //
+  // Deliberately the whole file, not just the fields a renderer is known to
+  // compare against `DateTime.now()`. Nobody knew `leaseTimeFormatted` did, and
+  // finding out cost a hardware repro; a rule that needs that knowledge up front
+  // is a rule that fails the same way twice.
+  group('the shared fixture pins no absolute date', () {
+    test('$_sharedFixturePath has no DateTime literal', () {
+      final file = File(_sharedFixturePath);
+      expect(
+        file.existsSync(),
+        isTrue,
+        reason: 'the shared fixture is not at $_sharedFixturePath. #1319 moves '
+            'it out of test/golden_test/ — update _sharedFixturePath here, '
+            'which is the only place this suite names the path.',
+      );
+
+      final offenders = <String>[];
+      final lines = file.readAsLinesSync();
+      for (var i = 0; i < lines.length; i++) {
+        final trimmed = lines[i].trimLeft();
+        // Prose about the dates this ticket removed is not a date.
+        if (trimmed.startsWith('//')) continue;
+        if (RegExp(r'DateTime\(\s*\d').hasMatch(lines[i])) {
+          offenders.add('  ${i + 1}: ${lines[i].trim()}');
+        }
+      }
+
+      expect(
+        offenders,
+        isEmpty,
+        reason:
+            'These fixtures pin an absolute date:\n${offenders.join('\n')}\n'
+            'A renderer that compares one against `DateTime.now()` starts '
+            'returning different content on a date nobody chose, and the gate '
+            'keeps reporting the coordinate clean — #1321 shipped an overflow '
+            'at two swept widths that way, and left `device_analytics` sweeping '
+            'an all-zero chart. Use `DateTime.now()`-relative offsets, and if a '
+            'constant genuinely is correct for a fixture, say why in a comment '
+            'on the line above and this check will not see it.',
+      );
+    });
+  });
+
+  // The **default** fixture's conditional content (#1321).
+  //
+  // Every case in this file that pumps a card measures the tree
+  // `kitchenSinkOverrides()` produces, which makes the fixture their silent
+  // premise. When a card renders something behind a condition and the fixture
+  // stops satisfying it, the row loses an operand, the sweep keeps passing, and
+  // the coordinate reads as covered — see `card_data_profiles.dart`'s "the
+  // default profile can also under-render". These assertions turn that into a
+  // failure.
+  //
+  // Deliberately *not* part of the width sweep: this is one pump per card
+  // coordinate at the desktop width, where nothing is absent for a density
+  // reason, in `en` because the patterns are untranslated. It answers "did the
+  // fixture render it", not "does it fit".
+  group('default fixture conditional content', () {
+    for (final marker in kDefaultFixtureMarkers) {
+      final spec = UspWidgetSpecs.all.firstWhere((s) => s.id == marker.cardId);
+
+      testWidgets('${marker.cardId} renders it (tab ${marker.tab})',
+          (tester) async {
+        await probeCardOverflow(
+          tester,
+          cardId: marker.cardId,
+          widthCase: desktopCaseFor(spec),
+          cardHeightRows: spec.getConstraints(DisplayMode.normal).minHeightRows,
+          tabIndex: marker.tab,
+          locale: const Locale('en'),
+        );
+
+        expect(
+          find.textContaining(marker.pattern),
+          findsNWidgets(marker.expected),
+          reason: '${marker.cardId} tab ${marker.tab} did not render '
+              '${marker.expected} matches for ${marker.pattern} — '
+              '${marker.why}.',
+        );
+      });
+    }
+  });
+
   for (final sweep in kCardDataProfileSweeps) {
     final spec = UspWidgetSpecs.all.firstWhere((s) => s.id == sweep.cardId);
     final rows = spec.getConstraints(DisplayMode.normal).minHeightRows;

--- a/test/page/dashboard/cards/dashboard_card_popup_overflow_test.dart
+++ b/test/page/dashboard/cards/dashboard_card_popup_overflow_test.dart
@@ -20,11 +20,11 @@ import '../../../util/overflow_probe.dart';
 ///
 /// The #1183 gate (`dashboard_card_overflow_test.dart`) pins no density, so
 /// every card selects its own form from the width the grid gives it — which for
-/// 12 of the 18 cards is still always normal, because they declare no
-/// `normalAbove` (#1240 AC 1). The other **six** declare one (#1288-#1291), and
-/// they are the cards a width can put into this form.
+/// 11 of the 18 cards is still always normal, because they declare no
+/// `normalAbove` (#1240 AC 1). The other **seven** declare one (#1288-#1291,
+/// #1321), and they are the cards a width can put into this form.
 ///
-/// The sweep below is wider than those six: it covers the **nine** cards the grid
+/// The sweep below is wider than those seven: it covers the **nine** cards the grid
 /// can render under [kPopupBelow] at all, whether or not they declare a threshold
 /// — see [_canReachPopupBand]. Three of the nine (`network_status`,
 /// `system_status`, `firewall_overview`) reach the band by width but stay normal
@@ -192,7 +192,7 @@ void main() {
       expect(UspWidgetSpecs.all, hasLength(18));
       expect(
         UspWidgetSpecs.all.where((s) => s.normalAbove != null).length,
-        6,
+        7,
         reason: 'the cards a width can put into a degraded form at all',
       );
       expect(
@@ -285,8 +285,8 @@ void main() {
   /// The one thing the fixed presentation width has to be measured against.
   ///
   /// `showCardNormalForm` gives every card the same [kCardPresentationWidth]
-  /// rather than the width its spec declares (250–386 across the six that declare
-  /// one). That is only sound while the fixed width clears all of them: a card
+  /// rather than the width its spec declares (250–386 across the seven that
+  /// declare one). That is only sound while the fixed width clears all of them: a card
   /// declaring more than the presentation offers would be handed back the very
   /// width it said it could not be read at.
   ///

--- a/test/page/dashboard/views/components/card_form_toolbar_test.dart
+++ b/test/page/dashboard/views/components/card_form_toolbar_test.dart
@@ -414,7 +414,7 @@ void main() {
 
       expect(chipForms(tester), ['Normal', 'Popup'],
           reason: 'topology declares no threshold, so no compact form was ever '
-              'built for it. #1299 is explicit that building the other twelve '
+              'built for it. #1299 is explicit that building the other eleven '
               'is out of scope — so the toolbar must not offer a form that does '
               'not exist.');
     });

--- a/test/page/dashboard/views/components/usp_dhcp_reservations_density_test.dart
+++ b/test/page/dashboard/views/components/usp_dhcp_reservations_density_test.dart
@@ -1,0 +1,458 @@
+@Tags(['dashboard-card'])
+library;
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/_shared/components/card_popup_form.dart';
+import 'package:privacy_gui/page/_shared/components/dashboard_card_template.dart';
+import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
+import 'package:privacy_gui/page/_shared/models/card_density.dart';
+import 'package:privacy_gui/page/_shared/models/dhcp_client_ui_model.dart';
+import 'package:privacy_gui/page/dashboard/models/display_mode.dart';
+import 'package:privacy_gui/page/dashboard/models/usp_widget_specs.dart';
+import 'package:privacy_gui/page/local_network/providers/dhcp_data_provider.dart';
+
+import '../../../../golden_test/golden_framework/mocks/mock_dashboard_cards.dart';
+import '../../../../golden_test/page/dashboard/cards/fixtures/cards_test_data.dart';
+import '../../../../util/app_test_fonts.dart';
+import '../../../../util/dashboard/dashboard_card_probe.dart';
+import '../../../../util/overflow_probe.dart';
+
+/// `dhcp_reservations` density: what the Active Leases row owes the reader at
+/// every width, and where the threshold that guarantees it comes from (#1321).
+///
+/// ## Why this file exists next to a green gate
+///
+/// #1183's gate asks one question — did a `RenderFlex` report overflow — against
+/// one fixture. #1321 is the ticket that showed both halves of that can be true
+/// and still measure the wrong row: the fixture's leases had expired in 2024, so
+/// `leaseTimeFormatted` returned the empty string, the trailing slot rendered
+/// IP-only, and two swept widths reported clean while a real router clipped the
+/// duration off the right edge.
+///
+/// The fix (a stacked trailing pair below `normalAbove`) makes the gate's own
+/// coordinates clean. What the gate still cannot say is *why those widths and not
+/// others*, and whether the row that fits is the row a user needs. Both are this
+/// file's job:
+///
+///  - the gate pumps `widthCasesFor` — 260.5px and 288.0px here — plus
+///    `normalBandCaseFor`. Every width in between, and the band's own edges, are
+///    widths the grid can produce and the gate never realizes.
+///  - the gate measures the *fixture*. This file measures the widest row the
+///    product can hand the card, which is what the threshold is derived from.
+///
+/// ## The criterion: both operands are bounded, so both are measured at the bound
+///
+/// #1289 states it as "a bounded token must never ellipsize, an unbounded one
+/// may" — a device *name* is router data no width can accommodate, so `MacBook-A…`
+/// is the designed trade. This row has no unbounded operand at all:
+///
+///  - **the IP** is bounded by its format at 15 characters. `255.255.255.255` is
+///    not a client address; it is the widest rendering of one, and the pool is
+///    user-editable, so `192.168.100.200` is ordinary. The fixture's
+///    `192.168.1.102` is two characters short of the bound, and those two
+///    characters are 25 of the 40px that moved the threshold.
+///  - **the lease** is bounded by the product's own validator:
+///    `validateLeaseTime` caps a pool's lease at 525600 minutes
+///    (`usp_local_network_service.dart:197`), so `364d 23h` is the widest string
+///    `leaseTimeFormatted` can render for a lease this app will accept.
+///
+/// Neither can be clipped, and neither ellipsizes if it is — the trailing texts
+/// set no `maxLines`, so the row overflows instead. That is why this file asserts
+/// **both** no-overflow and painted-inside-the-card: a `ClipRect` anywhere above
+/// the row would silence the first while cutting the glyphs, which is the
+/// "green but unreadable" failure the epic keeps finding (#1240 AC 1).
+///
+/// ## What is deliberately not here
+///
+/// **The popup form.** `minColumns: 4` floors this card at 260.5px, well above
+/// `kPopupBelow`, so no width the grid produces selects popup — only #1299's
+/// explicit pick reaches it, and
+/// `test/page/dashboard/cards/dashboard_card_forced_form_overflow_test.dart`
+/// pumps exactly that at 122px. A popup group here would restate it.
+///
+/// **Twenty-three locales.** Both operands are digits and both are measured at
+/// their format bound, so the trailing slot's demand does not move with the
+/// string table; the locale dimension belongs to the gate, which sweeps all 26.
+/// The threshold's own floor was verified in all 26 before it was declared (369px
+/// normal, 367px compact, worst-case rows, all clean) — that measurement is
+/// recorded in the spec comment rather than re-run here, because a per-locale
+/// sweep of a locale-independent demand is 52 cases that can only fail together.
+///
+/// ## Mutation ledger
+///
+/// Each mutation applied alone, reverted before the next, and run against this
+/// file and the full `dashboard-card` tag:
+///
+///   | mutation                                                  | this file | the tag |
+///   |-----------------------------------------------------------|-----------|---------|
+///   | A `normalAbove: 369` deleted from the spec                 | 9 fail    | 66 fail |
+///   | B `normalAbove: 369` → `329` (the fixture-measured floor)  | 1 fail    | 3 fail  |
+///   | C the trailing's `compact` branch removed (side by side)   | 4 fail    | 4 fail  |
+///   | D `DeviceRow` ignores `compact`, always builds the icon    | 4 fail    | 10 fail |
+///
+/// **A** is the loud one and belongs to the gate: without a threshold the card has
+/// no compact form, so #1183 pumps the original defect again — 52 of its 55
+/// failures are 260.5px and 288.0px across all 26 locales, the exact coordinates
+/// #1321 was filed for. The other 3 there, plus 1 in the popup file and 1 in the
+/// forced-form file, are inventory meta-tests noticing the card left the set.
+///
+/// **B is the row worth reading.** 329 is a real measurement — of the fixture — and
+/// the gate's 1698-case sweep stays green under it, because the gate pumps that same
+/// fixture. Its 3 failures are `@329.0px` here plus the two pinned-threshold maps in
+/// `dashboard_card_overflow_test.dart`, and those maps only record the number, they
+/// do not check it. So one assertion in this file — the worst-case pair at the
+/// declared floor — is the only thing in the repo that can tell 369 from 329. That
+/// is the whole argument for measuring content at its bound.
+///
+/// **C and D separate the two halves of the compact form**, and the split is the
+/// reason the card's docstring credits the stacking rather than the icon. C kills
+/// only the four `both are whole, and stacked` cases; D kills only the four
+/// `the icon block is not drawn` cases (plus 6 in
+/// `usp_connected_devices_density_test.dart`, which shares `DeviceRow`) — and
+/// under D no width in this file overflows, because the row's own title is
+/// unbounded and absorbs the 60px the icon takes back. The icon is spent for
+/// clarity; the stacking is what makes 200px declarable.
+void main() {
+  setUpAll(() async {
+    // Real fonts: under Ahem every glyph is one square em, so an address measured
+    // against a lease string is fiction.
+    await loadAppFonts();
+  });
+
+  const cardId = 'dhcp_reservations';
+  final spec = UspWidgetSpecs.getById(cardId)!;
+  final constraints = spec.getConstraints(DisplayMode.normal);
+  final heightRows = constraints.minHeightRows;
+
+  /// The declared threshold, with a literal fallback used **only** so the file can
+  /// still enumerate its cases when the declaration is missing: `spec.normalAbove!`
+  /// would throw before a single test registered, and mutation A would read as
+  /// "the file fails to load" rather than as nine assertions about forms the card
+  /// no longer selects. The first test is the one that asserts the declaration.
+  final normalAbove = spec.normalAbove ?? 369.0;
+
+  final narrowCases = widthCasesFor(spec);
+  final desktopCase = desktopCaseFor(spec);
+  final widestRealization =
+      narrowCases.map((c) => c.cardWidth).reduce(math.max);
+
+  /// The widths that exercise the compact band: its floor, both realizations, and
+  /// its top edge. `kPopupBelow` and `normalAbove - 2` are the edges — widths the
+  /// grid can hand this card (a 4-column span sizes anywhere between them) but
+  /// which no realization the gate enumerates lands on.
+  final compactWidths = <double>[
+    kPopupBelow,
+    ...narrowCases.map((c) => c.cardWidth),
+    normalAbove - 2,
+  ];
+
+  /// The widest row the product can produce: a 15-character quad and the longest
+  /// lease `validateLeaseTime` permits, on every row rather than one, so a fix
+  /// that happens to seat the first row is not enough.
+  const quad = '255.255.255.255';
+  const maxLease = Duration(days: 364, hours: 23, minutes: 59, seconds: 59);
+
+  /// `364d 23h`, derived rather than typed so the expectation cannot drift from
+  /// the getter. The trailing `seconds: 59` in [maxLease] is load-bearing for the
+  /// same reason the fixture carries it: without it the milliseconds between
+  /// construction and layout drop the string to a narrower one.
+  final maxLeaseText = DhcpClientUIModel(
+    mac: 'AA:BB:CC:DD:EE:02',
+    ip: quad,
+    leaseActive: true,
+    isOnline: true,
+    leaseExpiry: DateTime.now().add(maxLease),
+  ).leaseTimeFormatted;
+
+  final worstClients = [
+    for (final host in ['iPhone-15', 'MacBook-Air', 'Smart-Speaker'])
+      DhcpClientUIModel(
+        mac: 'AA:BB:CC:DD:EE:0${host.length % 9}',
+        ip: quad,
+        leaseActive: true,
+        isOnline: true,
+        hostName: host,
+        leaseExpiry: DateTime.now().add(maxLease),
+      ),
+  ];
+
+  /// Reservations are left at the fixture's three, so the Active Leases section
+  /// is under the same vertical load production gives it — the widest row is a
+  /// horizontal claim and shortening the card would weaken the vertical one.
+  final worstOverrides = cardOverrides(
+    dhcpData: DhcpData(
+      reservationModels: testDhcpReservations,
+      clientModels: worstClients,
+    ),
+  );
+
+  /// Pumps at an arbitrary [cardWidth] and, unless [pin] says otherwise, lets the
+  /// card select its own form through `CardDensityHost`'s `LayoutBuilder` — the
+  /// production path. The screen is held at 1440px while the card width varies,
+  /// which is the same separation the host makes: density comes from the
+  /// constraints the grid hands the card, never from the window.
+  Future<List<OverflowIncident>> pumpAt(
+    WidgetTester tester, {
+    required double cardWidth,
+    required String label,
+    CardDensity? pin,
+    bool worstCase = true,
+  }) =>
+      probeCardOverflow(
+        tester,
+        cardId: cardId,
+        widthCase: CardWidthCase(
+          screenWidth: 1440,
+          cardWidth: cardWidth,
+          columnSpan: constraints.minColumns,
+          label: label,
+        ),
+        cardHeightRows: heightRows,
+        tabIndex: 0,
+        locale: const Locale('en'),
+        density: pin,
+        extraOverrides: worstCase ? worstOverrides : const [],
+      );
+
+  /// Same 2.0px tolerance as the #1183 gate, for the same reason: sub-pixel
+  /// shaping differences between the mac and ubuntu rasterizers.
+  const tolerancePx = 2.0;
+
+  void expectNoOverflow(List<OverflowIncident> incidents,
+      {required String at}) {
+    final significant = incidents.where((i) => i.pixels > tolerancePx).toList();
+    expect(significant, isEmpty,
+        reason: 'overflowed at $at:\n${significant.join('\n')}');
+  }
+
+  /// Both operands, on all three rows, painted inside the card's own box.
+  ///
+  /// The rect check is not a restatement of [expectNoOverflow]. Overflow is a
+  /// `RenderFlex` diagnostic; a clip is a paint one, and the two are independent —
+  /// a `Wrap`, a `ClipRect`, or an `OverflowBox` above this row would report no
+  /// overflow while cutting glyphs at the card edge. That combination is what
+  /// makes a gate green and a card unreadable, so it is asserted separately.
+  void expectBothOperandsWhole(WidgetTester tester, {required String at}) {
+    final card = tester.getRect(find.byType(DashboardCardTemplate));
+
+    for (final entry in {'address': quad, 'lease': maxLeaseText}.entries) {
+      final finder = find.text(entry.value);
+      final found = finder.evaluate().length;
+      expect(found, worstClients.length,
+          reason: 'expected one ${entry.key} per lease row at $at but found '
+              '$found. The assertion below would pass by not looking at '
+              'anything, which is exactly how #1321 shipped: the fixture stopped '
+              'rendering the lease and every sweep kept reporting clean');
+
+      for (var i = 0; i < found; i++) {
+        final text = tester.getRect(finder.at(i));
+        expect(text.right, lessThanOrEqualTo(card.right + tolerancePx),
+            reason: 'the ${entry.key} on row $i is painted past the card\'s '
+                'right edge at $at (text ends at ${text.right.toStringAsFixed(1)}'
+                ', card ends at ${card.right.toStringAsFixed(1)}). Both operands '
+                'of this row are bounded tokens — a truncated address names no '
+                'host and a truncated duration is not a duration');
+        expect(text.left, greaterThanOrEqualTo(card.left - tolerancePx),
+            reason:
+                'the ${entry.key} on row $i starts left of the card at $at, '
+                'so the row is being pushed out of its own box rather than '
+                'shedding anything');
+      }
+    }
+  }
+
+  group('the card declares a threshold, and where', () {
+    test('normalAbove is declared, and bounded on both sides', () {
+      expect(spec.normalAbove, isNotNull,
+          reason: 'without a threshold every width selects the normal form, '
+              'which is the row #1321 measured overflowing by 51.0px at '
+              '260.5px on a real router. Every group below asserts a form the '
+              'card would no longer select');
+
+      expect(normalAbove, greaterThan(kPopupBelow),
+          reason:
+              'a threshold at or below $kPopupBelow leaves no compact band: '
+              'every width under it selects popup, so the card would drop from '
+              'the whole list straight to one number with nothing in between '
+              '(densityForWidth precedence rule 1)');
+
+      // The same inversion `connected_devices` declares, and for the same kind of
+      // reason: both realizations have to land in compact, because the normal row
+      // does not fit at either of them.
+      expect(normalAbove, greaterThan(widestRealization),
+          reason: 'a threshold at or below '
+              '${widestRealization.toStringAsFixed(1)}px leaves the widest width '
+              'the grid realizes for this card in the normal form, which is the '
+              'form that was clipping the lease there (#1321)');
+
+      expect(normalAbove, lessThan(desktopCase.cardWidth),
+          reason: 'a threshold at or above the ${desktopCase.cardWidth}px '
+              'desktop width degrades a card that has room: the stacked trailing '
+              'and the dropped status dot would ship to 1440px screens');
+    });
+  });
+
+  group('across the compact band the row keeps both operands', () {
+    for (final width in compactWidths) {
+      final label = '${width.toStringAsFixed(1)}px';
+
+      testWidgets('@$label both are whole, and stacked', (tester) async {
+        final incidents = await pumpAt(tester, cardWidth: width, label: 'band');
+        expectNoOverflow(incidents, at: label);
+
+        expect(find.byType(CardPopupForm), findsNothing,
+            reason:
+                'at $label the card gave up its list. $width is at or above '
+                '$kPopupBelow, so the compact form is what it owes the user '
+                'here — a list that fits, not a single count');
+        expectBothOperandsWhole(tester, at: label);
+
+        // The mechanism, asserted rather than inferred from the fact that it
+        // fits: stacking is what turns the slot's demand from `IP + gap + lease`
+        // into `max(IP, lease)`, and it is the only reason 200px is declarable.
+        final address = tester.getRect(find.text(quad).first);
+        final lease = tester.getRect(find.text(maxLeaseText).first);
+        expect(lease.top, greaterThanOrEqualTo(address.bottom),
+            reason:
+                'the lease is still beside the address at $label rather than '
+                'under it. Side by side the slot needs ~166px at this content '
+                'and the row does not have it — the fit here would be a '
+                'coincidence of this fixture rather than the compact form doing '
+                'its job (#1321)');
+      });
+
+      testWidgets('@$label the icon block is not drawn', (tester) async {
+        await pumpAt(tester, cardWidth: width, label: 'band');
+
+        final dots = find.descendant(
+          of: find.byType(DeviceRow),
+          matching: find.byWidgetPredicate((w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).shape == BoxShape.circle),
+        );
+        expect(dots, findsNothing,
+            reason:
+                'the status dot is still drawn at $label, so `DeviceRow` is '
+                'still paying 60px for the leading block — the 44px box plus the '
+                '16px gap ui_kit adds per occupied slot. Every row here is '
+                'online by construction (`build` filters on `isOnline`), so the '
+                'dot is the one thing on this row that can be spent');
+      });
+    }
+  });
+
+  group('above the threshold the row is one line again', () {
+    for (final width in [normalAbove, desktopCase.cardWidth]) {
+      final label = '${width.toStringAsFixed(1)}px';
+
+      testWidgets('@$label the pair is side by side and whole', (tester) async {
+        final incidents =
+            await pumpAt(tester, cardWidth: width, label: 'normal');
+        // Zero, not "under the tolerance": the threshold is defined as the first
+        // width at which the row clips nothing, so at the threshold itself the
+        // 2.0px allowance must be entirely unspent and available for rasterizer
+        // drift. The paired case in the last group asserts the other half — that
+        // 2px lower it is not.
+        expect(incidents.where((i) => i.pixels > 0), isEmpty,
+            reason: 'the row clips at $label, inside the gate\'s tolerance: '
+                '${incidents.map((i) => i.pixels.toStringAsFixed(1)).join(', ')}'
+                'px. A threshold that only passes because of the tolerance has '
+                'nothing left for the drift the tolerance is for');
+        expectBothOperandsWhole(tester, at: label);
+
+        final address = tester.getRect(find.text(quad).first);
+        final lease = tester.getRect(find.text(maxLeaseText).first);
+        expect(lease.top, address.top,
+            reason: 'the lease is stacked under the address at $label, so the '
+                'compact form has leaked past its own threshold — a degradation '
+                'that leaks upward is the failure mode a density mechanism has '
+                'and a fixed layout does not');
+
+        final dots = find.descendant(
+          of: find.byType(DeviceRow),
+          matching: find.byWidgetPredicate((w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).shape == BoxShape.circle),
+        );
+        expect(dots, findsNWidgets(worstClients.length),
+            reason: 'the status dots are missing at $label, which has room for '
+                'them: the compact form is being selected above its threshold');
+      });
+    }
+  });
+
+  group('the threshold is a measurement, not a preference', () {
+    // The only cases in the suite where a *failure* is the expected outcome. If a
+    // future change lets the normal form seat a 15-character quad and a
+    // `364d 23h` lease at these widths — a narrower gap, a smaller text style —
+    // these fail and the threshold should come down with them.
+    //
+    // The two use different standards on purpose, and the difference is the
+    // spec's "why 369 and not 368" argument made executable.
+    testWidgets(
+        'pinned normal @${widestRealization.toStringAsFixed(1)}px overflows '
+        'the gate\'s own standard', (tester) async {
+      final incidents = await pumpAt(
+        tester,
+        cardWidth: widestRealization,
+        label: 'normal-pinned',
+        pin: CardDensity.normal,
+      );
+
+      final significant =
+          incidents.where((i) => i.pixels > tolerancePx).toList();
+      expect(significant, isNotEmpty,
+          reason: 'the normal form fits the widest row the product can produce '
+              'at the widest width the grid realizes for this card, so the '
+              'compact form is buying nothing at the coordinate it was declared '
+              'for. Re-measure the floor and lower `normalAbove` rather than '
+              'leaving a degraded form selected where it is not needed (#1321)');
+    });
+
+    testWidgets(
+        'pinned normal @${(normalAbove - 2).toStringAsFixed(1)}px still clips, '
+        'inside the tolerance', (tester) async {
+      final incidents = await pumpAt(
+        tester,
+        cardWidth: normalAbove - 2,
+        label: 'normal-pinned-edge',
+        pin: CardDensity.normal,
+      );
+
+      // Any clipping at all, not clipping over `tolerancePx`. Two pixels below
+      // the threshold the row clips by ~1.4px, which the gate's 2.0px tolerance
+      // absorbs — so "the gate would pass here" is true and irrelevant. The
+      // tolerance exists for rasterizer drift between the mac and ubuntu font
+      // stacks; a threshold placed inside it spends the margin it is there to
+      // provide, and 1.4px locally is a failure on CI at the first 0.7px of
+      // drift. This is what makes the threshold 369 rather than 367 or 368.
+      expect(incidents.where((i) => i.pixels > 0), isNotEmpty,
+          reason: 'the normal form clips nothing 2px below the threshold, so '
+              '`normalAbove` is 2px higher than the measurement supports. Lower '
+              'it to the first width that clips nothing at all — that width, not '
+              'the widest one the tolerance forgives, is what the number means '
+              'here (#1321)');
+    });
+
+    testWidgets('and the fixture alone cannot tell 369 from 329',
+        (tester) async {
+      // Why the ledger's mutation B is invisible to the gate, pinned so the claim
+      // is measured rather than asserted in prose: at 329px the fixture's own
+      // rows fit the normal form. A threshold set from them is a real
+      // measurement of the wrong content.
+      final incidents = await pumpAt(
+        tester,
+        cardWidth: 329,
+        label: 'fixture-pinned',
+        pin: CardDensity.normal,
+        worstCase: false,
+      );
+      expectNoOverflow(incidents, at: '329.0px (fixture rows)');
+    });
+  });
+}

--- a/test/util/dashboard/card_data_profiles.dart
+++ b/test/util/dashboard/card_data_profiles.dart
@@ -44,6 +44,41 @@ import '../../golden_test/page/dashboard/cards/fixtures/cards_test_data.dart';
 /// Non-default profiles get their own allowlist keys (`card|width|tab@profile`),
 /// so the default profile's arithmetic — the number every closed ticket in this
 /// epic quotes — is untouched by anything here.
+///
+/// ## The stronger caveat #1321 found: the *default* profile can also under-render
+///
+/// The paragraph above bounds the gate's coverage in one direction — a card is
+/// unswept on a second data shape until someone adds it. #1321 showed the bound
+/// is wider than that, and in a direction nothing here was watching.
+///
+/// `dhcp_reservations` pinned its lease expiries to `DateTime(2024, 6, 16, ...)`,
+/// and `leaseTimeFormatted` returns the empty string for a lease that is both
+/// expired and active. So from 2024-06-16 onward — on the wall clock, with nobody
+/// touching the fixture — the card's Active Leases rows rendered an IP-only
+/// trailing slot, about 50px narrower than any live router's. The gate was built
+/// after that date, swept the card at 260.5px and 288.0px in 26 locales, and
+/// reported clean. On a real router both widths overflowed, by 51.0px and 31.0px,
+/// with the lease duration clipped off the right edge.
+///
+/// Two things follow, and they are worth separating:
+///
+///  - **"Clean on the default profile" is not the same claim as "clean at the
+///    widths swept."** The gate measures the tree the fixture produces. A fixture
+///    that renders *less* than production makes a coordinate green without
+///    covering it, and no amount of width or locale coverage detects that —
+///    those axes were swept, thoroughly, against the wrong row.
+///  - **`known_overflows.json == {}` is a statement about what the gate
+///    measures, not about the product.** The ratchet is exact about the
+///    coordinates it holds; it is silent about whether those coordinates render
+///    what a user would see. #1321 is the existence proof, found by hand on
+///    hardware rather than by the sweep.
+///
+/// [kDefaultFixtureMarkers] is the mechanism that answers the specific failure —
+/// content the default fixture renders *conditionally* is asserted present, on
+/// the same argument [CardDataProfile.markers] makes for the second profile. It
+/// does not answer the general one: a fixture can still be unrepresentative
+/// without being empty, and only measuring each card against production-shaped
+/// data does that.
 class CardDataProfile {
   /// Short key used in test names and in allowlist keys. Must be stable: it is
   /// part of the ratchet's identity for these cases.
@@ -129,6 +164,67 @@ final sixRadioProfile = CardDataProfile(
   // The fifth radio's channel, which no other profile produces.
   markers: const ['197 (Auto)'],
 );
+
+/// Content the **default** fixture renders only behind a condition, and the card
+/// coordinate it has to reach (#1321).
+///
+/// The distinction from [CardDataProfile.markers] is which fixture is being
+/// checked. That one guards a *layered override* — the risk is that the override
+/// misses and the default fixture renders instead. This one guards the default
+/// fixture itself: the risk is that a `if (x.isNotEmpty)` in the card stops being
+/// true, the row loses a whole operand, and every case the gate pumps measures a
+/// narrower row than production has.
+///
+/// Only conditional content belongs here. A title the card always renders cannot
+/// silently disappear — if it does, the card is broken in a way any test would
+/// catch. The entries are the places where the fixture decides, at render time,
+/// whether the widest thing in a row exists at all.
+class DefaultFixtureMarker {
+  final String cardId;
+  final int tab;
+
+  /// Matched with `find.textContaining`, so a [RegExp] is allowed and is the
+  /// right choice for content whose exact value moves (a duration counts down;
+  /// its shape does not).
+  final Pattern pattern;
+
+  /// How many widgets must match. Pinned rather than `findsWidgets`, because a
+  /// fixture that loses two of three rows is the same class of failure as one
+  /// that loses all three.
+  final int expected;
+
+  /// What is conditional, and what the card renders instead when the condition
+  /// fails — this is the failure message.
+  final String why;
+
+  const DefaultFixtureMarker({
+    required this.cardId,
+    required this.tab,
+    required this.pattern,
+    required this.expected,
+    required this.why,
+  });
+}
+
+final kDefaultFixtureMarkers = <DefaultFixtureMarker>[
+  DefaultFixtureMarker(
+    cardId: 'dhcp_reservations',
+    tab: 0,
+    // `leaseTimeFormatted`'s three buckets: `Nd Nh`, `Nh Nm`, `Nm`. Matched by
+    // shape rather than by value because the fixture is now-relative, so the
+    // literal counts down between the pump and this assertion.
+    pattern: RegExp(r'\b\d{1,2}[dh] \d{1,2}[hm]\b'),
+    expected: 3,
+    why: 'the Active Leases rows render `client.leaseTimeFormatted` behind an '
+        '`if (lease.isNotEmpty)`, and the getter returns the empty string for a '
+        'lease that is both expired and active. Three online clients in '
+        '`testDhcpClients` means three durations. If this fails, the fixture has '
+        'gone stale again (absolute expiry dates walk into the past) and every '
+        'coordinate the gate pumps for this card is measuring an IP-only '
+        'trailing slot ~50px narrower than production\'s — which is exactly how '
+        '#1321 shipped at two swept widths',
+  ),
+];
 
 /// Every non-default sweep the gate runs.
 ///

--- a/test/util/dashboard/dashboard_card_probe.dart
+++ b/test/util/dashboard/dashboard_card_probe.dart
@@ -308,14 +308,17 @@ CardWidthCase desktopCaseFor(WidgetSpec spec, {double screenWidth = 1440}) {
 /// [narrowestRealizationOf]'s doc states the gate's exhaustiveness argument:
 /// overflow is monotonic in width, so the narrowest realization of a span is that
 /// span's worst case. That holds only while the card renders the *same form* at
-/// every width. Since #1288/#1290 six cards declare a `normalAbove`, so their
-/// narrowest realization selects popup or compact — a different layout, not a
+/// every width. Since #1288/#1290/#1321 seven cards declare a `normalAbove`, so
+/// their narrowest realization selects popup or compact — a different layout, not a
 /// narrower instance of the same one — and it no longer dominates the widths where
-/// the normal form renders. Measured: all six select popup at 191.4px, and three of
-/// them (`connected_devices` 336, `network_health` 366, `ethernet_ports` 386) select
+/// the normal form renders. Measured: six of the seven select popup at 191.4px;
+/// `dhcp_reservations` selects compact at 260.5px instead, because `minColumns: 4`
+/// puts its narrowest realization above `kPopupBelow` and it has no popup form to
+/// reach by width at all. Four of the seven (`connected_devices` 336,
+/// `network_health` 366, `dhcp_reservations` 369, `ethernet_ports` 386) select
 /// compact at 288.0px too. [widthCasesFor] cannot reach past that, because spans 5
 /// upward all realize 288.0px at the 320px screen floor — a card spanning the whole
-/// 4-column mobile grid is full width. So for those three the normal form is not
+/// 4-column mobile grid is full width. So for those four the normal form is not
 /// merely unsampled by the gate: it is unreachable by the gate's width generator
 /// (#1318).
 ///
@@ -331,11 +334,11 @@ CardWidthCase desktopCaseFor(WidgetSpec spec, {double screenWidth = 1440}) {
 /// The smallest realization at or above the threshold, searched over every span in
 /// `minColumns..maxColumns` and the same enumerated screen range
 /// [narrowestRealizationOf] uses — so this is a width the grid genuinely produces,
-/// not the bare threshold value. Measured on this branch, every one of the six
+/// not the bare threshold value. Measured on this branch, every one of the seven
 /// thresholds is *exactly* realizable, at the card's `minColumns`: `lan_info`
 /// 250.0px @ screen 1096, `time_settings` 256.0px @ 1120, `device_info` 262.0px @
 /// 1144, `connected_devices` 336.0px @ 2096, `network_health` 366.0px @ 2216,
-/// `ethernet_ports` 386.0px @ 552. That is a coincidence of the grid's near-continuity
+/// `dhcp_reservations` 369.0px @ 401, `ethernet_ports` 386.0px @ 552. That is a coincidence of the grid's near-continuity
 /// in screen width, not something to rely on — hence the search rather than
 /// `cardWidth: spec.normalAbove!`.
 CardWidthCase? normalBandCaseFor(WidgetSpec spec) {


### PR DESCRIPTION
Closes #1321.

## The defect

The Active Leases row put an IP and a lease duration side by side in an unconstrained `trailing` slot, and overflowed by **51.0px at 260.5px** and **31.0px at 288.0px** — both widths #1183's gate sweeps. The gate reported clean because `testDhcpClients` pinned `leaseExpiry` to 2024-06-16: `leaseTimeFormatted` returns the empty string for a lease that is both expired and active, so every swept case measured an IP-only slot production does not have. The fixture went dead on the wall clock, with nobody touching it, before the gate was ever built.

## The fix

The compact form **stacks** the pair rather than dropping either operand (AC 2: the IP is what the row exists to show, and an ellipsized `10h…` is the reported defect, not a fix for it). Stacking is the half that matters at the narrow end — `DeviceRow.compact`'s 60px saving alone clears only 252px, not the 200px the band starts at.

`normalAbove: 369`, measured against the product's own bounds instead of the fixture — a 15-character IPv4 quad, and `364d 23h`, the widest string `leaseTimeFormatted` can render for a lease `validateLeaseTime` accepts (525600-minute cap):

| content | normal form needs |
|---|---|
| fixture IP + `23h 59m` | 329 |
| fixture IP + `364d 23h` | 330–336 |
| quad + `23h 59m` | 361–369 |
| **quad + `364d 23h`** | **369** (368 clips 0.7px) |

25 of the 40px difference is the two extra address characters, not the exotic lease — so the number is driven by the IPv4 format, the same way `connected_devices`' is. Compact is clean with worst-case rows across the entire band, including all 26 locales at both edges (367 compact, 369 normal). The band's cost is one always-green 8px dot between 329 and 368.

## Fixture and gate

- `testDhcpClients` and `_baseTime` are now-relative (AC 3, AC 5). `_baseTime` is truncated to the hour because `usp_device_analytics_card` looks its 24 slots up by exact `DateTime` equality — the stale constant was rendering an all-zero chart that the gate swept four tabs of.
- `kDefaultFixtureMarkers` asserts the lease string reached the rendered tree (AC 4).
- AC 6 is a guard rather than an enumeration: no `DateTime(<int>` literal anywhere in the shared fixture, comment lines exempt. A list of "the absolute dates as of today" is a comment that goes stale the next time someone adds a fixture, which is the failure mode this ticket is about.
- `usp_dhcp_reservations_density_test.dart` — 14 cases over the compact band, asserting no-overflow **and** painted-inside-the-card, since a `ClipRect` would silence the first while cutting the glyphs (#1240 AC 1). Mutation ledger in the file header, re-measured on this revision.

## Fallout worth reading

- The seventh threshold moves several pinned inventories from six to seven.
- It also **retires `card_form_choice_test.dart`'s one surviving mutation**. `minColumns: 4` is the first spec floor that differs from the compact floor once scaled, so reading it as raw twelfths is now observable on the 8-column grid — the note said this would become observable the first time such a card existed, and the test it was owed is in this PR.
- **Known consequence of AC 3:** the `card_dhcp_reservations` golden gains a cell that churns with the wall clock. Baselines are gitignored, so CI cannot fail on it, and the sibling fixture `test/golden_test/page/dhcp/fixtures/dhcp_test_data.dart:27` has shipped `DateTime.now()` behind an absolute `yyyy-MM-dd HH:mm` stamp that churns every minute. The systemic fix is a clock seam (`clock.now()` in the model, `withClock` in the golden harness) covering both files; it is deliberately not done here because it is a production model change outside what this ticket measured.

## Verification

| command | result |
|---|---|
| `./run_tests.sh` | 7159 passed, 0 failed |
| `flutter test --tags dashboard-card` | 3284 passed, no KNOWN OVERFLOW |
| `test/fixtures/known_overflows.json` | still `{}` |
| `dart format` / `dart analyze` | clean; no new issues in touched files |