### PR TITLE
fix(dashboard): let each card footer keep its own tap target (#1301)

### DIFF
--- a/lib/page/_shared/components/dashboard_card_template.dart
+++ b/lib/page/_shared/components/dashboard_card_template.dart
@@ -494,6 +494,15 @@ class DashboardCardTemplate extends StatelessWidget {
               // row still fits (#1227).
               Flexible(
                 child: Semantics(
+                  // The grid item that wraps every card is a semantics boundary
+                  // (sliver_dashboard's `Semantics(container: true)`), so
+                  // without a boundary of our own this button's tap action and
+                  // `button` flag are absorbed *up* into it — and that node's
+                  // rect is the whole card. Release web builds keep the
+                  // semantics tree alive for E2E, and clicks there route through
+                  // the DOM overlay, so the absorbed action makes the entire
+                  // card navigate (#1301).
+                  container: true,
                   button: true,
                   label: label,
                   child: InkWell(

--- a/lib/page/admin/cards/usp_device_info_card.dart
+++ b/lib/page/admin/cards/usp_device_info_card.dart
@@ -161,6 +161,10 @@ class UspDeviceInfoCard extends ConsumerWidget {
             // out exactly as before.
             Flexible(
               child: Semantics(
+                // Own boundary, or the grid item absorbs this tap action across
+                // the whole card — see DashboardCardTemplate._buildDetailFooter
+                // for the full reasoning (#1301).
+                container: true,
                 button: true,
                 label: label,
                 child: InkWell(

--- a/lib/page/dashboard/views/components/usp_system_status_card.dart
+++ b/lib/page/dashboard/views/components/usp_system_status_card.dart
@@ -148,6 +148,10 @@ class _UspSystemStatusCardState extends ConsumerState<UspSystemStatusCard> {
             // out exactly as before.
             Flexible(
               child: Semantics(
+                // Own boundary, or the grid item absorbs this tap action across
+                // the whole card — see DashboardCardTemplate._buildDetailFooter
+                // for the full reasoning (#1301).
+                container: true,
                 button: true,
                 label: label,
                 child: InkWell(

--- a/lib/page/dashboard/views/components/usp_traffic_analysis_card.dart
+++ b/lib/page/dashboard/views/components/usp_traffic_analysis_card.dart
@@ -167,6 +167,10 @@ class _UspTrafficAnalysisCardState
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
             Semantics(
+              // Own boundary, or the grid item absorbs this tap action across
+              // the whole card — see DashboardCardTemplate._buildDetailFooter
+              // for the full reasoning (#1301).
+              container: true,
               button: true,
               label: label,
               child: InkWell(

--- a/test/page/dashboard/views/components/dashboard_card_semantics_absorption_test.dart
+++ b/test/page/dashboard/views/components/dashboard_card_semantics_absorption_test.dart
@@ -1,0 +1,224 @@
+@Tags(['ui'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/page/_shared/components/dashboard_card_template.dart';
+import 'package:ui_kit_library/ui_kit.dart';
+
+/// Widget-layer regression coverage for PrivacyGUI#1301.
+///
+/// `sliver_dashboard` wraps every grid item in a semantics boundary spanning the
+/// whole card (`dashboard_item_widget.dart:227`):
+///
+/// ```dart
+/// child: Semantics(
+///   container: true,
+///   label: semanticLabel,      // 'Item ${id}, Row ${y}, Column ${x}'
+///   hint: ...,
+///   selected: isSelected,
+/// ```
+///
+/// A footer button that declares no boundary of its own has its tap action and
+/// `button` flag absorbed *up* into that node by
+/// `SemanticsConfiguration.absorbAll` — so the card's semantics node ends up
+/// carrying a tap handler over the entire card rect instead of the footer's
+/// ~90x20, and the DOM exports the card as `role=button`.
+///
+/// This only *manifests* in release web builds, because `main.dart` keeps the
+/// semantics tree alive there for E2E (`!kDebugMode`) and clicks are then routed
+/// by DOM hit testing against the `<flt-semantics>` overlay. The absorption
+/// itself is platform-independent and observable here.
+///
+/// The fix is `container: true` on the footer's `Semantics`.
+///
+/// ## Why this test reproduces the boundary instead of pumping `SliverDashboard`
+///
+/// Driving the real grid needs the whole dashboard provider stack, and its
+/// drag/measurement layer lays the item builder out under unbounded height —
+/// which makes `DashboardCardTemplate`'s `Expanded` overflow and drops the
+/// footer from the tree entirely, leaving nothing to assert on. What matters
+/// for absorption is only that an ancestor boundary exists, so the wrapper
+/// above is replicated verbatim. `expectFooterOwnsItsTapAction` guards the
+/// substitution by proving the footer is really rendered and really tappable.
+///
+/// ## Do not use `performActionAt` here
+///
+/// `SemanticsOwner.performActionAt` resolves a point by searching for a node
+/// that both contains it *and* carries the requested action, silently skipping
+/// others — whereas browsers dispatch to the topmost DOM element regardless. It
+/// reports this bug as fixed when it is not, which is exactly how #1008 came to
+/// be misdiagnosed. Assert on node ownership, not on delivered actions.
+void main() {
+  const cardLabel = 'Item network_status, Row 0, Column 0';
+
+  // Required, not cosmetic: without an `AppTheme` the kit's spacing resolves to
+  // degenerate values and the footer is laid out ~100000px outside the card, so
+  // it never reaches the semantics tree and every assertion below goes vacuous.
+  final testTheme = AppTheme.create(
+    brightness: Brightness.light,
+    seedColor: Colors.blue,
+    designThemeBuilder: (c) => CustomDesignTheme.fromJson({'style': 'flat'}),
+  );
+
+  /// Mirrors `sliver_dashboard`'s per-item wrapper so the card sits beneath a
+  /// card-sized semantics boundary, exactly as it does in the real grid.
+  Future<SemanticsNode> pumpCardUnderGridBoundary(
+    WidgetTester tester, {
+    required Widget content,
+    String? detailRoute,
+    Widget? footer,
+    int? itemCount,
+  }) async {
+    await tester.pumpWidget(MaterialApp(
+      theme: testTheme,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Center(
+          // A representative desktop card footprint (4 of 12 slots).
+          child: SizedBox(
+            width: 420,
+            height: 260,
+            child: Semantics(
+              container: true,
+              label: cardLabel,
+              selected: false,
+              child: DashboardCardTemplate(
+                title: 'Network Status',
+                detailRoute: detailRoute,
+                footer: footer,
+                itemCount: itemCount,
+                content: content,
+              ),
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    SemanticsNode? cardNode;
+    void walk(SemanticsNode n) {
+      if (n.label.contains('Item network_status')) cardNode ??= n;
+      n.visitChildren((c) {
+        walk(c);
+        return true;
+      });
+    }
+
+    // `rootPipelineOwner` (the suggested replacement) resolves to a different
+    // tree than the one `pumpWidget` builds, so the node lookup finds nothing
+    // there. This is the owner that actually holds the test's tree.
+    // ignore: deprecated_member_use
+    walk(tester.binding.pipelineOwner.semanticsOwner!.rootSemanticsNode!);
+    expect(cardNode, isNotNull,
+        reason: 'The card-sized semantics boundary was not found, so this test '
+            'is not exercising the absorption path at all.');
+    return cardNode!;
+  }
+
+  /// Proves the footer link is on screen AND owns a tappable semantics node of
+  /// its own. Without this, "the card has no tap action" passes trivially
+  /// whenever the footer failed to lay out — a false green that a previous
+  /// iteration of this probe actually hit.
+  void expectFooterOwnsItsTapAction(WidgetTester tester, String label) {
+    expect(find.text(label), findsOneWidget,
+        reason: 'The footer link was not laid out, so any assertion about the '
+            'card not absorbing its tap action would be vacuous.');
+
+    // The footer node's own label plus the `AppText` beneath it both mention
+    // the link, so the node's merged label reads "View details / View details" —
+    // hence `contains` rather than equality.
+    SemanticsNode? footerNode;
+    void walk(SemanticsNode n) {
+      if (n.label.contains(label) &&
+          n.getSemanticsData().hasAction(SemanticsAction.tap)) {
+        footerNode ??= n;
+      }
+      n.visitChildren((c) {
+        walk(c);
+        return true;
+      });
+    }
+
+    // ignore: deprecated_member_use — see the note in pumpCardUnderGridBoundary.
+    walk(tester.binding.pipelineOwner.semanticsOwner!.rootSemanticsNode!);
+    expect(footerNode, isNotNull,
+        reason: 'Expected a dedicated semantics node labelled "$label" owning '
+            'the tap action. Its absence means the action was absorbed into an '
+            'ancestor (the #1301 regression).');
+
+    // Pin the scope of that node: it must cover the link, not the card. Without
+    // this the test would still pass if the action were merged into a
+    // card-sized node that happened to carry the label too.
+    expect(footerNode!.rect.height, lessThan(60),
+        reason: 'The tappable node spans ${footerNode!.rect.height}px of '
+            'height — that is card-sized, not link-sized, so the tap target is '
+            'still far larger than the footer link (#1301).');
+  }
+
+  void expectCardIsNotTappable(SemanticsNode cardNode) {
+    final data = cardNode.getSemanticsData();
+    expect(data.hasAction(SemanticsAction.tap), isFalse,
+        reason: 'The card-wide node absorbed the footer button, so tapping '
+            'anywhere on the card navigates (#1301).');
+    expect(data.flagsCollection.isButton, isFalse,
+        reason: 'The card is not a button. The flag leaked up from the footer '
+            'and is exported to the DOM as role=button (#1301).');
+  }
+
+  group('#1301 the grid item must not absorb the card footer button', () {
+    testWidgets('detailRoute footer keeps its tap action to itself',
+        (tester) async {
+      final handle = tester.ensureSemantics();
+
+      final cardNode = await pumpCardUnderGridBoundary(
+        tester,
+        content: const Center(child: Text('card body')),
+        detailRoute: 'uspInternetSettings',
+      );
+
+      expectFooterOwnsItsTapAction(tester, 'View details');
+      expectCardIsNotTappable(cardNode);
+
+      handle.dispose();
+    });
+
+    testWidgets('itemCount variant ("View all") behaves the same',
+        (tester) async {
+      final handle = tester.ensureSemantics();
+
+      final cardNode = await pumpCardUnderGridBoundary(
+        tester,
+        content: const Center(child: Text('card body')),
+        detailRoute: 'uspInternetSettings',
+        itemCount: 3,
+      );
+
+      expectFooterOwnsItsTapAction(tester, 'View all');
+      expectCardIsNotTappable(cardNode);
+
+      handle.dispose();
+    });
+
+    testWidgets('a card with no tappable footer stays non-interactive',
+        (tester) async {
+      final handle = tester.ensureSemantics();
+
+      // Control case: no detailRoute and no footer. Clean both before and after
+      // the fix — it is here to catch a harness that reports "clean" for the
+      // wrong reason.
+      final cardNode = await pumpCardUnderGridBoundary(
+        tester,
+        content: const Center(child: Text('card body')),
+      );
+
+      expectCardIsNotTappable(cardNode);
+
+      handle.dispose();
+    });
+  });
+}

--- a/test/page/dashboard/views/components/dashboard_card_semantics_absorption_test.dart
+++ b/test/page/dashboard/views/components/dashboard_card_semantics_absorption_test.dart
@@ -1,4 +1,3 @@
-@Tags(['ui'])
 library;
 
 import 'package:flutter/material.dart';


### PR DESCRIPTION
Closes #1301

## Problem

In **release web builds only**, every dashboard card that renders a detail footer is tappable
across its *entire* surface, and its semantics node is exported to the DOM as `role=button`.
Tapping any dead zone inside such a card navigates to the card's detail route.

`sliver_dashboard` wraps every grid item in a semantics boundary spanning the whole card
(`dashboard_item_widget.dart:227`). A footer button that declares no boundary of its own has its
tap action and `button` flag absorbed *up* into that node by `SemanticsConfiguration.absorbAll`
— so the card's node ends up carrying a tap handler over the whole card rect instead of the
footer's ~90x20.

It is release-only because `main.dart:47-51` keeps the semantics tree alive on web for E2E
(`!kDebugMode`). With semantics on, clicks are routed by DOM hit testing against the
`<flt-semantics>` overlay rather than by Flutter's own hit test. The absorption itself is
platform-independent and is what the new test asserts on.

## Fix

`container: true` on the footer's `Semantics`, which gives it a boundary so the action stays on
the link. One edit in `DashboardCardTemplate._buildDetailFooter` covers 11 cards; the other
three cards have hand-written footers and are edited individually:

| File | Footer |
|---|---|
| `dashboard_card_template.dart` | `_buildDetailFooter` (11 cards) |
| `usp_device_info_card.dart` | `_buildNodeDetailFooter` |
| `usp_system_status_card.dart` | `_buildStatisticsFooter` |
| `usp_traffic_analysis_card.dart` | `_buildStatisticsFooter` |

Purely additive: 245 insertions, 0 deletions. No layout or paint change — `Semantics` only
annotates, so golden baselines are unaffected by construction.

## What this does NOT fix

**#1008's popup pass-through.** That is a separate defect in `ui_kit_library`'s `AppPopupButton`
(no semantics on the portal follower), tracked as `linksys/privacyGUI-UI-kit#45`. The fix here
only moves the card from the engine's `pointer-events: all` tier to `auto`; the card is still
above the popup in z-order. #1301's body carries the full correction.

## Test

`test/page/dashboard/views/components/dashboard_card_semantics_absorption_test.dart` (3 tests,
`ui` tag).

It replicates the grid item's boundary rather than pumping `SliverDashboard`, because the grid's
measurement pass lays the item builder out under unbounded height — which makes
`DashboardCardTemplate`'s `Expanded` overflow and drops the footer from the tree entirely,
leaving nothing to assert on. `expectFooterOwnsItsTapAction` guards that substitution by proving
the footer is really rendered and really owns a link-sized tappable node.

Two traps recorded in the test's own docs:

- **Do not use `SemanticsOwner.performActionAt`** as the oracle. It resolves a point by searching
  for a node that both contains it *and* carries the requested action, silently skipping others,
  whereas browsers dispatch to the topmost DOM element regardless. It reports this bug as fixed
  when it is not — that is how #1008 came to be misdiagnosed.
- The `AppTheme` in the harness is required, not cosmetic. Without it the kit's spacing resolves
  to degenerate values, the footer lays out ~100000px outside the card, and every assertion goes
  vacuous.

**Non-vacuity, re-measured after the rebase:** removing `container: true` from the template fails
2 of the 3 tests, with the tappable node measuring 260.0px of height (card-sized) instead of
link-sized. The third is a control case (no footer) that is clean either way and exists to catch
a harness reporting green for the wrong reason.

## Verification

| check | result |
|---|---|
| `dart format` | 5 files, 0 changed |
| `flutter analyze` | no issues |
| `--tags ui` | 67 passed |
| `--tags dashboard-card` (#1183 gate) | 3239 passed, `known_overflows.json` still `{}` |
| `./run_tests.sh` | 7113 passed, 0 failed |

## Note for E2E

The semantics tree shape changes: the card node no longer exports `role=button`, and the footer
becomes its own node. No `identifier` value is renamed and no hook is migrated, so the generated
selector map is unchanged — but any spec that navigated by clicking a card's dead zone was
relying on this bug and must target the footer link instead.

## Rebase note

Written on 2026-08-18 and rebased onto `dev-2.7.0` for this PR. The three hand-written footers
conflicted with #1227, which wrapped each of them in `Flexible` after the branch point; #1227's
shape is kept verbatim and `container: true` is inserted into the `Semantics` inside it.
