### PR TITLE
fix(ui): keep icon-plus-label rows within bounds in long-translation locales (#1302)

### DIFF
--- a/lib/page/_shared/components/detail_widgets.dart
+++ b/lib/page/_shared/components/detail_widgets.dart
@@ -333,7 +333,22 @@ class DetailSpeedCard extends StatelessWidget {
             children: [
               Icon(icon, size: 16, color: color),
               AppGap.xs(),
-              AppText.labelSmall(label, color: color),
+              // The label takes the space the icon leaves instead of its
+              // natural width: this card is laid out in a half-width Expanded,
+              // so a long translation (`fr` needs 192dp for `download` while
+              // the row has 172dp) overflowed the row. The value below carries
+              // the number, so shortening the caption loses nothing — and it
+              // must stay on one line, or sibling cards in the same Row would
+              // end up different heights in locales where only one caption is
+              // long (#1302).
+              Expanded(
+                child: AppText.labelSmall(
+                  label,
+                  color: color,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
             ],
           ),
           AppGap.xs(),

--- a/lib/page/topology/views/usp_node_detail_view.dart
+++ b/lib/page/topology/views/usp_node_detail_view.dart
@@ -339,8 +339,21 @@ class UspNodeDetailView extends ConsumerWidget {
                             Icon(Icons.wifi,
                                 size: 16, color: colorScheme.onSurfaceVariant),
                             AppGap.xs(),
-                            AppText.labelSmall(loc(context).labelInterface,
-                                color: colorScheme.onSurfaceVariant),
+                            // The caption takes the space the icon leaves
+                            // instead of its natural width: this tile is a
+                            // half-width Expanded, leaving the row 99dp, while
+                            // `fi` needs 102.6dp for `Käyttöliittymä`. The
+                            // interface name is on the line below, so
+                            // shortening the caption loses no information
+                            // (#1302).
+                            Expanded(
+                              child: AppText.labelSmall(
+                                loc(context).labelInterface,
+                                color: colorScheme.onSurfaceVariant,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
                           ],
                         ),
                         AppGap.xs(),

--- a/lib/page/topology/views/usp_node_detail_view.dart
+++ b/lib/page/topology/views/usp_node_detail_view.dart
@@ -472,9 +472,10 @@ class UspNodeDetailView extends ConsumerWidget {
                               // interface caption above — and this one does not
                               // even fit in English: 21 locales overflow the
                               // 99dp row, `en` by 2.4dp at 1241px and `ru` by
-                              // 39dp. No golden fixture sets lastContactTime,
-                              // so this whole row never renders in the golden
-                              // suite and the overflow went unreported (#1302).
+                              // 39dp. It went unreported in #1302 because no
+                              // fixture set lastContactTime, so the golden
+                              // suite never rendered this row; the
+                              // `slave_backhaul_timing` state now does.
                               Expanded(
                                 child: AppText.labelSmall(
                                   loc(context).lastContact,

--- a/lib/page/topology/views/usp_node_detail_view.dart
+++ b/lib/page/topology/views/usp_node_detail_view.dart
@@ -468,8 +468,21 @@ class UspNodeDetailView extends ConsumerWidget {
                                   size: 16,
                                   color: colorScheme.onSurfaceVariant),
                               AppGap.xs(),
-                              AppText.labelSmall(loc(context).lastContact,
-                                  color: colorScheme.onSurfaceVariant),
+                              // Same half-width tile, same treatment as the
+                              // interface caption above — and this one does not
+                              // even fit in English: 21 locales overflow the
+                              // 99dp row, `en` by 2.4dp at 1241px and `ru` by
+                              // 39dp. No golden fixture sets lastContactTime,
+                              // so this whole row never renders in the golden
+                              // suite and the overflow went unreported (#1302).
+                              Expanded(
+                                child: AppText.labelSmall(
+                                  loc(context).lastContact,
+                                  color: colorScheme.onSurfaceVariant,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
                             ],
                           ),
                           AppGap.xs(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,11 +59,11 @@ dependencies:
   ui_kit_library:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.39.0
+      ref: v2.40.1
   generative_ui:
     git:
       url: https://github.com/linksys/privacyGUI-UI-kit.git
-      ref: v2.39.0
+      ref: v2.40.1
       path: generative_ui
   flutter_blue_plus: ^1.4.0
   crypto: ^3.0.2

--- a/test/golden_test/page/topology/fixtures/topology_test_data.dart
+++ b/test/golden_test/page/topology/fixtures/topology_test_data.dart
@@ -158,29 +158,37 @@ final slaveNodeWithDevices = UspNodeDetailState(
   connectedClients: _meshSlaveClients,
 );
 
-// Slave node whose backhaul reports a PHY rate and a last-contact time, so the
-// backhaul card's bottom row renders. No other fixture sets either field, which
-// is why that row's overflow went unreported by the golden suite (#1302) — it
-// has never been rendered there.
-final slaveNodeWithBackhaulTiming = UspNodeDetailState(
-  node: SlaveNode(
-    deviceId: 'AA:BB:CC:DD:FF:03',
-    model: 'MX2000',
-    manufacturer: 'Linksys',
-    serialNumber: 'DEF789014',
-    softwareVersion: '1.0.10.200000',
-    connectedClients: _meshSlaveClients,
-    backhaul: BackhaulInfo(
-      mediaType: 'Wi-Fi',
-      signalStrength: -50,
-      phyRate: 1200,
-      // Fixed and far in the past: the tile renders this as a relative time, so
-      // a near date would change text as the clock moves.
-      lastContactTime: '2020-01-01T00:00:00Z',
-    ),
-  ),
-  connectedClients: _meshSlaveClients,
-);
+/// Slave node whose backhaul reports both a PHY rate and a last-contact time, so
+/// the card's bottom row renders (`usp_node_detail_view.dart:429`). Both fields
+/// matter: with `phyRate` at 0 the last-contact tile becomes the row's only
+/// child and takes the full width, which is not the half-width geometry the
+/// #1302 fix was measured against.
+///
+/// A getter rather than a `final`, and deliberately not a fixed date. The tile
+/// renders the timestamp through `DateFormatUtils.formatRelativeTime`, which
+/// reads `DateTime.now()` and cannot be faked from the golden harness (nothing
+/// there installs a clock). Any fixed past date therefore renders a day counter
+/// that increments daily, so a golden taken from this state would diff against
+/// its own baseline the next day. `Just now` (`diff.inSeconds < 60`) is the one
+/// branch of that formatter that does not move, and recomputing per access keeps
+/// every read inside that window however long a suite runs.
+UspNodeDetailState get slaveNodeWithBackhaulTiming => UspNodeDetailState(
+      node: SlaveNode(
+        deviceId: 'AA:BB:CC:DD:FF:03',
+        model: 'MX2000',
+        manufacturer: 'Linksys',
+        serialNumber: 'DEF789014',
+        softwareVersion: '1.0.10.200000',
+        connectedClients: _meshSlaveClients,
+        backhaul: BackhaulInfo(
+          mediaType: 'Wi-Fi',
+          signalStrength: -50,
+          phyRate: 1200,
+          lastContactTime: DateTime.now().toUtc().toIso8601String(),
+        ),
+      ),
+      connectedClients: _meshSlaveClients,
+    );
 
 final masterNodeEmptyDevices = UspNodeDetailState(
   node: MasterNode(

--- a/test/golden_test/page/topology/fixtures/topology_test_data.dart
+++ b/test/golden_test/page/topology/fixtures/topology_test_data.dart
@@ -158,6 +158,30 @@ final slaveNodeWithDevices = UspNodeDetailState(
   connectedClients: _meshSlaveClients,
 );
 
+// Slave node whose backhaul reports a PHY rate and a last-contact time, so the
+// backhaul card's bottom row renders. No other fixture sets either field, which
+// is why that row's overflow went unreported by the golden suite (#1302) — it
+// has never been rendered there.
+final slaveNodeWithBackhaulTiming = UspNodeDetailState(
+  node: SlaveNode(
+    deviceId: 'AA:BB:CC:DD:FF:03',
+    model: 'MX2000',
+    manufacturer: 'Linksys',
+    serialNumber: 'DEF789014',
+    softwareVersion: '1.0.10.200000',
+    connectedClients: _meshSlaveClients,
+    backhaul: BackhaulInfo(
+      mediaType: 'Wi-Fi',
+      signalStrength: -50,
+      phyRate: 1200,
+      // Fixed and far in the past: the tile renders this as a relative time, so
+      // a near date would change text as the clock moves.
+      lastContactTime: '2020-01-01T00:00:00Z',
+    ),
+  ),
+  connectedClients: _meshSlaveClients,
+);
+
 final masterNodeEmptyDevices = UspNodeDetailState(
   node: MasterNode(
     deviceId: '11:22:33:44:55:66',

--- a/test/golden_test/page/topology/localizations/usp_node_detail_view_test.dart
+++ b/test/golden_test/page/topology/localizations/usp_node_detail_view_test.dart
@@ -26,9 +26,16 @@ void main() {
         'link_local_ipv6': (overrides) => overrides.addAll(
               nodeDetailOverrides(slaveNodeLinkLocalIpv6),
             ),
-        // Backhaul reporting a PHY rate and a last-contact time — the only
-        // state that renders the card's bottom row, which is why that row's
-        // overflow was missing from the #1302 baseline report.
+        // Backhaul reporting a PHY rate and a last-contact time, the pair the
+        // card's bottom row is built for (`usp_node_detail_view.dart:429`) — no
+        // other state here sets either field, which is why #1302's report never
+        // saw that row. Visual coverage only, and partial: at phone480 the row
+        // is captured whole, while at desktop1280 the card sits low enough that
+        // only the caption line falls above the 800px fold. The overflow itself
+        // is gated by
+        // `test/page/topology/views/usp_node_detail_backhaul_overflow_test.dart`,
+        // which sweeps 320/1241/1280 — none of them widths this suite renders
+        // by default.
         'slave_backhaul_timing': (overrides) => overrides.addAll(
               nodeDetailOverrides(slaveNodeWithBackhaulTiming),
             ),

--- a/test/golden_test/page/topology/localizations/usp_node_detail_view_test.dart
+++ b/test/golden_test/page/topology/localizations/usp_node_detail_view_test.dart
@@ -26,6 +26,12 @@ void main() {
         'link_local_ipv6': (overrides) => overrides.addAll(
               nodeDetailOverrides(slaveNodeLinkLocalIpv6),
             ),
+        // Backhaul reporting a PHY rate and a last-contact time — the only
+        // state that renders the card's bottom row, which is why that row's
+        // overflow was missing from the #1302 baseline report.
+        'slave_backhaul_timing': (overrides) => overrides.addAll(
+              nodeDetailOverrides(slaveNodeWithBackhaulTiming),
+            ),
         'empty_devices': (overrides) => overrides.addAll(
               nodeDetailOverrides(masterNodeEmptyDevices),
             ),

--- a/test/page/devices/views/usp_device_detail_speed_card_overflow_test.dart
+++ b/test/page/devices/views/usp_device_detail_speed_card_overflow_test.dart
@@ -1,0 +1,216 @@
+@Tags(['dashboard-card'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/_shared/components/detail_widgets.dart';
+import 'package:privacy_gui/page/devices/views/usp_device_detail_view.dart';
+import 'package:privacy_gui/util/network_utils.dart';
+
+import '../../../golden_test/golden_framework/mocks/mock_devices.dart';
+import '../../../golden_test/page/devices/fixtures/devices_test_data.dart';
+import '../../../util/app_test_fonts.dart';
+import '../../../util/detail_view_probe.dart';
+import '../../../util/overflow_probe.dart';
+
+/// Overflow tests for [DetailSpeedCard]'s caption row (#1302).
+///
+/// ## Why this file exists
+///
+/// The card's caption was built as
+/// `Row(children: [Icon(size: 16), AppGap.xs(), AppText.labelSmall(label)])`, so
+/// the caption carried no flex constraint and sized itself to its natural width.
+/// Two of these cards sit in a `Row` of `Expanded`s on the device-detail page, so
+/// each gets half the card's width and the caption has nowhere to go: `fr` needs
+/// 192dp for `Débit descendant (Download)` where the row has 181dp at a 480px
+/// screen and 172dp at 1280px.
+///
+/// The #1183 overflow gate never sees this: it sweeps `UspWidgetSpecs.all`, which
+/// is the dashboard's card registry, and neither detail page is in it. The
+/// golden suite renders the row but does not fail on it — an overflowing layout
+/// is baked into the baseline PNG and compares clean forever after — so without
+/// this file the fix is guarded by nothing that blocks a PR.
+///
+/// Tagged `dashboard-card` so it does block one: `run_tests.sh` excludes
+/// `golden||loc||ui`, and a `ui`-tagged regression test would gate nothing.
+///
+/// The card is shared with the node-detail page's backhaul throughput row, which
+/// pumps it at its own widths — see `usp_node_detail_backhaul_overflow_test.dart`
+/// for the caption on the tile above it.
+///
+/// ## Mutation ledger
+///
+/// Every group here was shown to fail under a mutation of the code it guards; an
+/// overflow test that cannot fail is worse than none, because it reports the
+/// shape as pinned.
+///
+///   | mutation                                        | what failed              |
+///   |-------------------------------------------------|--------------------------|
+///   | caption's `Expanded` removed (the pre-fix shape) | clean rows: fr +11px@480, +20px@1280, +30px@1241, +91px@320 |
+///   | `maxLines: 1` + ellipsis dropped, `Expanded` kept | matching heights: fr@480 [106, 90], pl@320 [90, 106] |
+///   | value given `maxLines: 1` + ellipsis             | value stays whole (both cards) |
+void main() {
+  setUpAll(() async {
+    // Real fonts: text widths — and therefore overflow — are meaningless under
+    // the Ahem block font.
+    await loadAppFonts();
+  });
+
+  /// The golden suite's Wi-Fi device. It carries both a downlink and an uplink
+  /// rate, which is what makes the page render two speed cards side by side; a
+  /// fixture with one rate would render a single full-width card that cannot
+  /// overflow, and this whole file would pass vacuously.
+  final detail = wifiDetailNoReservation;
+
+  /// Pumps the real device-detail page once at [screenWidth] and returns the
+  /// RenderFlex overflows beyond the gate's own tolerance.
+  Future<List<OverflowIncident>> overflowsAt({
+    required WidgetTester tester,
+    required double screenWidth,
+    required String tag,
+  }) =>
+      probeViewOverflow(
+        tester,
+        view: UspDeviceDetailView(mac: detail.device!.mac),
+        overrides: deviceDetailOverrides(detail: detail),
+        screenWidth: screenWidth,
+        locale: localeForTag(tag),
+      );
+
+  /// The widths that carry signal, measured by sweeping all 26 locales against
+  /// the pre-fix shape:
+  ///
+  /// - **1241px** — the D1 desktop-large pinch: the 200px page margins open just
+  ///   above 1240px, so a 1241px screen lays the row out *narrower* than a
+  ///   1240px one. Worst desktop case (fr +30px).
+  /// - **1280px** — the golden suite's desktop coordinate, where #1302 was
+  ///   reported (fr +20px).
+  /// - **480px** — the golden suite's phone coordinate (fr +11px).
+  /// - **320px** — the framework's narrowest supported screen and the absolute
+  ///   worst case (fr +91px, and the only width where `fr_CA`, `pl` and `tr`
+  ///   overflow at all).
+  const widths = <double>[1241.0, 1280.0, 480.0, 320.0];
+
+  group('speed card caption row is clean (#1302)', () {
+    // Every locale that overflowed the pre-fix shape anywhere in the sweep. If
+    // the row were clean in English but not in these, the fix would rely on
+    // English being short.
+    //
+    // Deliberately the full cross-product, not only the cells that break: the
+    // load-bearing ones are the ledger's (fr at all four widths, and fr_CA / pl
+    // / tr at 320px), while the rest are the locales closest to breaking, held
+    // against a translation growing later. Each cell costs ~40ms.
+    for (final tag in ['fr', 'fr_CA', 'pl', 'tr']) {
+      for (final width in widths) {
+        testWidgets(
+          'no overflow at ${width.toStringAsFixed(0)}px in $tag',
+          (tester) async {
+            final overflows = await overflowsAt(
+              tester: tester,
+              screenWidth: width,
+              tag: tag,
+            );
+            expect(
+              overflows,
+              isEmpty,
+              reason: 'the speed card caption overflows in $tag at '
+                  '${width.toStringAsFixed(0)}px: ${overflows.join(', ')}',
+            );
+          },
+        );
+      }
+    }
+  });
+
+  group('sibling speed cards keep matching heights (#1302)', () {
+    // Why the caption ellipsizes on one line instead of wrapping. The two cards
+    // are independent `Expanded`s in a `Row`, so a caption that wraps makes only
+    // *its* card taller and the pair stops lining up — in `fr` at 480px the
+    // wrapped card measured 106dp against its sibling's 90dp. The row cannot fix
+    // that for them: `Row` stretches children to its own height, and its height
+    // is the tallest child's.
+    //
+    // These two coordinates are the ones where a wrapping caption actually
+    // diverges. `fr` at 320px is not among them: there both captions wrap, so
+    // both cards grow to 122dp and stay equal — a real property of that width,
+    // not a gap in the matrix.
+    for (final (tag, width) in [('fr', 480.0), ('pl', 320.0)]) {
+      testWidgets(
+        'both cards are the same height in $tag at ${width.toStringAsFixed(0)}px',
+        (tester) async {
+          await overflowsAt(tester: tester, screenWidth: width, tag: tag);
+
+          final cards = find.byType(DetailSpeedCard);
+          expect(
+            cards,
+            findsNWidgets(2),
+            reason: 'the fixture must render both cards — with one card there '
+                'is no sibling to line up with and this test would be vacuous',
+          );
+          final heights = cards
+              .evaluate()
+              .map((e) => tester.getSize(find.byWidget(e.widget)).height)
+              .toSet();
+          expect(
+            heights,
+            hasLength(1),
+            reason: 'the two speed cards have different heights in $tag at '
+                '${width.toStringAsFixed(0)}px ($heights) — a caption is '
+                'wrapping instead of ellipsizing on one line',
+          );
+        },
+      );
+    }
+  });
+
+  group('speed values stay whole (#1302)', () {
+    // The caption may shorten because the number below it carries the reading;
+    // that argument only holds while the number itself is never shortened. An
+    // ellipsis lands mid-value, and `400 Mbps` clipped to `4… Mbps` misreports
+    // the link in a way a missing value does not.
+    //
+    // Located by the exact formatted strings, derived from the same fixture the
+    // page is pumped with, and searched only inside a `DetailSpeedCard`: the
+    // page shows the same rates elsewhere, so an unscoped `find.text` would stay
+    // satisfied with both cards' values deleted.
+    for (final kind in ['downlink', 'uplink']) {
+      testWidgets('the $kind value is not clipped', (tester) async {
+        final device = detail.device!;
+        final kbps =
+            kind == 'downlink' ? device.downlinkRate : device.uplinkRate;
+        expect(
+          kbps,
+          isNotNull,
+          reason: 'the fixture must carry a $kind rate — the page renders a '
+              'speed card only when it does',
+        );
+        final (:value, unit: _) = NetworkUtils.formatSpeedWithUnit(kbps!);
+
+        await overflowsAt(tester: tester, screenWidth: 320.0, tag: 'fr');
+
+        final finder = find.descendant(
+          of: find.byType(DetailSpeedCard),
+          matching: find.text(value),
+        );
+        expect(
+          finder,
+          findsOneWidget,
+          reason: 'the $kind value ($value) must survive the degradation',
+        );
+
+        final text = tester.widget<Text>(finder);
+        expect(
+          text.overflow,
+          isNot(TextOverflow.ellipsis),
+          reason: 'the $kind value must never ellipsize: an ellipsis lands '
+              'mid-number',
+        );
+        expect(
+          text.maxLines,
+          isNull,
+          reason: 'the $kind value must not be line-capped',
+        );
+      });
+    }
+  });
+}

--- a/test/page/topology/views/usp_node_detail_backhaul_overflow_test.dart
+++ b/test/page/topology/views/usp_node_detail_backhaul_overflow_test.dart
@@ -30,13 +30,14 @@ import '../../../util/overflow_probe.dart';
 ///   **`en` by 2.4dp**, so this one is not a long-translation edge case at all.
 ///
 /// Nothing else fails on either. The #1183 gate sweeps the dashboard's
-/// `UspWidgetSpecs.all` registry, which does not contain this page; the golden
-/// suite renders the interface tile and compares byte-equal against a baseline
-/// PNG with the overflow stripe baked in, and it never renders the last-contact
-/// tile at all — no fixture set `lastContactTime` until this file added one, which
-/// is why that overflow was missing from #1302's report. Hence a test, and hence
-/// the `dashboard-card` tag: `run_tests.sh` excludes `golden||loc||ui`, so a
-/// `ui`-tagged test would not block a PR.
+/// `UspWidgetSpecs.all` registry, which does not contain this page. The golden
+/// suite does render both tiles now — `slave_backhaul_timing` was added for the
+/// last-contact one, whose absence is why that overflow was missing from #1302's
+/// report — but it cannot gate either: it compares byte-equal against a baseline
+/// PNG with the overflow stripe already baked in, and it runs neither of the
+/// widths that overflow. Hence a test, and hence the `dashboard-card` tag:
+/// `run_tests.sh` excludes `golden||loc||ui`, so a `ui`-tagged test would not
+/// block a PR.
 ///
 /// ## The Ethernet branch is out of scope, and measured safe
 ///
@@ -65,6 +66,7 @@ import '../../../util/overflow_probe.dart';
 ///   | last-contact caption's `Expanded` removed (pre-fix shape) | clean last-contact tile: ru +39px@1241, +33px@1280, +29px@320; fi +22px@1241, +15px@1280, +11px@320; da +12px@1241, +5.3px@1280; en +2.4px@1241 |
 ///   | interface value given `maxLines: 1` + ellipsis | interface value stays whole |
 ///   | last-contact caption's `maxLines`/ellipsis dropped (`Expanded` kept) | caption-shortens-value-does-not, and last-contact-matches-sibling-height (81dp against the sibling's 64dp in `ru`@320) — the clean groups all still pass, because wrapping trades the overflow for a taller tile rather than fixing it |
+///   | `slaveNodeWithBackhaulTiming.phyRate` set to 0 | the precondition group, plus last-contact-matches-sibling-height (the PHY Rate tile it compares against is no longer built at all). The overflow groups stay green: the tile is now full-width, so the caption fits — which is exactly why the precondition asserts `phyRate > 0` rather than trusting the fixture |
 void main() {
   setUpAll(() async {
     // Real fonts: under the Ahem block font every glyph is square and the
@@ -102,6 +104,15 @@ void main() {
       isNotNull,
       reason: 'slaveNodeWithBackhaulTiming must keep a lastContactTime — the '
           'last-contact tile is built only when it has one',
+    );
+    expect(
+      timingNode.backhaul.phyRate,
+      greaterThan(0),
+      reason: 'slaveNodeWithBackhaulTiming must keep a phyRate — at 0 the PHY '
+          'Rate tile is not built, the last-contact tile becomes the Row\'s '
+          'only child and its Expanded takes the full card width, which is not '
+          'the half-width geometry every number in this file was measured '
+          'against',
     );
   });
 

--- a/test/page/topology/views/usp_node_detail_backhaul_overflow_test.dart
+++ b/test/page/topology/views/usp_node_detail_backhaul_overflow_test.dart
@@ -1,0 +1,163 @@
+@Tags(['dashboard-card'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/_shared/models/node_entity.dart';
+import 'package:privacy_gui/page/topology/views/usp_node_detail_view.dart';
+
+import '../../../golden_test/golden_framework/mocks/mock_topology.dart';
+import '../../../golden_test/page/topology/fixtures/topology_test_data.dart';
+import '../../../util/app_test_fonts.dart';
+import '../../../util/detail_view_probe.dart';
+import '../../../util/overflow_probe.dart';
+
+/// Overflow tests for the node-detail backhaul interface tile (#1302).
+///
+/// ## Why this file exists
+///
+/// The tile's caption row was `Row(children: [Icon(size: 16), AppGap.xs(),
+/// AppText.labelSmall(labelInterface)])` — an unconstrained caption sized to its
+/// natural width. The tile shares a `Row` with the signal indicator as two
+/// `Expanded`s, so the caption gets half the card and no more: `fi` needs 102.6dp
+/// for `Käyttöliittymä` where the row has 99dp at 1280px.
+///
+/// Nothing else fails on this. The #1183 gate sweeps the dashboard's
+/// `UspWidgetSpecs.all` registry, which does not contain this page; the golden
+/// suite renders the tile and compares byte-equal against a baseline PNG that has
+/// the overflow stripe baked in. Hence a test, and hence the `dashboard-card`
+/// tag — `run_tests.sh` excludes `golden||loc||ui`, so a `ui`-tagged test would
+/// not block a PR.
+///
+/// ## Only the Wi-Fi branch is guarded, deliberately
+///
+/// `_buildBackhaulCard` has a second caption row in its `else` branch (Ethernet
+/// backhaul, `usp_node_detail_view.dart:383`) with exactly the same unguarded
+/// shape. It is **out of scope for #1302 by decision**, not by oversight, so
+/// these tests pump a Wi-Fi-backhaul fixture only. Do not "fix" the matrix by
+/// adding an Ethernet fixture here: it would fail on untouched code. The Ethernet
+/// row is only reachable at all when `backhaul.isEthernet`, and it is full-width
+/// rather than half-width there, so it has 2× the room this one does.
+///
+/// The throughput cards below the tile are `DetailSpeedCard`s, guarded by
+/// `usp_device_detail_speed_card_overflow_test.dart`; this fixture carries no
+/// backhaul rates, so they do not render here.
+///
+/// ## Mutation ledger
+///
+/// Both groups were shown to fail against a mutation of the code they guard. An
+/// overflow test that cannot fail is worse than no test, because it reports the
+/// row as pinned.
+///
+///   | mutation                                    | what failed                    |
+///   |---------------------------------------------|--------------------------------|
+///   | caption's `Expanded` removed (pre-fix shape) | clean tile: ja +19px@1241, +12px@1280, +8px@320; fi +10px@1241, +3.6px@1280; da +2.5px@1241 |
+///   | interface value given `maxLines: 1` + ellipsis | value stays whole |
+void main() {
+  setUpAll(() async {
+    // Real fonts: under the Ahem block font every glyph is square and the
+    // measured widths — the whole subject of this file — are fiction.
+    await loadAppFonts();
+  });
+
+  final state = slaveNodeWithDevices;
+  final node = state.node as SlaveNode;
+
+  test('the fixture is a Wi-Fi backhaul node', () {
+    // The guarded row is behind `if (isWifiBackhaul)`. If the fixture ever
+    // becomes an Ethernet node, every test below would pass without rendering
+    // the row at all, so assert the precondition instead of assuming it.
+    expect(
+      node.backhaul.isEthernet,
+      isFalse,
+      reason: 'slaveNodeWithDevices must keep a Wi-Fi backhaul — the interface '
+          'tile these tests measure is only built for one',
+    );
+  });
+
+  /// Pumps the real node-detail page once at [screenWidth] and returns the
+  /// RenderFlex overflows beyond the gate's own tolerance.
+  Future<List<OverflowIncident>> overflowsAt({
+    required WidgetTester tester,
+    required double screenWidth,
+    required String tag,
+  }) =>
+      probeViewOverflow(
+        tester,
+        view: UspNodeDetailView(deviceId: node.deviceId),
+        overrides: nodeDetailOverrides(state),
+        screenWidth: screenWidth,
+        locale: localeForTag(tag),
+      );
+
+  group('backhaul interface tile is clean (#1302)', () {
+    /// The widths that carry signal, from sweeping all 26 locales against the
+    /// pre-fix shape:
+    ///
+    /// - **1241px** — worst case (ja +19px). The page's 200px desktop margins
+    ///   open just above 1240px, so a 1241px screen lays this row out *narrower*
+    ///   than a 1240px one does.
+    /// - **1280px** — the golden suite's desktop coordinate, where #1302 was
+    ///   reported (ja +12px, fi +3.6px).
+    /// - **320px** — the narrowest supported screen (ja +8px).
+    ///
+    /// 480px is absent on purpose: the tile is clean there in every locale, in
+    /// the pre-fix shape too, so a test at that width could never fail.
+    const widths = <double>[1241.0, 1280.0, 320.0];
+
+    // Every locale that overflowed the pre-fix shape anywhere in the sweep.
+    // `da` only breaks at 1241px and only by 2.5px — kept because it is the
+    // margin this fix has to hold, not just the loudest case.
+    //
+    // The cross-product is deliberate: 6 of these 9 cells fail against the
+    // pre-fix shape (the ledger lists which), and the other 3 are the same
+    // near-miss locales at a width where they currently fit, held against a
+    // translation growing later.
+    for (final tag in ['ja', 'fi', 'da']) {
+      for (final width in widths) {
+        testWidgets(
+          'no overflow at ${width.toStringAsFixed(0)}px in $tag',
+          (tester) async {
+            final overflows = await overflowsAt(
+              tester: tester,
+              screenWidth: width,
+              tag: tag,
+            );
+            expect(
+              overflows,
+              isEmpty,
+              reason: 'the backhaul interface tile overflows in $tag at '
+                  '${width.toStringAsFixed(0)}px: ${overflows.join(', ')}',
+            );
+          },
+        );
+      }
+    }
+  });
+
+  testWidgets('the interface value stays whole (#1302)', (tester) async {
+    // Why the caption is allowed to ellipsize: the interface itself is spelled
+    // out on the line below. That argument only holds while *that* line is never
+    // clipped in turn — `Wi-Fi` shortened to `W…` names no interface.
+    final expected = node.backhaul.linkType ?? node.backhaul.mediaType;
+
+    await overflowsAt(tester: tester, screenWidth: 320.0, tag: 'ja');
+
+    final finder = find.text(expected);
+    expect(
+      finder,
+      findsOneWidget,
+      reason: 'the interface value ($expected) must survive the degradation',
+    );
+
+    final text = tester.widget<Text>(finder);
+    expect(
+      text.overflow,
+      isNot(TextOverflow.ellipsis),
+      reason: 'the interface value must never ellipsize — it is the only place '
+          'the medium is named once the caption is allowed to shorten',
+    );
+    expect(text.maxLines, isNull,
+        reason: 'the interface value must not be line-capped');
+  });
+}

--- a/test/page/topology/views/usp_node_detail_backhaul_overflow_test.dart
+++ b/test/page/topology/views/usp_node_detail_backhaul_overflow_test.dart
@@ -3,7 +3,9 @@ library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/page/_shared/components/layout_blocks.dart';
 import 'package:privacy_gui/page/_shared/models/node_entity.dart';
+import 'package:privacy_gui/page/topology/providers/node_detail_provider.dart';
 import 'package:privacy_gui/page/topology/views/usp_node_detail_view.dart';
 
 import '../../../golden_test/golden_framework/mocks/mock_topology.dart';
@@ -12,47 +14,57 @@ import '../../../util/app_test_fonts.dart';
 import '../../../util/detail_view_probe.dart';
 import '../../../util/overflow_probe.dart';
 
-/// Overflow tests for the node-detail backhaul interface tile (#1302).
+/// Overflow tests for the node-detail backhaul card's half-width tile captions
+/// (#1302).
 ///
 /// ## Why this file exists
 ///
-/// The tile's caption row was `Row(children: [Icon(size: 16), AppGap.xs(),
-/// AppText.labelSmall(labelInterface)])` — an unconstrained caption sized to its
-/// natural width. The tile shares a `Row` with the signal indicator as two
-/// `Expanded`s, so the caption gets half the card and no more: `fi` needs 102.6dp
-/// for `Käyttöliittymä` where the row has 99dp at 1280px.
+/// Two captions in `_buildBackhaulCard` were built as `Row(children: [Icon(size:
+/// 16), AppGap.xs(), AppText.labelSmall(caption)])` — unconstrained, sized to
+/// their natural width. Both tiles share a `Row` as two `Expanded`s, so each
+/// caption gets half the card and no more, 99dp at 1280px:
 ///
-/// Nothing else fails on this. The #1183 gate sweeps the dashboard's
+/// - **interface** — `fi` needs 102.6dp for `Käyttöliittymä`; worst case is `ja`
+///   at 1241px, 19dp over.
+/// - **last contact** — 21 of the 26 locales overflow, `ru` by 39dp at 1241px and
+///   **`en` by 2.4dp**, so this one is not a long-translation edge case at all.
+///
+/// Nothing else fails on either. The #1183 gate sweeps the dashboard's
 /// `UspWidgetSpecs.all` registry, which does not contain this page; the golden
-/// suite renders the tile and compares byte-equal against a baseline PNG that has
-/// the overflow stripe baked in. Hence a test, and hence the `dashboard-card`
-/// tag — `run_tests.sh` excludes `golden||loc||ui`, so a `ui`-tagged test would
-/// not block a PR.
+/// suite renders the interface tile and compares byte-equal against a baseline
+/// PNG with the overflow stripe baked in, and it never renders the last-contact
+/// tile at all — no fixture set `lastContactTime` until this file added one, which
+/// is why that overflow was missing from #1302's report. Hence a test, and hence
+/// the `dashboard-card` tag: `run_tests.sh` excludes `golden||loc||ui`, so a
+/// `ui`-tagged test would not block a PR.
 ///
-/// ## Only the Wi-Fi branch is guarded, deliberately
+/// ## The Ethernet branch is out of scope, and measured safe
 ///
-/// `_buildBackhaulCard` has a second caption row in its `else` branch (Ethernet
-/// backhaul, `usp_node_detail_view.dart:383`) with exactly the same unguarded
-/// shape. It is **out of scope for #1302 by decision**, not by oversight, so
-/// these tests pump a Wi-Fi-backhaul fixture only. Do not "fix" the matrix by
-/// adding an Ethernet fixture here: it would fail on untouched code. The Ethernet
-/// row is only reachable at all when `backhaul.isEthernet`, and it is full-width
-/// rather than half-width there, so it has 2× the room this one does.
+/// `_buildBackhaulCard` has a third caption row in its `else` branch (Ethernet
+/// backhaul, `usp_node_detail_view.dart:383`) with the same unguarded shape, left
+/// untouched **by decision**. It is also the one place where the shape is
+/// harmless: that `LayoutBlock` is a direct child of the card's `Column`, not a
+/// half-width `Expanded`, so it has ~2× the room. Sweeping an Ethernet fixture
+/// across all 26 locales × 320/480/601/905/1241/1280px produced zero overflows.
+/// Do not add an Ethernet fixture here to "complete" the matrix: it would pump
+/// untouched code that cannot fail.
 ///
-/// The throughput cards below the tile are `DetailSpeedCard`s, guarded by
-/// `usp_device_detail_speed_card_overflow_test.dart`; this fixture carries no
-/// backhaul rates, so they do not render here.
+/// The throughput cards in the same card are `DetailSpeedCard`s, guarded by
+/// `usp_device_detail_speed_card_overflow_test.dart`; neither fixture here sets
+/// `uplinkRate`/`downlinkRate`, so they do not render.
 ///
 /// ## Mutation ledger
 ///
-/// Both groups were shown to fail against a mutation of the code they guard. An
+/// Every group was shown to fail against a mutation of the code it guards. An
 /// overflow test that cannot fail is worse than no test, because it reports the
 /// row as pinned.
 ///
-///   | mutation                                    | what failed                    |
-///   |---------------------------------------------|--------------------------------|
-///   | caption's `Expanded` removed (pre-fix shape) | clean tile: ja +19px@1241, +12px@1280, +8px@320; fi +10px@1241, +3.6px@1280; da +2.5px@1241 |
-///   | interface value given `maxLines: 1` + ellipsis | value stays whole |
+///   | mutation                                      | what failed                  |
+///   |-----------------------------------------------|------------------------------|
+///   | interface caption's `Expanded` removed (pre-fix shape) | clean interface tile: ja +19px@1241, +12px@1280, +8px@320; fi +10px@1241, +3.6px@1280; da +2.5px@1241 |
+///   | last-contact caption's `Expanded` removed (pre-fix shape) | clean last-contact tile: ru +39px@1241, +33px@1280, +29px@320; fi +22px@1241, +15px@1280, +11px@320; da +12px@1241, +5.3px@1280; en +2.4px@1241 |
+///   | interface value given `maxLines: 1` + ellipsis | interface value stays whole |
+///   | last-contact caption's `maxLines`/ellipsis dropped (`Expanded` kept) | caption-shortens-value-does-not, and last-contact-matches-sibling-height (81dp against the sibling's 64dp in `ru`@320) — the clean groups all still pass, because wrapping trades the overflow for a taller tile rather than fixing it |
 void main() {
   setUpAll(() async {
     // Real fonts: under the Ahem block font every glyph is square and the
@@ -60,31 +72,50 @@ void main() {
     await loadAppFonts();
   });
 
-  final state = slaveNodeWithDevices;
-  final node = state.node as SlaveNode;
+  // The interface tile renders for any Wi-Fi backhaul; the last-contact tile
+  // needs a fixture that carries a lastContactTime, which only this one does.
+  final interfaceState = slaveNodeWithDevices;
+  final interfaceNode = interfaceState.node as SlaveNode;
+  final timingState = slaveNodeWithBackhaulTiming;
+  final timingNode = timingState.node as SlaveNode;
 
-  test('the fixture is a Wi-Fi backhaul node', () {
-    // The guarded row is behind `if (isWifiBackhaul)`. If the fixture ever
-    // becomes an Ethernet node, every test below would pass without rendering
-    // the row at all, so assert the precondition instead of assuming it.
+  test('both fixtures render the rows under test', () {
+    // The interface row is behind `if (isWifiBackhaul)` and the last-contact row
+    // behind `if (backhaul.lastContactTime != null)`. If either fixture drifts,
+    // the tests below would pass without rendering the row at all, so assert the
+    // preconditions rather than assume them.
     expect(
-      node.backhaul.isEthernet,
+      interfaceNode.backhaul.isEthernet,
       isFalse,
       reason: 'slaveNodeWithDevices must keep a Wi-Fi backhaul — the interface '
-          'tile these tests measure is only built for one',
+          'tile is only built for one',
+    );
+    expect(
+      timingNode.backhaul.isEthernet,
+      isFalse,
+      reason: 'slaveNodeWithBackhaulTiming must keep a Wi-Fi backhaul, so the '
+          'last-contact tile is measured in the same half-width layout the fix '
+          'was made for',
+    );
+    expect(
+      timingNode.backhaul.lastContactTime,
+      isNotNull,
+      reason: 'slaveNodeWithBackhaulTiming must keep a lastContactTime — the '
+          'last-contact tile is built only when it has one',
     );
   });
 
-  /// Pumps the real node-detail page once at [screenWidth] and returns the
-  /// RenderFlex overflows beyond the gate's own tolerance.
+  /// Pumps the real node-detail page for [state] once at [screenWidth] and
+  /// returns the RenderFlex overflows beyond the gate's own tolerance.
   Future<List<OverflowIncident>> overflowsAt({
     required WidgetTester tester,
+    required UspNodeDetailState state,
     required double screenWidth,
     required String tag,
   }) =>
       probeViewOverflow(
         tester,
-        view: UspNodeDetailView(deviceId: node.deviceId),
+        view: UspNodeDetailView(deviceId: state.node!.deviceId),
         overrides: nodeDetailOverrides(state),
         screenWidth: screenWidth,
         locale: localeForTag(tag),
@@ -120,6 +151,7 @@ void main() {
           (tester) async {
             final overflows = await overflowsAt(
               tester: tester,
+              state: interfaceState,
               screenWidth: width,
               tag: tag,
             );
@@ -135,13 +167,148 @@ void main() {
     }
   });
 
+  group('backhaul last-contact tile is clean (#1302)', () {
+    /// Same three widths as the interface tile, and the same 1241px pinch. This
+    /// caption is the worse of the two: 21 of 26 locales overflow it, so the four
+    /// below are a spread rather than the whole failing set — the worst (`ru`,
+    /// +39px@1241), a mid case (`fi`), the tightest margin (`da`, +5.3px@1280),
+    /// and `en`, which overflows by 2.4px at 1241px and is the reason this is a
+    /// layout bug rather than a translation-length one.
+    ///
+    /// 9 of these 12 cells fail against the pre-fix shape; `en` at 320/1280 and
+    /// `da` at 320 currently fit and are held against a font or copy change.
+    const widths = <double>[1241.0, 1280.0, 320.0];
+
+    for (final tag in ['ru', 'fi', 'da', 'en']) {
+      for (final width in widths) {
+        testWidgets(
+          'no overflow at ${width.toStringAsFixed(0)}px in $tag',
+          (tester) async {
+            final overflows = await overflowsAt(
+              tester: tester,
+              state: timingState,
+              screenWidth: width,
+              tag: tag,
+            );
+            // The interface caption in the same card is fixed and gated by the
+            // group above, so an incident here is this tile's.
+            expect(
+              overflows,
+              isEmpty,
+              reason: 'the backhaul last-contact tile overflows in $tag at '
+                  '${width.toStringAsFixed(0)}px: ${overflows.join(', ')}',
+            );
+          },
+        );
+      }
+    }
+  });
+
+  testWidgets(
+      'the last-contact caption shortens but its value does not (#1302)',
+      (tester) async {
+    // The caption may ellipsize because the timestamp is spelled out below it;
+    // the timestamp itself must not, since a clipped relative time reads as a
+    // different time. Asserted structurally rather than by string: the tile is
+    // the LayoutBlock around Icons.access_time, and its two Texts are the caption
+    // (line-capped) and the value (not), so this also catches the two being
+    // swapped.
+    await overflowsAt(
+      tester: tester,
+      state: timingState,
+      screenWidth: 320.0,
+      tag: 'ru',
+    );
+
+    final tile = find
+        .ancestor(
+          of: find.byIcon(Icons.access_time),
+          matching: find.byType(LayoutBlock),
+        )
+        .first;
+    final texts = find.descendant(of: tile, matching: find.byType(Text));
+    expect(
+      texts,
+      findsNWidgets(2),
+      reason: 'the last-contact tile should hold exactly a caption and a value',
+    );
+
+    final caption = tester.widget<Text>(texts.at(0));
+    final value = tester.widget<Text>(texts.at(1));
+    expect(
+      caption.maxLines,
+      1,
+      reason:
+          'the caption must stay on one line, or this half-width tile grows '
+          'taller than its sibling',
+    );
+    expect(
+      caption.overflow,
+      TextOverflow.ellipsis,
+      reason: 'the caption must shorten with an ellipsis rather than overflow',
+    );
+    expect(
+      value.overflow,
+      isNot(TextOverflow.ellipsis),
+      reason:
+          'the last-contact value must never ellipsize — a clipped relative '
+          'time reads as a different time',
+    );
+    expect(value.maxLines, isNull,
+        reason: 'the last-contact value must not be line-capped');
+  });
+
+  testWidgets('the last-contact tile matches its sibling in height (#1302)',
+      (tester) async {
+    // Why the caption is capped at one line rather than left to wrap: wrapping
+    // clears the overflow but makes this tile taller than the PHY Rate tile
+    // beside it, and `Row` centres them, so the pair reads as misaligned cards.
+    // `ru` at 320px is the widest caption in the narrowest tile.
+    await overflowsAt(
+      tester: tester,
+      state: timingState,
+      screenWidth: 320.0,
+      tag: 'ru',
+    );
+
+    final phyRateTile = find.ancestor(
+      of: find.byIcon(Icons.speed),
+      matching: find.byType(LayoutBlock),
+    );
+    final lastContactTile = find.ancestor(
+      of: find.byIcon(Icons.access_time),
+      matching: find.byType(LayoutBlock),
+    );
+    expect(phyRateTile, findsOneWidget,
+        reason: 'the PHY Rate tile is the sibling this height is compared to');
+    expect(lastContactTile, findsOneWidget);
+
+    // Not exact equality: `ru` renders through a Cyrillic fallback font whose
+    // line metrics run 1dp taller than the primary font used for the
+    // hardcoded-English `PHY Rate` caption beside it (in `en` the two are equal
+    // to the pixel). The failure this guards is a whole wrapped line — ~14dp —
+    // so a 2dp window separates the two cases without pinning font metrics.
+    expect(
+      tester.getSize(lastContactTile).height,
+      closeTo(tester.getSize(phyRateTile).height, 2.0),
+      reason: 'the two tiles share a Row and must stay the same height — a '
+          'wrapped caption grows one of them and the pair reads as misaligned',
+    );
+  });
+
   testWidgets('the interface value stays whole (#1302)', (tester) async {
     // Why the caption is allowed to ellipsize: the interface itself is spelled
     // out on the line below. That argument only holds while *that* line is never
     // clipped in turn — `Wi-Fi` shortened to `W…` names no interface.
-    final expected = node.backhaul.linkType ?? node.backhaul.mediaType;
+    final expected =
+        interfaceNode.backhaul.linkType ?? interfaceNode.backhaul.mediaType;
 
-    await overflowsAt(tester: tester, screenWidth: 320.0, tag: 'ja');
+    await overflowsAt(
+      tester: tester,
+      state: interfaceState,
+      screenWidth: 320.0,
+      tag: 'ja',
+    );
 
     final finder = find.text(expected);
     expect(

--- a/test/util/detail_view_probe.dart
+++ b/test/util/detail_view_probe.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:privacy_gui/l10n/gen/app_localizations.dart';
+import 'package:privacy_gui/localization/fallback_font_resolver.dart';
+import 'package:privacy_gui/route/route_model.dart';
+import 'package:privacy_gui/theme/theme_json_config.dart';
+
+import '../golden_test/golden_framework/mocks/mock_common.dart';
+import 'overflow_probe.dart';
+
+/// Shared overflow harness for the whole-page detail views (#1302).
+///
+/// ## Why this file exists
+///
+/// The Statistics and dashboard probes pump a *section* or a *card* — a widget
+/// that stands alone under a `SizedBox` of a computed width. The rows #1302 fixed
+/// cannot be reached that way: they sit inside `Expanded` children of rows built
+/// by private methods of `UspDeviceDetailView` / `UspNodeDetailView`, so the
+/// width that makes them overflow is produced by the page itself. Pumping a
+/// hand-built copy of the row would measure a width this app never renders, and
+/// the numbers in #1302's report (11dp, 20dp, 3.6dp) would be unreproducible.
+///
+/// So this probe pumps the **real view** and lets the page decide every width.
+/// The split against `overflow_probe.dart` is the same as the other probes': that
+/// file owns the *mechanism* (installing the collector, parsing Flutter's report,
+/// settling); this one owns the *scaffolding a full view needs before it will
+/// build at all* — GetIt's theme singletons, a `GoRouter` (`UspTopBar` calls
+/// `GoRouter.of`, and `AppSurface` does too), and `lib/app.dart`'s theme+locale
+/// wiring.
+///
+/// It is shared rather than inlined in its two callers because that scaffolding
+/// is not a fact about either page: it is the answer to "how do I pump a real
+/// view", and two copies of it would drift — the failure the Statistics probe
+/// documents from its own three-copy history (#1270).
+
+/// Built once per test process, not once per pump: `createLightTheme()` walks the
+/// whole JSON config, and every call site wants the same base.
+final _baseTheme = ThemeJsonConfig.defaultConfig().createLightTheme();
+
+/// Testers that have already pumped in the current test — see the one-pump rule
+/// in [probeViewOverflow]. Entries are removed by the tester's own tearDown, so
+/// this never grows beyond the tests running concurrently (one).
+final _pumped = <WidgetTester>{};
+
+/// Pumps [view] **once** at [screenWidth] as the app's only route, and returns
+/// the RenderFlex overflows beyond [tolerancePx].
+///
+/// [overrides] are the view's data providers (the golden suite's
+/// `deviceDetailOverrides` / `nodeDetailOverrides` fixtures); [commonOverrides]
+/// is always applied underneath, since it also registers the GetIt singletons
+/// `UspTopBar` reads.
+///
+/// [screenHeight] defaults to 1200 — the height the device-detail goldens use.
+/// These pages are a single `Column` in a scroll view, so every row builds and
+/// reports regardless of the height, but a taller surface keeps more of the page
+/// on screen when a failure is inspected.
+///
+/// ## One pump per call, and why this fails loudly instead of documenting it
+///
+/// Flutter reports a given `RenderFlex`'s overflow only once per render-object
+/// lifetime. A second pump in the same test reuses the element tree, so a
+/// genuinely overflowing width reads back **clean**. Calling this twice in one
+/// test is therefore an error rather than a caveat in a comment: measure a second
+/// width in a second `testWidgets`. (Same rule, same reason, as
+/// `probeSectionOverflow`.)
+Future<List<OverflowIncident>> probeViewOverflow(
+  WidgetTester tester, {
+  required Widget view,
+  required double screenWidth,
+  required Locale locale,
+  List<Override> overrides = const [],
+  double screenHeight = 1200.0,
+  double tolerancePx = kOverflowTolerancePx,
+}) async {
+  if (!_pumped.add(tester)) {
+    fail('probeViewOverflow was called twice in the same test. Flutter reports '
+        'a RenderFlex overflow once per render-object lifetime, so the second '
+        'call would read clean no matter how badly the view overflows. Split '
+        'the second measurement into its own testWidgets.');
+  }
+  addTearDown(() => _pumped.remove(tester));
+
+  final surface = Size(screenWidth, screenHeight);
+
+  // Same call as `lib/app.dart`, not a copy of its body — see #1285.
+  final theme = FallbackFontResolver.withFallbackFont(_baseTheme, locale);
+
+  return runWithOverflowCollection((sink) async {
+    await tester.binding.setSurfaceSize(surface);
+    tester.view.physicalSize = surface;
+    tester.view.devicePixelRatio = 1.0;
+
+    // `LinksysRoute`, not `GoRoute`: it is what the app builds its routes with,
+    // and it is what carries the dirty-guard contract these detail pages sit
+    // under. A plain `GoRoute` would pump a page the app never renders.
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        LinksysRoute(
+          path: '/',
+          name: 'test_root',
+          builder: (context, state) => view,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [...commonOverrides(), ...overrides],
+        child: MaterialApp.router(
+          locale: locale,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: theme,
+          // Applied inside the app via builder so the view under test actually
+          // observes disableAnimations: true — a MediaQuery wrapped outside
+          // MaterialApp would be overridden.
+          builder: (context, child) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(disableAnimations: true),
+            child: child ?? const SizedBox.shrink(),
+          ),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await settleIgnoringAnimations(tester);
+    return sink.where((i) => i.pixels > tolerancePx).toList();
+  });
+}
+
+/// The locale in [AppLocalizations.supportedLocales] whose tag is [tag], where a
+/// tag is `languageCode` or `languageCode_countryCode` (`fr`, `fr_CA`).
+///
+/// Resolved from the supported list rather than built with `Locale(tag)` so a
+/// locale that is dropped from the app fails the test that names it, instead of
+/// silently falling back to English and reporting a row as clean because it was
+/// measured in the one language it always fitted in.
+Locale localeForTag(String tag) =>
+    AppLocalizations.supportedLocales.firstWhere((l) {
+      final t = l.countryCode == null || l.countryCode!.isEmpty
+          ? l.languageCode
+          : '${l.languageCode}_${l.countryCode}';
+      return t == tag;
+    });


### PR DESCRIPTION
## What this branch does

Fixes the in-scope RenderFlex overflows from the golden CI baseline report (#1302)
that live in app code, all caused by the same anti-pattern: a label row built as
`Row(children: [Icon(size: 16), AppGap.xs(), AppText.labelSmall(label)])`, where
the label carries no flex constraint and sizes itself to its natural width inside
a half-width `Expanded`.

| Site | Available | Needed | Over |
|---|---|---|---|
| `DetailSpeedCard` (device detail, node detail) | 181dp @480px / 172dp @1280px | 192dp (`fr` download caption) | 11dp / 20dp |
| Wi-Fi backhaul interface tile (node detail) | 99dp @1280px | 102.6dp (`fi` `Käyttöliittymä`) | 3.6dp |
| Wi-Fi backhaul last-contact tile (node detail) | 99dp @1280px | 132dp (`ru` `Последний контакт`) | 33dp @1280px, 39dp @1241px |

Sweeping all 26 locales across 320/480/601/905/1241/1280px puts the worst cases
well above the reported ones: `fr` overflows the speed card by 91dp at 320px and
30dp at 1241px, and `ja` overflows the backhaul interface tile by 19dp at 1241px.
1241px is its own pinch — the 200px desktop margins open just above 1240px, so a
1241px screen lays these rows out narrower than a 1240px one.

The last-contact tile was not in the report at all, and is the worst of the
three: **21 of the 26 locales** overflow it, and **`en` overflows it by
2.4dp at 1241px**, so it is a layout bug rather than a long-translation edge case.
It was invisible because no test fixture sets `lastContactTime` — that row has
never been rendered in the golden suite. This branch adds a fixture that does.

Each caption now takes the space the icon leaves and shortens with an ellipsis
rather than wrapping — the value sits on the line below, so nothing is lost, and
wrapping would give sibling tiles in the same `Row` different heights in locales
where only one caption is long (`fr` speed cards at 480px measure 106dp against
90dp; the last-contact tile measures 81dp against its sibling's 64dp).

The statistics traffic-monitor legend, the one remaining site in the report, was
fixed independently on `dev-2.7.0` (#1252) while this branch was open. This branch was
rebased onto it and carries base's version unchanged.

## Tests

All three fixes are gated. Golden byte comparison cannot gate them: an overflowing
layout is baked into the baseline PNG and compares clean forever after. Nor does
the #1183 overflow sweep, which covers the dashboard's `UspWidgetSpecs.all`
registry — neither detail page is in it.

- `test/util/detail_view_probe.dart` — pumps a whole detail view at a given width
  and locale and collects overflows through the existing `overflow_probe` helpers.
  The guarded rows sit inside `Expanded` children of private build methods, so
  only the real page produces the width that overflows; a hand-built copy of the
  row would measure a width the app never renders. It refuses a second pump per
  test, because Flutter reports a given `RenderFlex` overflow once per
  render-object lifetime and a second pump reads clean no matter how bad the
  layout is.
- `usp_device_detail_speed_card_overflow_test.dart` — 4 locales × 4 widths, plus
  sibling-card height equality and "the speed value is never clipped".
- `usp_node_detail_backhaul_overflow_test.dart` — interface tile 3 locales × 3
  widths, last-contact tile 4 locales × 3 widths, plus tile height equality,
  "the caption shortens but its value does not", and a precondition test that
  fails if either fixture drifts to a shape where the guarded row is not built.

Tagged `dashboard-card`, which `run_tests.sh` does not exclude, so a regression
blocks a PR rather than landing silently.

Every group was verified to fail against a mutation of the code it guards, with
the numbers recorded in each file's mutation ledger: reverting the three captions
to their unconstrained shape fails 7, 6 and 9 cells at exactly the overflow
amounts above; dropping `maxLines: 1` fails the height-equality groups; clipping
the value texts fails the groups that keep the number whole.

## Verification

- `sh run_tests.sh` — 7158 tests, all passed
- `fvm flutter test --tags dashboard-card` — 3284 tests, all passed
- `fvm dart format --set-exit-if-changed` and `fvm flutter analyze` on all changed
  files — clean
- Golden tests for devices, topology and statistics re-run in compare mode
  (without `--update-goldens`) — 42 passed, and `overflow_warnings.json` was not
  produced, i.e. zero overflow records

## Not included

- The `shared` / `AppDialog` `fr_CA` overflow needs a `ui_kit_library` change and
  is left open in #1302.
- The Ethernet branch of the same backhaul card (`usp_node_detail_view.dart:383`)
  has the identical unguarded shape but is out of scope for this issue, so it is
  untouched. It is also the one place where the shape is harmless: that
  `LayoutBlock` is a direct child of the card's `Column` rather than a half-width
  `Expanded`, so it has roughly twice the room, and an Ethernet fixture swept
  across all 26 locales × 6 widths produced zero overflows. The test file records
  this, including a note not to add an Ethernet case to "complete" the matrix.
- Extracting a shared caption-row helper for this shape was considered and
  declined. The five remaining call sites in `lib/` are not one pattern: two are
  the safe node-detail tiles above, and three
  (`diagnostic_result_card.dart:310`, `remote_assistance_dialog.dart:687`,
  `remote_assistance_banner.dart:508`) are `MainAxisSize.min` badges, where an
  `Expanded` would be wrong. A helper would need an `expand:` flag and would
  relocate the mistake rather than prevent it.
- The hardcoded English `'PHY Rate'` caption beside the fixed tile is an l10n
  gap that will reproduce this bug once translated. Out of scope here (no ARB
  files are touched), but the new gate covers it: `probeViewOverflow` collects
  incidents from the whole page, so it would fail the last-contact group.

No golden PNGs are committed — they are gitignored build products regenerated by
the daily run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
