### PR TITLE
merge: promote dev-2.6.1 Remote Assistance fixes into dev-2.7.0 (#1330)

### DIFF
--- a/lib/core/usp/providers/remote_assistance_provider.dart
+++ b/lib/core/usp/providers/remote_assistance_provider.dart
@@ -127,15 +127,15 @@ class RemoteAssistanceNotifier extends Notifier<RemoteAssistanceState> {
       //
       // uspClientProvider caches whatever GetIt held when it was FIRST read,
       // and authProvider.init() reads it during app boot — long before RA
-      // activates. Without this, every USP request and every bridge call keeps
-      // using the disposed boot-time client, whose baseUrl is the web app's own
-      // origin instead of the Guardian API host.
+      // activates. In a Remote build that first read now yields null
+      // ([canUseAppOriginUspClient] keeps the boot slot empty), and this drops
+      // that cached null so watchers pick the session client up.
       //
-      // Invariant: only ref.watch consumers rebuild. Feature services capture
-      // the client via ref.read(uspClientProvider) in the body of a
-      // non-autoDispose provider, so they keep their first instance for the
-      // container's lifetime — the swap MUST happen before any feature service
-      // provider is first read.
+      // Only ref.watch consumers rebuild; a ref.read consumer keeps whatever it
+      // captured. That is no longer a correctness risk: in a Remote build the
+      // only client that can ever exist is this one, so the worst a too-early
+      // read can capture is null — which fails loudly instead of silently
+      // talking to the wrong host.
       ref.invalidate(uspClientProvider);
     });
 

--- a/lib/core/usp/providers/remote_assistance_provider.dart
+++ b/lib/core/usp/providers/remote_assistance_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:privacy_gui/constants/cloud_const.dart';
+import 'package:privacy_gui/core/usp/providers/usp_client_provider.dart';
 import 'package:privacy_gui/core/usp/providers/usp_mutation_lock.dart';
 import 'package:privacy_gui/core/usp/services/usp_client.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
@@ -20,6 +21,13 @@ class RemoteAssistanceConfig {
     required this.temporaryAccessToken,
     this.clientTypeId,
   });
+
+  /// Guardian API origin — the single host for ALL Remote Assistance traffic
+  /// (session REST, USP requests, subscriptions, SSE notifications).
+  ///
+  /// Must NOT be confused with the origin the web app is served from; the
+  /// Guardian API lives on a different host (e.g. `qa.guardian.tools`).
+  String get guardianOrigin => 'https://$guardianBaseUrl';
 
   /// Constructs the Guardian USP endpoint path.
   String get uspEndpoint =>
@@ -75,11 +83,11 @@ class RemoteAssistanceNotifier extends Notifier<RemoteAssistanceState> {
     }
 
     logger.i('[RA] Activating Remote Assistance: ${config.sessionId}');
-    logger.d('[RA] Guardian URL: https://${config.guardianBaseUrl}');
+    logger.d('[RA] Guardian URL: ${config.guardianOrigin}');
     logger.d('[RA] USP Endpoint: ${config.uspEndpoint}');
 
     // Build the client using UspClientBuilder
-    var builder = UspClientBuilderJS('https://${config.guardianBaseUrl}')
+    var builder = UspClientBuilderJS(config.guardianOrigin)
         .endpoint(config.uspEndpoint)
         .authToken(config.temporaryAccessToken);
 
@@ -89,8 +97,8 @@ class RemoteAssistanceNotifier extends Notifier<RemoteAssistanceState> {
     }
 
     final jsClient = builder.build();
-    final guardianUrl = 'https://${config.guardianBaseUrl}';
-    final raClient = UspClient.fromBuilder(jsClient, baseUrl: guardianUrl);
+    final raClient =
+        UspClient.fromBuilder(jsClient, baseUrl: config.guardianOrigin);
 
     // Swap UspClient atomically with mutation lock to prevent races
     await ref.read(uspMutationLockProvider).withLock(() async {
@@ -111,6 +119,13 @@ class RemoteAssistanceNotifier extends Notifier<RemoteAssistanceState> {
       isActive: true,
       config: config,
     );
+
+    // uspClientProvider caches whatever GetIt held when it was FIRST read
+    // (authProvider.init() reads it during app boot, before RA activates).
+    // Without this invalidation, every USP request and every bridge call keeps
+    // using the disposed boot-time client — whose baseUrl is the web app's own
+    // origin, not the Guardian API host.
+    ref.invalidate(uspClientProvider);
   }
 
   /// Deactivates Remote Assistance mode.
@@ -131,6 +146,10 @@ class RemoteAssistanceNotifier extends Notifier<RemoteAssistanceState> {
     });
 
     state = const RemoteAssistanceState();
