### PR TITLE
test(static-routing): let the #1332 regression guard actually run in CI

### DIFF
--- a/test/page/static_routing/views/dialogs/static_route_dialog_test.dart
+++ b/test/page/static_routing/views/dialogs/static_route_dialog_test.dart
@@ -1,4 +1,3 @@
-@Tags(['ui'])
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';


### PR DESCRIPTION
#1347 merged the #1332 fix together with six widget tests meant to guard it. The tests have not run once since.

The file was tagged `ui`, and `run_tests.sh` excludes that tag in all three of its `flutter test` invocations (`:80`, `:92`, `:96`) — which is the script `ci.yml:84` runs. So the guard sits in the tree, unexecuted. Delete `_onInputChanged` and put `_validate()` back in the four `onChanged` handlers, and CI stays green.

This is one line: the `@Tags(['ui'])` annotation comes off. No product code, no test logic, no other file.

## Evidence

CI's own exclude expression, before and after, on the merged file:

```
before:  No tests ran.
         No tests match the requested tag selectors:
           exclude: "golden || loc || ui"

after:   00:04 +6: All tests passed!
```

Cross-checked against the merged CI log for #1347 (run `32441744841`): the file appears **0 times** among the 265 test files that executed. The `7113 tests passed` headline on that PR made the path look covered when it was not.

## Why remove the tag instead of moving it to `dashboard-card`

`dart_test.yaml` documents `dashboard-card` as the tag deliberately left in the PR test command:

```yaml
  # Defensive widget gates that must run in the PR test command (#1183).
  # NOT excluded by run_tests.sh's --exclude-tags="golden||loc||ui", so a
  # failure here blocks the PR.
  dashboard-card:
```

36 files use it, so it would work. But the name describes dashboard card gates, not a static-routing dialog, and the tag taxonomy is under separate review. An untagged widget test falls into the default `flutter test` set — the behaviour wanted here, and it needs no taxonomy decision.

Worth noting: `--exclude-tags` drops a test if **any** of its tags match, so `['ui', 'dashboard-card']` would still have been excluded. The `ui` tag had to come off either way.

## This is not an isolated file

Eleven others are in the same state — **66 tests, zero CI executions between them**:

| file | tests | guards |
|---|---|---|
| `dhcp_reservation_edit_dialog_test.dart` | 7 | #1070 |
| `wifi_channel_dialog_test.dart` | 19 | #1023, #1025 |
| `usp_port_forwarding_tab_identifier_widget_test.dart` | 3 | #1172, #1218, #1246 |
| `usp_advanced_settings_identifier_widget_test.dart` | 2 | #1218 |
| `topology_node_identifier_widget_test.dart` | 2 | #1208 |
| `node_detail_popup_identifier_widget_test.dart` | 6 | #1254 |
| `service_error_view_test.dart` | 6 | — |
| `usp_network_health_card_test.dart` | 4 | #1143 |
| `usp_network_health_card_legend_test.dart` | 3 | #1145 |
| `general_settings_widget_test.dart` | 5 | — |
| `pnp_no_internet_view_test.dart` | 3 | — |

The identifier ones are the sharpest: they guard the semantics identifiers `PrivacyGUI-USP-E2E` locates elements by, referenced in **24 places** across its specs (`P15-topology` 8, `P04a` 6, `S05` 2). Drop an identifier app-side and this repo's CI passes; the breakage surfaces the next day in another repo's scheduled E2E run.

All twelve pass locally when run directly, so the tag is the only thing keeping them out. #1327 is about to add a thirteenth (`dashboard_card_semantics_absorption_test.dart`, 224 lines, 3 tests) — raised there independently as a Critical.

**This PR deliberately changes only one file** so the mechanism is proven on Linux CI before the other eleven follow. Local green on macOS is not evidence that a widget test is stable on the CI runner.

## Check when reviewing

The claim to verify is not "the tests pass" — they passed before this PR too, when run by hand. It is that they now **execute as part of the normal CI test command**. In this PR's run, `static_route_dialog_test.dart` should appear in the executed set, and the total should rise by 6 against #1347's 7113.
