### PR TITLE
fix(ai): key signal levels by label so a tool result stays encodable

### DIFF
--- a/lib/ai/providers/usp_command_provider.dart
+++ b/lib/ai/providers/usp_command_provider.dart
@@ -756,10 +756,43 @@ class UspCommandProvider implements IRouterCommandProvider {
         'totalCount': distribution.totalCount,
       },
       'bandDistribution': distribution.bandDistribution,
-      'signalLevelDistribution': distribution.signalLevelDistribution,
+      'signalLevelDistribution':
+          _labelSignalLevels(distribution.signalLevelDistribution),
       'bandSignalQuality': distribution.bandSignalQuality,
       'hourlyHistoryCount': data.hourlyHistory.length,
     });
+  }
+
+  /// Signal level label for each numeric level, matching the labels the
+  /// dashboard and statistics pages already show for the same data.
+  static const _signalLevelLabels = {
+    3: 'excellent',
+    2: 'good',
+    1: 'fair',
+    0: 'poor',
+  };
+
+  /// Re-keys the signal level distribution from `int` to `String`.
+  ///
+  /// Two reasons, both load-bearing:
+  ///
+  /// 1. **JSON keys must be strings.** A tool result travels to the model as
+  ///    `jsonEncode(result)`, and an `int`-keyed map throws there. That throw
+  ///    lands after the result is already in the conversation history, so every
+  ///    later request re-encodes the same bad entry and fails — one unusable
+  ///    map permanently bricks the session rather than failing one answer.
+  /// 2. **The numbers alone don't say which end is good.** Sending `0`–`3`
+  ///    leaves the model to guess the direction; the labels carry it.
+  ///
+  /// Unrecognised levels are kept under `level<n>` rather than dropped: losing
+  /// devices from a distribution silently would misreport totals.
+  static Map<String, int> _labelSignalLevels(Map<int, int> byLevel) {
+    return byLevel.map(
+      (level, count) => MapEntry(
+        _signalLevelLabels[level] ?? 'level$level',
+        count,
+      ),
+    );
   }
 
   Future<RouterCommandResult> _getWifiStatus() async {

--- a/test/ai/providers/usp_command_provider_test.dart
+++ b/test/ai/providers/usp_command_provider_test.dart
@@ -1,8 +1,16 @@
+import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:privacy_gui/ai/abstraction/_abstraction.dart';
 import 'package:privacy_gui/ai/providers/usp_command_provider.dart';
 import 'package:privacy_gui/page/_shared/models/client_device.dart';
+import 'package:privacy_gui/page/_shared/models/device_analytics_state.dart';
+import 'package:privacy_gui/page/_shared/models/system_monitor_state.dart';
+import 'package:privacy_gui/page/_shared/models/traffic_analysis_state.dart';
+import 'package:privacy_gui/page/_shared/providers/usp_device_analytics_notifier.dart';
+import 'package:privacy_gui/page/_shared/providers/usp_system_monitor_notifier.dart';
+import 'package:privacy_gui/page/_shared/providers/usp_traffic_analysis_notifier.dart';
 import 'package:privacy_gui/page/_shared/models/mesh_network.dart';
 import 'package:privacy_gui/page/_shared/models/node_entity.dart';
 import 'package:privacy_gui/page/_shared/models/system_info_ui_model.dart';
@@ -37,6 +45,27 @@ void main() {
           ),
           wanDataProvider.overrideWith(
             () => _FixedWanNotifier(_testWanData),
+          ),
+          // These three are stubbed for two reasons beyond supplying data.
+          //
+          // Their real notifiers open a `Timer.periodic` that fetches over USP,
+          // guarded only by `appConnectionStateProvider` not being
+          // `authenticated` — which happens to hold in tests but is nothing this
+          // file states or controls. Stubbing keeps a unit test from depending
+          // on that, and from starting timers if it ever stops holding.
+          //
+          // They also carry the tools most likely to reach the model with an
+          // un-encodable value: histories and distributions rather than flat
+          // scalars. Left unstubbed they return "no data" and the encodability
+          // test below passes over them without ever seeing a populated result.
+          uspDeviceAnalyticsProvider.overrideWith(
+            () => _FixedDeviceAnalyticsNotifier(_testDeviceAnalyticsState),
+          ),
+          uspSystemMonitorProvider.overrideWith(
+            () => _FixedSystemMonitorNotifier(_testSystemMonitorState),
+          ),
+          uspTrafficAnalysisProvider.overrideWith(
+            () => _FixedTrafficAnalysisNotifier(_testTrafficAnalysisState),
           ),
         ],
       );
@@ -179,6 +208,71 @@ void main() {
           () => provider.execute('unknownCommand', {}),
           throwsA(isA<UnauthorizedCommandException>()),
         );