+
+    // Drop the cached (now disposed) client so downstream providers tear down
+    // instead of calling into freed WASM memory.
+    ref.invalidate(uspClientProvider);
   }
 }
 

--- a/lib/core/usp/providers/remote_assistance_provider.dart
+++ b/lib/core/usp/providers/remote_assistance_provider.dart
@@ -22,12 +22,23 @@ class RemoteAssistanceConfig {
     this.clientTypeId,
   });
 
-  /// Guardian API origin — the single host for ALL Remote Assistance traffic
-  /// (session REST, USP requests, subscriptions, SSE notifications).
+  /// Guardian API origin — the host every USP-over-Guardian call must use:
+  /// USP requests, subscriptions and SSE notifications.
   ///
   /// Must NOT be confused with the origin the web app is served from; the
   /// Guardian API lives on a different host (e.g. `qa.guardian.tools`).
-  String get guardianOrigin => 'https://$guardianBaseUrl';
+  ///
+  /// The session REST API ends up on the same host by construction — both this
+  /// config ([RemoteAssistanceConfig.guardianBaseUrl], set from
+  /// `cloudEnvironmentConfig[kCloudBase]`) and `GuardianApiClient._buildUrl`
+  /// read that same entry — but it builds its URL independently.
+  String get guardianOrigin {
+    // Kept as an assert rather than a constructor assert: the constructor is
+    // const, and const asserts only accept potentially-constant expressions.
+    assert(!guardianBaseUrl.contains('://'),
+        'guardianBaseUrl must be a bare host, without a scheme');
+    return 'https://$guardianBaseUrl';
+  }
 
   /// Constructs the Guardian USP endpoint path.
   String get uspEndpoint =>
@@ -110,6 +121,22 @@ class RemoteAssistanceNotifier extends Notifier<RemoteAssistanceState> {
       }
       getIt.registerSingleton<UspClient>(raClient);
       logger.i('[RA] UspClient replaced with Guardian-proxied client');
+
+      // Invalidated in the same critical section as the swap, so "client
+      // identity changed" and "cache dropped" can never drift apart.
+      //
+      // uspClientProvider caches whatever GetIt held when it was FIRST read,
+      // and authProvider.init() reads it during app boot — long before RA
+      // activates. Without this, every USP request and every bridge call keeps
+      // using the disposed boot-time client, whose baseUrl is the web app's own
+      // origin instead of the Guardian API host.
+      //
+      // Invariant: only ref.watch consumers rebuild. Feature services capture
+      // the client via ref.read(uspClientProvider) in the body of a
+      // non-autoDispose provider, so they keep their first instance for the
+      // container's lifetime — the swap MUST happen before any feature service
+      // provider is first read.
+      ref.invalidate(uspClientProvider);
     });
 
     // Set login type to remote so auth checks pass
@@ -119,13 +146,6 @@ class RemoteAssistanceNotifier extends Notifier<RemoteAssistanceState> {
       isActive: true,
       config: config,
     );
-
-    // uspClientProvider caches whatever GetIt held when it was FIRST read
-    // (authProvider.init() reads it during app boot, before RA activates).
-    // Without this invalidation, every USP request and every bridge call keeps
-    // using the disposed boot-time client — whose baseUrl is the web app's own
-    // origin, not the Guardian API host.
-    ref.invalidate(uspClientProvider);
   }
 
   /// Deactivates Remote Assistance mode.
@@ -143,13 +163,13 @@ class RemoteAssistanceNotifier extends Notifier<RemoteAssistanceState> {
         client.dispose();
         logger.d('[RA] UspClient unregistered and disposed');
       }
+
+      // Drop the cached instance in the same critical section, so watchers
+      // rebuild against an empty GetIt instead of holding a disposed client.
+      ref.invalidate(uspClientProvider);
     });
 
     state = const RemoteAssistanceState();
-
-    // Drop the cached (now disposed) client so downstream providers tear down
-    // instead of calling into freed WASM memory.
-    ref.invalidate(uspClientProvider);
   }
 }
 

