### PR TITLE
fix(ai): rebuild the router state summary per request

### DIFF
--- a/lib/ai/orchestrator/router_chat_controller.dart
+++ b/lib/ai/orchestrator/router_chat_controller.dart
@@ -78,18 +78,22 @@ class PendingConfirmation extends Equatable {
 /// user confirms or cancels, then flushed together with the write result. This
 /// is invisible to the user because tool results are never rendered in the chat.
 class RouterChatController extends ChangeNotifier {
+  /// [routerContextBuilder] is called for every request rather than once, so
+  /// the state the model reads is the state at the time of asking.
+  ///
+  /// It is a callback and not a `String` because a session outlives the network
+  /// it describes: a panel left open sees devices join and leave and the WAN
+  /// drop, and a summary captured at construction would keep asserting the
+  /// network it found on open. Building it per request is close to free — it
+  /// reads Riverpod caches already in memory and touches no device.
   RouterChatController({
     required IConversationGenerator generator,
     required IRouterCommandProvider commandProvider,
-    required String routerContext,
+    required String Function() routerContextBuilder,
   })  : _generator = generator,
         _commandProvider = commandProvider,
-        _routerContext = routerContext {
+        _routerContextBuilder = routerContextBuilder {
     _log('RouterChatController initialized');
-    // The router context is the user's network: model, IP addresses, SSIDs,
-    // device names. Debug builds only.
-    aiLogSensitive(() => 'Router context:\n$routerContext');
-    _initializeSystemPrompt();
   }
 
   static void _log(String message) => aiLog(message);
@@ -103,12 +107,11 @@ class RouterChatController extends ChangeNotifier {
 
   final IConversationGenerator _generator;
   final IRouterCommandProvider _commandProvider;
-  final String _routerContext;
+  final String Function() _routerContextBuilder;
 
   ConversationState _state = ConversationState.initial();
   PendingConfirmation? _pendingConfirmation;
   String? _lastUserMessage;
-  List<SystemPromptPart>? _systemPromptParts;
   List<GenTool>? _routerTools;
   Map<String, RouterCommand>? _commandsByName;
   Future<Map<String, RouterCommand>>? _commandsLoad;
@@ -185,12 +188,24 @@ class RouterChatController extends ChangeNotifier {
   /// Total tokens (input + output) used in this session.
   int get totalTokens => _totalInputTokens + _totalOutputTokens;
 
-  /// Initialize system prompt parts with router context (for caching).
-  void _initializeSystemPrompt() {
-    _systemPromptParts =
-        RouterSystemPrompt.buildParts(routerContext: _routerContext);
-    _log(
-        'System prompt initialized: ${_systemPromptParts!.length} parts, static cached: ${_systemPromptParts!.first.cache}');
+  /// Assemble the system prompt for one request, with a freshly read summary.
+  ///
+  /// Deliberately not stored. Holding the parts in a field is what let the
+  /// summary go stale, and a field would have to be invalidated from every
+  /// path that starts a request to stay correct. Rebuilding removes the
+  /// question.
+  ///
+  /// Prompt caching is unaffected: [RouterSystemPrompt.buildParts] puts the
+  /// static instructions in their own part, marked for caching and ordered
+  /// first, and caching matches on prefixes. The summary sits past that
+  /// boundary, so it can differ on every request and still leave the cached
+  /// prefix intact — cache hits are visible in the per-response token logs.
+  List<SystemPromptPart> _buildSystemPromptParts() {
+    final routerContext = _routerContextBuilder();
+    // The summary is the user's network: model, IP addresses, SSIDs, device
+    // names. Debug builds only.
+    aiLogSensitive(() => 'Router context:\n$routerContext');
+    return RouterSystemPrompt.buildParts(routerContext: routerContext);
   }
 
   /// Load the command registry once per conversation.
@@ -320,7 +335,7 @@ class RouterChatController extends ChangeNotifier {
         final response = await _generator.generateWithHistory(
           _state.messages,
           tools: tools.isNotEmpty ? tools : null,
-          systemPromptParts: _systemPromptParts,
+          systemPromptParts: _buildSystemPromptParts(),
         );
         if (_isStale(batch)) return;
         _log(
@@ -847,14 +862,7 @@ class RouterChatController extends ChangeNotifier {
     // the view sees `isLoading == false` alongside a non-zero round.
     _currentRound = 0;
 
-    // Refresh router context
-    _initializeSystemPrompt();
     notifyListeners();
-  }
-
-  /// Refresh router context (call when dashboard data changes).
-  void refreshContext() {
-    _initializeSystemPrompt();
   }
 
   /// Test seam for [_abandonedToolResult], which is otherwise only reachable

--- a/lib/ai/orchestrator/router_chat_controller.dart
+++ b/lib/ai/orchestrator/router_chat_controller.dart
@@ -200,8 +200,23 @@ class RouterChatController extends ChangeNotifier {
   /// first, and caching matches on prefixes. The summary sits past that
   /// boundary, so it can differ on every request and still leave the cached
   /// prefix intact — cache hits are visible in the per-response token logs.
+  ///
+  /// A summary that cannot be built costs the context, not the answer. The
+  /// model still has its instructions and its tools, so it can fetch what it
+  /// needs; dropping the exchange instead would turn a degraded reply into a
+  /// generic error. This became reachable when the build moved inside the
+  /// request loop — it now runs once per round rather than once per session.
   List<SystemPromptPart> _buildSystemPromptParts() {
-    final routerContext = _routerContextBuilder();
+    String routerContext;
+    try {
+      routerContext = _routerContextBuilder();
+    } catch (e) {
+      // Structural only: the summary is the user's network, so its contents
+      // must not reach a release log.
+      _log('_buildSystemPromptParts: router context unavailable, '
+          'continuing without it (${e.runtimeType})');
+      routerContext = '';
+    }
     // The summary is the user's network: model, IP addresses, SSIDs, device
     // names. Debug builds only.
     aiLogSensitive(() => 'Router context:\n$routerContext');

--- a/lib/page/ai_assistant/providers/router_command_provider.dart
+++ b/lib/page/ai_assistant/providers/router_command_provider.dart
@@ -7,3 +7,17 @@ import 'package:privacy_gui/ai/_ai.dart';
 final routerCommandProviderProvider = Provider<IRouterCommandProvider>((ref) {
   return UspCommandProvider(ref);
 });
+
+/// Builds the router state summary on demand, for the chat's system prompt.
+///
+/// Exists so the summary can be rebuilt per request without the caller holding a
+/// `WidgetRef`. The chat controller assembles its system prompt inside a loop
+/// that spans `await`s, and the view that started the exchange can be gone by a
+/// later round — `WidgetRef.read` throws once its widget is disposed, whereas
+/// this closure captures a ref owned by the container and stays callable.
+///
+/// Must not be `autoDispose`: a disposed provider's ref throws in the same way,
+/// which would reintroduce exactly the failure this avoids.
+final routerContextBuilderProvider = Provider<String Function()>((ref) {
+  return () => buildRouterContext(ref.read);
+});

--- a/lib/page/ai_assistant/views/router_assistant_view.dart
+++ b/lib/page/ai_assistant/views/router_assistant_view.dart
@@ -117,7 +117,7 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
       _controller = RouterChatController(
         generator: AwsContentGenerator(config: awsConfig),
         commandProvider: ref.read(routerCommandProviderProvider),
-        routerContext: buildRouterContext(ref.read),
+        routerContextBuilder: ref.read(routerContextBuilderProvider),
       );
       _controller!.addListener(_onControllerChanged);
       _needsConfig = false;
@@ -237,7 +237,7 @@ class _RouterAssistantViewState extends ConsumerState<RouterAssistantView> {
       _controller = RouterChatController(
         generator: AwsContentGenerator(config: awsConfig),
         commandProvider: commandProvider,
-        routerContext: buildRouterContext(ref.read),
+        routerContextBuilder: ref.read(routerContextBuilderProvider),
       );
       _controller!.addListener(_onControllerChanged);
 

--- a/test/ai/orchestrator/router_chat_controller_test.dart
+++ b/test/ai/orchestrator/router_chat_controller_test.dart
@@ -17,6 +17,10 @@ void main() {
   late MockRouterCommandProvider mockCommandProvider;
   late RouterChatController controller;
 
+  /// Stands in for the live router state. Reassign it mid-test to represent the
+  /// network changing under a session that is already open.
+  late String routerContext;
+
   setUpAll(() {
     registerFallbackValue(<ChatMessage>[]);
     registerFallbackValue(<GenTool>[]);
@@ -26,6 +30,7 @@ void main() {
   setUp(() {
     mockGenerator = MockConversationGenerator();
     mockCommandProvider = MockRouterCommandProvider();
+    routerContext = '# Test Router Context\nModel: TestRouter';
 
     when(() => mockCommandProvider.listCommands()).thenAnswer(
       (_) async => [
@@ -53,7 +58,7 @@ void main() {
     controller = RouterChatController(
       generator: mockGenerator,
       commandProvider: mockCommandProvider,
-      routerContext: '# Test Router Context\nModel: TestRouter',
+      routerContextBuilder: () => routerContext,
     );
   });
 
@@ -79,6 +84,76 @@ void main() {
       test('has no error initially', () {
         expect(controller.hasError, isFalse);
         expect(controller.errorMessage, isNull);
+      });
+    });
+
+    group('router context freshness', () {
+      /// The summary used to be captured once in the constructor, so a session
+      /// left open kept describing the network as it was when the panel opened —
+      /// under a heading that reads `# Current Router State`.
+      test('each request carries the summary as it is at that moment',
+          () async {
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async => _textResponse('ok'));
+
+        await controller.sendMessage('how many devices?');
+
+        // The network changes while the session stays open.
+        routerContext = '# Current Router State\n- Total connected devices: 9';
+
+        await controller.sendMessage('and now?');
+
+        final sent = verify(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: captureAny(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).captured.cast<List<SystemPromptPart>?>();
+
+        expect(sent.length, 2);
+        expect(
+          _summaryOf(sent.first),
+          contains('Model: TestRouter'),
+          reason:
+              'first request should carry the summary from before the change',
+        );
+        expect(
+          _summaryOf(sent.last),
+          contains('Total connected devices: 9'),
+          reason: 'second request should carry the changed summary, not the '
+              'one captured when the controller was built',
+        );
+      });
+
+      /// Guards the property the refresh depends on: the static instructions are
+      /// their own cacheable part and come first, so a summary that differs on
+      /// every request still leaves the cached prefix untouched.
+      test('static instructions stay cacheable and ordered first', () async {
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async => _textResponse('ok'));
+
+        await controller.sendMessage('hi');
+
+        final sent = verify(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: captureAny(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).captured.cast<List<SystemPromptPart>?>();
+
+        final parts = sent.single!;
+        expect(parts.first.cache, isTrue);
+        expect(parts.first.text, isNot(contains('TestRouter')),
+            reason: 'the cached part must not carry the volatile summary');
+        expect(parts.skip(1).every((p) => p.cache == false), isTrue);
       });
     });
 
@@ -998,6 +1073,10 @@ LLMResponse _textResponse(String text) {
     content: [TextBlock(text: text)],
   );
 }
+
+/// The parts after the cached static instructions, where the summary lives.
+String _summaryOf(List<SystemPromptPart>? parts) =>
+    (parts ?? []).skip(1).map((p) => p.text).join();
 
 LLMResponse _toolUseResponse(String toolName, Map<String, dynamic> input) {
   return LLMResponse(

--- a/test/ai/orchestrator/router_chat_controller_test.dart
+++ b/test/ai/orchestrator/router_chat_controller_test.dart
@@ -21,6 +21,10 @@ void main() {
   /// network changing under a session that is already open.
   late String routerContext;
 
+  /// Set mid-test to make the summary builder throw, standing in for a provider
+  /// read that fails while the exchange is already under way.
+  late bool throwingContext;
+
   setUpAll(() {
     registerFallbackValue(<ChatMessage>[]);
     registerFallbackValue(<GenTool>[]);
@@ -30,7 +34,12 @@ void main() {
   setUp(() {
     mockGenerator = MockConversationGenerator();
     mockCommandProvider = MockRouterCommandProvider();
+    // Deliberately not production's `# Current Router State` heading: the
+    // freshness test reassigns this and then asserts the two requests carried
+    // different summaries, which needs the before and after to be tellable
+    // apart. Aligning it with production would make that assertion vacuous.
     routerContext = '# Test Router Context\nModel: TestRouter';
+    throwingContext = false;
 
     when(() => mockCommandProvider.listCommands()).thenAnswer(
       (_) async => [
@@ -58,7 +67,10 @@ void main() {
     controller = RouterChatController(
       generator: mockGenerator,
       commandProvider: mockCommandProvider,
-      routerContextBuilder: () => routerContext,
+      routerContextBuilder: () {
+        if (throwingContext) throw StateError('provider unavailable');
+        return routerContext;
+      },
     );
   });
 
@@ -127,6 +139,26 @@ void main() {
           reason: 'second request should carry the changed summary, not the '
               'one captured when the controller was built',
         );
+      });
+
+      test('a builder that throws costs the context, not the answer', () async {
+        when(() => mockGenerator.generateWithHistory(
+              any(),
+              tools: any(named: 'tools'),
+              systemPromptParts: any(named: 'systemPromptParts'),
+              forceToolUse: any(named: 'forceToolUse'),
+            )).thenAnswer((_) async => _textResponse('ok'));
+
+        throwingContext = true;
+
+        await controller.sendMessage('hi');
+
+        expect(controller.hasError, isFalse,
+            reason:
+                'a summary that cannot be built must not abort the exchange');
+        final assistant =
+            controller.messages.where((m) => m.role == ChatRole.assistant);
+        expect(assistant, isNotEmpty, reason: 'the model should still answer');
       });
 
       /// Guards the property the refresh depends on: the static instructions are

--- a/test/page/ai_assistant/providers/router_command_provider_test.dart
+++ b/test/page/ai_assistant/providers/router_command_provider_test.dart
@@ -1,7 +1,30 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:privacy_gui/ai/_ai.dart';
 import 'package:privacy_gui/page/ai_assistant/providers/router_command_provider.dart';
+
+/// Hands the builder it obtained during `initState` back to the test, so the
+/// test can keep calling it after this widget is gone.
+class _BuilderCaptor extends ConsumerStatefulWidget {
+  const _BuilderCaptor({required this.onBuilder});
+
+  final void Function(String Function()) onBuilder;
+
+  @override
+  ConsumerState<_BuilderCaptor> createState() => _BuilderCaptorState();
+}
+
+class _BuilderCaptorState extends ConsumerState<_BuilderCaptor> {
+  @override
+  void initState() {
+    super.initState();
+    widget.onBuilder(ref.read(routerContextBuilderProvider));
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox();
+}
 
 void main() {
   group('routerCommandProviderProvider', () {
@@ -48,6 +71,39 @@ void main() {
       expect(resources, isNotEmpty);
       expect(resources.any((r) => r.uri == 'router://system'), isTrue);
       expect(resources.any((r) => r.uri == 'router://devices'), isTrue);
+    });
+  });
+
+  group('routerContextBuilderProvider', () {
+    test('builds a summary on each call', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final build = container.read(routerContextBuilderProvider);
+
+      expect(build(), contains('Current Router State'));
+      expect(build(), contains('Current Router State'));
+    });
+
+    // The chat controller assembles its system prompt inside a loop that spans
+    // `await`s, so a later round can run after the user has navigated away. A
+    // builder closing over `WidgetRef` throws there — "Cannot use ref after the
+    // widget was disposed" — and takes the exchange down with it.
+    testWidgets('stays callable after the widget that obtained it is disposed',
+        (tester) async {
+      String Function()? build;
+
+      await tester.pumpWidget(ProviderScope(
+        child: _BuilderCaptor(onBuilder: (b) => build = b),
+      ));
+      expect(build, isNotNull);
+      expect(build!(), contains('Current Router State'));
+
+      // The user leaves the chat while an exchange is still in flight.
+      await tester.pumpWidget(const ProviderScope(child: SizedBox()));
+
+      expect(build!, returnsNormally);
+      expect(build!(), contains('Current Router State'));
     });
   });
 }

--- a/test/page/ai_assistant/providers/router_command_provider_test.dart
+++ b/test/page/ai_assistant/providers/router_command_provider_test.dart
@@ -85,6 +85,20 @@ void main() {
       expect(build(), contains('Current Router State'));
     });
 
+    // The class comment forbids `autoDispose`: a disposed provider's ref throws
+    // exactly like a disposed widget's, which is the failure this provider
+    // exists to avoid. Nothing enforced that, and the widget test below does
+    // NOT catch it — with `autoDispose` the captured closure still answers
+    // there, so the regression would land silently.
+    test('is not autoDispose', () {
+      expect(
+        routerContextBuilderProvider,
+        isNot(isA<AutoDisposeProvider<String Function()>>()),
+        reason: 'autoDispose would let the provider be disposed while the chat '
+            'controller still holds its builder',
+      );
+    });
+
     // The chat controller assembles its system prompt inside a loop that spans
     // `await`s, so a later round can run after the user has navigated away. A
     // builder closing over `WidgetRef` throws there — "Cannot use ref after the


### PR DESCRIPTION
Fixes #1354.

## What's wrong

Leave the assistant open, go do something else, come back and ask "how many devices are connected?" or "is my internet OK?"

The summary of router state in the system prompt was captured **once, in the constructor**, and stored. A session outlives the network it describes — a panel left open sees devices join and leave and the WAN drop — so every request kept re-sending the state found when the panel opened, under a heading that reads `# Current Router State`. Nothing told the model the contents might be hours old.

The failure is quiet and selective. Model, firmware and SSIDs don't change, so answers stay plausible and nothing looks broken. What goes wrong is exactly the fast-moving fields users ask about: device counts, whether the internet is up, CPU load. And it gets worse the more the feature is used — someone who keeps the panel open all day is the most exposed.

Tools were never affected: they read the L1 provider caches at call time. So the assistant was *capable* of being right, and whether it was depended on it choosing to call a tool — which the system prompt correctly discourages, since it tells the model to check the context first.

## Why not just call the existing hook

A `refreshContext()` method already existed for precisely this, and **nothing ever called it**. Someone saw the problem, built the escape hatch, and never wired it up.

That is the argument against fixing it by wiring it up. Correctness that depends on remembering to invalidate is what failed here, and a stored field would have to be invalidated from every path that starts a request. So the stored parts are gone and the prompt is assembled per request instead — there is no longer a field to keep fresh. `refreshContext()` and the now-redundant refresh in `clearConversation()` are removed with it.

## Prompt caching is unaffected

`buildParts()` already puts the static instructions in their own `SystemPromptPart` marked `cache: true` and ordered first, and caching matches on prefixes. The summary sits past that boundary, so it can differ on every request while leaving the cached prefix intact. Measured: static part 13,478 chars (cached), summary a few hundred (not cached).

A test pins that ordering, because moving the summary into the cached part would silently cost the cache on every request — the kind of regression that shows up as a bill, not a failure.

## The builder comes from a provider, not the view

Worth calling out, because the first version of this change got it wrong.

The prompt is now assembled inside the loop in `_processConversation()`, which spans `await`s. A later round can therefore run after the user has navigated away — and `WidgetRef.read` throws once its widget is disposed (`Bad state: Cannot use "ref" after the widget was disposed`, verified). Two things make that reachable: the view's `dispose()` only removes its listener and never disposes the controller, and `_isStale()` tracks conversation generation, not view lifetime.

So the builder comes from `routerContextBuilderProvider`, closing over a ref owned by the container. It must not be `autoDispose` — a disposed provider's ref throws the same way — and the comment says so.

## Tests

Three, each pinning a distinct property, all verified by mutation:

| Test | Mutation that makes it fail |
|---|---|
| Each request carries the summary as it is at that moment | Capture the summary in the constructor again |
| Static instructions stay cacheable and ordered first | Move the summary into the cached part |
| Builder stays callable after its widget is disposed | Close over `WidgetRef` instead of the provider's ref |

The third fails with the exact `StateError` above, so it pins the real failure and not a proxy for it.

## Verification

- Affected tests: 46 pass. Wider `test/ai/` + `test/page/ai_assistant/`: 157 pass
- `flutter analyze` — no issues in any changed file
- `fvm dart format` — clean

## Not covered

`RouterChatController` is never disposed — the view's `dispose()` only removes the listener — and an in-flight `_processConversation()` loop has no cancellation. Pre-existing, and this change makes it less consequential by removing the loop's dependence on widget lifetime, but the leak and the uncancelled loop remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