+      });
+    });
+
+    // Every result here is handed to `jsonEncode` on its way to the model. An
+    // un-encodable value does not merely spoil one answer: the throw happens
+    // after the result is already in the conversation history, so each later
+    // request re-encodes the same entry and fails too, leaving the session
+    // permanently unable to reply. These tests exist to keep that class of
+    // value out of tool results.
+    group('tool results are JSON-encodable', () {
+      test('getDeviceAnalytics keys signal levels by label, not by int',
+          () async {
+        final provider = container.read(_testUspCommandProvider);
+
+        final result = await provider.execute('getDeviceAnalytics', {});
+
+        expect(result.success, isTrue);
+        // The assertion that matters: an int-keyed map throws here.
+        expect(() => jsonEncode(result.data), returnsNormally);
+        expect(result.data['signalLevelDistribution'], {
+          'excellent': 4,
+          'good': 2,
+          'fair': 1,
+        });
+      });
+
+      test('unrecognised signal levels are kept rather than dropped', () async {
+        final analyticsContainer = ProviderContainer(
+          overrides: [
+            uspDeviceAnalyticsProvider.overrideWith(
+              () => _FixedDeviceAnalyticsNotifier(
+                const DeviceAnalyticsState(
+                  current: DeviceDistribution(
+                    signalLevelDistribution: {7: 3},
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+        addTearDown(analyticsContainer.dispose);
+        final provider = analyticsContainer.read(_testUspCommandProvider);
+
+        final result = await provider.execute('getDeviceAnalytics', {});
+
+        expect(() => jsonEncode(result.data), returnsNormally);
+        expect(result.data['signalLevelDistribution'], {'level7': 3});
+      });
+
+      // Covers every command at once. Commands whose providers are not stubbed
+      // return a failure result, which is still encoded and sent, so they are
+      // worth asserting on even though they carry no data.
+      test('every command produces an encodable result', () async {
+        final provider = container.read(_testUspCommandProvider);
+        final commands = await provider.listCommands();
+
+        for (final cmd in commands) {
+          final result = await provider.execute(cmd.name, {});
+          expect(
+            () => jsonEncode(result.data),
+            returnsNormally,
+            reason: '${cmd.name} returned a result that cannot be encoded',
+          );
+          _expectStringKeysThroughout(result.data, cmd.name);
+        }
       });
     });
 
@@ -326,8 +420,60 @@ void main() {
 }
 
 // =============================================================================
+// Helpers
+// =============================================================================
+
+/// Fails if any map nested anywhere under [value] is keyed by something other
+/// than a `String`.
+///
+/// `jsonEncode` already rejects those keys, so this adds nothing for a result
+/// that is fully populated. It earns its place on the sparse ones: a tool whose
+/// provider holds no data returns an empty map, which encodes cleanly and would
+/// let a non-string key pass unnoticed until the day that tool has data.
+void _expectStringKeysThroughout(Object? value, String commandName) {
+  if (value is Map) {
+    for (final entry in value.entries) {
+      expect(
+        entry.key,
+        isA<String>(),
+        reason: '$commandName has a non-String map key: ${entry.key}',
+      );
+      _expectStringKeysThroughout(entry.value, commandName);
+    }
+  } else if (value is Iterable) {
+    for (final element in value) {
+      _expectStringKeysThroughout(element, commandName);
+    }
+  }
+}
+
+// =============================================================================
 // Fixed Notifiers (set state immediately in build)
 // =============================================================================
+
+class _FixedDeviceAnalyticsNotifier extends UspDeviceAnalyticsNotifier {
+  final DeviceAnalyticsState _data;
+  _FixedDeviceAnalyticsNotifier(this._data);
+
+  @override
+  DeviceAnalyticsState build() => _data;
+}
+
+class _FixedSystemMonitorNotifier extends UspSystemMonitorNotifier {
+  final SystemMonitorState _data;
+  _FixedSystemMonitorNotifier(this._data);
+
+  @override
+  SystemMonitorState build() => _data;
+}
+
+class _FixedTrafficAnalysisNotifier extends UspTrafficAnalysisNotifier {
+  final TrafficAnalysisState _data;
+  _FixedTrafficAnalysisNotifier(this._data);
+
+  @override
+  TrafficAnalysisState build() => _data;
+}
 
 class _FixedSystemInfoNotifier extends SystemInfoDataNotifier {
   final SystemInfoData _data;
@@ -496,6 +642,80 @@ final _testWifiData = WifiData(
           isGuest: false,
         ),
       ],
+    ),
+  ],
+);
+
+/// Levels 3/2/1 populated and 0 absent, matching the notifier, which only
+/// records levels it actually saw.
+const _testDeviceAnalyticsState = DeviceAnalyticsState(
+  current: DeviceDistribution(
+    wifiCount: 7,
+    wiredCount: 2,
+    onlineCount: 9,
+    offlineCount: 1,
+    bandDistribution: {'2.4GHz': 3, '5GHz': 4, 'Wired': 2},
+    signalLevelDistribution: {3: 4, 2: 2, 1: 1},
+    bandSignalQuality: {'2.4GHz': 0.62, '5GHz': 0.88},
+  ),
+);
+
+/// Two snapshots so the history arrays the tool builds are non-empty; the tools
+/// treat an empty history as "no data yet" and return a failure instead.
+final _testSystemMonitorState = SystemMonitorState(
+  refreshInterval: const Duration(seconds: 30),
+  history: [
+    SystemSnapshot(
+      timestamp: DateTime.utc(2026, 1, 1, 0, 0),
+      cpuPercent: 21,
+      memoryPercent: 47,
+      totalMemoryKb: 524288,
+      freeMemoryKb: 277872,
+      uptimeSeconds: 86400,
+    ),
+    SystemSnapshot(
+      timestamp: DateTime.utc(2026, 1, 1, 0, 0, 30),
+      cpuPercent: 25,
+      memoryPercent: 49,
+      totalMemoryKb: 524288,
+      freeMemoryKb: 267386,
+      uptimeSeconds: 86430,
+    ),
+  ],
+);
+
+final _testTrafficAnalysisState = TrafficAnalysisState(
+  refreshInterval: const Duration(seconds: 10),
+  history: [
+    MultiInterfaceSnapshot(
+      timestamp: DateTime.utc(2026, 1, 1, 0, 0),
+      interfaces: const {
+        TrafficInterface.wan: InterfaceTrafficSnapshot(
+          uploadBytesPerSec: 12000,
+          downloadBytesPerSec: 98000,
+          uploadPacketsPerSec: 41,
+          downloadPacketsPerSec: 133,
+          totalBytesSent: 4200000,
+          totalBytesReceived: 51000000,
+          totalPacketsSent: 18400,
+          totalPacketsReceived: 62100,
+        ),
+      },
+    ),
+    MultiInterfaceSnapshot(
+      timestamp: DateTime.utc(2026, 1, 1, 0, 0, 10),
+      interfaces: const {
+        TrafficInterface.wan: InterfaceTrafficSnapshot(
+          uploadBytesPerSec: 15500,
+          downloadBytesPerSec: 143000,
+          uploadPacketsPerSec: 52,
+          downloadPacketsPerSec: 190,
+          totalBytesSent: 4355000,
+          totalBytesReceived: 52430000,
+          totalPacketsSent: 18920,
+          totalPacketsReceived: 64000,
+        ),
+      },
     ),
   ],
 );


### PR DESCRIPTION
## What broke

Asking the assistant how many devices are on WiFi vs Ethernet produced:

> An unexpected error occurred: Converting object to an encodable object failed: Instance of 'IdentityMap<int, int>'

…and then the chat stopped answering entirely. Two follow-up messages got no response.

`getDeviceAnalytics` passed `signalLevelDistribution` straight through, and that map is keyed by `int`. JSON object keys must be strings, so `jsonEncode` threw on it.

The reason it took the whole session down rather than one answer: encoding happens on the way out to the model, **after** the result is already in the conversation history. Every later request re-serialised the same entry and hit the same throw, leaving the session permanently unable to reply — recoverable only via the clear-conversation button.

## What this PR changes

Signal levels are now keyed by the labels the dashboard and statistics pages already show for this same data (`excellent`/`good`/`fair`/`poor`, matching the documented `3/2/1/0` convention in `usp_device_analytics_card.dart`).

That fixes the encoding failure and settles a second problem at the same time: the bare `0`–`3` never told the model which end of the range was good, so it had to guess. The labels carry it.

Unrecognised levels are kept as `level<n>` rather than dropped — silently losing devices from a distribution would misreport its total.

## Audit

All 15 read commands were checked for values that cannot survive `jsonEncode`. `getDeviceAnalytics` was the only one affected; the rest carry scalars, `List<String>`, `List<int>`, `List<double>` or `Map<String, *>`. Also confirmed `currentLocalTime`, `dnsServers` and `supportedStandards` are `String` (not `DateTime`), and the `*Formatted` accessors all return `String`.

Verified there is no coupling to the old shape: `signalLevelDistribution` appears nowhere in `lib/ai/prompts/`, `lib/ai/registry/` or `lib/ai/components/`, so no prompt or A2UI component documented the `int` keys.

## Tests

Three assertions, all in `usp_command_provider_test.dart`:

1. `getDeviceAnalytics` encodes, and its keys are the labels
2. An unrecognised level is kept, not dropped
3. Every command's result encodes, with string keys at every depth

**Verified by mutation** — reintroducing the raw map makes all three fail, with the same error class seen in the app.

The three timer-backed providers (`uspDeviceAnalyticsProvider`, `uspSystemMonitorProvider`, `uspTrafficAnalysisProvider`) are now stubbed in the shared container. Two reasons: they supply the populated results assertion 3 needs (unstubbed, those tools return "no data" and the assertion passes over them without seeing real data), and they keep a unit test from depending on `appConnectionStateProvider` not being `authenticated` — the only thing currently stopping the real notifiers from opening a `Timer.periodic` that fetches over USP.

## Verification

- Affected tests (direct + dependents): 27 pass. Wider `test/ai/` + `test/page/ai_assistant/`: 156 pass
- `flutter analyze` — no issues in either changed file
- `dart format` / `fvm dart format` — clean
- Verified on hardware: the question that triggered the error now renders correctly

## Follow-up

This removes the one bad value; **the mechanism that let it disable the session is unchanged**, and any future tool returning a non-encodable value would repeat it. Tracked in #1350, including why #1191's batching fix does not cover this failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