--- a/lib/core/usp/providers/sse_providers.dart
+++ b/lib/core/usp/providers/sse_providers.dart
@@ -38,6 +38,8 @@ final uspBridgeClientProvider = Provider<UspBridgeClient?>((ref) {
     bridge = UspBridgeClient(
       usp,
       endpoints: BridgeEndpoints.remote(config.sessionId),
+      // Same host as the Guardian session REST API — NOT the app's own origin.
+      baseUrl: config.guardianOrigin,
       authToken: config.temporaryAccessToken,
       clientTypeId: config.clientTypeId,
       authBehavior: AuthBehavior.remote,

--- a/lib/core/usp/providers/usp_client_provider.dart
+++ b/lib/core/usp/providers/usp_client_provider.dart
@@ -10,6 +10,15 @@ import 'bridge_request_throttler_provider.dart';
 /// Returns null on non-Web platforms since USP is only available
 /// through the WASM transport layer.
 ///
+/// Also null in a Remote Assistance build until
+/// `RemoteAssistanceNotifier.activate()` has registered the session client —
+/// such builds get no boot-time client, because the app's own origin is not the
+/// USP host (see `canUseAppOriginUspClient` in `di.dart`).
+///
+/// Caches for the container's lifetime: a `ref.read` consumer keeps the instance
+/// it first saw. `activate()` invalidates this provider after the swap so
+/// `ref.watch` consumers follow.
+///
 /// Binds the [BridgeRequestThrottler] so all `usp.get()` calls are
 /// automatically throttled to prevent overwhelming the router.
 final uspClientProvider = Provider<UspClient?>((ref) {

--- a/lib/core/usp/services/usp_bridge_client_base.dart
+++ b/lib/core/usp/services/usp_bridge_client_base.dart
@@ -25,6 +25,7 @@ class UspBridgeClient {
   UspBridgeClient(
     UspClient usp, {
     BridgeEndpoints? endpoints,
+    String? baseUrl,
     String? authToken,
     String? clientTypeId,
     AuthBehavior authBehavior = AuthBehavior.local,

--- a/lib/core/usp/services/usp_bridge_client_web.dart
+++ b/lib/core/usp/services/usp_bridge_client_web.dart
@@ -38,6 +38,7 @@ external set _jsSseAbort(JSAny? value);
 class UspBridgeClient {
   final UspClient _usp;
   final BridgeEndpoints _endpoints;
+  final String? _overrideBaseUrl;
   final String? _overrideToken;
   final String? _clientTypeId;
   final AuthBehavior _authBehavior;
@@ -48,10 +49,12 @@ class UspBridgeClient {
   UspBridgeClient(
     this._usp, {
     BridgeEndpoints? endpoints,
+    String? baseUrl,
     String? authToken,
     String? clientTypeId,
     AuthBehavior authBehavior = AuthBehavior.local,
   })  : _endpoints = endpoints ?? BridgeEndpoints.local,
+        _overrideBaseUrl = baseUrl,
         _overrideToken = authToken,
         _clientTypeId = clientTypeId,
         _authBehavior = authBehavior;
@@ -60,7 +63,12 @@ class UspBridgeClient {
   /// synchronously from a `beforeunload` handler.
   web.AbortController? _sseAbortController;
 
-  String get _baseUrl => _usp.baseUrl;
+  /// Host for REST/SSE calls.
+  ///
+  /// Remote mode passes the Guardian API origin explicitly — it must not be
+  /// derived from [UspClient.baseUrl], which may still point at the origin the
+  /// web app was served from.
+  String get _baseUrl => _overrideBaseUrl ?? _usp.baseUrl;
 
   String get _token {
     // Remote mode: use override token (temporaryAccessToken from Guardian)

--- a/lib/di.dart
+++ b/lib/di.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:privacy_gui/constants/build_config.dart';
 import 'package:privacy_gui/core/utils/logger.dart';
 import 'package:privacy_gui/theme/theme_json_config.dart';
 import 'package:privacy_gui/core/usp/services/usp_client.dart';
@@ -44,13 +45,34 @@ void dependencySetup() {
 
   // Register UspClient on Web platform only
   if (kIsWeb && !getIt.isRegistered<UspClient>()) {
-    try {
-      getIt.registerSingleton<UspClient>(UspClient(
-        Uri.base.origin,
-      ));
-      logger.d('[DI]: UspClient registered (Web)');
-    } catch (e) {
-      logger.w('[DI]: UspClient registration failed: $e');
+    if (canUseAppOriginUspClient()) {
+      try {
+        getIt.registerSingleton<UspClient>(UspClient(
+          Uri.base.origin,
+        ));
+        logger.d('[DI]: UspClient registered (Web)');
+      } catch (e) {
+        logger.w('[DI]: UspClient registration failed: $e');
+      }
+    } else {
+      logger.d('[DI]: UspClient boot registration skipped — Remote build, '
+          'the client is built from the Remote Assistance session config');
     }
   }
 }
+
+/// Whether a boot-time [UspClient] may be built against the app's own origin.
+///
+/// True for Local (and unforced) builds: the app is served by the router itself,
+/// so `Uri.base.origin` IS the USP host.
+///
+/// False for Remote Assistance builds: there the app is served from static
+/// hosting and USP is reached through the Guardian API on a different host. A
+/// boot client would therefore point at a host that answers no USP request, and
+/// because [uspClientProvider] caches whatever GetIt held when it was FIRST read
+/// — during `authProvider.init()`, long before a session exists — that wrong
+/// client is what every consumer keeps. Leaving the slot empty makes
+/// `RemoteAssistanceNotifier.activate()` the only thing that can ever create the
+/// client, so no consumer can capture a pre-session instance.
+@visibleForTesting
+bool canUseAppOriginUspClient() => !BuildConfig.isRemote();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 2.6.0+100000
+version: 2.6.1+100000
 
 environment:
   sdk: ">=3.3.0 <4.0.0"

--- a/test/core/usp/providers/remote_assistance_provider_test.dart
+++ b/test/core/usp/providers/remote_assistance_provider_test.dart
@@ -39,6 +39,16 @@ void main() {
       expect(config.clientTypeId, 'client-type-456');
     });
 
+    test('guardianOrigin prefixes the Guardian API host with https', () {
+      const config = RemoteAssistanceConfig(
+        guardianBaseUrl: 'qa.guardian.tools',
+        sessionId: 'session-123',
+        temporaryAccessToken: 'token-abc',
+      );
+
+      expect(config.guardianOrigin, 'https://qa.guardian.tools');
+    });
+
     test('uspEndpoint returns correct path format', () {
       const config = RemoteAssistanceConfig(
         guardianBaseUrl: 'api.example.com',

--- a/test/core/usp/providers/remote_assistance_provider_test.dart
+++ b/test/core/usp/providers/remote_assistance_provider_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:privacy_gui/core/usp/providers/remote_assistance_provider.dart';
+import 'package:privacy_gui/core/usp/providers/usp_client_provider.dart';
 import 'package:privacy_gui/providers/auth/auth_provider.dart';
 
 class MockAuthNotifier extends Mock implements AuthNotifier {}
@@ -187,16 +188,40 @@ void main() {
       expect(state.config, isNull);
     });
 
-    test('deactivate resets state to inactive', () {
+    test('deactivate resets state to inactive', () async {
       // First manually set an active state via notifier
       final notifier = container.read(remoteAssistanceProvider.notifier);
 
-      // Call deactivate
-      notifier.deactivate();
+      // Must be awaited — deactivate() resets state only after the GetIt swap
+      // completes inside the mutation lock.
+      await notifier.deactivate();
 
       final state = container.read(remoteAssistanceProvider);
       expect(state.isActive, false);
       expect(state.config, isNull);
+    });
+
+    test('deactivate invalidates uspClientProvider', () async {
+      var builds = 0;
+      final container = ProviderContainer(
+        overrides: [
+          authProvider.overrideWith(() => mockAuthNotifier),
+          uspClientProvider.overrideWith((ref) {
+            builds++;
+            return null;
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      container.read(uspClientProvider);
+      expect(builds, 1);
+
+      await container.read(remoteAssistanceProvider.notifier).deactivate();
+      container.read(uspClientProvider);
+
+      // Rebuilt after the swap — consumers must not keep the pre-swap client.
+      expect(builds, 2);
     });
 
     // activate() requires web platform and WASM — test the platform check
@@ -284,7 +309,7 @@ void main() {
       expect(identical(state1, state2), isTrue);
     });
 
-    test('notifier updates trigger state changes', () {
+    test('notifier updates trigger state changes', () async {
       final container = ProviderContainer();
       addTearDown(container.dispose);
 
@@ -296,7 +321,7 @@ void main() {
       );
 
       final notifier = container.read(remoteAssistanceProvider.notifier);
-      notifier.deactivate();
+      await notifier.deactivate();
 
       // Initial state + state after deactivate
       expect(states.length, greaterThanOrEqualTo(1));

--- a/test/di_test.dart
+++ b/test/di_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:privacy_gui/constants/build_config.dart';
+import 'package:privacy_gui/di.dart';
+
+void main() {
+  group('canUseAppOriginUspClient', () {
+    final original = BuildConfig.forceCommandType;
+
+    tearDown(() {
+      BuildConfig.forceCommandType = original;
+    });
+
+    test('allows the boot client in a Local build', () {
+      BuildConfig.forceCommandType = ForceCommand.local;
+
+      expect(canUseAppOriginUspClient(), isTrue);
+    });
+
+    test('allows the boot client when no mode is forced', () {
+      BuildConfig.forceCommandType = ForceCommand.none;
+
+      expect(canUseAppOriginUspClient(), isTrue);
+    });
+
+    test('rejects the boot client in a Remote Assistance build', () {
+      // The app is served from static hosting, not by the router — a client
+      // built on Uri.base.origin would answer no USP request, and whoever read
+      // uspClientProvider first would cache it. Only activate() may build the
+      // client in this mode.
+      BuildConfig.forceCommandType = ForceCommand.remote;
+
+      expect(canUseAppOriginUspClient(), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Closes #1330

## Summary

Promotion merge — brings the three Remote Assistance fixes that shipped only on the `dev-2.6.1`
hotfix line into `dev-2.7.0`. **No new code**; every commit here was already reviewed and merged on
2.6.1.

| commit | change |
|---|---|
| `6d1aef0a` | `fix(remote-assistance): stop building a USP client on the app's own origin (#1309)` — adds `canUseAppOriginUspClient()`, skips the boot-time GetIt registration in Remote builds |
| `64306778` | `fix(remote-assistance): invalidate the client cache inside the swap` — `ref.invalidate(uspClientProvider)` inside the mutation-lock critical section, in both `activate()` and `deactivate()` |
| `9cf72b52` | `fix(remote-assistance): send every RA call to the Guardian host` — adds `RemoteAssistanceConfig.guardianOrigin` and a `baseUrl` override on `UspBridgeClient`, so REST/SSE stop deriving the host from `UspClient.baseUrl` |

`aadb14ef` (version bump to 2.6.1) is superseded by 2.7.0's own bump.

This is also a prerequisite for #1322: that fix builds on `6d1aef0a`. Without it, `dev-2.7.0` still
registers a boot-time `UspClient(Uri.base.origin)` in a Remote build, so even the **first**
`activate()` frees an instance that boot-time consumers already captured.

## Conflict resolution

One conflict, in `pubspec.yaml` only:

```
HEAD:             version: 2.7.0+100000
origin/dev-2.6.1: version: 2.6.1+100000
```

Resolved to `2.7.0+100000`. Everything else auto-merged — `dev-2.7.0` has not touched a single one
of the six `lib/` files since the merge-base (`5beff305`); its own commits since then all sit on the
dashboard / topology / test / ui_kit side. `test/di_test.dart` is a clean add.

## Why merge rather than cherry-pick

A real merge makes `dev-2.6.1` an ancestor of `dev-2.7.0`, so any further 2.6.1 hotfix promotes
without replaying these same conflicts. Cherry-picking would leave the branches permanently
divergent on the same content.

## Verification (on the merged tree)

| check | result |
|---|---|
| `fvm dart format --set-exit-if-changed` on the 8 changed files | 0 changed |
| `flutter analyze lib/core/usp/ lib/di.dart` + both test files | No issues found |
| `flutter analyze` (whole repo) | 474 issues, **0 error / 0 warning** — all pre-existing `curly_braces_in_flow_control_structures` info |
| affected tests (34 files: `test/core/usp/`, `test/core/connection/`, auth, admin, wifi, local_network, internet_settings, devices, diagnostics, firmware, pnp) | **797 passed** |
| `./run_tests.sh` (full functional suite) | **7118 passed** |
| `git merge-base --is-ancestor origin/dev-2.6.1 HEAD` | passes |

Semantic premises re-checked against 2.7.0:

- `lib/constants/build_config.dart` is byte-identical between the branches, and 2.7.0's `di.dart`
  still registers the boot client unconditionally — exactly the state `6d1aef0a` was written against.
- The 41 `ref.read(uspClientProvider)` sites are the same set on both branches. 2.7.0's one new
  `ref.watch` consumer, `wan_interface_path_provider.dart:63`, follows the invalidation correctly.
- `uspBridgeClientProvider` has the same shape on both branches, so the `baseUrl:` override applies
  unchanged.

## Known consequence, carried over from 2.6.1

After `6d1aef0a`, `uspClientProvider` returns `null` in a Remote build until `activate()` runs, and
the tree has 16 `ref.read(uspClientProvider)!` force-unwraps that would throw on a too-early read.
That is `6d1aef0a`'s deliberate trade-off — a too-early read captures null, which fails loudly
instead of silently talking to the wrong host — not a regression introduced here. #1322 removes the
whole class by keeping the `UspClient` façade instance stable and rebinding its transport.

## Review notes

One INFO from the pre-PR review, pre-existing rather than introduced by this merge: the `baseUrl`
override on `UspBridgeClient` has no dedicated test file. `guardianOrigin` itself is covered
(`remote_assistance_provider_test.dart:43`), but "the override actually reaches the bridge client"
is only covered indirectly.

Refs #1309, #1322
